### PR TITLE
Pass additionalContext to Qwen3VL

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -73,7 +73,11 @@ public struct Qwen3VLProcessor: UserInputProcessor {
 
     public func prepare(input: UserInput) async throws -> LMInput {
         let messages = Qwen3VLMessageGenerator().generate(from: input)
-        var promptTokens = try tokenizer.applyChatTemplate(messages: messages, tools: input.tools)
+        var promptTokens = try tokenizer.applyChatTemplate(
+            messages: messages,
+            tools: input.tools,
+            additionalContext: input.additionalContext
+        )
 
         if input.images.isEmpty, input.videos.isEmpty {
             let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)


### PR DESCRIPTION
## Proposed changes

Pass `additionalContext` to Qwen3VL. Useful for enabling thinking with `"enable_thinking"` on the new Qwen 3.5 models.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
