### PR TITLE
fix unreliable tests

### DIFF
--- a/Tests/MLXLMIntegrationTests/EmbedderIntegrationTests.swift
+++ b/Tests/MLXLMIntegrationTests/EmbedderIntegrationTests.swift
@@ -51,13 +51,7 @@ struct EmbedderIntegrationtests {
 
     @Test("MLXEmbedders README.md example")
     func testReadMeExample() async throws {
-        guard let (searchInputs, resultEmbeddings) = try? await readeMeExampleResult() else {
-            throw NSError(
-                domain: "EmbedderIntegrationtests",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to get example results"]
-            )
-        }
+        let (searchInputs, resultEmbeddings) = try await readeMeExampleResult()
 
         // Compute similarities
         let searchQueryEmbedding = resultEmbeddings[0]

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -15,8 +15,8 @@ public class ChatSessionTests: XCTestCase {
     private func model() -> ModelContext {
         let config = Gemma3TextConfiguration(
             modelType: "text",
-            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 128, attentionHeads: 8,
-            headDim: 256,
+            hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64, attentionHeads: 4,
+            headDim: 64,
             rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 4,
             ropeTheta: 1_000_000, ropeLocalBaseFreq: 10_000,
             ropeTraditional: false, queryPreAttnScalar: 256,
@@ -39,11 +39,13 @@ public class ChatSessionTests: XCTestCase {
             tokenizer: processor.tokenizer)
     }
 
+    private var generationParameters = GenerateParameters(maxTokens: 50)
+
     private let targetLength = 1
 
     func testChatSessionSync() async throws {
         let model = model()
-        let session = ChatSession(model)
+        let session = ChatSession(model, generateParameters: generationParameters)
 
         let result1 = try await session.respond(to: "hello")
         XCTAssertGreaterThan(result1.count, targetLength, result1)
@@ -53,7 +55,7 @@ public class ChatSessionTests: XCTestCase {
 
     func testChatSessionAsync() async throws {
         let model = model()
-        let session = ChatSession(model)
+        let session = ChatSession(model, generateParameters: generationParameters)
 
         var result1 = ""
         for try await part in session.streamResponse(to: "hello") {
@@ -71,7 +73,7 @@ public class ChatSessionTests: XCTestCase {
     func testChatSessionAsyncInterrupt() async throws {
         // interrupt the streamResponse and continue with another request
         let model = model()
-        let session = ChatSession(model)
+        let session = ChatSession(model, generateParameters: generationParameters)
 
         for _ in 0 ..< 10 {
             var result1 = ""
@@ -119,7 +121,9 @@ public class ChatSessionTests: XCTestCase {
                 ] as [String: any Sendable],
             ] as ToolSpec
         ]
-        let session = ChatSession(model, tools: tools)
+        let session = ChatSession(
+            model, generateParameters: generationParameters, tools: tools
+        )
 
         let result = try await session.respond(to: "What is the weather in SF?")
         XCTAssertGreaterThan(result.count, targetLength, result)
@@ -144,7 +148,9 @@ public class ChatSessionTests: XCTestCase {
                 ] as [String: any Sendable],
             ] as ToolSpec
         ]
-        let session = ChatSession(model, tools: tools)
+        let session = ChatSession(
+            model, generateParameters: generationParameters, tools: tools
+        )
 
         var result = ""
         for try await part in session.streamResponse(to: "hello") {
@@ -209,8 +215,8 @@ public class ChatSessionTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(10))
         }
 
-        // try another message, wait for full completion
-        model.respond("message2")
+        // try another message, wait for full completion (but cap the length)
+        model.session.generateParameters = .init(maxTokens: 50)
         while model.isBusy {
             try await Task.sleep(for: .milliseconds(10))
         }

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -39,7 +39,7 @@ public class ChatSessionTests: XCTestCase {
             tokenizer: processor.tokenizer)
     }
 
-    private var generationParameters = GenerateParameters(maxTokens: 50)
+    private let generationParameters = GenerateParameters(maxTokens: 50)
 
     private let targetLength = 1
 
@@ -216,7 +216,8 @@ public class ChatSessionTests: XCTestCase {
         }
 
         // try another message, wait for full completion (but cap the length)
-        model.session.generateParameters = .init(maxTokens: 50)
+        model.session.generateParameters = self.generationParameters
+        model.respond("message2")
         while model.isBusy {
             try await Task.sleep(for: .milliseconds(10))
         }

--- a/Tests/MLXLMTests/TestTokenizer.swift
+++ b/Tests/MLXLMTests/TestTokenizer.swift
@@ -41,11 +41,7 @@ struct TestTokenizer: Tokenizer {
 
     func encode(text: String) -> [Int] {
         (0 ..< length).enumerated().map { (index, _) in
-            if index > length {
-                _eosTokenId
-            } else {
-                Int.random(in: 1 ..< vocabularySize)
-            }
+            Int.random(in: 1 ..< vocabularySize)
         }
     }
 

--- a/Tests/MLXLMTests/TestTokenizer.swift
+++ b/Tests/MLXLMTests/TestTokenizer.swift
@@ -9,11 +9,18 @@ import Tokenizers
 struct TestTokenizer: Tokenizer {
 
     let length = 8
+    let maxLength = 50
 
-    var vocabulary: [Int: String]
+    /// a token outside the range that the model will generate, see vocabularySize
+    let _eosTokenId = 101
+    let _unknownTokenId = 102
+
+    let vocabularySize: Int
+    let vocabulary: [Int: String]
 
     init(vocabularySize: Int = 100) {
         let letters = "abcdefghijklmnopqrstuvwxyz"
+        self.vocabularySize = vocabularySize
         self.vocabulary = Dictionary(
             uniqueKeysWithValues: (0 ..< vocabularySize)
                 .map { t in
@@ -33,8 +40,12 @@ struct TestTokenizer: Tokenizer {
     }
 
     func encode(text: String) -> [Int] {
-        (0 ..< length).map { _ in
-            Int.random(in: 0 ..< 100)
+        (0 ..< length).enumerated().map { (index, _) in
+            if index > length {
+                _eosTokenId
+            } else {
+                Int.random(in: 1 ..< vocabularySize)
+            }
         }
     }
 
@@ -44,18 +55,18 @@ struct TestTokenizer: Tokenizer {
 
     func decode(tokens: [Int], skipSpecialTokens: Bool) -> String {
         var tokens = tokens
-        if tokens.count > 50 {
-            tokens.append(19)
+        if tokens.count > maxLength {
+            tokens.append(_eosTokenId)
         }
         return tokens.map { convertIdToToken($0) ?? "" }.joined(separator: " ")
     }
 
     func convertTokenToId(_ token: String) -> Int? {
-        Int.random(in: 0 ..< 100)
+        Int.random(in: 1 ..< vocabularySize)
     }
 
     func convertIdToToken(_ id: Int) -> String? {
-        if id == 19 {
+        if id == eosTokenId {
             return "EOS"
         }
         return vocabulary[id]
@@ -67,11 +78,11 @@ struct TestTokenizer: Tokenizer {
 
     var eosToken: String? = nil
 
-    var eosTokenId: Int? = 0
+    var eosTokenId: Int? { _eosTokenId }
 
     var unknownToken: String? = nil
 
-    var unknownTokenId: Int? = 0
+    var unknownTokenId: Int? { _unknownTokenId }
 
     func applyChatTemplate(messages: [Tokenizers.Message]) throws -> [Int] {
         encode(text: "")


### PR DESCRIPTION
## Proposed changes

- fixes https://github.com/ml-explore/mlx-swift-lm/issues/119
- make the random weight model and tokenizer behave in a predictable way

The TLDR on that is there are some integration tests that use a fake tokenizer and a real model with random weights.  If you are unlucky the model would generate a valid token (0) that would be taken as EOS and the test would not get the expected length string (basically > 0 length).  It _mostly_ works, but mostly isn't great for CI.  This makes sure the model won't accidentally generate EOS and we just use a cap on the number of tokens.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
