### PR TITLE
Fix Mistral3TextConfiguration parsing

### DIFF
--- a/Libraries/MLXLLM/Models/Mistral3Text.swift
+++ b/Libraries/MLXLLM/Models/Mistral3Text.swift
@@ -435,7 +435,6 @@ public struct Mistral3TextConfiguration: Codable, Sendable {
                 try decoder.container(keyedBy: CodingKeys.self)
             }
 
-
         modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "ministral3"
         hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
         hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)


### PR DESCRIPTION
Problem:
Loading mlx-community/Ministral-3-8B-Instruct-2512-4bit (and similar VLM-style Mistral3 models) via LLMModelFactory failed with:
```
Unable to set lm_head on Mistral3TextModel: none not compatible with [biases: [131072, 64], scales: [131072, 64]]
```
Root Cause:
The model's config.json has a VLM structure where tie_word_embeddings: false is at the top level, not inside text_config. The parser only checked text_config and defaulted to true, causing lmHead module to not be created, which then failed when loading the quantized lm_head weights.

Changes
  1. First, try to decode `tieWordEmbeddings` from container (which is either the top-level or text_config, depending on the model type).
      If not found there, fallback to topLevelContainer (always the root level).
      If still not found, default to false
  2. Changed tieWordEmbeddings default from true to false - Safer default because:
      - Creating an unused lmHead module is wasteful but works
      - Missing lmHead when loading quantized weights crashes 
      - Matches Mistral3VLMTextConfiguration which also defaults to false

