### PR TITLE
trim vocabulary padding in weight sanitization in Gemma3Text

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -375,6 +375,18 @@ public class Gemma3TextModel: Module, LLMModel {
             processedWeights = Dictionary(uniqueKeysWithValues: lm.flattened())
         }
 
+        let expectedVocab = config.vocabularySize
+        let keysToCheck = [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ]
+
+        for key in keysToCheck {
+            if let tensor = processedWeights[key], tensor.dim(0) > expectedVocab {
+                processedWeights[key] = tensor[0 ..< expectedVocab]
+            }
+        }
+
         if processedWeights["lm_head.weight"] == nil {
             ["weight", "scales", "biases"].forEach { key in
                 if let embedWeight = processedWeights["model.embed_tokens.\(key)"] {

--- a/Libraries/MLXLLM/Models/Gemma3nText.swift
+++ b/Libraries/MLXLLM/Models/Gemma3nText.swift
@@ -1013,6 +1013,22 @@ public class Gemma3nTextModel: Module, LLMModel {
             }
         }
 
+        let expectedVocab = config.vocabSize
+        let keysToCheck = [
+            "language_model.model.embed_tokens.weight",
+            "language_model.model.embed_tokens.scales",
+            "language_model.model.embed_tokens.biases",
+            "language_model.lm_head.weight",
+            "language_model.lm_head.scales",
+            "language_model.lm_head.biases",
+        ]
+
+        for key in keysToCheck {
+            if let tensor = processedWeights[key], tensor.dim(0) > expectedVocab {
+                processedWeights[key] = tensor[0 ..< expectedVocab]
+            }
+        }
+
         return processedWeights
     }
 


### PR DESCRIPTION
Gemma 3 12B weights often include extra padding tokens (e.g., 262208 vs 262144) that cause dimension mismatches when loading into MLX.

## Proposed changes

This PR fixes an MLXNN.UpdateError.mismatchedSize crash occurring when loading Gemma 3 12B models.

The issue is caused by a discrepancy between the config.json (listing a vocab_size of 262,144) and the actual weights (padded to 262,208).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
