### PR TITLE
perf: eliminate CPU←GPU sync in penalty processors, optimize TopPSampler

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -280,16 +280,14 @@ public struct TopPSampler: LogitSampler {
     }
 
     /// Keep only the top-k highest-probability tokens.
-    /// Matches `apply_top_k` from `mlx_lm/sample_utils.py`.
+    /// Mirrors `apply_top_k` from `mlx_lm/sample_utils.py`.
     private func applyTopK(_ logprobs: MLXArray, topK: Int) -> MLXArray {
         let vocabularySize = logprobs.dim(-1)
         guard topK < vocabularySize else { return logprobs }
-        // O(V) partition: the element at position kth is the top-K boundary.
-        let kth = vocabularySize - topK
-        let partitioned = argPartition(logprobs, kth: kth, axis: -1)
-        let thresholdIdx = partitioned[0..., kth ..< (kth + 1)]
-        let threshold = takeAlong(logprobs, thresholdIdx, axis: -1)
-        return MLX.where(logprobs .>= threshold, logprobs, negInf)
+        // O(V) partition on negated logprobs so top-k land at [0, topK).
+        // Indices at [topK, V) are the tokens to mask out.
+        let maskIndices = argPartition(-logprobs, kth: topK - 1, axis: -1)[0..., topK...]
+        return putAlong(logprobs, maskIndices, values: negInf, axis: -1)
     }
 }
 


### PR DESCRIPTION
## Summary

- **GPU-only penalty processors**: Replace `[Int]` token buffers with GPU-resident `TokenRing` struct using `MLXArray.arange` + `MLX.where` mask writes. Eliminates `token.item(Int.self)` CPU←GPU sync in `didSample()`, restoring `asyncEval()` pipelining.
- **Align sampling with Python mlx-lm**: Replace `softmax` with `logSoftmax`, work in log-prob space throughout. Apply filters in the same order as `mlx_lm.sample_utils.make_sampler`: top_p → min_p → top_k. Each filter operates on the full vocabulary in original token order.
- **Remove `Sendable` from `LogitProcessor`**: `MLXArray` is not `Sendable`; aligns with existing `LogitSampler` precedent.

## Changes

### Penalty processors
- `TokenRing` struct encapsulates shared ring buffer logic (was duplicated 3×)
- `positions` array via `MLXArray.arange()` computed once in `init` (was CPU-allocated per token)
- `ring` property marked `private` on all penalty structs

### TopPSampler
- `logSoftmax(logits)` instead of `softmax(logits)` — matches Python's `logits - logsumexp(logits)`
- Mask with `-inf` in log-space instead of `0` in linear-prob space — no more `log(0)` round-trip
- Separate `applyTopP`, `applyMinP`, `applyTopK` methods matching `mlx_lm/sample_utils.py`
- `applyTopP` uses `putAlong` for O(V) scatter-back instead of double `argSort`
- `categorical` on `[B, V]` returns `[B]` directly — batch-safe by construction

## Test plan

- [x] Verified correct generation output matches original implementation
- [x] Benchmarked with presence penalty + topK sampling
- [x] swift-format clean, builds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)