### PR TITLE
Fix XMLFunctionParser regex to match newlines

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -11,10 +11,10 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
     public init() {}
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
-        // Pattern: <function=(.*?)</function>
+        // Pattern: <function=(content)</function> — [\s\S] matches newlines
         guard
             let funcMatch = content.range(
-                of: #"<function=(.*?)</function>"#, options: .regularExpression)
+                of: #"<function=([\s\S]*?)</function>"#, options: .regularExpression)
         else { return nil }
 
         let funcContent = String(content[funcMatch])

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -250,6 +250,40 @@ struct ToolTests {
         #expect(toolCall.function.arguments["enabled"] == .bool(true))
     }
 
+    @Test("Test XML Function Parser - Multiline Content (Qwen3.5 style)")
+    func testXMLFunctionParserMultiline() throws {
+        let parser = XMLFunctionParser()
+        // Qwen3.5 models generate newlines between the XML tags
+        let content = """
+            <tool_call>
+            <function=get_current_datetime>
+            </function>
+            </tool_call>
+            """
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "get_current_datetime")
+        #expect(toolCall.function.arguments.isEmpty)
+    }
+
+    @Test("Test XML Function Parser - Multiline Parameters")
+    func testXMLFunctionParserMultilineParams() throws {
+        let parser = XMLFunctionParser()
+        let content = """
+            <function=get_weather>
+            <parameter=location>
+            Tokyo
+            </parameter>
+            </function>
+            """
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Tokyo"))
+    }
+
     // MARK: - GLM4 Format Tests
 
     @Test("Test GLM4 Tool Call Parser")


### PR DESCRIPTION
## Proposed changes

Swift/ICU regex `.` does not match `\n`. Models like Qwen3.5 generate newlines between XML function tags, so the parser silently fails. Use `[\s\S]` instead. 

fixed #130

## Checklist

Put an `x` in the boxes that apply.

- [x ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have updated the necessary documentation (if needed)
