### PR TITLE
Expose inner model for all models

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -95,7 +95,7 @@ private func yarnLinearRampMask(minVal: Float, maxVal: Float, dim: Int) -> MLXAr
     return clip(linearFunc, min: 0, max: 1)
 }
 
-private class DeepseekV3YarnRotaryEmbedding: Module {
+class DeepseekV3YarnRotaryEmbedding: Module {
     var mscale: Float
     let dim: Int
     let maxPositionEmbeddings: Int
@@ -155,7 +155,7 @@ private func clippedSilu(_ x: MLXArray) -> MLXArray {
     clip(x * sigmoid(x), min: -100, max: 100)
 }
 
-private class DeepseekV3Attention: Module {
+class DeepseekV3Attention: Module {
     var config: DeepseekV3Configuration
     var hiddenSize: Int
     var numHeads: Int
@@ -306,7 +306,7 @@ private class DeepseekV3Attention: Module {
     }
 }
 
-private class DeepseekV3MLP: Module, UnaryLayer {
+class DeepseekV3MLP: Module, UnaryLayer {
     var config: DeepseekV3Configuration
     var hiddenSize: Int
     var intermediateSize: Int
@@ -328,7 +328,7 @@ private class DeepseekV3MLP: Module, UnaryLayer {
     }
 }
 
-private class MoEGate: Module {
+class MoEGate: Module {
     var config: DeepseekV3Configuration
     var topK: Int?
     var normTopkProb: Bool
@@ -379,7 +379,7 @@ private class MoEGate: Module {
     }
 }
 
-private class DeepseekV3MoE: Module, UnaryLayer {
+class DeepseekV3MoE: Module, UnaryLayer {
     var config: DeepseekV3Configuration
     var numExpertsPerTok: Int
     @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
@@ -418,7 +418,7 @@ private class DeepseekV3MoE: Module, UnaryLayer {
     }
 }
 
-private class DeepseekV3DecoderLayer: Module {
+class DeepseekV3DecoderLayer: Module {
     @ModuleInfo(key: "self_attn") var selfAttn: DeepseekV3Attention
     var mlp: UnaryLayer
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
@@ -452,7 +452,7 @@ private class DeepseekV3DecoderLayer: Module {
     }
 }
 
-private class DeepseekV3ModelInner: Module {
+public class DeepseekV3ModelInner: Module {
     var config: DeepseekV3Configuration
     var vocabSize: Int
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
@@ -497,7 +497,7 @@ public class DeepseekV3Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
     public var kvHeads: [Int] = []
 
     var args: DeepseekV3Configuration
-    fileprivate var model: DeepseekV3ModelInner
+    public var model: DeepseekV3ModelInner
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 
     init(_ args: DeepseekV3Configuration) {

--- a/Libraries/MLXLLM/Models/GLM4.swift
+++ b/Libraries/MLXLLM/Models/GLM4.swift
@@ -12,7 +12,7 @@ import MLXNN
 
 // port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/glm4.py
 
-private class Attention: Module {
+class GLM4Attention: Module {
     let args: GLM4Configuration
     let scale: Float
 
@@ -76,7 +76,7 @@ private class Attention: Module {
     }
 }
 
-private class MLP: Module, UnaryLayer {
+class GLM4MLP: Module, UnaryLayer {
     @ModuleInfo(key: "gate_up_proj") var gateUp: Linear
     @ModuleInfo(key: "down_proj") var down: Linear
 
@@ -92,9 +92,9 @@ private class MLP: Module, UnaryLayer {
     }
 }
 
-private class GLM4DecoderLayer: Module {
-    @ModuleInfo(key: "self_attn") var attention: Attention
-    let mlp: MLP
+class GLM4DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: GLM4Attention
+    let mlp: GLM4MLP
 
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
@@ -102,8 +102,8 @@ private class GLM4DecoderLayer: Module {
     @ModuleInfo(key: "post_mlp_layernorm") var postMlpLayerNorm: RMSNorm
 
     public init(_ args: GLM4Configuration) {
-        _attention.wrappedValue = Attention(args)
-        self.mlp = MLP(args)
+        _attention.wrappedValue = GLM4Attention(args)
+        self.mlp = GLM4MLP(args)
         _inputLayerNorm.wrappedValue = RMSNorm(
             dimensions: args.hiddenSize, eps: args.rmsNormEps)
         _postAttentionLayerNorm.wrappedValue = RMSNorm(
@@ -128,7 +128,7 @@ private class GLM4DecoderLayer: Module {
     }
 }
 
-private class GLM4ModelInner: Module {
+public class GLM4ModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
     fileprivate let layers: [GLM4DecoderLayer]
@@ -164,7 +164,7 @@ public class GLM4Model: Module, LLMModel, KVCacheDimensionProvider {
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    private let model: GLM4ModelInner
+    public let model: GLM4ModelInner
     let configuration: GLM4Configuration
     let modelType: String
 

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -12,7 +12,7 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
-private enum GraniteMoeHybridLayerType {
+enum GraniteMoeHybridLayerType {
     case mamba
     case attention
 }
@@ -21,7 +21,7 @@ private func createSSMMask(cache: KVCache?) -> MLXArray? {
     nil
 }
 
-private class GraniteMoeHybridRMSNormGated: Module {
+class GraniteMoeHybridRMSNormGated: Module {
     @ParameterInfo(key: "weight") var weight: MLXArray
     let eps: Float
 
@@ -40,7 +40,7 @@ private class GraniteMoeHybridRMSNormGated: Module {
     }
 }
 
-private class GraniteMoeHybridMamba2Mixer: Module {
+class GraniteMoeHybridMamba2Mixer: Module {
     let numHeads: Int
     let hiddenSize: Int
     let ssmStateSize: Int
@@ -188,7 +188,7 @@ private class GraniteMoeHybridMamba2Mixer: Module {
     }
 }
 
-private class GraniteMoeHybridAttention: Module {
+class GraniteMoeHybridAttention: Module {
     let args: GraniteMoeHybridConfiguration
     let scale: Float
 
@@ -271,7 +271,7 @@ private class GraniteMoeHybridAttention: Module {
     }
 }
 
-private class GraniteMoeHybridTopKGating: Module {
+class GraniteMoeHybridTopKGating: Module {
     let numExperts: Int
     let topK: Int
 
@@ -293,7 +293,7 @@ private class GraniteMoeHybridTopKGating: Module {
     }
 }
 
-private class GraniteMoeHybridMoE: Module, UnaryLayer {
+class GraniteMoeHybridMoE: Module, UnaryLayer {
     @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
     let router: GraniteMoeHybridTopKGating
 
@@ -325,7 +325,7 @@ private class GraniteMoeHybridMoE: Module, UnaryLayer {
     }
 }
 
-private class GraniteMoeHybridSharedMLP: Module, UnaryLayer {
+class GraniteMoeHybridSharedMLP: Module, UnaryLayer {
     @ModuleInfo(key: "input_linear") var inputLinear: Linear
     @ModuleInfo(key: "output_linear") var outputLinear: Linear
 
@@ -348,7 +348,7 @@ private class GraniteMoeHybridSharedMLP: Module, UnaryLayer {
     }
 }
 
-private class GraniteMoeHybridMLP: Module, UnaryLayer {
+class GraniteMoeHybridMLP: Module, UnaryLayer {
     @ModuleInfo(key: "gate_proj") var gate: Linear
     @ModuleInfo(key: "down_proj") var down: Linear
     @ModuleInfo(key: "up_proj") var up: Linear
@@ -365,7 +365,7 @@ private class GraniteMoeHybridMLP: Module, UnaryLayer {
     }
 }
 
-private class GraniteMoeHybridLayer: Module {
+class GraniteMoeHybridLayer: Module {
     let layerType: GraniteMoeHybridLayerType
     let residualMultiplier: Float
     let useMoE: Bool
@@ -440,7 +440,7 @@ private class GraniteMoeHybridLayer: Module {
     }
 }
 
-private class GraniteMoeHybridModelInner: Module {
+public class GraniteMoeHybridModelInner: Module {
     let args: GraniteMoeHybridConfiguration
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
     fileprivate let layers: [GraniteMoeHybridLayer]
@@ -494,7 +494,7 @@ public class GraniteMoeHybridModel: Module, LLMModel, KVCacheDimensionProvider {
     public let kvHeads: [Int]
     let logitsScaling: Float
 
-    private let model: GraniteMoeHybridModelInner
+    public let model: GraniteMoeHybridModelInner
     let configuration: GraniteMoeHybridConfiguration
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -107,7 +107,7 @@ public struct JambaConfiguration: Codable, Sendable {
     }
 }
 
-private class JambaMLP: Module {
+class JambaMLP: Module {
     @ModuleInfo(key: "gate_proj") var gateProj: Linear
     @ModuleInfo(key: "up_proj") var upProj: Linear
     @ModuleInfo(key: "down_proj") var downProj: Linear
@@ -123,7 +123,7 @@ private class JambaMLP: Module {
     }
 }
 
-private class JambaAttention: Module {
+class JambaAttention: Module {
     let numAttentionHeads: Int
     let numKeyValueHeads: Int
     let headDim: Int
@@ -182,7 +182,7 @@ private func fma(_ a: MLXArray, _ b: MLXArray, _ c: MLXArray) -> MLXArray {
     return a * b + c
 }
 
-private class JambaMambaMixer: Module {
+class JambaMambaMixer: Module {
     let hiddenSize: Int
     let ssmStateSize: Int
     let convKernelSize: Int
@@ -331,7 +331,7 @@ private class JambaMambaMixer: Module {
     }
 }
 
-private class JambaSparseMoeBlock: Module {
+class JambaSparseMoeBlock: Module {
     let numExpertsPerTok: Int
 
     @ModuleInfo(key: "router") var router: Linear
@@ -361,7 +361,7 @@ private class JambaSparseMoeBlock: Module {
     }
 }
 
-private class JambaDecoderLayer: Module {
+class JambaDecoderLayer: Module {
     let isAttn: Bool
     let isSparseMoe: Bool
 
@@ -418,7 +418,7 @@ private class JambaDecoderLayer: Module {
     }
 }
 
-private class JambaModelInner: Module {
+public class JambaModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
     fileprivate let layers: [JambaDecoderLayer]
@@ -469,7 +469,7 @@ public class JambaModel: Module, LLMModel, KVCacheDimensionProvider {
     public let kvHeads: [Int]
     let modelType: String
     let config: JambaConfiguration
-    fileprivate let model: JambaModelInner
+    public let model: JambaModelInner
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 

--- a/Libraries/MLXLLM/Models/Lille130m.swift
+++ b/Libraries/MLXLLM/Models/Lille130m.swift
@@ -12,7 +12,7 @@ import MLXNN
 
 // MARK: - Attention
 
-private final class Lille130mAttention: Module {
+final class Lille130mAttention: Module {
     let args: Lille130mConfiguration
     let headDim: Int
     let scale: Float
@@ -89,7 +89,7 @@ private final class Lille130mAttention: Module {
 
 // MARK: - MLP
 
-private final class Lille130mMLP: Module, UnaryLayer {
+final class Lille130mMLP: Module, UnaryLayer {
     @ModuleInfo(key: "norm") var norm: RMSNorm
     @ModuleInfo(key: "gate_proj") var gate: Linear
     @ModuleInfo(key: "up_proj") var up: Linear
@@ -114,7 +114,7 @@ private final class Lille130mMLP: Module, UnaryLayer {
 
 // MARK: - Block
 
-private final class Lille130mBlock: Module {
+final class Lille130mBlock: Module {
     @ModuleInfo(key: "attention") var attention: Lille130mAttention
     @ModuleInfo(key: "feed_forward") var feedForward: Lille130mMLP
 
@@ -135,7 +135,7 @@ private final class Lille130mBlock: Module {
 
 // MARK: - Model (inner)
 
-private final class Lille130mModelInner: Module {
+public final class Lille130mModelInner: Module {
     @ModuleInfo(key: "tok_embeddings") var embedTokens: Embedding
 
     let layers: [Lille130mBlock]
@@ -165,7 +165,7 @@ public final class Lille130mModel: Module, LLMModel, KVCacheDimensionProvider {
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    @ModuleInfo(key: "transformer") fileprivate var transformer: Lille130mModelInner
+    @ModuleInfo(key: "transformer") public var transformer: Lille130mModelInner
     private let configuration: Lille130mConfiguration
 
     public init(_ args: Lille130mConfiguration) {

--- a/Libraries/MLXLLM/Models/NanoChat.swift
+++ b/Libraries/MLXLLM/Models/NanoChat.swift
@@ -28,7 +28,7 @@ private func applySoftcap(_ logits: MLXArray, cap: Float) -> MLXArray {
 
 // MARK: - Attention
 
-private final class NanoChatAttention: Module {
+final class NanoChatAttention: Module {
     let config: NanoChatConfiguration
     let numHeads: Int
     let numKVHeads: Int
@@ -118,7 +118,7 @@ private final class NanoChatAttention: Module {
 
 // MARK: - MLP
 
-private final class NanoChatMLP: Module, UnaryLayer {
+final class NanoChatMLP: Module, UnaryLayer {
     let config: NanoChatConfiguration
 
     @ModuleInfo(key: "c_fc") var fc: Linear
@@ -138,7 +138,7 @@ private final class NanoChatMLP: Module, UnaryLayer {
 
 // MARK: - Transformer Block
 
-private final class NanoChatBlock: Module {
+final class NanoChatBlock: Module {
     let config: NanoChatConfiguration
 
     @ModuleInfo(key: "attn") var attention: NanoChatAttention
@@ -165,7 +165,7 @@ private final class NanoChatBlock: Module {
 
 // MARK: - Model (inner)
 
-private final class NanoChatModelInner: Module {
+public final class NanoChatModelInner: Module {
     let config: NanoChatConfiguration
 
     @ModuleInfo(key: "wte") var embedTokens: Embedding
@@ -205,7 +205,7 @@ public final class NanoChatModel: Module, LLMModel, KVCacheDimensionProvider {
 
     let config: NanoChatConfiguration
 
-    @ModuleInfo(key: "transformer") fileprivate var transformer: NanoChatModelInner
+    @ModuleInfo(key: "transformer") public var transformer: NanoChatModelInner
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 
     public init(_ config: NanoChatConfiguration) {

--- a/Libraries/MLXLLM/Models/OpenELM.swift
+++ b/Libraries/MLXLLM/Models/OpenELM.swift
@@ -25,7 +25,7 @@ func makeDivisible(_ v: Float, divisor: Int = 8, minValue: Float? = nil) -> Int 
     return Int(roundDown)
 }
 
-private class MultiHeadCausalAttention: Module {
+class MultiHeadCausalAttention: Module {
     let scale: Float
     let heads: Int
     let headDim: Int
@@ -99,7 +99,7 @@ private class MultiHeadCausalAttention: Module {
     }
 }
 
-private class FeedForwardNetwork: Module, UnaryLayer {
+class FeedForwardNetwork: Module, UnaryLayer {
     @ModuleInfo var proj_1: Linear
     @ModuleInfo var proj_2: Linear
 
@@ -122,7 +122,7 @@ private class FeedForwardNetwork: Module, UnaryLayer {
     }
 }
 
-private class TransformerDecoderLayer: Module {
+class OpenELMTransformerDecoderLayer: Module {
     @ModuleInfo(key: "attn") var attn: MultiHeadCausalAttention
     let ffn: FeedForwardNetwork
 
@@ -148,10 +148,10 @@ private class TransformerDecoderLayer: Module {
     }
 }
 
-class OpenELMModelInner: Module {
+public class OpenELMModelInner: Module {
     @ModuleInfo(key: "token_embeddings") var embedTokens: Embedding
 
-    fileprivate let layers: [TransformerDecoderLayer]
+    fileprivate let layers: [OpenELMTransformerDecoderLayer]
     fileprivate let norm: RMSNorm
 
     public init(_ args: OpenElmConfiguration) {
@@ -162,7 +162,7 @@ class OpenELMModelInner: Module {
 
         self.layers = (0 ..< args.numTransformerLayers)
             .map { layerId in
-                TransformerDecoderLayer(args, layerId: layerId)
+                OpenELMTransformerDecoderLayer(args, layerId: layerId)
             }
 
         self.norm = RMSNorm(dimensions: args.modelDim, eps: args.rmsNormEps)
@@ -184,7 +184,7 @@ public class OpenELMModel: Module, LLMModel, KVCacheDimensionProvider {
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    let transformer: OpenELMModelInner
+    public let transformer: OpenELMModelInner
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 

--- a/Libraries/MLXLLM/Models/Phi.swift
+++ b/Libraries/MLXLLM/Models/Phi.swift
@@ -7,7 +7,7 @@ import MLXNN
 
 // https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/phi.py
 
-private class PhiAttention: Module {
+class PhiAttention: Module {
 
     let args: PhiConfiguration
     let heads: Int
@@ -83,7 +83,7 @@ private class PhiAttention: Module {
     }
 }
 
-private class PhiMLP: Module, UnaryLayer {
+class PhiMLP: Module, UnaryLayer {
 
     @ModuleInfo var fc1: Linear
     @ModuleInfo var fc2: Linear
@@ -100,7 +100,7 @@ private class PhiMLP: Module, UnaryLayer {
     }
 }
 
-private class PhiDecoderLayer: Module {
+class PhiDecoderLayer: Module {
 
     @ModuleInfo(key: "self_attn") var selfAttention: PhiAttention
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: LayerNorm
@@ -123,7 +123,7 @@ private class PhiDecoderLayer: Module {
     }
 }
 
-private class PhiModelInner: Module {
+public class PhiModelInner: Module {
 
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
@@ -160,7 +160,7 @@ public class PhiModel: Module, LLMModel, KVCacheDimensionProvider {
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    fileprivate let model: PhiModelInner
+    public let model: PhiModelInner
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 

--- a/Libraries/MLXLLM/Models/PhiMoE.swift
+++ b/Libraries/MLXLLM/Models/PhiMoE.swift
@@ -39,7 +39,7 @@ public struct PhiMoEConfiguration: Codable, Sendable {
     }
 }
 
-private class Attention: Module {
+class PhiMoEAttention: Module {
     let args: PhiMoEConfiguration
     let scale: Float
 
@@ -114,7 +114,7 @@ private class Attention: Module {
     }
 }
 
-private class PhiMoESparseMoeBlock: Module {
+class PhiMoESparseMoeBlock: Module {
     let hiddenDim: Int
     let ffnDim: Int
     let numExperts: Int
@@ -151,10 +151,10 @@ private class PhiMoESparseMoeBlock: Module {
     }
 }
 
-private class PhiMoEDecoderLayer: Module {
+class PhiMoEDecoderLayer: Module {
     let hiddenSize: Int
 
-    @ModuleInfo(key: "self_attn") var selfAttn: Attention
+    @ModuleInfo(key: "self_attn") var selfAttn: PhiMoEAttention
     @ModuleInfo(key: "block_sparse_moe") var blockSparseMoe: PhiMoESparseMoeBlock
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: LayerNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: LayerNorm
@@ -162,7 +162,7 @@ private class PhiMoEDecoderLayer: Module {
     init(_ args: PhiMoEConfiguration) {
         self.hiddenSize = args.hiddenSize
 
-        self._selfAttn.wrappedValue = Attention(args)
+        self._selfAttn.wrappedValue = PhiMoEAttention(args)
         self._blockSparseMoe.wrappedValue = PhiMoESparseMoeBlock(args)
         self._inputLayerNorm.wrappedValue = LayerNorm(
             dimensions: args.hiddenSize, eps: args.rmsNormEps)
@@ -187,7 +187,7 @@ private class PhiMoEDecoderLayer: Module {
     }
 }
 
-private class PhiMoEModelInner: Module {
+public class PhiMoEModelInner: Module {
     let args: PhiMoEConfiguration
 
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
@@ -220,7 +220,7 @@ public class PhiMoEModel: Module, LLMModel, KVCacheDimensionProvider {
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
-    fileprivate let model: PhiMoEModelInner
+    public let model: PhiMoEModelInner
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 
     public init(_ args: PhiMoEConfiguration) {


### PR DESCRIPTION
## Proposed changes

A problem I've encountered while implementing some TTS models with LLM backbones in [mlx-swift-audio](https://github.com/DePasqualeOrg/mlx-swift-audio) is that mlx-swift-lm does not expose the inner model, as mlx-lm in Python does, which means that this part of the model needs to be re-implemented. Exposing the inner model can also be useful for customizing inference with techniques such as masking or speculative decoding.

The changes here mirror the public API of mlx-lm in Python, exposing the inner model via `model.model` (or `model.transformer` for OpenELM, NanoChat, and Lille130m).

This requires helper classes like `Attention` and `MLP` that were previously private to be given unique names to prevent collisions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
