### PR TITLE
Remove consuming keyword from LoRAContainer.init parameter

### DIFF
--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
@@ -83,7 +83,7 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
 
     public init(
         configuration: LoRAConfiguration,
-        parameters: consuming ModuleParameters
+        parameters: ModuleParameters
     ) {
         // ensure that the parameters are fully evaluated before we promise
         // that they are Sendable


### PR DESCRIPTION
## Proposed changes

Fixes #94 

This PR removes `consuming` from `LoRAContainer.init`’s `parameters` argument. 

The initializer needs to `eval` the parameters to force MLX arrays to be fully evaluated, and then store them. Marking the argument as `consuming` makes that a double-consume under Swift 6.1 ownership checking. (I'm not sure why this doesn't appear to be a problem in Swift 6.2)

Dropping `consuming` preserves the original intent while restoring correct semantics.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
