### PR TITLE
Add topK, minP and penalty parameters to GenerateParameters

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -78,11 +78,29 @@ public struct GenerateParameters: Sendable {
     /// top p sampling
     public var topP: Float
 
+    /// top k sampling (0 disables)
+    public var topK: Int
+
+    /// min p sampling threshold relative to the highest probability token (0 disables)
+    public var minP: Float
+
     /// penalty factor for repeating tokens
     public var repetitionPenalty: Float?
 
     /// number of tokens to consider for repetition penalty
     public var repetitionContextSize: Int
+
+    /// additive penalty for tokens that appear in recent context
+    public var presencePenalty: Float?
+
+    /// number of tokens to consider for presence penalty
+    public var presenceContextSize: Int
+
+    /// additive penalty that scales with token frequency in recent context
+    public var frequencyPenalty: Float?
+
+    /// number of tokens to consider for frequency penalty
+    public var frequencyContextSize: Int
 
     public init(
         maxTokens: Int? = nil,
@@ -92,8 +110,14 @@ public struct GenerateParameters: Sendable {
         quantizedKVStart: Int = 0,
         temperature: Float = 0.6,
         topP: Float = 1.0,
+        topK: Int = 0,
+        minP: Float = 0.0,
         repetitionPenalty: Float? = nil,
         repetitionContextSize: Int = 20,
+        presencePenalty: Float? = nil,
+        presenceContextSize: Int = 20,
+        frequencyPenalty: Float? = nil,
+        frequencyContextSize: Int = 20,
         prefillStepSize: Int = 512
     ) {
         self.maxTokens = maxTokens
@@ -103,28 +127,71 @@ public struct GenerateParameters: Sendable {
         self.quantizedKVStart = quantizedKVStart
         self.temperature = temperature
         self.topP = topP
+        self.topK = topK
+        self.minP = minP
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.presencePenalty = presencePenalty
+        self.presenceContextSize = presenceContextSize
+        self.frequencyPenalty = frequencyPenalty
+        self.frequencyContextSize = frequencyContextSize
         self.prefillStepSize = prefillStepSize
     }
 
     public func sampler() -> LogitSampler {
+        let usesTopP = topP > 0 && topP < 1
+        let usesTopK = topK > 0
+        let usesMinP = minP > 0
+
         if temperature == 0 {
             return ArgMaxSampler()
-        } else if topP > 0 && topP < 1 {
-            return TopPSampler(temperature: temperature, topP: topP)
+        } else if usesTopP || usesTopK || usesMinP {
+            return TopPSampler(temperature: temperature, topP: topP, topK: topK, minP: minP)
         } else {
             return CategoricalSampler(temperature: temperature)
         }
     }
 
     public func processor() -> LogitProcessor? {
-        if let repetitionPenalty, repetitionContextSize > 0 {
-            return RepetitionContext(
-                repetitionPenalty: repetitionPenalty, repetitionContextSize: repetitionContextSize)
+        let repetitionContext: RepetitionContext?
+        if let repetitionPenalty, repetitionPenalty != 0, repetitionContextSize > 0 {
+            repetitionContext = RepetitionContext(
+                repetitionPenalty: repetitionPenalty,
+                repetitionContextSize: repetitionContextSize
+            )
         } else {
+            repetitionContext = nil
+        }
+
+        let presenceContext: PresencePenaltyContext?
+        if let presencePenalty, presencePenalty != 0, presenceContextSize > 0 {
+            presenceContext = PresencePenaltyContext(
+                presencePenalty: presencePenalty,
+                presenceContextSize: presenceContextSize
+            )
+        } else {
+            presenceContext = nil
+        }
+
+        let frequencyContext: FrequencyPenaltyContext?
+        if let frequencyPenalty, frequencyPenalty != 0, frequencyContextSize > 0 {
+            frequencyContext = FrequencyPenaltyContext(
+                frequencyPenalty: frequencyPenalty,
+                frequencyContextSize: frequencyContextSize
+            )
+        } else {
+            frequencyContext = nil
+        }
+
+        if repetitionContext == nil && presenceContext == nil && frequencyContext == nil {
             return nil
         }
+
+        return PenaltyProcessor(
+            repetitionContext: repetitionContext,
+            presenceContext: presenceContext,
+            frequencyContext: frequencyContext
+        )
     }
 }
 
@@ -137,15 +204,24 @@ public struct ArgMaxSampler: LogitSampler {
     }
 }
 
-/// Sampler that uses `topP` and `temperature` to sample the logits.
+/// Sampler that uses probability filters (`topP`, `topK`, `minP`) and `temperature`
+/// to sample the logits.
 public struct TopPSampler: LogitSampler {
     let temp: MLXArray
-    let topP: MLXArray
+    let topP: MLXArray?
+    let topK: Int?
+    let minP: MLXArray?
     let randomState: MLXRandom.RandomState
 
-    public init(temperature: Float, topP: Float) {
+    public init(temperature: Float, topP: Float = 1.0, topK: Int = 0, minP: Float = 0.0) {
         self.temp = MLXArray(temperature)
-        self.topP = MLXArray(topP)
+        if topP > 0 && topP < 1 {
+            self.topP = MLXArray(topP)
+        } else {
+            self.topP = nil
+        }
+        self.topK = topK > 0 ? topK : nil
+        self.minP = minP > 0 ? MLXArray(minP) : nil
         self.randomState = MLXRandom.RandomState()
     }
 
@@ -156,18 +232,43 @@ public struct TopPSampler: LogitSampler {
         }
 
         return withRandomState(randomState) {
-            let probs = softmax(logits / temp, axis: -1)
+            // Match mlx-lm Python behavior:
+            // apply filtering on the base distribution, then apply temperature at sampling time.
+            let probs = softmax(logits, axis: -1)
             let sortedIndices = argSort(probs, axis: -1)
 
             // probs shape is [B,V] and after take it will be [1, B, V], so we squeeze it back to [B, V]
             let sortedProbs = take(probs, sortedIndices, axis: -1).squeezed(axis: 0)
 
-            let cumulativeProbs = cumsum(sortedProbs, axis: -1)
+            var filteredProbs = sortedProbs
 
-            let topProbs = MLX.where(
-                cumulativeProbs .> (1 - topP), sortedProbs, zeros(like: sortedProbs))
+            if let topP {
+                let cumulativeProbs = cumsum(sortedProbs, axis: -1)
+                filteredProbs = MLX.where(
+                    cumulativeProbs .> (1 - topP), filteredProbs, zeros(like: filteredProbs))
+            }
 
-            let sortedToken = categorical(log(topProbs))
+            if let minP {
+                let maxProbs = sortedProbs[0..., -1].expandedDimensions(axis: -1)
+                let keepMask = sortedProbs .>= (maxProbs * minP)
+                filteredProbs = MLX.where(keepMask, filteredProbs, zeros(like: filteredProbs))
+            }
+
+            if let topK {
+                let vocabularySize = sortedProbs.dim(-1)
+                if topK < vocabularySize {
+                    let cutOff = vocabularySize - topK
+                    let sortedPositions = MLXArray(Array(0 ..< vocabularySize))
+                    let keepMask = sortedPositions .>= cutOff
+                    filteredProbs = MLX.where(
+                        keepMask, filteredProbs, zeros(like: filteredProbs))
+                }
+            }
+
+            // Always keep the maximum-probability token so sampling always has a valid candidate.
+            filteredProbs[0..., -1] = sortedProbs[0..., -1]
+
+            let sortedToken = categorical(log(filteredProbs) * (1 / temp))
             return sortedIndices.squeezed(axis: 0)[sortedToken]
         }
     }
@@ -241,6 +342,137 @@ public struct RepetitionContext: LogitProcessor {
         } else {
             tokens.append(token.item(Int.self))
         }
+    }
+}
+
+/// Processor that applies an additive presence penalty to tokens in a recent context window.
+public struct PresencePenaltyContext: LogitProcessor {
+    var tokens = [Int]()
+    var index = 0
+
+    let presencePenalty: Float
+    let presenceContextSize: Int
+
+    public init(presencePenalty: Float, presenceContextSize: Int) {
+        precondition(presenceContextSize > 0)
+        self.presencePenalty = presencePenalty
+        self.presenceContextSize = presenceContextSize
+    }
+
+    mutating public func prompt(_ prompt: MLXArray) {
+        if prompt.shape[0] <= presenceContextSize {
+            self.tokens = prompt.asArray(Int.self)
+        } else {
+            self.tokens = prompt[(-presenceContextSize)...].asArray(Int.self)
+        }
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        if tokens.isEmpty {
+            return logits
+        }
+
+        let uniqueTokens = Array(Set(tokens))
+        let indices = MLXArray(uniqueTokens.map { UInt32($0) })
+        logits[0..., indices] = logits[0..., indices] - presencePenalty
+        return logits
+    }
+
+    mutating public func didSample(token: MLXArray) {
+        if tokens.count >= presenceContextSize {
+            tokens[index] = token.item(Int.self)
+            index = (index + 1) % presenceContextSize
+        } else {
+            tokens.append(token.item(Int.self))
+        }
+    }
+}
+
+/// Processor that applies an additive frequency penalty to tokens in a recent context window.
+public struct FrequencyPenaltyContext: LogitProcessor {
+    var tokens = [Int]()
+    var index = 0
+
+    let frequencyPenalty: Float
+    let frequencyContextSize: Int
+
+    public init(frequencyPenalty: Float, frequencyContextSize: Int) {
+        precondition(frequencyContextSize > 0)
+        self.frequencyPenalty = frequencyPenalty
+        self.frequencyContextSize = frequencyContextSize
+    }
+
+    mutating public func prompt(_ prompt: MLXArray) {
+        if prompt.shape[0] <= frequencyContextSize {
+            self.tokens = prompt.asArray(Int.self)
+        } else {
+            self.tokens = prompt[(-frequencyContextSize)...].asArray(Int.self)
+        }
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        if tokens.isEmpty {
+            return logits
+        }
+
+        var counts = [Int: Int]()
+        for token in tokens {
+            counts[token, default: 0] += 1
+        }
+
+        let orderedTokens = Array(counts.keys)
+        let indices = MLXArray(orderedTokens.map { UInt32($0) })
+        let penalties = MLXArray(
+            orderedTokens.map { frequencyPenalty * Float(counts[$0] ?? 0) }
+        )
+        logits[0..., indices] = logits[0..., indices] - penalties
+        return logits
+    }
+
+    mutating public func didSample(token: MLXArray) {
+        if tokens.count >= frequencyContextSize {
+            tokens[index] = token.item(Int.self)
+            index = (index + 1) % frequencyContextSize
+        } else {
+            tokens.append(token.item(Int.self))
+        }
+    }
+}
+
+/// Processor that composes penalty processors in Python mlx-lm order.
+public struct PenaltyProcessor: LogitProcessor {
+    var repetitionContext: RepetitionContext?
+    var presenceContext: PresencePenaltyContext?
+    var frequencyContext: FrequencyPenaltyContext?
+
+    public init(
+        repetitionContext: RepetitionContext?,
+        presenceContext: PresencePenaltyContext?,
+        frequencyContext: FrequencyPenaltyContext?
+    ) {
+        self.repetitionContext = repetitionContext
+        self.presenceContext = presenceContext
+        self.frequencyContext = frequencyContext
+    }
+
+    mutating public func prompt(_ prompt: MLXArray) {
+        repetitionContext?.prompt(prompt)
+        presenceContext?.prompt(prompt)
+        frequencyContext?.prompt(prompt)
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        var logits = logits
+        logits = repetitionContext?.process(logits: logits) ?? logits
+        logits = presenceContext?.process(logits: logits) ?? logits
+        logits = frequencyContext?.process(logits: logits) ?? logits
+        return logits
+    }
+
+    mutating public func didSample(token: MLXArray) {
+        repetitionContext?.didSample(token: token)
+        presenceContext?.didSample(token: token)
+        frequencyContext?.didSample(token: token)
     }
 }
 

--- a/Tests/MLXLMTests/SampleTests.swift
+++ b/Tests/MLXLMTests/SampleTests.swift
@@ -1,0 +1,207 @@
+// Copyright © 2025 Apple Inc.
+
+import MLX
+import MLXLMCommon
+import XCTest
+
+public class SampleTests: XCTestCase {
+
+    private func sampleCounts(sampler: TopPSampler, logits: MLXArray, draws: Int) -> [Int: Int] {
+        var counts: [Int: Int] = [:]
+        for _ in 0 ..< draws {
+            let token = sampler.sample(logits: logits).item(Int.self)
+            counts[token, default: 0] += 1
+        }
+        return counts
+    }
+
+    private func frequency(_ counts: [Int: Int], token: Int, draws: Int) -> Float {
+        Float(counts[token, default: 0]) / Float(draws)
+    }
+
+    private func assertOnlySampled(
+        _ counts: [Int: Int], allowedTokens: Set<Int>, file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for token in counts.keys {
+            XCTAssertTrue(
+                allowedTokens.contains(token), "Unexpected sampled token: \(token)", file: file,
+                line: line)
+        }
+    }
+
+    func testTopKSamplerKeepsOnlyTopToken() {
+        let sampler = TopPSampler(temperature: 1.0, topK: 1)
+        let logits = MLXArray([0.1 as Float, 2.0 as Float, 1.0 as Float])[.newAxis, .ellipsis]
+
+        for _ in 0 ..< 10 {
+            let token = sampler.sample(logits: logits).item(Int.self)
+            XCTAssertEqual(token, 1)
+        }
+    }
+
+    func testTopPSamplerLowThresholdKeepsMaxToken() {
+        let probs = MLXArray([0.9 as Float, 0.0 as Float, 0.0 as Float, 0.1 as Float])[
+            .newAxis, .ellipsis]
+        let sampler = TopPSampler(temperature: 1.0, topP: 0.3)
+        let counts = sampleCounts(sampler: sampler, logits: log(probs), draws: 200)
+
+        XCTAssertEqual(counts[0], 200)
+        assertOnlySampled(counts, allowedTokens: [0])
+    }
+
+    func testTopPSamplerPartialMassKeepsExpectedDistribution() {
+        let probs = MLXArray([0.0 as Float, 0.5 as Float, 0.4 as Float, 0.1 as Float])[
+            .newAxis, .ellipsis]
+        let draws = 4000
+        let sampler = TopPSampler(temperature: 1.0, topP: 0.6)
+        let counts = sampleCounts(sampler: sampler, logits: log(probs), draws: draws)
+
+        assertOnlySampled(counts, allowedTokens: [1, 2])
+        XCTAssertEqual(frequency(counts, token: 1, draws: draws), 0.5556, accuracy: 0.06)
+        XCTAssertEqual(frequency(counts, token: 2, draws: draws), 0.4444, accuracy: 0.06)
+    }
+
+    func testTopPSamplerHighThresholdKeepsExpectedDistribution() {
+        let probs = MLXArray([0.0 as Float, 0.5 as Float, 0.4 as Float, 0.1 as Float])[
+            .newAxis, .ellipsis]
+        let draws = 4000
+        let sampler = TopPSampler(temperature: 1.0, topP: 0.95)
+        let counts = sampleCounts(sampler: sampler, logits: log(probs), draws: draws)
+
+        assertOnlySampled(counts, allowedTokens: [1, 2, 3])
+        XCTAssertEqual(frequency(counts, token: 1, draws: draws), 0.5, accuracy: 0.06)
+        XCTAssertEqual(frequency(counts, token: 2, draws: draws), 0.4, accuracy: 0.06)
+        XCTAssertEqual(frequency(counts, token: 3, draws: draws), 0.1, accuracy: 0.04)
+    }
+
+    func testTopKSamplerTopTwoKeepsExpectedDistribution() {
+        let probs = MLXArray([0.6 as Float, 0.0 as Float, 0.1 as Float, 0.3 as Float])[
+            .newAxis, .ellipsis]
+        let draws = 4000
+        let sampler = TopPSampler(temperature: 1.0, topK: 2)
+        let counts = sampleCounts(sampler: sampler, logits: log(probs), draws: draws)
+
+        assertOnlySampled(counts, allowedTokens: [0, 3])
+        XCTAssertEqual(frequency(counts, token: 0, draws: draws), 0.6667, accuracy: 0.06)
+        XCTAssertEqual(frequency(counts, token: 3, draws: draws), 0.3333, accuracy: 0.06)
+    }
+
+    func testMinPSamplerKeepsOnlyHighProbabilityToken() {
+        let sampler = TopPSampler(temperature: 1.0, minP: 0.95)
+        let logits = MLXArray([0.0 as Float, 0.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+
+        for _ in 0 ..< 10 {
+            let token = sampler.sample(logits: logits).item(Int.self)
+            XCTAssertEqual(token, 2)
+        }
+    }
+
+    func testMinPSamplerLowThresholdKeepsExpectedDistribution() {
+        let probs = MLXArray([0.9 as Float, 0.0 as Float, 0.0 as Float, 0.1 as Float])[
+            .newAxis, .ellipsis]
+        let draws = 4000
+        let sampler = TopPSampler(temperature: 1.0, minP: 0.05)
+        let counts = sampleCounts(sampler: sampler, logits: log(probs), draws: draws)
+
+        assertOnlySampled(counts, allowedTokens: [0, 3])
+        XCTAssertEqual(frequency(counts, token: 0, draws: draws), 0.9, accuracy: 0.05)
+        XCTAssertEqual(frequency(counts, token: 3, draws: draws), 0.1, accuracy: 0.05)
+    }
+
+    func testGenerateParametersCreatesExpectedSampler() {
+        XCTAssertTrue(GenerateParameters(temperature: 0.7, topK: 40).sampler() is TopPSampler)
+        XCTAssertTrue(GenerateParameters(temperature: 0.7, minP: 0.1).sampler() is TopPSampler)
+        XCTAssertTrue(GenerateParameters(temperature: 0).sampler() is ArgMaxSampler)
+    }
+
+    func testPresencePenaltyContextPenalizesSeenTokens() {
+        var processor = PresencePenaltyContext(presencePenalty: 0.5, presenceContextSize: 20)
+        processor.prompt(MLXArray([1, 1, 3]))
+
+        let logits =
+            MLXArray([1.0 as Float, 2.0 as Float, 3.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 1.5, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 3.5, accuracy: 1e-6)
+    }
+
+    func testFrequencyPenaltyContextPenalizesByCount() {
+        var processor = FrequencyPenaltyContext(frequencyPenalty: 0.5, frequencyContextSize: 20)
+        processor.prompt(MLXArray([1, 1, 3]))
+
+        let logits =
+            MLXArray([1.0 as Float, 2.0 as Float, 3.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 3.5, accuracy: 1e-6)
+    }
+
+    func testGenerateParametersCreatesExpectedPenaltyProcessor() {
+        XCTAssertNotNil(GenerateParameters(repetitionPenalty: 1.1).processor())
+        XCTAssertNotNil(GenerateParameters(presencePenalty: 0.5).processor())
+        XCTAssertNotNil(GenerateParameters(frequencyPenalty: 0.5).processor())
+        XCTAssertNotNil(
+            GenerateParameters(
+                repetitionPenalty: 1.1, presencePenalty: 0.5, frequencyPenalty: 0.5
+            ).processor()
+        )
+    }
+
+    func testPresencePenaltyContextPenalizesUniqueSeenTokens() {
+        var processor = PresencePenaltyContext(presencePenalty: 0.5, presenceContextSize: 5)
+        processor.prompt(MLXArray([0, 0, 0, 1, 1]))
+
+        let logits = MLXArray.zeros([1, 4], type: Float.self)
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+
+        XCTAssertEqual(values[0], -0.5, accuracy: 1e-6)
+        XCTAssertEqual(values[1], -0.5, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 0.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 0.0, accuracy: 1e-6)
+    }
+
+    func testFrequencyPenaltyContextPenalizesByTokenCount() {
+        var processor = FrequencyPenaltyContext(frequencyPenalty: 0.5, frequencyContextSize: 5)
+        processor.prompt(MLXArray([0, 0, 0, 1, 1]))
+
+        let logits = MLXArray.zeros([1, 4], type: Float.self)
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+
+        XCTAssertEqual(values[0], -1.5, accuracy: 1e-6)
+        XCTAssertEqual(values[1], -1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 0.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 0.0, accuracy: 1e-6)
+    }
+
+    func testGenerateParametersPenaltyProcessorComposesPenaltiesInOrder() {
+        var processor = GenerateParameters(
+            repetitionPenalty: 1.5, repetitionContextSize: 5,
+            presencePenalty: 0.5, presenceContextSize: 5,
+            frequencyPenalty: 0.25, frequencyContextSize: 5
+        ).processor()
+        XCTAssertNotNil(processor)
+
+        processor?.prompt(MLXArray([0, 0, 0, 1, 1]))
+        let logits = MLXArray([1.0 as Float, 0.5 as Float, 0.0 as Float, -0.5 as Float])[
+            .newAxis, .ellipsis
+        ]
+        let processed = processor?.process(logits: logits)
+        guard let values = processed?[0].asArray(Float.self) else {
+            XCTFail("Expected processed logits")
+            return
+        }
+        XCTAssertEqual(values[0], -0.5833, accuracy: 1e-4)
+        XCTAssertEqual(values[1], -0.6667, accuracy: 1e-4)
+        XCTAssertEqual(values[2], 0.0, accuracy: 1e-4)
+        XCTAssertEqual(values[3], -0.5, accuracy: 1e-4)
+    }
+}


### PR DESCRIPTION
## Proposed changes

The Swift `func GenerateParameters` has been lacking some parameters compared to Python mlx-lm. This is an attempt to add more parameters using [mlx_lm/sample_utils.py ](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/sample_utils.py) as reference.

Motivated mainly by the new Qwen 3.5 models recommending more parameters for inference.

Example from https://huggingface.co/Qwen/Qwen3.5-4B:

> We recommend using the following set of sampling parameters for generation
> 
> Thinking mode for general tasks: temperature=1.0, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=1.5, repetition_penalty=1.0
> Thinking mode for precise coding tasks (e.g. WebDev): temperature=0.6, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=0.0, repetition_penalty=1.0
> Instruct (or non-thinking) mode for general tasks: temperature=0.7, top_p=0.8, top_k=20, min_p=0.0, presence_penalty=1.5, repetition_penalty=1.0
> Instruct (or non-thinking) mode for reasoning tasks: temperature=1.0, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=1.5, repetition_penalty=1.0

Hard to correctly test in real world but here some examples I have used:

```swift
// 1) Deterministic top-k gate (manual test: run same prompt 5x)
// Prompt: "The capital of France is"
let parameters = GenerateParameters(
    maxTokens: 32,
    temperature: 1.0,
    topP: 1.0,
    topK: 1,
    minP: 0.0
)

// 2) Top-k diversity (manual test: run same prompt 10x)
// Prompt: "The capital of France is"
let parameters = GenerateParameters(
    maxTokens: 32,
    temperature: 1.0,
    topP: 1.0,
    topK: 40,
    minP: 0.0
)

// 3) Aggressive min-p pruning
// Prompt: "Answer with one word: true or false. 2+2=4"
let parameters = GenerateParameters(
    maxTokens: 16,
    temperature: 1.0,
    topP: 1.0,
    topK: 0,
    minP: 0.95
)

// 4) Presence penalty (reduce token re-use)
// Prompt: "Output 30 comma-separated animals."
let parameters = GenerateParameters(
    maxTokens: 80,
    temperature: 0.8,
    topP: 1.0,
    topK: 0,
    minP: 0.0,
    presencePenalty: 1.0,
    presenceContextSize: 20
)

// 5) Frequency penalty (reduce repeated words by count)
// Prompt: "Write 40 words about the ocean."
let parameters = GenerateParameters(
    maxTokens: 80,
    temperature: 0.8,
    topP: 1.0,
    topK: 0,
    minP: 0.0,
    frequencyPenalty: 1.0,
    frequencyContextSize: 20
)
```

Would appreciate a review from someone more knowledgeable than me on the subject, making sure no regression and correct implementation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
