### PR TITLE
use ReerCodable macro to allow for default values

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,7 +89,7 @@ jobs:
           xcrun --show-sdk-build-version
           swift --version
           rm -rf ~/Library/Developer/Xcode/DerivedData/*
-          xcodebuild build-for-testing -scheme mlx-swift-lm-Package -destination 'platform=macOS'
+          xcodebuild build-for-testing -scheme mlx-swift-lm-Package -destination 'platform=macOS' -skipMacroValidation
 
       - name: Run Tests (Xcode, macOS)
         shell: sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,6 +83,7 @@ jobs:
         run: xcodebuild -showComponent MetalToolchain
 
       - name: Build (Xcode, macOS)
+        # note skipMacroValidation causes CI to trust the codable macros
         shell: sh
         run: |
           xcodebuild -version

--- a/Libraries/MLXLLM/Codable+Support.swift
+++ b/Libraries/MLXLLM/Codable+Support.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+/// `swift-transformers` also declares a public `Decoder` and it conflicts with the `Codable`
+/// implementations.
+public typealias Decoder = Swift.Decoder

--- a/Libraries/MLXLLM/Documentation.docc/adding-model.md
+++ b/Libraries/MLXLLM/Documentation.docc/adding-model.md
@@ -14,17 +14,12 @@ and create a `.swift` file for your new model:
 Create a configuration struct to match the `config.json` (any parameters needed).
 
 ```swift
-public struct YourModelConfiguration: Codable, Sendable {
-    public let hiddenSize: Int
-    
-    // use this pattern for values that need defaults
-    public let _layerNormEps: Float?
-    public var layerNormEps: Float { _layerNormEps ?? 1e-6 }
-    
-    enum CodingKeys: String, CodingKey {
-        case hiddenSize = "hidden_size"
-        case _layerNormEps = "layer_norm_eps"
-    }
+import ReerCodable
+
+@Codable
+public struct YourModelConfiguration: Sendable {
+    @CodingKey("hidden_size") public var hiddenSize: Int
+    @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
 }
 ```
 

--- a/Libraries/MLXLLM/Models/Cohere.swift
+++ b/Libraries/MLXLLM/Models/Cohere.swift
@@ -2,6 +2,7 @@ import Foundation
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 
 // port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cohere.py
 
@@ -172,63 +173,21 @@ public class CohereModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 }
 
-public struct CohereConfiguration: Codable, Sendable {
+@Codable
+public struct CohereConfiguration: Sendable {
 
-    var hiddenSize: Int
-    var hiddenLayers: Int
-    var intermediateSize: Int
-    var attentionHeads: Int
-    var layerNormEps: Float
-    var vocabularySize: Int
-    var kvHeads: Int
-    var ropeTheta: Float = 8000000.0
-    var ropeTraditional: Bool = true
-    var ropeScaling: [String: StringOrNumber]? = nil
-    var logitScale: Float
+    @CodingKey("hidden_size") public var hiddenSize: Int = 8192
+    @CodingKey("num_hidden_layers") public var hiddenLayers: Int = 40
+    @CodingKey("intermediate_size") public var intermediateSize: Int = 22528
+    @CodingKey("num_attention_heads") public var attentionHeads: Int = 64
+    @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-5
+    @CodingKey("vocab_size") public var vocabularySize: Int = 256000
+    @CodingKey("num_key_value_heads") public var kvHeads: Int = 64
+    @CodingKey("rope_theta") public var ropeTheta: Float = 8000000.0
+    @CodingKey("rope_traditional") public var ropeTraditional: Bool = true
+    @CodingKey("rope_scaling") public var ropeScaling: [String: StringOrNumber]? = nil
+    @CodingKey("logit_scale") public var logitScale: Float = 0.0625
 
-    enum CodingKeys: String, CodingKey {
-        case hiddenSize = "hidden_size"
-        case hiddenLayers = "num_hidden_layers"
-        case intermediateSize = "intermediate_size"
-        case attentionHeads = "num_attention_heads"
-        case kvHeads = "num_key_value_heads"
-        case ropeTheta = "rope_theta"
-        case vocabularySize = "vocab_size"
-        case layerNormEps = "layer_norm_eps"
-        case logitScale = "logit_scale"
-        case ropeTraditional = "rope_traditional"
-        case ropeScaling = "rope_scaling"
-    }
-
-    public init(from decoder: Decoder) throws {
-        // custom implementation to handle optional keys with required values
-        let container: KeyedDecodingContainer<CohereConfiguration.CodingKeys> =
-            try decoder.container(
-                keyedBy: CohereConfiguration.CodingKeys.self)
-
-        self.hiddenSize = try container.decode(
-            Int.self, forKey: CohereConfiguration.CodingKeys.hiddenSize)
-        self.hiddenLayers = try container.decode(
-            Int.self, forKey: CohereConfiguration.CodingKeys.hiddenLayers)
-        self.intermediateSize = try container.decode(
-            Int.self, forKey: CohereConfiguration.CodingKeys.intermediateSize)
-        self.attentionHeads = try container.decode(
-            Int.self, forKey: CohereConfiguration.CodingKeys.attentionHeads)
-        self.layerNormEps = try container.decode(
-            Float.self, forKey: CohereConfiguration.CodingKeys.layerNormEps)
-        self.vocabularySize = try container.decode(
-            Int.self, forKey: CohereConfiguration.CodingKeys.vocabularySize)
-        self.kvHeads = try container.decode(
-            Int.self, forKey: CohereConfiguration.CodingKeys.kvHeads)
-        self.ropeTheta =
-            try container.decodeIfPresent(
-                Float.self, forKey: CohereConfiguration.CodingKeys.ropeTheta)
-            ?? 8000000.0
-        self.ropeScaling = try container.decodeIfPresent(
-            [String: StringOrNumber].self, forKey: CohereConfiguration.CodingKeys.ropeScaling)
-        self.logitScale = try container.decode(
-            Float.self, forKey: CohereConfiguration.CodingKeys.logitScale)
-    }
 }
 
 // MARK: - LoRA

--- a/Libraries/MLXLLM/Models/Gemma2.swift
+++ b/Libraries/MLXLLM/Models/Gemma2.swift
@@ -4,6 +4,7 @@ import Foundation
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 import Tokenizers
 
 // Port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/gemma2.py
@@ -204,70 +205,21 @@ public class Gemma2Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 }
 
-public struct Gemma2Configuration: Codable {
-    var hiddenSize: Int
-    var hiddenLayers: Int
-    var intermediateSize: Int
-    var attentionHeads: Int
-    var headDimensions: Int
-    var rmsNormEps: Float
-    var vocabularySize: Int
-    var kvHeads: Int
-    var ropeTheta: Float = 10_000
-    var ropeTraditional: Bool = false
-    var attnLogitSoftcapping: Float = 50.0
-    var finalLogitSoftcapping: Float = 30.0
-    var queryPreAttnScalar: Float = 144.0
-
-    enum CodingKeys: String, CodingKey {
-        case hiddenSize = "hidden_size"
-        case hiddenLayers = "num_hidden_layers"
-        case intermediateSize = "intermediate_size"
-        case attentionHeads = "num_attention_heads"
-        case headDimensions = "head_dim"
-        case rmsNormEps = "rms_norm_eps"
-        case vocabularySize = "vocab_size"
-        case kvHeads = "num_key_value_heads"
-        case ropeTheta = "rope_theta"
-        case ropeTraditional = "rope_traditional"
-        case attnLogitSoftcapping = "attn_logit_softcapping"
-        case finalLogitSoftcapping = "final_logit_softcapping"
-        case queryPreAttnScalar = "query_pre_attn_scalar"
-    }
-
-    public init(from decoder: Swift.Decoder) throws {
-        // Custom implementation to handle optional keys with required values
-        let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(
-            keyedBy: CodingKeys.self)
-
-        self.hiddenSize = try container.decode(
-            Int.self, forKey: CodingKeys.hiddenSize)
-        self.hiddenLayers = try container.decode(
-            Int.self, forKey: CodingKeys.hiddenLayers)
-        self.intermediateSize = try container.decode(
-            Int.self, forKey: CodingKeys.intermediateSize)
-        self.attentionHeads = try container.decode(
-            Int.self, forKey: CodingKeys.attentionHeads)
-        self.headDimensions = try container.decode(
-            Int.self, forKey: CodingKeys.headDimensions)
-        self.rmsNormEps = try container.decode(
-            Float.self, forKey: CodingKeys.rmsNormEps)
-        self.vocabularySize = try container.decode(
-            Int.self, forKey: CodingKeys.vocabularySize)
-        self.kvHeads = try container.decode(Int.self, forKey: CodingKeys.kvHeads)
-        self.ropeTheta =
-            try container.decodeIfPresent(Float.self, forKey: CodingKeys.ropeTheta)
-            ?? 10_000
-        self.ropeTraditional =
-            try container.decodeIfPresent(
-                Bool.self, forKey: CodingKeys.ropeTraditional) ?? false
-        self.attnLogitSoftcapping = try container.decode(
-            Float.self, forKey: CodingKeys.attnLogitSoftcapping)
-        self.finalLogitSoftcapping = try container.decode(
-            Float.self, forKey: CodingKeys.finalLogitSoftcapping)
-        self.queryPreAttnScalar = try container.decode(
-            Float.self, forKey: CodingKeys.queryPreAttnScalar)
-    }
+@Codable
+public struct Gemma2Configuration: Sendable {
+    @CodingKey("hidden_size") public var hiddenSize: Int
+    @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+    @CodingKey("intermediate_size") public var intermediateSize: Int
+    @CodingKey("num_attention_heads") public var attentionHeads: Int
+    @CodingKey("head_dim") public var headDimensions: Int
+    @CodingKey("rms_norm_eps") public var rmsNormEps: Float
+    @CodingKey("vocab_size") public var vocabularySize: Int
+    @CodingKey("num_key_value_heads") public var kvHeads: Int
+    @CodingKey("rope_theta") public var ropeTheta: Float = 10_000
+    @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
+    @CodingKey("attn_logit_softcapping") public var attnLogitSoftcapping: Float = 50.0
+    @CodingKey("final_logit_softcapping") public var finalLogitSoftcapping: Float = 30.0
+    @CodingKey("query_pre_attn_scalar") public var queryPreAttnScalar: Float = 144.0
 }
 
 // MARK: - LoRA

--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -351,7 +351,7 @@ public struct LlamaConfiguration: Sendable {
     @CodingKey("head_dim") public var headDimensions: Int?
     @CodingKey("rms_norm_eps") public var rmsNormEps: Float
     @CodingKey("vocab_size") public var vocabularySize: Int
-    @CodingKey("num_key_value_heads") public var kvHeads: Int
+    @CodingKey("num_key_value_heads", "num_attention_heads") public var kvHeads: Int
     @CodingKey("max_position_embeddings") public var maxPositionEmbeddings: Int?
     @CodingKey("rope_theta") public var ropeTheta: Float = 10_000
     @CodingKey("rope_traditional") public var ropeTraditional: Bool = false

--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -4,6 +4,7 @@ import Foundation
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 import Tokenizers
 
 // port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/llama.py
@@ -340,108 +341,37 @@ public class LlamaModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 }
 
-public struct LlamaConfiguration: Codable, Sendable {
+@Codable
+public struct LlamaConfiguration: Sendable {
 
-    var hiddenSize: Int
-    var hiddenLayers: Int
-    var intermediateSize: Int
-    var attentionHeads: Int
-    var headDimensions: Int?
-    var rmsNormEps: Float
-    var vocabularySize: Int
-    var kvHeads: Int
-    var maxPositionEmbeddings: Int?
-    var ropeTheta: Float = 10_000
-    var ropeTraditional: Bool = false
-    var ropeScaling: [String: StringOrNumber]?
-    var tieWordEmbeddings: Bool = true
-    var attentionBias: Bool = false
-    var mlpBias: Bool = false
-
-    public init(
-        hiddenSize: Int, hiddenLayers: Int, intermediateSize: Int, attentionHeads: Int,
-        headDimensions: Int? = nil, rmsNormEps: Float, vocabularySize: Int, kvHeads: Int,
-        maxPositionEmbeddings: Int? = nil, ropeTheta: Float = 10_000, ropeTraditional: Bool = false,
-        ropeScaling: [String: StringOrNumber]? = nil, tieWordEmbeddings: Bool = true,
-        attentionBias: Bool = false, mlpBias: Bool = false
-    ) {
-        self.hiddenSize = hiddenSize
-        self.hiddenLayers = hiddenLayers
-        self.intermediateSize = intermediateSize
-        self.attentionHeads = attentionHeads
-        self.headDimensions = headDimensions
-        self.rmsNormEps = rmsNormEps
-        self.vocabularySize = vocabularySize
-        self.kvHeads = kvHeads
-        self.maxPositionEmbeddings = maxPositionEmbeddings
-        self.ropeTheta = ropeTheta
-        self.ropeTraditional = ropeTraditional
-        self.ropeScaling = ropeScaling
-        self.tieWordEmbeddings = tieWordEmbeddings
-        self.attentionBias = attentionBias
-        self.mlpBias = mlpBias
-    }
+    @CodingKey("hidden_size") public var hiddenSize: Int
+    @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+    @CodingKey("intermediate_size") public var intermediateSize: Int
+    @CodingKey("num_attention_heads") public var attentionHeads: Int
+    @CodingKey("head_dim") public var headDimensions: Int?
+    @CodingKey("rms_norm_eps") public var rmsNormEps: Float
+    @CodingKey("vocab_size") public var vocabularySize: Int
+    @CodingKey("num_key_value_heads") public var kvHeads: Int
+    @CodingKey("max_position_embeddings") public var maxPositionEmbeddings: Int?
+    @CodingKey("rope_theta") public var ropeTheta: Float = 10_000
+    @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
+    @CodingKey("rope_scaling") public var ropeScaling: [String: StringOrNumber]?
+    @CodingKey("tie_word_embeddings") public var tieWordEmbeddings: Bool = true
+    @CodingKey("attention_bias") public var attentionBias: Bool = false
+    @CodingKey("mlp_bias") public var mlpBias: Bool = false
 
     var resolvedHeadDimensions: Int {
         headDimensions ?? (hiddenSize / attentionHeads)
     }
 
-    enum CodingKeys: String, CodingKey {
-        case hiddenSize = "hidden_size"
-        case hiddenLayers = "num_hidden_layers"
-        case intermediateSize = "intermediate_size"
-        case attentionHeads = "num_attention_heads"
-        case headDimensions = "head_dim"
-        case rmsNormEps = "rms_norm_eps"
-        case vocabularySize = "vocab_size"
-        case kvHeads = "num_key_value_heads"
-        case maxPositionEmbeddings = "max_position_embeddings"
-        case ropeTheta = "rope_theta"
-        case ropeTraditional = "rope_traditional"
-        case ropeScaling = "rope_scaling"
-        case tieWordEmbeddings = "tie_word_embeddings"
-        case attentionBias = "attention_bias"
-        case mlpBias = "mlp_bias"
-    }
-
-    public init(from decoder: Swift.Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
-        hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)
-        intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
-        attentionHeads = try container.decode(Int.self, forKey: .attentionHeads)
-        headDimensions = try container.decodeIfPresent(Int.self, forKey: .headDimensions)
-        rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
-        vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
-        kvHeads = try container.decodeIfPresent(Int.self, forKey: .kvHeads) ?? attentionHeads
-        maxPositionEmbeddings = try container.decodeIfPresent(
-            Int.self, forKey: .maxPositionEmbeddings)
-        if let ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) {
-            self.ropeTheta = ropeTheta
-        }
-        if let ropeTraditional = try container.decodeIfPresent(Bool.self, forKey: .ropeTraditional)
-        {
-            self.ropeTraditional = ropeTraditional
-        }
-        ropeScaling = try container.decodeIfPresent(
-            [String: StringOrNumber].self, forKey: .ropeScaling)
-        if let tieWordEmbeddings = try container.decodeIfPresent(
-            Bool.self, forKey: .tieWordEmbeddings)
-        {
-            self.tieWordEmbeddings = tieWordEmbeddings
-        }
-        if let attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) {
-            self.attentionBias = attentionBias
-        }
-        if let mlpBias = try container.decodeIfPresent(Bool.self, forKey: .mlpBias) {
-            self.mlpBias = mlpBias
-        }
+    public func didDecode(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        let codingKey = AnyCodingKey("rope_scaling")
 
         if let ropeScaling {
             if ropeScaling["factor"] == nil {
                 throw DecodingError.dataCorruptedError(
-                    forKey: .ropeScaling, in: container,
+                    forKey: codingKey, in: container,
                     debugDescription: "rope_scaling must contain 'factor'")
             }
             if let ropeType = ropeScaling["type"] ?? ropeScaling["rope_type"] {
@@ -452,7 +382,7 @@ public struct LlamaConfiguration: Codable, Sendable {
                     ]
                     if !options.contains(ropeType) {
                         throw DecodingError.dataCorruptedError(
-                            forKey: .ropeScaling, in: container,
+                            forKey: codingKey, in: container,
                             debugDescription:
                                 "rope_scaling 'type' currently only supports 'linear', 'dynamic', or 'llama3'"
                         )
@@ -460,7 +390,7 @@ public struct LlamaConfiguration: Codable, Sendable {
                 }
             } else {
                 throw DecodingError.dataCorruptedError(
-                    forKey: .ropeScaling, in: container,
+                    forKey: codingKey, in: container,
                     debugDescription: "rope_scaling must contain either 'type' or 'rope_type'")
             }
         }

--- a/Libraries/MLXLLM/README.md
+++ b/Libraries/MLXLLM/README.md
@@ -11,7 +11,7 @@
 
 This is a port of several models from:
 
-- https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/
+- https://github.com/ml-explore/mlx-lm/tree/main/mlx_lm/models/
 
 using the Hugging Face swift transformers package to provide tokenization:
 
@@ -99,17 +99,12 @@ and create a `.swift` file for your new model:
 Create a configuration struct to match the `config.json` (any parameters needed).
 
 ```swift
-public struct YourModelConfiguration: Codable, Sendable {
-    public let hiddenSize: Int
-    
-    // use this pattern for values that need defaults
-    public let _layerNormEps: Float?
-    public var layerNormEps: Float { _layerNormEps ?? 1e-6 }
-    
-    enum CodingKeys: String, CodingKey {
-        case hiddenSize = "hidden_size"
-        case _layerNormEps = "layer_norm_eps"
-    }
+import ReerCodable
+
+@Codable
+public struct YourModelConfiguration: Sendable {
+    @CodingKey("hidden_size") public var hiddenSize: Int
+    @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
 }
 ```
 

--- a/Libraries/MLXLMCommon/Documentation.docc/porting.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/porting.md
@@ -58,38 +58,24 @@ This will be loaded from a JSON file and used to configure the model, including 
 
 This translates naturally into a `Codable` struct in Swift with a few details:
 
-- The keys in the JSON file will be `snake_case`. The simplest way to accommodate that is to specify `CodingKeys` to name them explicitly.
+- The keys in the JSON file will be `snake_case`.  If using ReerCodable (recommended) you can explicitly give the coding key name as shown or by annotating the property or type with `@SnakeCase`.
 - Some of the parameters have default values.
 
 ```swift
-public struct GemmaConfiguration: Codable, Sendable {
-    var modelType: String
-    var hiddenSize: Int
-    var hiddenLayers: Int
-    var intermediateSize: Int
-    var attentionHeads: Int
-    var headDimensions: Int
-    var rmsNormEps: Float
-    var vocabularySize: Int
-    var kvHeads: Int
-    private let _ropeTheta: Float?
-    public var ropeTheta: Float { _ropeTheta ?? 10_000 }
-    private let _ropeTraditional: Bool?
-    public var ropeTraditional: Bool { _ropeTraditional ?? false }
+import ReerCodable
 
-    enum CodingKeys: String, CodingKey {
-        case modelType = "model_type"
-        case hiddenSize = "hidden_size"
-        case hiddenLayers = "num_hidden_layers"
-        case intermediateSize = "intermediate_size"
-        case attentionHeads = "num_attention_heads"
-        case headDimensions = "head_dim"
-        case rmsNormEps = "rms_norm_eps"
-        case vocabularySize = "vocab_size"
-        case kvHeads = "num_key_value_heads"
-        case _ropeTheta = "rope_theta"
-        case _ropeTraditional = "rope_traditional"
-    }
+@Codable
+public struct GemmaConfiguration: Sendable {
+    @CodingKey("hidden_size") public var hiddenSize: Int
+    @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+    @CodingKey("intermediate_size") public var intermediateSize: Int
+    @CodingKey("num_attention_heads") public var attentionHeads: Int
+    @CodingKey("head_dim") public var headDimensions: Int
+    @CodingKey("rms_norm_eps") public var rmsNormEps: Float
+    @CodingKey("vocab_size") public var vocabularySize: Int
+    @CodingKey("num_key_value_heads") public var kvHeads: Int
+    @CodingKey("rope_theta") public var ropeTheta: Float = 10_000
+    @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
 }
 ```
 

--- a/Libraries/MLXVLM/Codable+Support.swift
+++ b/Libraries/MLXVLM/Codable+Support.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+/// `swift-transformers` also declares a public `Decoder` and it conflicts with the `Codable`
+/// implementations.
+public typealias Decoder = Swift.Decoder

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -31,7 +31,7 @@ public struct Idefics3Configuration: Sendable {
         @CodingKey("rms_norm_eps") public var rmsNormEps: Float
         @CodingKey("vocab_size") public var vocabSize: Int
         @CodingKey("num_key_value_heads") public var numKeyValueHeads: Int
-        @CodingKey("rope_theta") public var ropeTheta: Float
+        @CodingKey("rope_theta") public var ropeTheta: Float = 1000000.0
         @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
         @CodingKey("tie_word_embeddings") public var tieWordEmbeddings: Bool = false
     }
@@ -44,7 +44,7 @@ public struct Idefics3Configuration: Sendable {
         @CodingKey("intermediate_size") public var intermediateSize: Int = 3072
         @CodingKey("num_attention_heads") public var numAttentionHeads: Int
         @CodingKey("patch_size") public var patchSize: Int
-        @CodingKey("image_size") public var imageSize: Int
+        @CodingKey("image_size") public var imageSize: Int = 224
         @CodingKey("num_channels") public var numChannels: Int = 3
         @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
     }
@@ -52,7 +52,7 @@ public struct Idefics3Configuration: Sendable {
     @CodingKey("text_config") public var textConfig: TextConfiguration
     @CodingKey("vision_config") public var visionConfig: VisionConfiguration
     @CodingKey("model_type") public var modelType: String
-    @CodingKey("ignore_index") public var ignoreIndex: Int = -10
+    @CodingKey("ignore_index") public var ignoreIndex: Int = -100
     @CodingKey("vocab_size") public var vocabSize: Int = 128259
     @CodingKey("scale_factor") public var scaleFactor: Int = 2
     @CodingKey("image_token_id") public var imageTokenId: Int = 49153

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -13,110 +13,50 @@ import Hub
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 import Tokenizers
 
 // MARK: - Configuration
 
-public struct Idefics3Configuration: Codable, Sendable {
+@Codable
+public struct Idefics3Configuration: Sendable {
 
-    public struct TextConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let hiddenSize: Int
-        public var numHiddenLayers: Int { _numHiddenLayers ?? 32 }
-        public let intermediateSize: Int
-        public let numAttentionHeads: Int
-        public let rmsNormEps: Float
-        public let vocabSize: Int
-        public let numKeyValueHeads: Int
-        public let ropeTheta: Float
-        public var ropeTraditional: Bool { _ropeTraditional ?? false }
-        public var tieWordEmbeddings: Bool { _tieWordEmbeddings ?? false }
-
-        private let _numHiddenLayers: Int?
-        private let _ropeTraditional: Bool?
-        private let _tieWordEmbeddings: Bool?
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case hiddenSize = "hidden_size"
-            case _numHiddenLayers = "num_hidden_layers"
-            case intermediateSize = "intermediate_size"
-            case numAttentionHeads = "num_attention_heads"
-            case rmsNormEps = "rms_norm_eps"
-            case vocabSize = "vocab_size"
-            case numKeyValueHeads = "num_key_value_heads"
-            case ropeTheta = "rope_theta"
-            case _ropeTraditional = "rope_traditional"
-            case _tieWordEmbeddings = "tie_word_embeddings"
-        }
+    @Codable
+    public struct TextConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_hidden_layers") public var numHiddenLayers: Int = 32
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("num_attention_heads") public var numAttentionHeads: Int
+        @CodingKey("rms_norm_eps") public var rmsNormEps: Float
+        @CodingKey("vocab_size") public var vocabSize: Int
+        @CodingKey("num_key_value_heads") public var numKeyValueHeads: Int
+        @CodingKey("rope_theta") public var ropeTheta: Float
+        @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
+        @CodingKey("tie_word_embeddings") public var tieWordEmbeddings: Bool = false
     }
 
-    public struct VisionConfiguration: Codable, Sendable {
-        public let modelType: String
-        public var numHiddenLayers: Int { _numHiddenLayers ?? 12 }
-        public let hiddenSize: Int
-        public var intermediateSize: Int { _intermediateSize ?? 3072 }
-        public let numAttentionHeads: Int
-        public let patchSize: Int
-        public let imageSize: Int
-        public var numChannels: Int { _numChannels ?? 3 }
-        public var layerNormEps: Float { _layerNormEps ?? 1e-6 }
-
-        private let _numHiddenLayers: Int?
-        private let _intermediateSize: Int?
-        private let _numChannels: Int?
-        private let _layerNormEps: Float?
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case _numHiddenLayers = "num_hidden_layers"
-            case hiddenSize = "hidden_size"
-            case _intermediateSize = "intermediate_size"
-            case numAttentionHeads = "num_attention_heads"
-            case patchSize = "patch_size"
-            case imageSize = "image_size"
-            case _numChannels = "num_channels"
-            case _layerNormEps = "layer_norm_eps"
-        }
+    @Codable
+    public struct VisionConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("num_hidden_layers") public var numHiddenLayers: Int = 12
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int = 3072
+        @CodingKey("num_attention_heads") public var numAttentionHeads: Int
+        @CodingKey("patch_size") public var patchSize: Int
+        @CodingKey("image_size") public var imageSize: Int
+        @CodingKey("num_channels") public var numChannels: Int = 3
+        @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
     }
 
-    public let textConfig: TextConfiguration
-    public let visionConfig: VisionConfiguration
-    public let modelType: String
-    public let ignoreIndex: Int
-    public let vocabSize: Int
-    public let scaleFactor: Int
-    public let imageTokenId: Int
-    public let imageTokenIndex: Int
-
-    enum CodingKeys: String, CodingKey {
-        case textConfig = "text_config"
-        case visionConfig = "vision_config"
-        case modelType = "model_type"
-        case ignoreIndex = "ignore_index"
-        case vocabSize = "vocab_size"
-        case scaleFactor = "scale_factor"
-        case imageTokenId = "image_token_id"
-        case imageTokenIndex = "image_token_index"
-    }
-
-    public init(from decoder: any Swift.Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        self.textConfig =
-            try container
-            .decode(TextConfiguration.self, forKey: .textConfig)
-        self.visionConfig =
-            try container
-            .decode(VisionConfiguration.self, forKey: .visionConfig)
-        self.modelType = try container.decode(String.self, forKey: .modelType)
-        self.ignoreIndex = (try? container.decode(Int.self, forKey: .ignoreIndex)) ?? -100
-        self.vocabSize = (try? container.decode(Int.self, forKey: .vocabSize)) ?? 128259
-        self.scaleFactor = (try? container.decode(Int.self, forKey: .scaleFactor)) ?? 2
-        self.imageTokenId = (try? container.decode(Int.self, forKey: .imageTokenId)) ?? 49153
-        self.imageTokenIndex =
-            (try? container.decode(Int.self, forKey: .imageTokenIndex)) ?? self.imageTokenId
-    }
+    @CodingKey("text_config") public var textConfig: TextConfiguration
+    @CodingKey("vision_config") public var visionConfig: VisionConfiguration
+    @CodingKey("model_type") public var modelType: String
+    @CodingKey("ignore_index") public var ignoreIndex: Int = -10
+    @CodingKey("vocab_size") public var vocabSize: Int = 128259
+    @CodingKey("scale_factor") public var scaleFactor: Int = 2
+    @CodingKey("image_token_id") public var imageTokenId: Int = 49153
+    @CodingKey("image_token_index", "image_token_id") public var imageTokenIndex: Int
 }
 
 // MARK: - Connector
@@ -778,31 +718,24 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
 }
 
 // MARK: - Processor Configuration
-public struct Idefics3ProcessorConfiguration: Codable, Sendable {
-    public struct Size: Codable, Sendable {
-        public let longestEdge: Int
-        enum CodingKeys: String, CodingKey {
-            case longestEdge = "longest_edge"
-        }
+@Codable
+public struct Idefics3ProcessorConfiguration: Sendable {
+
+    @Codable
+    public struct Size: Sendable {
+        @CodingKey("longest_edge") public var longestEdge: Int
     }
 
-    public let imageMean: [CGFloat]
-    public let imageStd: [CGFloat]
-    public let size: Size
-    public let imageSequenceLength: Int?
+    @CodingKey("image_mean") public var imageMean: [CGFloat]
+    @CodingKey("image_std") public var imageStd: [CGFloat]
+    public var size: Size
+    @CodingKey("image_seq_len") public var imageSequenceLength: Int?
 
     public var imageMeanTuple: (CGFloat, CGFloat, CGFloat) {
         (imageMean[0], imageMean[1], imageMean[2])
     }
     public var imageStdTuple: (CGFloat, CGFloat, CGFloat) {
         (imageStd[0], imageStd[1], imageStd[2])
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case imageMean = "image_mean"
-        case imageStd = "image_std"
-        case size
-        case imageSequenceLength = "image_seq_len"
     }
 }
 

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -8,6 +8,7 @@ import Hub
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 import Tokenizers
 
 // MARK: - Language
@@ -627,112 +628,68 @@ public class PaliGemma: Module, VLMModel, KVCacheDimensionProvider {
 // MARK: - Configuration
 
 /// Confguration for ``PaliGemma``
-public struct PaliGemmaConfiguration: Codable, Sendable {
+@Codable
+public struct PaliGemmaConfiguration: Sendable {
 
-    public struct TextConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let hiddenSize: Int
-        public let hiddenLayers: Int
-        public let intermediateSize: Int
-        public let attentionHeads: Int
-        public let kvHeads: Int
-        public let vocabularySize: Int
-        private let _rmsNormEps: Float?
-        public var rmsNormEps: Float { _rmsNormEps ?? 1e-6 }
-        private let _ropeTheta: Float?
-        public var ropeTheta: Float { _ropeTheta ?? 10_000 }
-        private let _ropeTraditional: Bool?
-        public var ropeTraditional: Bool { _ropeTraditional ?? false }
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case hiddenSize = "hidden_size"
-            case hiddenLayers = "num_hidden_layers"
-            case intermediateSize = "intermediate_size"
-            case attentionHeads = "num_attention_heads"
-            case kvHeads = "num_key_value_heads"
-            case vocabularySize = "vocab_size"
-            case _rmsNormEps = "rms_norm_eps"
-            case _ropeTheta = "rope_theta"
-            case _ropeTraditional = "rope_traditional"
-        }
+    @Codable
+    public struct TextConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("num_attention_heads") public var attentionHeads: Int
+        @CodingKey("num_key_value_heads") public var kvHeads: Int
+        @CodingKey("vocab_size") public var vocabularySize: Int
+        @CodingKey("rms_norm_eps") public var rmsNormEps: Float = 1e-6
+        @CodingKey("rope_theta") public var ropeTheta: Float = 10_000
+        @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
     }
 
-    public struct VisionConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let hiddenSize: Int
-        public let hiddenLayers: Int
-        public let intermediateSize: Int
-        public let attentionHeads: Int
-        public let patchSize: Int
-        public let projectionDimensions: Int
-        public let imageSize: Int
-        private let _channels: Int?
-        public var channels: Int { _channels ?? 3 }
-        private let _layerNormEps: Float?
-        public var layerNormEps: Float { _layerNormEps ?? 1e-6 }
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case hiddenSize = "hidden_size"
-            case hiddenLayers = "num_hidden_layers"
-            case intermediateSize = "intermediate_size"
-            case attentionHeads = "num_attention_heads"
-            case patchSize = "patch_size"
-            case projectionDimensions = "projection_dim"
-            case imageSize = "image_size"
-            case _channels = "num_channels"
-            case _layerNormEps = "layer_norm_eps"
-        }
+    @Codable
+    public struct VisionConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("num_attention_heads") public var attentionHeads: Int
+        @CodingKey("patch_size") public var patchSize: Int
+        @CodingKey("projection_dim") public var projectionDimensions: Int
+        @CodingKey("image_size") public var imageSize: Int
+        @CodingKey("num_channels") public var channels: Int = 3
+        @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
     }
 
-    public let textConfiguration: TextConfiguration
-    public let visionConfiguration: VisionConfiguration
-    public let modelType: String
-    public let vocabularySize: Int
-    public let ignoreIndex: Int
-    public let imageTokenIndex: Int
-    public let hiddenSize: Int
-    public let padTokenId: Int
-
-    enum CodingKeys: String, CodingKey {
-        case textConfiguration = "text_config"
-        case visionConfiguration = "vision_config"
-        case modelType = "model_type"
-        case vocabularySize = "vocab_size"
-        case ignoreIndex = "ignore_index"
-        case imageTokenIndex = "image_token_index"
-        case hiddenSize = "hidden_size"
-        case padTokenId = "pad_token_id"
-    }
+    @CodingKey("text_config") public var textConfiguration: TextConfiguration
+    @CodingKey("vision_config") public var visionConfiguration: VisionConfiguration
+    @CodingKey("model_type") public var modelType: String
+    @CodingKey("vocab_size") public var vocabularySize: Int
+    @CodingKey("ignore_index") public var ignoreIndex: Int
+    @CodingKey("image_token_index") public var imageTokenIndex: Int
+    @CodingKey("hidden_size") public var hiddenSize: Int
+    @CodingKey("pad_token_id") public var padTokenId: Int
 }
 
 /// Configuration for ``PaliGemmaProcessor``
-public struct PaliGemmaProcessorConfiguration: Codable, Sendable {
+@Codable
+public struct PaliGemmaProcessorConfiguration: Sendable {
 
-    public struct Size: Codable, Sendable {
-        public let width: Int
-        public let height: Int
+    @Codable
+    public struct Size: Sendable {
+        public var width: Int
+        public var height: Int
 
         var cgSize: CGSize { .init(width: width, height: height) }
     }
 
-    public let imageMean: [CGFloat]
-    public let imageStd: [CGFloat]
-    public let size: Size
-    public let imageSequenceLength: Int
+    @CodingKey("image_mean") public var imageMean: [CGFloat]
+    @CodingKey("image_std") public var imageStd: [CGFloat]
+    public var size: Size
+    @CodingKey("image_seq_length") public var imageSequenceLength: Int
 
     public var imageMeanTuple: (CGFloat, CGFloat, CGFloat) {
         (imageMean[0], imageMean[1], imageMean[2])
     }
     public var imageStdTuple: (CGFloat, CGFloat, CGFloat) {
         (imageStd[0], imageStd[1], imageStd[2])
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case imageMean = "image_mean"
-        case imageStd = "image_std"
-        case size
-        case imageSequenceLength = "image_seq_length"
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -6,6 +6,7 @@ import Hub
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 import Tokenizers
 
 // MARK: - Language
@@ -911,125 +912,62 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
 /// Configuration for ``Qwen25VL``
 public struct Qwen25VLConfiguration: Codable, Sendable {
 
-    public struct TextConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let hiddenSize: Int
-        public let hiddenLayers: Int
-        public let intermediateSize: Int
-        public let attentionHeads: Int
-        private let _rmsNormEps: Float?
-        public var rmsNormEps: Float { _rmsNormEps ?? 1e-6 }
-        public let vocabularySize: Int
-        public let kvHeads: Int
-        private let _maxPositionEmbeddings: Int?
-        public var maxPositionEmbeddings: Int { _maxPositionEmbeddings ?? 128000 }
-        private let _ropeTheta: Float?
-        public var ropeTheta: Float { _ropeTheta ?? 1_000_000 }
-        private let _ropeTraditional: Bool?
-        public var ropeTraditional: Bool { _ropeTraditional ?? false }
-        public let ropeScaling: [String: StringOrNumber]?
-        private let _tieWordEmbeddings: Bool?
-        public var tieWordEmbeddings: Bool { _tieWordEmbeddings ?? true }
-        private let _slidingWindow: Int?
-        public var slidingWindow: Int { _slidingWindow ?? 32768 }
-        private let _useSlidingWindow: Bool?
-        public var useSlidingWindow: Bool { _useSlidingWindow ?? false }
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case hiddenSize = "hidden_size"
-            case hiddenLayers = "num_hidden_layers"
-            case intermediateSize = "intermediate_size"
-            case attentionHeads = "num_attention_heads"
-            case _rmsNormEps = "rms_norm_eps"
-            case vocabularySize = "vocab_size"
-            case kvHeads = "num_key_value_heads"
-            case _maxPositionEmbeddings = "max_position_embeddings"
-            case _ropeTheta = "rope_theta"
-            case _ropeTraditional = "rope_traditional"
-            case ropeScaling = "rope_scaling"
-            case _tieWordEmbeddings = "tie_word_embeddings"
-            case _slidingWindow = "sliding_window"
-            case _useSlidingWindow = "use_sliding_window"
-        }
+    @Codable
+    public struct TextConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("num_attention_heads") public var attentionHeads: Int
+        @CodingKey("rms_norm_eps") public var rmsNormEps: Float = 1e-6
+        @CodingKey("vocab_size") public var vocabularySize: Int
+        @CodingKey("num_key_value_heads") public var kvHeads: Int
+        @CodingKey("max_position_embeddings") public var maxPositionEmbeddings: Int = 128000
+        @CodingKey("rope_theta") public var ropeTheta: Float = 1_000_000
+        @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
+        @CodingKey("rope_scaling") public var ropeScaling: [String: StringOrNumber]?
+        @CodingKey("tie_word_embeddings") public var tieWordEmbeddings: Bool = true
+        @CodingKey("sliding_window") public var slidingWindow: Int = 32768
+        @CodingKey("use_sliding_window") public var useSlidingWindow: Bool = false
     }
 
-    public struct VisionConfiguration: Codable, Sendable {
-        public let depth: Int
-        public let hiddenSize: Int
-        public let intermediateSize: Int
-        public let outHiddenSize: Int
-        public let numHeads: Int
-        public let patchSize: Int
-        private let _inChans: Int?
-        public var inChannels: Int { _inChans ?? 3 }
-        private let _layerNormEps: Float?
-        public var layerNormEps: Float { _layerNormEps ?? 1e-6 }
-        public let spatialPatchSize: Int
-        public let spatialMergeSize: Int
-        public let temporalPatchSize: Int
-        public let windowSize: Int
-        public let fullattBlockIndexes: [Int]
-        public let tokensPerSecond: Int
-        private let _skipVision: Bool?
-        public var skipVision: Bool { _skipVision ?? false }
-        private let _hiddenAct: String?
-        public var hiddenAct: String { _hiddenAct ?? "silu" }
-
-        enum CodingKeys: String, CodingKey {
-            case depth
-            case hiddenSize = "hidden_size"
-            case intermediateSize = "intermediate_size"
-            case outHiddenSize = "out_hidden_size"
-            case numHeads = "num_heads"
-            case patchSize = "patch_size"
-            case _inChans = "in_chans"
-            case _layerNormEps = "layer_norm_eps"  // Added this line
-            case spatialPatchSize = "spatial_patch_size"
-            case spatialMergeSize = "spatial_merge_size"
-            case temporalPatchSize = "temporal_patch_size"
-            case windowSize = "window_size"
-            case fullattBlockIndexes = "fullatt_block_indexes"
-            case tokensPerSecond = "tokens_per_second"
-            case _skipVision = "skip_vision"
-            case _hiddenAct = "hidden_act"
-        }
+    @Codable
+    public struct VisionConfiguration: Sendable {
+        public var depth: Int
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("out_hidden_size") public var outHiddenSize: Int
+        @CodingKey("num_heads") public var numHeads: Int
+        @CodingKey("patch_size") public var patchSize: Int
+        @CodingKey("in_chans") public var inChannels: Int = 3
+        @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
+        @CodingKey("spatial_patch_size") public var spatialPatchSize: Int
+        @CodingKey("spatial_merge_size") public var spatialMergeSize: Int
+        @CodingKey("temporal_patch_size") public var temporalPatchSize: Int
+        @CodingKey("window_size") public var windowSize: Int
+        @CodingKey("fullatt_block_indexes") public var fullattBlockIndexes: [Int]
+        @CodingKey("tokens_per_second") public var tokensPerSecond: Int
+        @CodingKey("skip_vision") public var skipVision: Bool = false
+        @CodingKey("hidden_act") public var hiddenAct: String = "silu"
     }
 
+    @Codable
     public struct BaseConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let vocabularySize: Int
-        public let imageTokenId: Int
-        public let videoTokenId: Int
-        public let visionStartTokenId: Int
-        public let visionEndTokenId: Int
-        public let visionTokenId: Int
-        public let hiddenSize: Int
-        public let numAttentionHeads: Int
-        public let numHiddenLayers: Int
-        public let intermediateSize: Int
-        public let numKeyValueHeads: Int
-        public let slidingWindow: Int
-        public let useSlidingWindow: Bool
-        public let maxWindowLayers: Int
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case vocabularySize = "vocab_size"
-            case imageTokenId = "image_token_id"
-            case videoTokenId = "video_token_id"
-            case visionStartTokenId = "vision_start_token_id"
-            case visionEndTokenId = "vision_end_token_id"
-            case visionTokenId = "vision_token_id"
-            case hiddenSize = "hidden_size"
-            case numAttentionHeads = "num_attention_heads"
-            case numHiddenLayers = "num_hidden_layers"
-            case intermediateSize = "intermediate_size"
-            case numKeyValueHeads = "num_key_value_heads"
-            case slidingWindow = "sliding_window"
-            case useSlidingWindow = "use_sliding_window"
-            case maxWindowLayers = "max_window_layers"
-        }
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("vocab_size") public var vocabularySize: Int
+        @CodingKey("image_token_id") public var imageTokenId: Int
+        @CodingKey("video_token_id") public var videoTokenId: Int
+        @CodingKey("vision_start_token_id") public var visionStartTokenId: Int
+        @CodingKey("vision_end_token_id") public var visionEndTokenId: Int
+        @CodingKey("vision_token_id") public var visionTokenId: Int
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_attention_heads") public var numAttentionHeads: Int
+        @CodingKey("num_hidden_layers") public var numHiddenLayers: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("num_key_value_heads") public var numKeyValueHeads: Int
+        @CodingKey("sliding_window") public var slidingWindow: Int
+        @CodingKey("use_sliding_window") public var useSlidingWindow: Bool
+        @CodingKey("max_window_layers") public var maxWindowLayers: Int
     }
 
     public let textConfiguration: TextConfiguration
@@ -1050,6 +988,14 @@ public struct Qwen25VLConfiguration: Codable, Sendable {
         // these are overlaid in the top level
         self.textConfiguration = try TextConfiguration(from: decoder)
         self.baseConfiguration = try BaseConfiguration(from: decoder)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(visionConfiguration, forKey: .visionConfiguration)
+        try textConfiguration.encode(to: encoder)
+        try baseConfiguration.encode(to: encoder)
     }
 }
 

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -910,7 +910,7 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
 // MARK: - Configuration
 
 /// Configuration for ``Qwen25VL``
-public struct Qwen25VLConfiguration: Codable, Sendable {
+public struct Qwen25VLConfiguration: Sendable {
 
     @Codable
     public struct TextConfiguration: Sendable {

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -910,7 +910,7 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
 // MARK: - Configuration
 
 /// Configuration for ``Qwen25VL``
-public struct Qwen25VLConfiguration: Sendable {
+public struct Qwen25VLConfiguration: Codable, Sendable {
 
     @Codable
     public struct TextConfiguration: Sendable {

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -952,7 +952,7 @@ public struct Qwen25VLConfiguration: Codable, Sendable {
     }
 
     @Codable
-    public struct BaseConfiguration: Codable, Sendable {
+    public struct BaseConfiguration: Sendable {
         @CodingKey("model_type") public var modelType: String
         @CodingKey("vocab_size") public var vocabularySize: Int
         @CodingKey("image_token_id") public var imageTokenId: Int

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -8,6 +8,7 @@ import Hub
 import MLX
 import MLXLMCommon
 import MLXNN
+import ReerCodable
 import Tokenizers
 
 // MARK: - Language
@@ -751,87 +752,45 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
 /// Configuration for ``Qwen2VL``
 public struct Qwen2VLConfiguration: Codable, Sendable {
 
-    public struct TextConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let hiddenSize: Int
-        public let hiddenLayers: Int
-        public let intermediateSize: Int
-        public let attentionHeads: Int
-        private let _rmsNormEps: Float?
-        public var rmsNormEps: Float { _rmsNormEps ?? 1e-6 }
-        public let vocabularySize: Int
-        public let kvHeads: Int
-        private let _maxPositionEmbeddings: Int?
-        public var maxpPositionEmbeddings: Int { _maxPositionEmbeddings ?? 32768 }
-        private let _ropeTheta: Float?
-        public var ropeTheta: Float { _ropeTheta ?? 1_000_000 }
-        private let _ropeTraditional: Bool?
-        public var ropeTraditional: Bool { _ropeTraditional ?? false }
-        public let ropeScaling: [String: StringOrNumber]?
-        private let _tieWordEmbeddings: Bool?
-        public var tieWordEmbeddings: Bool { _tieWordEmbeddings ?? true }
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case hiddenSize = "hidden_size"
-            case hiddenLayers = "num_hidden_layers"
-            case intermediateSize = "intermediate_size"
-            case attentionHeads = "num_attention_heads"
-            case _rmsNormEps = "rms_norm_eps"
-            case vocabularySize = "vocab_size"
-            case kvHeads = "num_key_value_heads"
-            case _maxPositionEmbeddings = "max_position_embeddings"
-            case _ropeTheta = "rope_theta"
-            case _ropeTraditional = "rope_traditional"
-            case ropeScaling = "rope_scaling"
-            case _tieWordEmbeddings = "tie_word_embeddings"
-        }
+    @Codable
+    public struct TextConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_hidden_layers") public var hiddenLayers: Int
+        @CodingKey("intermediate_size") public var intermediateSize: Int
+        @CodingKey("num_attention_heads") public var attentionHeads: Int
+        @CodingKey("rms_norm_eps") public var rmsNormEps: Float = 1e-6
+        @CodingKey("vocab_size") public var vocabularySize: Int
+        @CodingKey("num_key_value_heads") public var kvHeads: Int
+        @CodingKey("max_position_embeddings") public var maxPositionEmbeddings: Int = 32768
+        @CodingKey("rope_theta") public var ropeTheta: Float = 1_000_000
+        @CodingKey("rope_traditional") public var ropeTraditional: Bool = false
+        @CodingKey("rope_scaling") public var ropeScaling: [String: StringOrNumber]?
+        @CodingKey("tie_word_embeddings") public var tieWordEmbeddings: Bool = true
     }
 
-    public struct VisionConfiguration: Codable, Sendable {
-        public let depth: Int
-        public let embedDimensions: Int
-        public let hiddenSize: Int
-        public let numHeads: Int
-        public let patchSize: Int
-        public let mlpRatio: Float
-        public let _inChannels: Int?
-        public var inChannels: Int { _inChannels ?? 3 }
-        public let _layerNormEps: Float?
-        public var layerNormEps: Float { _layerNormEps ?? 1e-6 }
-        public let spatialPatchSize: Int
-        public let spatialMergeSize: Int
-        public let temporalPatchSize: Int
-
-        enum CodingKeys: String, CodingKey {
-            case depth
-            case embedDimensions = "embed_dim"
-            case hiddenSize = "hidden_size"
-            case numHeads = "num_heads"
-            case patchSize = "patch_size"
-            case mlpRatio = "mlp_ratio"
-            case _inChannels = "in_channels"
-            case _layerNormEps = "layer_norm_eps"
-            case spatialPatchSize = "spatial_patch_size"
-            case spatialMergeSize = "spatial_merge_size"
-            case temporalPatchSize = "temporal_patch_size"
-        }
+    @Codable
+    public struct VisionConfiguration: Sendable {
+        public var depth: Int
+        @CodingKey("embed_dim") public var embedDimensions: Int
+        @CodingKey("hidden_size") public var hiddenSize: Int
+        @CodingKey("num_heads") public var numHeads: Int
+        @CodingKey("patch_size") public var patchSize: Int
+        @CodingKey("mlp_ratio") public var mlpRatio: Float
+        @CodingKey("in_channels") public var inChannels: Int = 3
+        @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
+        @CodingKey("spatial_patch_size") public var spatialPatchSize: Int
+        @CodingKey("spatial_merge_size") public var spatialMergeSize: Int
+        @CodingKey("temporal_patch_size") public var temporalPatchSize: Int
     }
 
-    public struct BaseConfiguration: Codable, Sendable {
-        public let modelType: String
-        public let vocabularySize: Int
-        public let imageTokenId: Int
-        public let videoTokenId: Int
-        public let hiddenSize: Int
-
-        enum CodingKeys: String, CodingKey {
-            case modelType = "model_type"
-            case vocabularySize = "vocab_size"
-            case imageTokenId = "image_token_id"
-            case videoTokenId = "video_token_id"
-            case hiddenSize = "hidden_size"
-        }
+    @Codable
+    public struct BaseConfiguration: Sendable {
+        @CodingKey("model_type") public var modelType: String
+        @CodingKey("vocab_size") public var vocabularySize: Int
+        @CodingKey("image_token_id") public var imageTokenId: Int
+        @CodingKey("video_token_id") public var videoTokenId: Int
+        @CodingKey("hidden_size") public var hiddenSize: Int
     }
 
     public let textConfiguration: TextConfiguration
@@ -853,30 +812,34 @@ public struct Qwen2VLConfiguration: Codable, Sendable {
         self.textConfiguration = try TextConfiguration(from: decoder)
         self.baseConfiguration = try BaseConfiguration(from: decoder)
     }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(visionConfiguration, forKey: .visionConfiguration)
+        try textConfiguration.encode(to: encoder)
+        try baseConfiguration.encode(to: encoder)
+    }
 }
 
 /// Configuration for ``Qwen2VLProcessor``
-public struct Qwen2VLProcessorConfiguration: Codable, Sendable {
+@Codable
+public struct Qwen2VLProcessorConfiguration: Sendable {
 
-    public struct Size: Codable, Sendable {
-        public let maxPixels: Int
-        public let minPixels: Int
-
-        enum CodingKeys: String, CodingKey {
-            case maxPixels = "max_pixels"
-            case minPixels = "min_pixels"
-        }
+    @Codable
+    public struct Size: Sendable {
+        @CodingKey("max_pixels") public var maxPixels: Int
+        @CodingKey("min_pixels") public var minPixels: Int
     }
 
-    public let imageMean: [CGFloat]
-    public let imageStd: [CGFloat]
-    public let mergeSize: Int
-    public let patchSize: Int
-    public let temporalPatchSize: Int
-
-    private let _size: Size?
-    private let _maxPixels: Int?
-    private let _minPixels: Int?
+    @CodingKey("image_mean") public var imageMean: [CGFloat]
+    @CodingKey("image_std") public var imageStd: [CGFloat]
+    @CodingKey("merge_size") public var mergeSize: Int
+    @CodingKey("patch_size") public var patchSize: Int
+    @CodingKey("temporal_patch_size") public var temporalPatchSize: Int
+    @CodingKey("max_pixels") private var _maxPixels: Int?
+    @CodingKey("min_pixels") private var _minPixels: Int?
+    @CodingKey("size") private var _size: Size?
 
     public var minPixels: Int {
         _minPixels ?? _size?.minPixels ?? 3136
@@ -890,17 +853,6 @@ public struct Qwen2VLProcessorConfiguration: Codable, Sendable {
     }
     public var imageStdTuple: (CGFloat, CGFloat, CGFloat) {
         (imageStd[0], imageStd[1], imageStd[2])
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case imageMean = "image_mean"
-        case imageStd = "image_std"
-        case mergeSize = "merge_size"
-        case patchSize = "patch_size"
-        case temporalPatchSize = "temporal_patch_size"
-        case _maxPixels = "max_pixels"
-        case _minPixels = "min_pixels"
-        case _size = "size"
     }
 }
 

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -4,6 +4,7 @@ import Foundation
 import Hub
 import MLX
 import MLXLMCommon
+import ReerCodable
 import Tokenizers
 
 public enum VLMError: LocalizedError, Equatable {
@@ -43,12 +44,9 @@ public enum VLMError: LocalizedError, Equatable {
     }
 }
 
-public struct BaseProcessorConfiguration: Codable, Sendable {
-    public let processorClass: String
-
-    enum CodingKeys: String, CodingKey {
-        case processorClass = "processor_class"
-    }
+@Codable
+public struct BaseProcessorConfiguration: Sendable {
+    @CodingKey("processor_class") public let processorClass: String
 }
 
 /// Creates a function that loads a configuration file and instantiates a model with the proper configuration

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
             url: "https://github.com/huggingface/swift-transformers",
             .upToNextMinor(from: "1.1.9")
         ),
+        .package(url: "https://github.com/reers/ReerCodable.git", from: "1.5.3"),
     ],
     targets: [
         .target(
@@ -41,6 +42,7 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "ReerCodable", package: "ReerCodable"),
             ],
             path: "Libraries/MLXLLM",
             exclude: [
@@ -58,6 +60,7 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "ReerCodable", package: "ReerCodable"),
             ],
             path: "Libraries/MLXVLM",
             exclude: [
@@ -74,6 +77,7 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "ReerCodable", package: "ReerCodable"),
             ],
             path: "Libraries/MLXLMCommon",
             exclude: [
@@ -90,6 +94,7 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
                 .target(name: "MLXLMCommon"),
+                .product(name: "ReerCodable", package: "ReerCodable"),
             ],
             path: "Libraries/MLXEmbedders",
             exclude: [

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             url: "https://github.com/huggingface/swift-transformers",
             .upToNextMinor(from: "1.1.9")
         ),
-        .package(url: "https://github.com/reers/ReerCodable.git", from: "1.5.3"),
+        .package(url: "https://github.com/reers/ReerCodable.git", .upToNextMinor(from: "1.7.1")),
     ],
     targets: [
         .target(
@@ -77,7 +77,6 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
-                .product(name: "ReerCodable", package: "ReerCodable"),
             ],
             path: "Libraries/MLXLMCommon",
             exclude: [
@@ -94,7 +93,6 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
                 .target(name: "MLXLMCommon"),
-                .product(name: "ReerCodable", package: "ReerCodable"),
             ],
             path: "Libraries/MLXEmbedders",
             exclude: [


### PR DESCRIPTION
## Proposed changes

Looking at moving to a Codable macro that makes it easier to integrate with JSON configuration files.  Specifically:

- easy default values
- easy to override json keys

These are both possible with standard Swift Coding but are unwieldy in the quantity we need here.   See:

- https://github.com/ml-explore/mlx-swift-lm/blob/main/Libraries/MLXLMCommon/Documentation.docc/porting.md#configuration

For an example.  This changes:

```swift
public struct YourModelConfiguration: Codable, Sendable {
    public let hiddenSize: Int

    // use this pattern for values that need defaults
    public let _layerNormEps: Float?
    public var layerNormEps: Float { _layerNormEps ?? 1e-6 }

    enum CodingKeys: String, CodingKey {
        case hiddenSize = "hidden_size"
        case _layerNormEps = "layer_norm_eps"
    }
}
```

to this:

```swift
@Codable
public struct YourModelConfiguration: Sendable {
    @CodingKey("hidden_size") public var hiddenSize: Int
    @CodingKey("layer_norm_eps") public var layerNormEps: Float = 1e-6
}
```

The downside is that we are using macros (there is some additional build cost).

There was a previous attempt here: https://github.com/ml-explore/mlx-swift-examples/pull/316. This is roughly the same approach but doesn't attempt to port all the configuration at once.  Keeping that up-to-date was too much.  Once this is in we can migrate the configuration in chunks.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
