### PR TITLE
Fix GPTOSS Fatal error in getSlidingWindowMask

### DIFF
--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -256,11 +256,11 @@ private class AttentionBlock: Module {
 
         if L > 1 {
             _previousMask = nil
-            return makeMask(L, min(windowSize + 1, offset))
+            return makeMask(L, min(windowSize, offset))
         }
 
         if _previousMask == nil {
-            _previousMask = makeMask(L, windowSize + 1)
+            _previousMask = makeMask(L, windowSize)
         }
 
         return _previousMask![.ellipsis, 0 ..< min(L + offset, windowSize + 1)]


### PR DESCRIPTION
Fix GPTOSS `Fatal error: [broadcast_shapes] Shapes (1,64,512,641) and (1,64,512,640) cannot be broadcast`

 In GPTOSS's getSlidingWindowMask function, the mask size calculation for prefill (L > 1) was off by one compared to what RotatingKVCache actually produces after trimming.

  The Bug:
  - RotatingKVCache is initialized with maxSize = slidingWindow + 1 = 129
  - During prefill with chunk size L, after trimming, the cache contains maxSize + L - 1 entries
  - But the mask was computed with min(windowSize + 1, offset), producing L + min(windowSize + 1, offset) columns
  - This led to mask having more columns than k/v having entries

Tested using opencode and GPTOSS 20B
