### PR TITLE
Fix Qwen35 VLM crash on text-only inference

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -921,6 +921,10 @@ enum Qwen35Language {
             imageGridTHW: [THW]? = nil,
             videoGridTHW: [THW]? = nil
         ) -> LMOutput {
+            // Ensure inputs is 2D [batch, seq]. Text-only callers (e.g.
+            // WiredMemoryUtils, TokenIterator) may pass 1D token arrays.
+            let inputs = inputs.ndim == 1 ? inputs.expandedDimensions(axis: 0) : inputs
+
             if pixelValues != nil {
                 precomputedPositionIds = nil
                 ropeDeltas = nil


### PR DESCRIPTION
## Problem

Loading a Qwen3.5 MoE model (e.g. `mlx-community/Qwen3.5-35B-A3B-4bit`) via `VLMModelFactory` works fine — the containr loads successfully. But the first text-only inference call crashes with:

```
Fatal error: SmallVector out of range.
at mlx-c/mlx/c/array.cpp:335
```

The same model loads and runs without issue through `LLMModelFactory`.

## Root Cause

`Qwen35Language.LanguageModel.callAsFunction` passes `inputs` directly to `Qwen3VLLanguage.getRopeIndex()`, which does:

```swift
let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
```

When the VLM container is used for text-only generation (no images), callers like `WiredMemoryUtils.tune()` and `TokenIterator` pass 1D `[seq]` token tensors. `dim(1)` on a 1D array is out of range → fatal crash.

The same issue affects `inputs.dim(1)` at lines 946 and 966 in the same function.

## Fix

Add an `ndim` check at the top of `callAsFunction` to expand 1D inputs to 2D `[1, seq]` before any dimension-dependent logic runs. This matches what the LLM path does via `tokens[text: .newAxis]` in `prefillOnly`.

## Testing

Verified locally with `mlx-community/Qwen3.5-35B-A3B-4bit` on M4 Max 96GB:
- Container loads via `VLMModelFactory` ✅
- `WiredMemoryUtils.tune()` completes (was crashing) ✅  
- Text inference produces correct output ✅
- Full e2e test suite passes ✅

Fixes #148