### PR TITLE
Add harmony tool call parser

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/HarmonyToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/HarmonyToolCallParser.swift
@@ -1,0 +1,55 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+
+/// Parser for OpenAI Harmony format.
+///
+/// Format: `<|start|>assistant<|channel|>commentary to=functions.name <|constrain|>json<|message|>{JSON}<|call|>`
+///
+/// The function name follows `to=` with an optional namespace prefix (e.g. `functions.`),
+/// and arguments are JSON-encoded between `<|message|>` and `<|call|>`.
+///
+/// Reference: https://developers.openai.com/cookbook/articles/openai-harmony
+public struct HarmonyToolCallParser: ToolCallParser, Sendable {
+    public let startTag: String? = "<|start|>assistant<|channel|>commentary to="
+    public let endTag: String? = "<|call|>"
+
+    public init() {}
+
+    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        var text = content
+
+        // Strip start tag if present
+        if let start = startTag, let startRange = text.range(of: start) {
+            text = String(text[startRange.upperBound...])
+        }
+
+        // Strip end tag if present
+        if let end = endTag, let endRange = text.range(of: end) {
+            text = String(text[..<endRange.lowerBound])
+        }
+
+        // text is now: "functions.func_name <|constrain|>json<|message|>{...}"
+        // Extract function name — ends at the first space or '<'
+        let funcNameEnd = text.firstIndex(where: { $0 == " " || $0 == "<" }) ?? text.endIndex
+        var funcName = String(text[..<funcNameEnd])
+
+        // Strip namespace prefix (e.g. "functions.")
+        if let dotIndex = funcName.firstIndex(of: ".") {
+            funcName = String(funcName[funcName.index(after: dotIndex)...])
+        }
+
+        guard !funcName.isEmpty else { return nil }
+
+        // Extract JSON arguments between <|message|> and end of text
+        guard let messageRange = text.range(of: "<|message|>") else { return nil }
+        let argsStr = String(text[messageRange.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let arguments = deserialize(argsStr) as? [String: any Sendable] else {
+            return nil
+        }
+
+        return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -66,6 +66,10 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// Example: `<invoke name="f"><parameter name="k">v</parameter></invoke>`
     case minimaxM2 = "minimax_m2"
 
+    /// OpenAI Harmony format with channel-based tool dispatch.
+    /// Example: `<|start|>assistant<|channel|>commentary to=functions.name <|constrain|>json<|message|>{...}<|call|>`
+    case harmony
+
     // MARK: - Factory Methods
 
     /// Create the appropriate parser for this format.
@@ -87,6 +91,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return KimiK2ToolCallParser()
         case .minimaxM2:
             return MiniMaxM2ToolCallParser()
+        case .harmony:
+            return HarmonyToolCallParser()
         }
     }
 
@@ -108,6 +114,10 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // GLM4 family (glm4, glm4_moe, glm4_moe_lite, etc.)
         if type.hasPrefix("glm4") {
             return .glm4
+        }
+
+        if type.hasPrefix("gpt_oss") {
+            return .harmony
         }
 
         // Gemma

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -26,17 +26,17 @@ public class ToolCallProcessor {
 
     // MARK: - Properties
 
-    private let parser: any ToolCallParser
     private let tools: [[String: any Sendable]]?
-    private var state = State.normal
     private var toolCallBuffer = ""
+    var state = State.normal
+    let parser: any ToolCallParser
 
     /// The tool calls extracted during processing.
     public var toolCalls: [ToolCall] = []
 
     // MARK: - State Enum
 
-    private enum State {
+    enum State {
         case normal
         case potentialToolCall
         case collectingToolCall


### PR DESCRIPTION
As mentioned in issue #61, mlx-swift-lm includes a GPT-OSS model definition, but GPT-OSS requires Harmony formatting end-to-end. However, since thinking case is not yet standardized (see #79), it can be parsed from applications. For tool calls, as they are available for most supported models, this PR adds the tool call parser for gpt-oss model.

## Proposed changes

Adds:
- HarmonyToolCallParser to parse tool call for GPT-OSS model
- Move `includeStopToken` to ToolHandler impl, as it's used only in `RawTokenLoopHandler`. generateLoopTask should not know this setting as it's ToolHandler impl-specific logic.
- In Harmony, <|call|> is a tool call end tag but also an EOS chunk, so this PR added a check for the current tool call parser state and detokenize to complete the tool parse and emit.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
