### PR TITLE
fix: @ModuleInfo for pooler + attention mask dtype in Bert/NomicBert

### DIFF
--- a/Libraries/MLXEmbedders/Models/Bert.swift
+++ b/Libraries/MLXEmbedders/Models/Bert.swift
@@ -306,15 +306,19 @@ public class BertModel: Module, EmbeddingModel {
         if inp.ndim == 1 {
             inp = inp.reshaped(1, -1)
         }
+        let embeddings = embedder(inp, positionIds: positionIds, tokenTypeIds: tokenTypeIds)
         var mask = attentionMask
         if mask != nil {
-            mask = mask!.asType(embedder.wordEmbeddings.weight.dtype).expandedDimensions(axes: [
+            // Cast mask to the same dtype as the embeddings output so it is
+            // compatible with scaled_dot_product_attention's type promotion
+            // rules. Using the embedding weight dtype can produce a mismatch
+            // when Linear layers are quantized to float16 but Embedding
+            // weights remain float32.
+            mask = mask!.asType(embeddings.dtype).expandedDimensions(axes: [
                 1, 2,
             ]).log()
         }
-        let outputs = encoder(
-            embedder(inp, positionIds: positionIds, tokenTypeIds: tokenTypeIds),
-            attentionMask: mask)
+        let outputs = encoder(embeddings, attentionMask: mask)
         if let lmHead {
             return EmbeddingModelOutput(hiddenStates: lmHead(outputs), pooledOutput: nil)
         } else {

--- a/Libraries/MLXEmbedders/Models/NomicBert.swift
+++ b/Libraries/MLXEmbedders/Models/NomicBert.swift
@@ -739,18 +739,22 @@ public class NomicBertModel: Module, EmbeddingModel {
         // Operation: .log().
         //   log(1) = 0    (Add 0 to attention score -> No change)
         //   log(0) = -inf (Add -inf to attention score -> Zero probability after Softmax)
+        let embeddings = embedder(
+            inp, positionIds: positionIds, tokenTypeIds: tokenTypeIds)
         var mask = attentionMask
         if mask != nil {
-            mask = mask!.asType(embedder.wordEmbeddings.weight.dtype).expandedDimensions(axes: [
+            // Cast mask to the same dtype as the embeddings output so it is
+            // compatible with scaled_dot_product_attention's type promotion
+            // rules. Using the embedding weight dtype can produce a mismatch
+            // when Linear layers are quantized to float16 but Embedding
+            // weights remain float32.
+            mask = mask!.asType(embeddings.dtype).expandedDimensions(axes: [
                 1, 2,
             ]).log()
         }
 
         // 3. Encoder Pass
-        let outputs = encoder(
-            embedder(
-                inp, positionIds: positionIds, tokenTypeIds: tokenTypeIds),
-            attentionMask: mask)
+        let outputs = encoder(embeddings, attentionMask: mask)
 
         // 4a. Return LM Head Output (if active)
         if let lmHead {


### PR DESCRIPTION
## Summary

Two fixes for `BertModel` and `NomicBertModel` in MLXEmbedders:

### 1. Add `@ModuleInfo` to `pooler` property

`BertModel.pooler` and `NomicBertModel.pooler` were declared as `let` without `@ModuleInfo`. During quantized model loading, `quantize()` → `model.update(modules:)` → `try!` on `needModuleInfo` error → SIGABRT:

```
MLXNN/Module.swift:570: Fatal error: 'try!' expression unexpectedly raised an error:
MLXNN.UpdateError.needModuleInfo("Unable to get @ModuleInfo for BertModel.pooler
-- must be wrapped to receive updates")
```

**Fix:** Changed `let pooler: Linear?` → `@ModuleInfo var pooler: Linear?` and updated init to use `_pooler.wrappedValue`.

### 2. Cast attention mask to embeddings output dtype

The attention mask was cast to `embedder.wordEmbeddings.weight.dtype`, which remains `float32` since `Embedding` layers are not quantized. When `Linear` layers (Q/K/V projections) are quantized to `float16`, `MLXFast.scaledDotProductAttention` requires the mask dtype to promote to the output type (`float16`). A `float32` mask cannot promote *down* to `float16`:

```
[scaled_dot_product_attention] Mask type must promote to output type float16.
```

**Fix:** Compute embeddings first, then cast the mask to `embeddings.dtype` instead of the embedding weight's storage dtype.

## Files changed

- `Libraries/MLXEmbedders/Models/Bert.swift`
- `Libraries/MLXEmbedders/Models/NomicBert.swift`