### PR TITLE
Add qwen3_5_text model type support

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -39,6 +39,7 @@ public enum LLMTypeRegistry {
         "qwen3_next": create(Qwen3NextConfiguration.self, Qwen3NextModel.init),
         "qwen3_5": create(Qwen35Configuration.self, Qwen35Model.init),
         "qwen3_5_moe": create(Qwen35Configuration.self, Qwen35MoEModel.init),
+        "qwen3_5_text": create(Qwen35TextConfiguration.self, Qwen35TextModel.init),
         "minicpm": create(MiniCPMConfiguration.self, MiniCPMModel.init),
         "starcoder2": create(Starcoder2Configuration.self, Starcoder2Model.init),
         "cohere": create(CohereConfiguration.self, CohereModel.init),


### PR DESCRIPTION
## Summary

- Registers `qwen3_5_text` in `LLMTypeRegistry` using `Qwen35TextConfiguration` and `Qwen35TextModel`
- Follows the same pattern as `gemma3_text` → `Gemma3TextConfiguration` / `Gemma3TextModel`
- Fixes `Error: Unsupported model type: qwen3_5_text` when loading Qwen 3.5 text-only models

## Context

`qwen3_5` and `qwen3_5_moe` are already supported. The `qwen3_5_text` variant has its config at the top level (no nested `text_config`), so it maps directly to `Qwen35TextConfiguration` / `Qwen35TextModel`.

Related: https://github.com/osaurus-ai/osaurus/issues/588