### PR TITLE
feat: add ParoQuant (pairwise rotation quantization) support

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -174,8 +174,7 @@ final class Qwen35GatedDeltaNet: Module {
     @ModuleInfo(key: "conv1d") var conv1d: Conv1d
     @ModuleInfo(key: "in_proj_qkv") var inProjQKV: Linear
     @ModuleInfo(key: "in_proj_z") var inProjZ: Linear
-    @ModuleInfo(key: "in_proj_b") var inProjB: Linear
-    @ModuleInfo(key: "in_proj_a") var inProjA: Linear
+    @ModuleInfo(key: "in_proj_ba") var inProjBA: Linear
 
     @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
     @ParameterInfo(key: "A_log") var aLog: MLXArray
@@ -212,8 +211,7 @@ final class Qwen35GatedDeltaNet: Module {
 
         _inProjQKV.wrappedValue = Linear(hiddenSize, keyDim * 2 + valueDim, bias: false)
         _inProjZ.wrappedValue = Linear(hiddenSize, valueDim, bias: false)
-        _inProjB.wrappedValue = Linear(hiddenSize, numVHeads, bias: false)
-        _inProjA.wrappedValue = Linear(hiddenSize, numVHeads, bias: false)
+        _inProjBA.wrappedValue = Linear(hiddenSize, numVHeads * 2, bias: false)
 
         _dtBias.wrappedValue = MLXArray.ones([numVHeads])
         let a = MLXRandom.uniform(low: 0, high: 16, [numVHeads])
@@ -235,8 +233,9 @@ final class Qwen35GatedDeltaNet: Module {
 
         var qkv = inProjQKV(inputs)
         let z = inProjZ(inputs).reshaped(B, S, numVHeads, headVDim)
-        let b = inProjB(inputs)
-        let a = inProjA(inputs)
+        let ba = inProjBA(inputs)
+        let b = ba[0..., 0..., ..<numVHeads]
+        let a = ba[0..., 0..., numVHeads...]
 
         let convState: MLXArray
         if let cacheState = cache?[0] {
@@ -624,6 +623,17 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
             {
                 weights[k] = v + MLXArray(1, dtype: v.dtype)
             }
+        }
+
+        // Fuse in_proj_b + in_proj_a → in_proj_ba (eliminates 1 matmul dispatch per layer)
+        for k in Array(weights.keys) where k.hasSuffix(".in_proj_b.weight") {
+            let prefix = String(k.dropLast(".in_proj_b.weight".count))
+            let aKey = "\(prefix).in_proj_a.weight"
+            guard let bWeight = weights.removeValue(forKey: k),
+                let aWeight = weights.removeValue(forKey: aKey)
+            else { continue }
+            weights["\(prefix).in_proj_ba.weight"] = concatenated(
+                [bWeight, aWeight], axis: 0)
         }
 
         return weights

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -626,20 +626,6 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
             }
         }
 
-        // Split pre-fused in_proj_ba → in_proj_b + in_proj_a
-        // (PARO checkpoints store these as a single fused key)
-        for k in Array(weights.keys) where k.hasSuffix(".in_proj_ba.weight") {
-            let prefix = String(k.dropLast(".in_proj_ba.weight".count))
-            guard weights["\(prefix).in_proj_b.weight"] == nil else { continue }
-            for suffix in [".weight", ".scales", ".biases", ".bias"] {
-                let baKey = "\(prefix).in_proj_ba\(suffix)"
-                guard let baVal = weights.removeValue(forKey: baKey) else { continue }
-                let half = baVal.dim(0) / 2
-                weights["\(prefix).in_proj_b\(suffix)"] = baVal[0 ..< half]
-                weights["\(prefix).in_proj_a\(suffix)"] = baVal[half...]
-            }
-        }
-
         return weights
     }
 }

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -174,7 +174,8 @@ final class Qwen35GatedDeltaNet: Module {
     @ModuleInfo(key: "conv1d") var conv1d: Conv1d
     @ModuleInfo(key: "in_proj_qkv") var inProjQKV: Linear
     @ModuleInfo(key: "in_proj_z") var inProjZ: Linear
-    @ModuleInfo(key: "in_proj_ba") var inProjBA: Linear
+    @ModuleInfo(key: "in_proj_b") var inProjB: Linear
+    @ModuleInfo(key: "in_proj_a") var inProjA: Linear
 
     @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
     @ParameterInfo(key: "A_log") var aLog: MLXArray
@@ -211,7 +212,8 @@ final class Qwen35GatedDeltaNet: Module {
 
         _inProjQKV.wrappedValue = Linear(hiddenSize, keyDim * 2 + valueDim, bias: false)
         _inProjZ.wrappedValue = Linear(hiddenSize, valueDim, bias: false)
-        _inProjBA.wrappedValue = Linear(hiddenSize, numVHeads * 2, bias: false)
+        _inProjB.wrappedValue = Linear(hiddenSize, numVHeads, bias: false)
+        _inProjA.wrappedValue = Linear(hiddenSize, numVHeads, bias: false)
 
         _dtBias.wrappedValue = MLXArray.ones([numVHeads])
         let a = MLXRandom.uniform(low: 0, high: 16, [numVHeads])
@@ -233,9 +235,8 @@ final class Qwen35GatedDeltaNet: Module {
 
         var qkv = inProjQKV(inputs)
         let z = inProjZ(inputs).reshaped(B, S, numVHeads, headVDim)
-        let ba = inProjBA(inputs)
-        let b = ba[0..., 0..., ..<numVHeads]
-        let a = ba[0..., 0..., numVHeads...]
+        let b = inProjB(inputs)
+        let a = inProjA(inputs)
 
         let convState: MLXArray
         if let cacheState = cache?[0] {
@@ -623,17 +624,6 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
             {
                 weights[k] = v + MLXArray(1, dtype: v.dtype)
             }
-        }
-
-        // Fuse in_proj_b + in_proj_a → in_proj_ba (eliminates 1 matmul dispatch per layer)
-        for k in Array(weights.keys) where k.hasSuffix(".in_proj_b.weight") {
-            let prefix = String(k.dropLast(".in_proj_b.weight".count))
-            let aKey = "\(prefix).in_proj_a.weight"
-            guard let bWeight = weights.removeValue(forKey: k),
-                let aWeight = weights.removeValue(forKey: aKey)
-            else { continue }
-            weights["\(prefix).in_proj_ba.weight"] = concatenated(
-                [bWeight, aWeight], axis: 0)
         }
 
         return weights

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -626,6 +626,20 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
             }
         }
 
+        // Split pre-fused in_proj_ba → in_proj_b + in_proj_a
+        // (PARO checkpoints store these as a single fused key)
+        for k in Array(weights.keys) where k.hasSuffix(".in_proj_ba.weight") {
+            let prefix = String(k.dropLast(".in_proj_ba.weight".count))
+            guard weights["\(prefix).in_proj_b.weight"] == nil else { continue }
+            for suffix in [".weight", ".scales", ".biases", ".bias"] {
+                let baKey = "\(prefix).in_proj_ba\(suffix)"
+                guard let baVal = weights.removeValue(forKey: baKey) else { continue }
+                let half = baVal.dim(0) / 2
+                weights["\(prefix).in_proj_b\(suffix)"] = baVal[0 ..< half]
+                weights["\(prefix).in_proj_a\(suffix)"] = baVal[half...]
+            }
+        }
+
         return weights
     }
 }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1639,10 +1639,12 @@ public func maybeQuantizeKVCache(
     kvGroupSize: Int = 64,
     quantizedKVStart: Int = 0
 ) {
-    guard let kvBits = kvBits,
-        !cache.isEmpty,
-        !(cache[0] is QuantizedKVCache),
-        cache[0].offset > quantizedKVStart
+    guard let kvBits = kvBits, !cache.isEmpty else { return }
+
+    // Find the first quantizable (non-Mamba, non-already-quantized) cache entry
+    guard let firstQuantizable = cache.first(where: { $0 is KVCacheSimple }),
+        !(firstQuantizable is QuantizedKVCache),
+        firstQuantizable.offset > quantizedKVStart
     else {
         return
     }

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -314,9 +314,9 @@ private struct ParoQuantInputProcessor: UserInputProcessor {
 
 /// Load a ParoQuant model from a local directory, returning a ``ModelContainer``.
 ///
-/// Handles AutoAWQ weight conversion, rotation layer patching, and optional
-/// weight pre-rotation with disk caching. On first load, pre-rotated weights
-/// are saved to `prerotated_cache.safetensors` for fast subsequent loads.
+/// Handles AutoAWQ weight conversion, rotation layer patching, and IO layer
+/// quantization. Rotation parameters (theta, pairs, channel_scales) are kept
+/// in the model and applied to activations at runtime via Metal kernel.
 ///
 /// - Parameters:
 ///   - directory: Local path to the model checkpoint directory.
@@ -373,148 +373,63 @@ public func loadParoQuantModel(
     var config = ModelConfiguration(directory: directory, toolCallFormat: toolCallFormat)
     config.eosTokenIds = eosTokenIds
 
-    // 5. Check for pre-rotated weight cache (invalidate if source weights are newer)
-    let cacheURL = directory.appendingPathComponent("prerotated_cache.safetensors")
-    let hasCachedWeights: Bool = {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: cacheURL.path),
-            let cacheAttrs = try? fm.attributesOfItem(atPath: cacheURL.path),
-            let cacheMtime = cacheAttrs[.modificationDate] as? Date
-        else { return false }
-
-        // Invalidate if any source safetensors file is newer than the cache
-        guard
-            let enumerator = fm.enumerator(
-                at: directory, includingPropertiesForKeys: [.contentModificationDateKey])
-        else {
-            return true
-        }
-        while let url = enumerator.nextObject() as? URL {
-            guard url.pathExtension == "safetensors",
-                url.lastPathComponent != "prerotated_cache.safetensors"
-            else { continue }
-            if let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
-                let sourceMtime = values.contentModificationDate,
-                sourceMtime > cacheMtime
-            {
-                logger.info("Cache invalidated: \(url.lastPathComponent) is newer than cache")
-                return false
+    // 5. Load raw safetensors
+    var weights = [String: MLXArray]()
+    let enumerator = FileManager.default.enumerator(
+        at: directory, includingPropertiesForKeys: nil)!
+    while let url = enumerator.nextObject() as? URL {
+        if url.pathExtension == "safetensors",
+            url.lastPathComponent != "prerotated_cache.safetensors"
+        {
+            let w = try loadArrays(url: url)
+            for (key, value) in w {
+                weights[key] = value
             }
-        }
-        return true
-    }()
-
-    if hasCachedWeights {
-        // Fast path: load pre-rotated weights directly (no AWQ conversion, no rotation)
-        logger.info("Loading pre-rotated weight cache")
-        let cachedWeights = try loadArrays(url: cacheURL)
-        var sanitized = model.sanitize(weights: cachedWeights)
-
-        // Swap Linear → QuantizedLinear where .scales exist
-        quantize(model: model) { path, module in
-            guard module is Quantizable else { return nil }
-            guard sanitized["\(path).scales"] != nil else { return nil }
-            return (paroConfig.groupSize, paroConfig.bits, .affine)
-        }
-
-        let params = ModuleParameters.unflattened(sanitized)
-        try model.update(parameters: params, verify: [.allModelKeysSet, .shapeMismatch])
-        eval(model)
-        logger.info("ParoQuant model loaded from cache")
-    } else {
-        // Full path: AWQ conversion + rotation patching + pre-rotation + cache save
-
-        // 5a. Load raw safetensors
-        var weights = [String: MLXArray]()
-        let enumerator = FileManager.default.enumerator(
-            at: directory, includingPropertiesForKeys: nil)!
-        while let url = enumerator.nextObject() as? URL {
-            if url.pathExtension == "safetensors" {
-                let w = try loadArrays(url: url)
-                for (key, value) in w {
-                    weights[key] = value
-                }
-            }
-        }
-
-        logger.info("Loaded \(weights.count) weight keys from safetensors")
-
-        // 6. Convert AutoAWQ format → MLX format (BEFORE sanitize)
-        if weights.keys.contains(where: { $0.hasSuffix(".qweight") }) {
-            convertAutoAWQ(&weights, groupSize: paroConfig.groupSize)
-            logger.info("Converted AutoAWQ weights to MLX format")
-        }
-
-        // 7. Model-specific sanitization
-        weights = model.sanitize(weights: weights)
-
-        // 8. Patch rotation layers
-        try patchRotationLayers(
-            model: model, weights: weights,
-            bits: paroConfig.bits, groupSize: paroConfig.groupSize
-        )
-
-        // 9. Quantize non-rotation layers in MLX quantized form
-        quantize(model: model) { path, module in
-            guard module is Quantizable else { return nil }
-            guard isCheckpointQuantizedLayer(path: path, weights: weights) else {
-                return nil
-            }
-            return (paroConfig.groupSize, paroConfig.bits, .affine)
-        }
-
-        // 10. Load checkpoint weights into the patched model
-        let parameters = ModuleParameters.unflattened(weights)
-        let verify: Module.VerifyUpdate = [.allModelKeysSet, .shapeMismatch]
-        try model.update(parameters: parameters, verify: verify)
-
-        // 11. Quantize IO embedding path from FP16 weights
-        quantize(model: model) { path, module in
-            guard isParoQuantIOLayer(path: path, module: module) else {
-                return nil
-            }
-            return (paroConfig.groupSize, paroConfig.bits, .affine)
-        }
-
-        // 12. Pre-rotate weights: bake rotation + channel_scales into quantized weights
-        let rotationModules = model.leafModules().flattened()
-            .compactMap { (_, module) in module as? RotateQuantizedLinear }
-        if !rotationModules.isEmpty {
-            logger.info(
-                "Pre-rotating weights for \(rotationModules.count) RotateQuantizedLinear layers"
-            )
-            for (i, module) in rotationModules.enumerated() {
-                try module.preRotateWeights()
-                if (i + 1) % 6 == 0 {
-                    Memory.clearCache()
-                }
-            }
-        }
-
-        // 13. Materialize
-        eval(model)
-        logger.info("ParoQuant model loaded and evaluated")
-
-        // 14. Save pre-rotated weight cache for fast subsequent loads.
-        // Failure is non-fatal — the directory may be read-only (e.g. bundled resources).
-        do {
-            var cacheWeights = [String: MLXArray]()
-            for (key, value) in model.parameters().flattened() {
-                // Skip rotation-specific keys (already baked into weights)
-                if key.hasSuffix(".theta") || key.hasSuffix(".pairs")
-                    || key.hasSuffix(".channel_scales")
-                {
-                    continue
-                }
-                cacheWeights[key] = value
-            }
-            eval(cacheWeights)
-            try save(arrays: cacheWeights, url: cacheURL)
-            logger.info("Saved pre-rotated weight cache (\(cacheWeights.count) keys)")
-        } catch {
-            logger.warning("Failed to save weight cache: \(error)")
         }
     }
+
+    logger.info("Loaded \(weights.count) weight keys from safetensors")
+
+    // 6. Convert AutoAWQ format → MLX format (BEFORE sanitize)
+    if weights.keys.contains(where: { $0.hasSuffix(".qweight") }) {
+        convertAutoAWQ(&weights, groupSize: paroConfig.groupSize)
+        logger.info("Converted AutoAWQ weights to MLX format")
+    }
+
+    // 7. Model-specific sanitization
+    weights = model.sanitize(weights: weights)
+
+    // 8. Patch rotation layers
+    try patchRotationLayers(
+        model: model, weights: weights,
+        bits: paroConfig.bits, groupSize: paroConfig.groupSize
+    )
+
+    // 9. Quantize non-rotation layers in MLX quantized form
+    quantize(model: model) { path, module in
+        guard module is Quantizable else { return nil }
+        guard isCheckpointQuantizedLayer(path: path, weights: weights) else {
+            return nil
+        }
+        return (paroConfig.groupSize, paroConfig.bits, .affine)
+    }
+
+    // 10. Load checkpoint weights into the patched model
+    let parameters = ModuleParameters.unflattened(weights)
+    let verify: Module.VerifyUpdate = [.allModelKeysSet, .shapeMismatch]
+    try model.update(parameters: parameters, verify: verify)
+
+    // 11. Quantize IO embedding path from FP16 weights
+    quantize(model: model) { path, module in
+        guard isParoQuantIOLayer(path: path, module: module) else {
+            return nil
+        }
+        return (paroConfig.groupSize, paroConfig.bits, .affine)
+    }
+
+    // 12. Materialize
+    eval(model)
+    logger.info("ParoQuant model loaded and evaluated")
 
     // 13. Load tokenizer
     let tokenizer = try await loadTokenizer(configuration: config, hub: defaultHubApi)

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -394,18 +394,19 @@ public func loadParoQuantModel(
     var config = ModelConfiguration(directory: directory, toolCallFormat: toolCallFormat)
     config.eosTokenIds = eosTokenIds
 
-    // 5. Load raw safetensors
+    // 5. Load raw safetensors (top-level only; do not recurse into
+    //    subdirectories, otherwise nested artefacts like an HF snapshot
+    //    cache under the checkpoint dir would be pulled in).
     var weights = [String: MLXArray]()
-    let enumerator = FileManager.default.enumerator(
-        at: directory, includingPropertiesForKeys: nil)!
-    while let url = enumerator.nextObject() as? URL {
-        if url.pathExtension == "safetensors",
-            url.lastPathComponent != "prerotated_cache.safetensors"
-        {
-            let w = try loadArrays(url: url)
-            for (key, value) in w {
-                weights[key] = value
-            }
+    let contents = try FileManager.default.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: nil)
+    for url in contents
+    where url.pathExtension == "safetensors"
+        && url.lastPathComponent != "prerotated_cache.safetensors"
+    {
+        let w = try loadArrays(url: url)
+        for (key, value) in w {
+            weights[key] = value
         }
     }
 

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -1,5 +1,3 @@
-// Copyright © 2025 INQTR. All rights reserved.
-
 import Foundation
 import Hub
 import MLX

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -418,6 +418,16 @@ public func loadParoQuantModel(
     let verify: Module.VerifyUpdate = [.allModelKeysSet, .shapeMismatch]
     try model.update(parameters: parameters, verify: verify)
 
+    // 10b. Finalize rotation-derived state. Must run *after* the checkpoint
+    //      update (so theta / pairs / channel_scales hold real values) and
+    //      *before* any forward pass. `prepareDerivedRotationState()`
+    //      eval(...)s its own derived arrays because they live in underscore-
+    //      prefixed private fields that Module reflection — and therefore
+    //      step 12's eval(model) — skips.
+    for (_, layer) in rotationLeafModules(model: model) {
+        (layer as? RotateQuantizedLinear)?.prepareDerivedRotationState()
+    }
+
     // 11. Quantize IO embedding path from FP16 weights
     quantize(model: model) { path, module in
         guard isParoQuantIOLayer(path: path, module: module) else {
@@ -426,7 +436,7 @@ public func loadParoQuantModel(
         return (paroConfig.groupSize, paroConfig.bits, .affine)
     }
 
-    // 12. Materialize
+    // 12. Materialize the @ParameterInfo tensors
     eval(model)
     logger.info("ParoQuant model loaded and evaluated")
 

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -1,8 +1,6 @@
 import Foundation
-import Hub
 import MLX
 import MLXNN
-import Tokenizers
 import os
 
 private let logger = Logger(subsystem: "mlx-swift-lm", category: "paroquant")
@@ -324,6 +322,7 @@ private struct ParoQuantInputProcessor: UserInputProcessor {
 public func loadParoQuantModel(
     from directory: URL,
     typeRegistry: ModelTypeRegistry,
+    tokenizerLoader: any TokenizerLoader,
     toolCallFormat: ToolCallFormat? = nil
 ) async throws -> ModelContainer {
     // 1. Parse config.json (flatten VLM text_config if present)
@@ -430,7 +429,7 @@ public func loadParoQuantModel(
     logger.info("ParoQuant model loaded and evaluated")
 
     // 13. Load tokenizer
-    let tokenizer = try await loadTokenizer(configuration: config, hub: defaultHubApi)
+    let tokenizer = try await tokenizerLoader.load(from: directory)
 
     // 14. Create processor with messageGenerator
     // Use DefaultMessageGenerator — LLMModel.messageGenerator(tokenizer:) is in MLXLLM

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -1,0 +1,570 @@
+// Copyright © 2025 INQTR. All rights reserved.
+
+import Foundation
+import Hub
+import MLX
+import MLXNN
+import Tokenizers
+import os
+
+private let logger = Logger(subsystem: "mlx-swift-lm", category: "paroquant")
+
+// MARK: - Detection
+
+/// Returns `true` if the model directory contains a ParoQuant checkpoint.
+///
+/// Inspects `config.json` for `quant_method == "paroquant"` in `quantization_config`
+/// and verifies a supported architecture is declared.
+public func isParoQuantModel(directory: URL) -> Bool {
+    guard let configData = try? Data(contentsOf: directory.appendingPathComponent("config.json"))
+    else {
+        return false
+    }
+    return isSupportedParoQuantModel(directory: directory, configData: configData)
+}
+
+// MARK: - Config
+
+struct ParoQuantConfig: Sendable {
+    let bits: Int
+    let groupSize: Int
+    let krot: Int
+}
+
+/// Reads ParoQuant quantization config from config.json data.
+private func readParoQuantConfig(_ configData: Data) -> ParoQuantConfig? {
+    guard let json = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
+        let qc = json["quantization_config"] as? [String: Any]
+    else { return nil }
+
+    let bits = qc["bits"] as? Int ?? 4
+    let groupSize = qc["group_size"] as? Int ?? 128
+    let krot = qc["krot"] as? Int ?? 8
+    return ParoQuantConfig(bits: bits, groupSize: groupSize, krot: krot)
+}
+
+/// Checks whether a model directory contains a ParoQuant checkpoint by inspecting
+/// `quant_method` and `architectures` in config.json.
+private func isSupportedParoQuantModel(directory: URL, configData: Data) -> Bool {
+    guard let json = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
+        let qc = json["quantization_config"] as? [String: Any],
+        let method = qc["quant_method"] as? String,
+        method == "paroquant"
+    else { return false }
+
+    let architectures = json["architectures"] as? [String] ?? []
+    return architectures.contains("Qwen3_5ForConditionalGeneration")
+}
+
+// MARK: - AutoAWQ Conversion
+
+private enum AWQ {
+    static let bits = 4
+    static let packFactor = 32 / bits  // 8 values per uint32
+    static let mask: Int32 = (1 << bits) - 1
+    static let shifts: [Int32] = (0 ..< 8).map { Int32($0 * bits) }
+    /// Inverse of AutoAWQ reorder [0,2,4,6,1,3,5,7] → [0,4,1,5,2,6,3,7]
+    static let inverseReorder = [0, 4, 1, 5, 2, 6, 3, 7]
+
+    // Pre-computed MLXArrays (created once, reused across calls)
+    nonisolated(unsafe) static let shiftsArray = MLXArray(shifts.map { Int64($0) }).reshaped(
+        1, 1, 8)
+    nonisolated(unsafe) static let reorderIndices = MLXArray(inverseReorder.map { Int32($0) })
+}
+
+/// Unpack AutoAWQ int32 → raw uint8 values, undoing the [0,2,4,6,1,3,5,7] reorder.
+private func unpackAndReorder(_ packed: MLXArray) -> MLXArray {
+    let rows = packed.dim(0)
+    let cols = packed.dim(1)
+
+    let expanded = packed.asType(.int64).expandedDimensions(axis: 2)
+    let raw = ((expanded >> AWQ.shiftsArray) & Int64(AWQ.mask)).asType(.uint8)
+    let reordered = raw.take(AWQ.reorderIndices, axis: 2)
+
+    return reordered.reshaped(rows, cols * 8)
+}
+
+/// Pack raw uint8 values into uint32 (MLX sequential layout).
+private func packMLX(_ w: MLXArray) -> MLXArray {
+    let rows = w.dim(0)
+    let reshaped = w.reshaped(rows, -1, AWQ.packFactor)  // [rows, cols/8, 8]
+
+    var packed = reshaped[0..., 0..., 0].asType(.uint32)
+    for i in 1 ..< AWQ.packFactor {
+        packed = packed | (reshaped[0..., 0..., i].asType(.uint32) << UInt32(i * AWQ.bits))
+    }
+    return packed
+}
+
+/// Convert AutoAWQ checkpoint weights to MLX quantized format in-place.
+private func convertAutoAWQ(
+    _ weights: inout [String: MLXArray], groupSize: Int
+) {
+    let prefixes = Set(
+        weights.keys
+            .filter { $0.hasSuffix(".qweight") }
+            .compactMap { key -> String? in
+                let pfx = String(key.dropLast("qweight".count))
+                return weights["\(pfx)theta"] != nil ? pfx : nil
+            }
+    )
+
+    guard !prefixes.isEmpty else { return }
+
+    // Pass 1: compute biases from qzeros + scales BEFORE scales are transposed.
+    for pfx in prefixes {
+        guard let qzeros = weights.removeValue(forKey: "\(pfx)qzeros"),
+            let scales = weights["\(pfx)scales"]
+        else { continue }
+        let zeros = unpackAndReorder(qzeros).asType(.float32)
+        weights["\(pfx)biases"] = (-scales.asType(.float32) * zeros).transposed().asType(.float16)
+    }
+
+    // Pass 2: convert remaining keys (qweight, scales, channel_scales)
+    let keysToConvert = weights.keys.filter { key in
+        prefixes.contains(where: { key.hasPrefix($0) })
+    }
+
+    for key in keysToConvert {
+        guard let pfx = prefixes.first(where: { key.hasPrefix($0) }) else { continue }
+        let suffix = String(key.dropFirst(pfx.count))
+
+        switch suffix {
+        case "qweight":
+            let val = weights.removeValue(forKey: key)!
+            weights["\(pfx)weight"] = packMLX(unpackAndReorder(val).transposed())
+
+        case "scales":
+            weights[key] = weights[key]!.transposed()
+
+        case "channel_scales":
+            if let val = weights[key], val.ndim == 1 {
+                weights[key] = val.reshaped(1, -1)
+            }
+
+        default:
+            break  // theta, pairs, bias — keep as-is
+        }
+    }
+}
+
+// MARK: - Layer Patching
+
+private func requireTensor(
+    _ key: String, weights: [String: MLXArray]
+) throws -> MLXArray {
+    guard let tensor = weights[key] else {
+        throw ParoQuantError.missingTensor(key)
+    }
+    return tensor
+}
+
+private func verifyTensorShape(
+    _ tensor: MLXArray, key: String, expected: [Int]
+) throws {
+    guard tensor.shape == expected else {
+        throw ParoQuantError.invalidTensorShape(
+            key: key,
+            expected: expected,
+            actual: tensor.shape
+        )
+    }
+}
+
+private func rotationLeafModules(model: Module) -> [String: Module] {
+    Dictionary(uniqueKeysWithValues: model.leafModules().flattened())
+}
+
+private func rotationModuleSpec(
+    prefix: String,
+    leafModules: [String: Module],
+    weights: [String: MLXArray],
+    bits: Int,
+    groupSize: Int
+) throws -> (inputDims: Int, outputDims: Int, hasBias: Bool, krot: Int) {
+    guard let original = leafModules[prefix] else {
+        throw ParoQuantError.rotationLayerNotFound(prefix)
+    }
+    guard let linear = original as? Linear else {
+        throw ParoQuantError.rotationLayerTypeMismatch(
+            path: prefix,
+            actualType: String(describing: type(of: original))
+        )
+    }
+
+    let outputDims = linear.shape.0
+    let inputDims = linear.shape.1
+    let groups = inputDims / groupSize
+    let packedInputDims = inputDims * bits / 32
+    let expectsBias = linear.bias != nil
+
+    let theta = try requireTensor("\(prefix).theta", weights: weights)
+    let pairs = try requireTensor("\(prefix).pairs", weights: weights)
+    let channelScales = try requireTensor("\(prefix).channel_scales", weights: weights)
+    let weight = try requireTensor("\(prefix).weight", weights: weights)
+    let scales = try requireTensor("\(prefix).scales", weights: weights)
+    let biases = try requireTensor("\(prefix).biases", weights: weights)
+
+    let krot = theta.dim(0)
+    try verifyTensorShape(theta, key: "\(prefix).theta", expected: [krot, inputDims / 2])
+    try verifyTensorShape(pairs, key: "\(prefix).pairs", expected: [krot, inputDims])
+    try verifyTensorShape(
+        channelScales, key: "\(prefix).channel_scales", expected: [1, inputDims])
+    try verifyTensorShape(
+        weight, key: "\(prefix).weight", expected: [outputDims, packedInputDims])
+    try verifyTensorShape(scales, key: "\(prefix).scales", expected: [outputDims, groups])
+    try verifyTensorShape(biases, key: "\(prefix).biases", expected: [outputDims, groups])
+
+    if expectsBias {
+        _ = try requireTensor("\(prefix).bias", weights: weights)
+    }
+
+    return (inputDims, outputDims, expectsBias, krot)
+}
+
+/// Replace Linear layers with RotateQuantizedLinear where rotation parameters exist.
+private func patchRotationLayers(
+    model: Module, weights: [String: MLXArray],
+    bits: Int, groupSize: Int
+) throws {
+    let prefixes = weights.keys
+        .filter { $0.hasSuffix(".theta") }
+        .map { String($0.dropLast(".theta".count)) }
+        .sorted()
+
+    guard !prefixes.isEmpty else { return }
+
+    let leafModules = rotationLeafModules(model: model)
+    var updates = [(String, Module)]()
+
+    for prefix in prefixes {
+        let spec = try rotationModuleSpec(
+            prefix: prefix,
+            leafModules: leafModules,
+            weights: weights,
+            bits: bits,
+            groupSize: groupSize
+        )
+
+        let replacement = RotateQuantizedLinear(
+            inputDims: spec.inputDims,
+            outputDims: spec.outputDims,
+            hasBias: spec.hasBias,
+            groupSize: groupSize,
+            bits: bits,
+            krot: spec.krot
+        )
+
+        updates.append((prefix, replacement))
+    }
+
+    if !updates.isEmpty {
+        try model.update(modules: ModuleChildren.unflattened(updates), verify: [.noUnusedKeys])
+
+        let patchedLeaves = rotationLeafModules(model: model)
+        for (path, _) in updates {
+            guard patchedLeaves[path] is RotateQuantizedLinear else {
+                throw ParoQuantError.rotationLayerPatchFailed(path)
+            }
+        }
+    }
+}
+
+/// Predicate for the native MLX quantization pass.
+private func isParoQuantIOLayer(path: String, module: Module) -> Bool {
+    guard module is Quantizable else { return false }
+    return path.hasSuffix("embed_tokens") || path.hasSuffix("lm_head")
+}
+
+/// Layers already represented in MLX quantized checkpoint form.
+private func isCheckpointQuantizedLayer(
+    path: String, weights: [String: MLXArray]
+) -> Bool {
+    weights["\(path).scales"] != nil && weights["\(path).theta"] == nil
+}
+
+// MARK: - UserInputProcessor
+
+/// Local UserInputProcessor for ParoQuant models.
+private struct ParoQuantInputProcessor: UserInputProcessor {
+    let tokenizer: Tokenizer
+    let configuration: ModelConfiguration
+    let messageGenerator: MessageGenerator
+
+    func prepare(input: UserInput) throws -> LMInput {
+        let messages = messageGenerator.generate(from: input)
+        do {
+            let promptTokens = try tokenizer.applyChatTemplate(
+                messages: messages, tools: input.tools,
+                additionalContext: input.additionalContext)
+            return LMInput(tokens: MLXArray(promptTokens))
+        } catch {
+            // Fallback for missing chat template or other tokenizer errors
+            let prompt =
+                messages
+                .compactMap { $0["content"] as? String }
+                .joined(separator: "\n\n")
+            let promptTokens = tokenizer.encode(text: prompt)
+            return LMInput(tokens: MLXArray(promptTokens))
+        }
+    }
+}
+
+// MARK: - Load Entry Point
+
+/// Load a ParoQuant model from a local directory, returning a ``ModelContainer``.
+///
+/// Handles AutoAWQ weight conversion, rotation layer patching, and optional
+/// weight pre-rotation with disk caching. On first load, pre-rotated weights
+/// are saved to `prerotated_cache.safetensors` for fast subsequent loads.
+///
+/// - Parameters:
+///   - directory: Local path to the model checkpoint directory.
+///   - typeRegistry: Registry used to create the underlying model architecture.
+///   - toolCallFormat: Optional tool-call format for the model configuration.
+/// - Returns: A ``ModelContainer`` ready for inference.
+public func loadParoQuantModel(
+    from directory: URL,
+    typeRegistry: ModelTypeRegistry,
+    toolCallFormat: ToolCallFormat? = nil
+) async throws -> ModelContainer {
+    // 1. Parse config.json (flatten VLM text_config if present)
+    let configURL = directory.appendingPathComponent("config.json")
+    var configData = try Data(contentsOf: configURL)
+    guard isSupportedParoQuantModel(directory: directory, configData: configData) else {
+        throw ParoQuantError.unsupportedModel
+    }
+    guard var configJSON = try JSONSerialization.jsonObject(with: configData) as? [String: Any]
+    else {
+        throw ParoQuantError.missingConfig
+    }
+    if let textConfig = configJSON["text_config"] as? [String: Any] {
+        for (key, value) in textConfig {
+            configJSON[key] = value
+        }
+        configJSON["model_type"] = "qwen3_5"
+        configData = try JSONSerialization.data(withJSONObject: configJSON)
+    }
+    let baseConfig = try JSONDecoder().decode(BaseConfiguration.self, from: configData)
+
+    // 2. Read ParoQuant params
+    guard let paroConfig = readParoQuantConfig(configData) else {
+        throw ParoQuantError.missingConfig
+    }
+    logger.info(
+        "ParoQuant config: bits=\(paroConfig.bits), groupSize=\(paroConfig.groupSize), krot=\(paroConfig.krot)"
+    )
+
+    // 3. Create model via standard typeRegistry
+    let model =
+        try await typeRegistry
+        .createModel(configuration: configData, modelType: baseConfig.modelType)
+
+    // 4. EOS token override from generation_config.json
+    var eosTokenIds = Set(baseConfig.eosTokenIds?.values ?? [])
+    let genConfigURL = directory.appendingPathComponent("generation_config.json")
+    if let genData = try? Data(contentsOf: genConfigURL),
+        let genConfig = try? JSONDecoder().decode(GenerationConfigFile.self, from: genData),
+        let genEos = genConfig.eosTokenIds?.values
+    {
+        eosTokenIds = Set(genEos)
+    }
+
+    var config = ModelConfiguration(directory: directory, toolCallFormat: toolCallFormat)
+    config.eosTokenIds = eosTokenIds
+
+    // 5. Check for pre-rotated weight cache (invalidate if source weights are newer)
+    let cacheURL = directory.appendingPathComponent("prerotated_cache.safetensors")
+    let hasCachedWeights: Bool = {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: cacheURL.path),
+            let cacheAttrs = try? fm.attributesOfItem(atPath: cacheURL.path),
+            let cacheMtime = cacheAttrs[.modificationDate] as? Date
+        else { return false }
+
+        // Invalidate if any source safetensors file is newer than the cache
+        guard
+            let enumerator = fm.enumerator(
+                at: directory, includingPropertiesForKeys: [.contentModificationDateKey])
+        else {
+            return true
+        }
+        while let url = enumerator.nextObject() as? URL {
+            guard url.pathExtension == "safetensors",
+                url.lastPathComponent != "prerotated_cache.safetensors"
+            else { continue }
+            if let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                let sourceMtime = values.contentModificationDate,
+                sourceMtime > cacheMtime
+            {
+                logger.info("Cache invalidated: \(url.lastPathComponent) is newer than cache")
+                return false
+            }
+        }
+        return true
+    }()
+
+    if hasCachedWeights {
+        // Fast path: load pre-rotated weights directly (no AWQ conversion, no rotation)
+        logger.info("Loading pre-rotated weight cache")
+        let cachedWeights = try loadArrays(url: cacheURL)
+        var sanitized = model.sanitize(weights: cachedWeights)
+
+        // Swap Linear → QuantizedLinear where .scales exist
+        quantize(model: model) { path, module in
+            guard module is Quantizable else { return nil }
+            guard sanitized["\(path).scales"] != nil else { return nil }
+            return (paroConfig.groupSize, paroConfig.bits, .affine)
+        }
+
+        let params = ModuleParameters.unflattened(sanitized)
+        try model.update(parameters: params, verify: [.allModelKeysSet, .shapeMismatch])
+        eval(model)
+        logger.info("ParoQuant model loaded from cache")
+    } else {
+        // Full path: AWQ conversion + rotation patching + pre-rotation + cache save
+
+        // 5a. Load raw safetensors
+        var weights = [String: MLXArray]()
+        let enumerator = FileManager.default.enumerator(
+            at: directory, includingPropertiesForKeys: nil)!
+        while let url = enumerator.nextObject() as? URL {
+            if url.pathExtension == "safetensors" {
+                let w = try loadArrays(url: url)
+                for (key, value) in w {
+                    weights[key] = value
+                }
+            }
+        }
+
+        logger.info("Loaded \(weights.count) weight keys from safetensors")
+
+        // 6. Convert AutoAWQ format → MLX format (BEFORE sanitize)
+        if weights.keys.contains(where: { $0.hasSuffix(".qweight") }) {
+            convertAutoAWQ(&weights, groupSize: paroConfig.groupSize)
+            logger.info("Converted AutoAWQ weights to MLX format")
+        }
+
+        // 7. Model-specific sanitization
+        weights = model.sanitize(weights: weights)
+
+        // 8. Patch rotation layers
+        try patchRotationLayers(
+            model: model, weights: weights,
+            bits: paroConfig.bits, groupSize: paroConfig.groupSize
+        )
+
+        // 9. Quantize non-rotation layers in MLX quantized form
+        quantize(model: model) { path, module in
+            guard module is Quantizable else { return nil }
+            guard isCheckpointQuantizedLayer(path: path, weights: weights) else {
+                return nil
+            }
+            return (paroConfig.groupSize, paroConfig.bits, .affine)
+        }
+
+        // 10. Load checkpoint weights into the patched model
+        let parameters = ModuleParameters.unflattened(weights)
+        let verify: Module.VerifyUpdate = [.allModelKeysSet, .shapeMismatch]
+        try model.update(parameters: parameters, verify: verify)
+
+        // 11. Quantize IO embedding path from FP16 weights
+        quantize(model: model) { path, module in
+            guard isParoQuantIOLayer(path: path, module: module) else {
+                return nil
+            }
+            return (paroConfig.groupSize, paroConfig.bits, .affine)
+        }
+
+        // 12. Pre-rotate weights: bake rotation + channel_scales into quantized weights
+        let rotationModules = model.leafModules().flattened()
+            .compactMap { (_, module) in module as? RotateQuantizedLinear }
+        if !rotationModules.isEmpty {
+            logger.info(
+                "Pre-rotating weights for \(rotationModules.count) RotateQuantizedLinear layers"
+            )
+            for (i, module) in rotationModules.enumerated() {
+                try module.preRotateWeights()
+                if (i + 1) % 6 == 0 {
+                    Memory.clearCache()
+                }
+            }
+        }
+
+        // 13. Materialize
+        eval(model)
+        logger.info("ParoQuant model loaded and evaluated")
+
+        // 14. Save pre-rotated weight cache for fast subsequent loads.
+        // Failure is non-fatal — the directory may be read-only (e.g. bundled resources).
+        do {
+            var cacheWeights = [String: MLXArray]()
+            for (key, value) in model.parameters().flattened() {
+                // Skip rotation-specific keys (already baked into weights)
+                if key.hasSuffix(".theta") || key.hasSuffix(".pairs")
+                    || key.hasSuffix(".channel_scales")
+                {
+                    continue
+                }
+                cacheWeights[key] = value
+            }
+            eval(cacheWeights)
+            try save(arrays: cacheWeights, url: cacheURL)
+            logger.info("Saved pre-rotated weight cache (\(cacheWeights.count) keys)")
+        } catch {
+            logger.warning("Failed to save weight cache: \(error)")
+        }
+    }
+
+    // 13. Load tokenizer
+    let tokenizer = try await loadTokenizer(configuration: config, hub: defaultHubApi)
+
+    // 14. Create processor with messageGenerator
+    // Use DefaultMessageGenerator — LLMModel.messageGenerator(tokenizer:) is in MLXLLM
+    // and this loader lives in MLXLMCommon. Callers who need custom message generation
+    // can swap the processor after loading.
+    let messageGenerator: MessageGenerator = DefaultMessageGenerator()
+    let processor = ParoQuantInputProcessor(
+        tokenizer: tokenizer, configuration: config,
+        messageGenerator: messageGenerator
+    )
+
+    // 15. Assemble ModelContext → ModelContainer
+    let context = ModelContext(
+        configuration: config, model: model,
+        processor: processor, tokenizer: tokenizer
+    )
+    return ModelContainer(context: context)
+}
+
+// MARK: - Errors
+
+public enum ParoQuantError: LocalizedError {
+    case missingConfig
+    case unsupportedModel
+    case missingTensor(String)
+    case invalidTensorShape(key: String, expected: [Int], actual: [Int])
+    case rotationLayerNotFound(String)
+    case rotationLayerTypeMismatch(path: String, actualType: String)
+    case rotationLayerPatchFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingConfig:
+            return "Missing quantization_config in config.json for ParoQuant model"
+        case .unsupportedModel:
+            return "The custom ParoQuant loader only supports z-lab/Qwen3.5-4B-PARO"
+        case .missingTensor(let key):
+            return "Missing required ParoQuant tensor: \(key)"
+        case .invalidTensorShape(let key, let expected, let actual):
+            return "Invalid ParoQuant tensor shape for \(key): expected \(expected), got \(actual)"
+        case .rotationLayerNotFound(let path):
+            return "Unable to find ParoQuant rotation layer in model: \(path)"
+        case .rotationLayerTypeMismatch(let path, let actualType):
+            return
+                "ParoQuant rotation layer \(path) is not a Linear-compatible module: \(actualType)"
+        case .rotationLayerPatchFailed(let path):
+            return "Failed to replace ParoQuant layer with RotateQuantizedLinear: \(path)"
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -94,6 +94,28 @@ private func packMLX(_ w: MLXArray) -> MLXArray {
     return packed
 }
 
+/// Split pre-fused `in_proj_ba` tensors back into separate `in_proj_b` / `in_proj_a`
+/// entries. PARO and some AutoAWQ-Mamba checkpoints concatenate the B and A
+/// projections along the output axis before quantising; the architecture code
+/// (e.g. `Qwen35TextModel`) expects them as distinct projections. Runs before
+/// model-specific `sanitize` so downstream layers see the standard layout.
+///
+/// No-op for keys that don't exist (non-Mamba PARO checkpoints) and for keys
+/// that already have an `in_proj_b` entry (idempotent on repeat calls).
+private func splitFusedMambaProjections(_ weights: inout [String: MLXArray]) {
+    for k in Array(weights.keys) where k.hasSuffix(".in_proj_ba.weight") {
+        let prefix = String(k.dropLast(".in_proj_ba.weight".count))
+        guard weights["\(prefix).in_proj_b.weight"] == nil else { continue }
+        for suffix in [".weight", ".scales", ".biases", ".bias"] {
+            let baKey = "\(prefix).in_proj_ba\(suffix)"
+            guard let baVal = weights.removeValue(forKey: baKey) else { continue }
+            let half = baVal.dim(0) / 2
+            weights["\(prefix).in_proj_b\(suffix)"] = baVal[0 ..< half]
+            weights["\(prefix).in_proj_a\(suffix)"] = baVal[half...]
+        }
+    }
+}
+
 /// Convert AutoAWQ checkpoint weights to MLX quantized format in-place.
 private func convertAutoAWQ(
     _ weights: inout [String: MLXArray], groupSize: Int
@@ -394,6 +416,12 @@ public func loadParoQuantModel(
         convertAutoAWQ(&weights, groupSize: paroConfig.groupSize)
         logger.info("Converted AutoAWQ weights to MLX format")
     }
+
+    // 6b. Split fused Mamba `in_proj_ba` into `in_proj_b` / `in_proj_a`.
+    //     PARO-specific layout detail, so it lives here rather than in the
+    //     generic Qwen35 sanitize. Runs before `model.sanitize` so downstream
+    //     layers see the already-split keys.
+    splitFusedMambaProjections(&weights)
 
     // 7. Model-specific sanitization
     weights = model.sanitize(weights: weights)

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -58,24 +58,26 @@ private enum AWQ {
     static let bits = 4
     static let packFactor = 32 / bits  // 8 values per uint32
     static let mask: Int32 = (1 << bits) - 1
-    static let shifts: [Int32] = (0 ..< 8).map { Int32($0 * bits) }
     /// Inverse of AutoAWQ reorder [0,2,4,6,1,3,5,7] → [0,4,1,5,2,6,3,7]
     static let inverseReorder = [0, 4, 1, 5, 2, 6, 3, 7]
-
-    // Pre-computed MLXArrays (created once, reused across calls)
-    nonisolated(unsafe) static let shiftsArray = MLXArray(shifts.map { Int64($0) }).reshaped(
-        1, 1, 8)
-    nonisolated(unsafe) static let reorderIndices = MLXArray(inverseReorder.map { Int32($0) })
 }
 
 /// Unpack AutoAWQ int32 → raw uint8 values, undoing the [0,2,4,6,1,3,5,7] reorder.
+///
+/// The shift table and reorder indices are rebuilt per call rather than cached
+/// as module-level statics — they're tiny (8 × 8 bytes) and only touched at
+/// model load time, so caching bought nothing and only created thread-safety
+/// concerns around unevaluated `MLXArray`s (PR #164 review comment C2).
 private func unpackAndReorder(_ packed: MLXArray) -> MLXArray {
     let rows = packed.dim(0)
     let cols = packed.dim(1)
 
+    let shifts = MLXArray((0 ..< 8).map { Int64($0 * AWQ.bits) }).reshaped(1, 1, 8)
+    let reorderIndices = MLXArray(AWQ.inverseReorder.map { Int32($0) })
+
     let expanded = packed.asType(.int64).expandedDimensions(axis: 2)
-    let raw = ((expanded >> AWQ.shiftsArray) & Int64(AWQ.mask)).asType(.uint8)
-    let reordered = raw.take(AWQ.reorderIndices, axis: 2)
+    let raw = ((expanded >> shifts) & Int64(AWQ.mask)).asType(.uint8)
+    let reordered = raw.take(reorderIndices, axis: 2)
 
     return reordered.reshaped(rows, cols * 8)
 }

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -146,21 +146,20 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
     let pairs: MLXArray
     @ParameterInfo(key: "channel_scales") var channelScales: MLXArray
 
-    /// Pre-computed rotation data, lazily initialized on first forward pass.
-    private struct CachedRotation {
-        let cos: MLXArray
-        let sin: MLXArray
-        let packedPairs: MLXArray
-        let scalesFlat: MLXArray
-        let dim: Int
-        let halfGroup: Int
-        let numGroups: Int
-        let krot: Int
-    }
-
-    private var cached: CachedRotation?
-    private var cachedParams: MLXArray?
-    private var cachedBatch: Int = -1
+    // Rotation-derived state. Populated once by `prepareDerivedRotationState()`
+    // after the checkpoint parameters are loaded (see ParoQuantLoader), and
+    // never mutated afterwards. Underscore-prefixed private properties are
+    // ignored by Module reflection — see Documentation.docc/porting.md
+    // "Computed vs Loaded Parameters" — so they don't participate in weight
+    // loading, which keeps the loader's strict `verify: [.allModelKeysSet]`
+    // contract intact.
+    //
+    // Kept out of the forward pass's `eval` graph by materialising them
+    // explicitly inside `prepareDerivedRotationState()`.
+    private var _cosTheta: MLXArray
+    private var _sinTheta: MLXArray
+    private var _packedPairs: MLXArray
+    private var _scalesFlat: MLXArray
 
     public init(
         inputDims: Int, outputDims: Int, hasBias: Bool,
@@ -176,6 +175,15 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
         // fails with `keyNotFound`. Pattern matches `LoRA+Layers.swift`.
         self._channelScales.wrappedValue = MLXArray.ones([1, inputDims])
 
+        // Placeholder values — `prepareDerivedRotationState()` overwrites
+        // these with real derived tensors after checkpoint load. Shapes are
+        // correct so a forward pass before finalize would be degenerate
+        // (identity-ish rotation) rather than crash.
+        self._cosTheta = MLXArray.ones([krot, inputDims / 2])
+        self._sinTheta = MLXArray.zeros([krot, inputDims / 2])
+        self._packedPairs = MLXArray.zeros([krot, inputDims / 2], type: Int32.self)
+        self._scalesFlat = MLXArray.ones([inputDims])
+
         super.init(
             weight: MLXArray.zeros([outputDims, inputDims * bits / 32], type: UInt32.self),
             bias: hasBias ? MLXArray.zeros([outputDims]) : nil,
@@ -186,47 +194,48 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
         )
     }
 
-    private func ensureCached() -> CachedRotation {
-        if let c = cached { return c }
-        let dim = theta.dim(1) * 2
-        let cosTheta = MLX.cos(theta)
-        let sinTheta = MLX.sin(theta)
-        let packed = packPairs(pairs, groupSize: groupSize)
-        let flat = channelScales.reshaped(-1)
-
-        // Force GPU materialization so rotation constants are resident
-        // and not recomputed as part of each forward pass graph.
-        eval(cosTheta, sinTheta, packed, flat)
-
-        let c = CachedRotation(
-            cos: cosTheta,
-            sin: sinTheta,
-            packedPairs: packed,
-            scalesFlat: flat,
-            dim: dim,
-            halfGroup: groupSize / 2,
-            numGroups: dim / groupSize,
-            krot: theta.dim(0)
-        )
-        cached = c
-        return c
+    /// Compute rotation-derived tensors from the loaded checkpoint parameters.
+    ///
+    /// Must be called once, after `update(parameters:)` populates
+    /// `theta` / `pairs` / `channelScales`, and before any forward pass.
+    /// Must not be called concurrently with forward passes — the loader
+    /// owns this call, nothing else should.
+    ///
+    /// Each forward pass previously generated this state lazily on first
+    /// call and cached it in a mutable `CachedRotation?` field. That pattern
+    /// is unsafe under multi-threaded inference (issue #157 — a shared model
+    /// container is driven by multiple tasks simultaneously), so derivation
+    /// is now done explicitly at load time.
+    ///
+    /// The four derived arrays are `eval(...)`ed here because underscore-
+    /// prefixed private fields are invisible to Module reflection — the
+    /// loader's later `eval(model)` walks `@ParameterInfo` tensors only, so
+    /// these would otherwise stay unmaterialised promises until the first
+    /// forward pass, and materialisation would then become part of that
+    /// pass's graph (exactly the eval-time state we're eliminating).
+    public func prepareDerivedRotationState() {
+        _cosTheta = MLX.cos(theta)
+        _sinTheta = MLX.sin(theta)
+        _packedPairs = packPairs(pairs, groupSize: groupSize)
+        _scalesFlat = channelScales.reshaped(-1)
+        eval(_cosTheta, _sinTheta, _packedPairs, _scalesFlat)
     }
 
-    private func rotate(_ x: MLXArray, cache c: CachedRotation) -> MLXArray {
+    private func rotate(_ x: MLXArray) -> MLXArray {
+        let dim = _scalesFlat.dim(0)
+        let halfGroup = groupSize / 2
+        let numGroups = dim / groupSize
+        let krot = theta.dim(0)
+
         let batch = x.dim(0)
         let tile = batch <= 1 ? 1 : 4
+        let gridX = ((batch + tile - 1) / tile) * halfGroup
+        let params = MLXArray([Int32(batch), Int32(dim), Int32(krot), Int32(groupSize)])
 
-        // Cache params array — batch rarely changes during autoregressive generation
-        if batch != cachedBatch {
-            cachedParams = MLXArray([Int32(batch), Int32(c.dim), Int32(c.krot), Int32(groupSize)])
-            cachedBatch = batch
-        }
-
-        let gridX = ((batch + tile - 1) / tile) * c.halfGroup
         return getRotationKernel(tile: tile)(
-            [x, c.packedPairs, c.cos, c.sin, c.scalesFlat, cachedParams!],
-            grid: (gridX, c.numGroups, 1),
-            threadGroup: (c.halfGroup, 1, 1),
+            [x, _packedPairs, _cosTheta, _sinTheta, _scalesFlat, params],
+            grid: (gridX, numGroups, 1),
+            threadGroup: (halfGroup, 1, 1),
             outputShapes: [x.shape],
             outputDTypes: [x.dtype]
         )[0]
@@ -235,11 +244,11 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
     /// Forward pass: applies pairwise Givens rotation then quantized matmul.
     ///
     /// Computes `y = quantizedMM(rotate(x), W)` where `rotate(x)` fuses channel
-    /// scaling and Givens rotations in a single Metal kernel.
+    /// scaling and Givens rotations in a single Metal kernel. No mutable
+    /// state is read or written by this method.
     open override func callAsFunction(_ x: MLXArray) -> MLXArray {
-        let c = ensureCached()
         let shape = x.shape
-        let rotated = rotate(x.reshaped(-1, c.dim), cache: c)
+        let rotated = rotate(x.reshaped(-1, _scalesFlat.dim(0)))
 
         var y = quantizedMM(
             rotated.reshaped(shape), weight,

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -1,5 +1,3 @@
-// Copyright © 2025 INQTR. All rights reserved.
-
 import Foundation
 import MLX
 import MLXNN

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -304,6 +304,19 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
         preRotated = true
     }
 
+    /// Forward pass: applies pairwise Givens rotation then quantized matmul.
+    ///
+    /// Standard path computes `y = quantizedMM(rotate(x), W)` where
+    /// `rotate(x) = R @ diag(channel_scales) @ x` fuses channel scaling and
+    /// Givens rotations in a single Metal kernel.
+    ///
+    /// - Note: The stored weights are quantized in the rotated+scaled space:
+    ///   `W_q = Q(R @ diag(s) @ W_train)`. This means the effective computation
+    ///   is `x @ diag(s²) @ W_train^T` rather than `x @ W_train^T`. The `diag(s²)`
+    ///   factor is compensated during the original ParoQuant optimization, which
+    ///   jointly trains W, θ, and s to match the pretrained model's layer outputs.
+    ///   This is an inherent property of the algorithm (present in the reference
+    ///   Python implementation as well), not a bug in this port.
     open override func callAsFunction(_ x: MLXArray) -> MLXArray {
         if preRotated {
             // Fast path: weights already include rotation + channel_scales

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -139,10 +139,12 @@ nonisolated private func packPairs(_ pairs: MLXArray, groupSize: Int) -> MLXArra
 /// the quantization-friendly properties of the original weights.
 nonisolated open class RotateQuantizedLinear: QuantizedLinear {
 
-    // Rotation parameters — discovered by Module reflection for update(parameters:)
+    // Rotation parameters — discovered by Module reflection for update(parameters:).
+    // `channelScales` uses @ParameterInfo so it can keep the snake_case checkpoint
+    // key while having a Swift-idiomatic property name.
     let theta: MLXArray
     let pairs: MLXArray
-    let channel_scales: MLXArray  // swiftlint:disable:this identifier_name
+    @ParameterInfo(key: "channel_scales") var channelScales: MLXArray
 
     /// Pre-computed rotation data, lazily initialized on first forward pass.
     private struct CachedRotation {
@@ -166,7 +168,13 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
     ) {
         self.theta = MLXArray.zeros([krot, inputDims / 2])
         self.pairs = MLXArray.zeros([krot, inputDims], type: Int16.self)
-        self.channel_scales = MLXArray.ones([1, inputDims])
+        // Assign through `.wrappedValue` so the `@ParameterInfo(key:)` metadata
+        // survives init. Replacing the wrapper with `.init(wrappedValue:)` drops
+        // the `key: "channel_scales"` annotation — Module reflection then looks
+        // up the parameter by the Swift property name `channelScales`, which
+        // doesn't exist in the checkpoint, and `update(parameters:verify:)`
+        // fails with `keyNotFound`. Pattern matches `LoRA+Layers.swift`.
+        self._channelScales.wrappedValue = MLXArray.ones([1, inputDims])
 
         super.init(
             weight: MLXArray.zeros([outputDims, inputDims * bits / 32], type: UInt32.self),
@@ -184,7 +192,7 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
         let cosTheta = MLX.cos(theta)
         let sinTheta = MLX.sin(theta)
         let packed = packPairs(pairs, groupSize: groupSize)
-        let flat = channel_scales.reshaped(-1)
+        let flat = channelScales.reshaped(-1)
 
         // Force GPU materialization so rotation constants are resident
         // and not recomputed as part of each forward pass graph.

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -131,8 +131,8 @@ nonisolated private func packPairs(_ pairs: MLXArray, groupSize: Int) -> MLXArra
 /// via `update(modules:)`. Only overrides `callAsFunction` to insert the rotation
 /// step before the standard quantized matmul.
 ///
-/// After `preRotateWeights()` is called, the rotation is baked into the weights
-/// and runtime is identical to a plain QuantizedLinear (no rotation kernel dispatch).
+/// Rotation is applied to activations at runtime via a Metal kernel, preserving
+/// the quantization-friendly properties of the original weights.
 nonisolated open class RotateQuantizedLinear: QuantizedLinear {
 
     // Rotation parameters — discovered by Module reflection for update(parameters:)
@@ -155,9 +155,6 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
     private var cached: CachedRotation?
     private var cachedParams: MLXArray?
     private var cachedBatch: Int = -1
-
-    /// When true, weights have been pre-rotated and callAsFunction skips the rotation kernel.
-    private var preRotated = false
 
     public init(
         inputDims: Int, outputDims: Int, hasBias: Bool,
@@ -223,113 +220,11 @@ nonisolated open class RotateQuantizedLinear: QuantizedLinear {
         )[0]
     }
 
-    /// Pre-rotate weights at load time to eliminate per-token rotation kernel dispatches.
-    ///
-    /// Transforms: `y = quantizedMM(rotate(x), W)` → `y = quantizedMM(x, W_pre)`
-    /// where `W_pre` incorporates both channel_scales and the Givens rotation.
-    ///
-    /// The rotation matrix is block-diagonal (independent per group), so we build it
-    /// group-by-group to keep memory usage at O(group_size²) per group.
-    public func preRotateWeights() throws {
-        let c = ensureCached()
-        let dim = c.dim
-        let gs = groupSize
-        let numGroups = c.numGroups
-
-        // 1. Dequantize current weights to float16
-        let wFloat = dequantized(
-            weight, scales: scales, biases: biases,
-            groupSize: gs, bits: bits
-        )
-        // wFloat is [outputDims, inputDims] in float16
-
-        // 2. Build rotation matrix group-by-group and pre-rotate columns of W.
-        //    rotate(I_g) computes the rotation+scale block for group g.
-        //    W_pre[:, g] = wFloat[:, g] @ block_g^T
-        var preRotatedGroups = [MLXArray]()
-        preRotatedGroups.reserveCapacity(numGroups)
-
-        for g in 0 ..< numGroups {
-            let colStart = g * gs
-            let colEnd = colStart + gs
-
-            // Build [gs, dim] input: identity block at columns [colStart, colEnd), zeros elsewhere
-            let eye = MLXArray.identity(gs).asType(.float16)
-            if colStart == 0 && colEnd == dim {
-                // Single group spans entire dim
-                let rotated = rotate(eye, cache: c)
-                let wCols = wFloat[0..., colStart ..< colEnd]
-                preRotatedGroups.append(matmul(wCols, rotated.transposed()))
-            } else {
-                let leftPad =
-                    colStart > 0
-                    ? MLXArray.zeros([gs, colStart], dtype: .float16) : nil
-                let rightPad =
-                    colEnd < dim
-                    ? MLXArray.zeros([gs, dim - colEnd], dtype: .float16) : nil
-                var parts = [MLXArray]()
-                if let leftPad { parts.append(leftPad) }
-                parts.append(eye)
-                if let rightPad { parts.append(rightPad) }
-                let groupInput = concatenated(parts, axis: 1)
-
-                let rotated = rotate(groupInput, cache: c)
-                let block = rotated[0..., colStart ..< colEnd]
-
-                let wCols = wFloat[0..., colStart ..< colEnd]
-                preRotatedGroups.append(matmul(wCols, block.transposed()))
-            }
-
-            // Eval every few groups to bound computation graph size
-            if (g + 1) % 8 == 0 || g == numGroups - 1 {
-                eval(preRotatedGroups)
-            }
-        }
-
-        // 3. Reassemble the full pre-rotated weight matrix
-        let wPre = concatenated(preRotatedGroups, axis: 1)
-        eval(wPre)
-
-        // 4. Re-quantize
-        let (wq, sc, bi) = quantized(wPre, groupSize: gs, bits: bits)
-
-        // 5. Update the QuantizedLinear properties
-        let params: [String: MLXArray] = [
-            "weight": wq,
-            "scales": sc,
-            "biases": bi ?? MLXArray.zeros(scales.shape),
-        ]
-        try self.update(parameters: ModuleParameters.unflattened(params), verify: [])
-
-        preRotated = true
-    }
-
     /// Forward pass: applies pairwise Givens rotation then quantized matmul.
     ///
-    /// Standard path computes `y = quantizedMM(rotate(x), W)` where
-    /// `rotate(x) = R @ diag(channel_scales) @ x` fuses channel scaling and
-    /// Givens rotations in a single Metal kernel.
-    ///
-    /// - Note: The stored weights are quantized in the rotated+scaled space:
-    ///   `W_q = Q(R @ diag(s) @ W_train)`. This means the effective computation
-    ///   is `x @ diag(s²) @ W_train^T` rather than `x @ W_train^T`. The `diag(s²)`
-    ///   factor is compensated during the original ParoQuant optimization, which
-    ///   jointly trains W, θ, and s to match the pretrained model's layer outputs.
-    ///   This is an inherent property of the algorithm (present in the reference
-    ///   Python implementation as well), not a bug in this port.
+    /// Computes `y = quantizedMM(rotate(x), W)` where `rotate(x)` fuses channel
+    /// scaling and Givens rotations in a single Metal kernel.
     open override func callAsFunction(_ x: MLXArray) -> MLXArray {
-        if preRotated {
-            // Fast path: weights already include rotation + channel_scales
-            var y = quantizedMM(
-                x, weight,
-                scales: scales, biases: biases,
-                transpose: true, groupSize: groupSize, bits: bits
-            )
-            if let bias { y = y + bias }
-            return y
-        }
-
-        // Standard path: apply rotation kernel then quantized matmul
         let c = ensureCached()
         let shape = x.shape
         let rotated = rotate(x.reshaped(-1, c.dim), cache: c)

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -83,24 +83,30 @@ nonisolated private func metalSource(
 
 // MARK: - Kernel Cache
 
-/// Cached compiled Metal kernels keyed by tile size.
-/// `nonisolated(unsafe)` — kernel creation is idempotent (same tile size always produces
-/// the same compiled kernel), so concurrent stores are benign. Same pattern as
-/// `GatedDeltaKernelManager` in the existing codebase.
+/// Cached compiled Metal kernels keyed by tile size, guarded by `kernelCacheLock`.
+/// Callers are multi-threaded (each `ModelContainer.perform` closure can run on its
+/// own task), so the dictionary read-modify-write is serialised. Contention is
+/// practically nil — only two tile sizes (1 and 4) are ever requested, so the lock
+/// is contended exactly twice per process before steady-state hits.
 nonisolated(unsafe) private var kernelCache: [Int: MLXFast.MLXFastKernel] = [:]
+private let kernelCacheLock = NSLock()
 
 nonisolated private func getRotationKernel(tile: Int) -> MLXFast.MLXFastKernel {
-    if let cached = kernelCache[tile] {
-        return cached
+    kernelCacheLock.withLock {
+        if let cached = kernelCache[tile] {
+            return cached
+        }
+        let kernel = MLXFast.metalKernel(
+            name: "paro_rotate_r\(tile)",
+            inputNames: [
+                "x", "packed_pairs", "cos_theta", "sin_theta", "channel_scales", "params",
+            ],
+            outputNames: ["out"],
+            source: metalSource(rowsPerTile: tile)
+        )
+        kernelCache[tile] = kernel
+        return kernel
     }
-    let kernel = MLXFast.metalKernel(
-        name: "paro_rotate_r\(tile)",
-        inputNames: ["x", "packed_pairs", "cos_theta", "sin_theta", "channel_scales", "params"],
-        outputNames: ["out"],
-        source: metalSource(rowsPerTile: tile)
-    )
-    kernelCache[tile] = kernel
-    return kernel
 }
 
 // MARK: - Pair Packing

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -1,0 +1,332 @@
+// Copyright © 2025 INQTR. All rights reserved.
+
+import Foundation
+import MLX
+import MLXNN
+
+// MARK: - Metal Kernel Source
+
+/// Pairwise Givens rotation kernel for Metal (Apple Silicon).
+/// Template parameters are substituted at compile time.
+nonisolated private func metalSource(
+    rowsPerTile: Int, maxGroupSize: Int = 128, maxKrot: Int = 16
+) -> String {
+    """
+    constexpr int ROWS_PER_TILE = \(rowsPerTile);
+    constexpr int MAX_KROT      = \(maxKrot);
+
+    const int batch_size  = params[0];
+    const int hidden_size = params[1];
+    const int krot        = params[2];
+    const int group_size  = params[3];
+
+    const int half_gs     = group_size / 2;
+    const int half_hidden = hidden_size / 2;
+
+    const int tile_idx  = threadgroup_position_in_grid.x;
+    const int group_idx = threadgroup_position_in_grid.y;
+    const int tid       = thread_index_in_threadgroup;
+
+    if (tid >= half_gs) return;
+
+    // Load rotation coefficients into registers
+    float cos_vals[MAX_KROT], sin_vals[MAX_KROT];
+    int   pair_vals[MAX_KROT];
+
+    for (int k = 0; k < krot; k++) {
+        int idx = k * half_hidden + group_idx * half_gs + tid;
+        cos_vals[k]  = float(cos_theta[idx]);
+        sin_vals[k]  = float(sin_theta[idx]);
+        pair_vals[k] = int(packed_pairs[idx]);
+    }
+
+    // Load activation tile into shared memory (fuse channel scales)
+    threadgroup float tile[\(maxGroupSize) * ROWS_PER_TILE];
+
+    const int ch_lo = group_idx * group_size + tid;
+    const int ch_hi = ch_lo + half_gs;
+    float scale_lo = float(channel_scales[ch_lo]);
+    float scale_hi = float(channel_scales[ch_hi]);
+
+    for (int r = 0; r < ROWS_PER_TILE; r++) {
+        int row = tile_idx * ROWS_PER_TILE + r;
+        if (row < batch_size) {
+            tile[tid * ROWS_PER_TILE + r]              = float(x[row * hidden_size + ch_lo]) * scale_lo;
+            tile[(tid + half_gs) * ROWS_PER_TILE + r]  = float(x[row * hidden_size + ch_hi]) * scale_hi;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Apply pairwise Givens rotations in-place
+    for (int k = 0; k < krot; k++) {
+        int i_local = pair_vals[k] & 0xFFFF;
+        int j_local = pair_vals[k] >> 16;
+        float c = cos_vals[k], s = sin_vals[k];
+
+        for (int m = 0; m < ROWS_PER_TILE; m++) {
+            float a = tile[i_local * ROWS_PER_TILE + m];
+            float b = tile[j_local * ROWS_PER_TILE + m];
+            tile[i_local * ROWS_PER_TILE + m] = a * c + b * s;
+            tile[j_local * ROWS_PER_TILE + m] = b * c - a * s;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Write results back
+    for (int r = 0; r < ROWS_PER_TILE; r++) {
+        int row = tile_idx * ROWS_PER_TILE + r;
+        if (row < batch_size) {
+            out[row * hidden_size + ch_lo] = tile[tid * ROWS_PER_TILE + r];
+            out[row * hidden_size + ch_hi] = tile[(tid + half_gs) * ROWS_PER_TILE + r];
+        }
+    }
+    """
+}
+
+// MARK: - Kernel Cache
+
+/// Cached compiled Metal kernels keyed by tile size.
+/// `nonisolated(unsafe)` — kernel creation is idempotent (same tile size always produces
+/// the same compiled kernel), so concurrent stores are benign. Same pattern as
+/// `GatedDeltaKernelManager` in the existing codebase.
+nonisolated(unsafe) private var kernelCache: [Int: MLXFast.MLXFastKernel] = [:]
+
+nonisolated private func getRotationKernel(tile: Int) -> MLXFast.MLXFastKernel {
+    if let cached = kernelCache[tile] {
+        return cached
+    }
+    let kernel = MLXFast.metalKernel(
+        name: "paro_rotate_r\(tile)",
+        inputNames: ["x", "packed_pairs", "cos_theta", "sin_theta", "channel_scales", "params"],
+        outputNames: ["out"],
+        source: metalSource(rowsPerTile: tile)
+    )
+    kernelCache[tile] = kernel
+    return kernel
+}
+
+// MARK: - Pair Packing
+
+/// Pack int16 pair indices into int32 for the Metal kernel.
+///
+/// Each pair `(i, j)` is packed as `i | (j << 16)` within each group.
+nonisolated private func packPairs(_ pairs: MLXArray, groupSize: Int) -> MLXArray {
+    let krot = pairs.dim(0)
+    let numGroups = pairs.dim(1) / groupSize
+
+    // Reshape to [krot, numGroups, groupSize]
+    let p = pairs.reshaped(krot, numGroups, groupSize).asType(.int32)
+
+    // Even indices (lo) and odd indices (hi) within each group
+    let lo = p[0..., 0..., .stride(by: 2)]
+    let hi = p[0..., 0..., .stride(from: 1, by: 2)]
+    return (lo | (hi << 16)).reshaped(krot, -1)
+}
+
+// MARK: - RotateQuantizedLinear
+
+/// Pairwise Givens rotation + quantized matmul.
+///
+/// Subclasses `QuantizedLinear` so it can replace `Linear` in `@ModuleInfo` slots
+/// via `update(modules:)`. Only overrides `callAsFunction` to insert the rotation
+/// step before the standard quantized matmul.
+///
+/// After `preRotateWeights()` is called, the rotation is baked into the weights
+/// and runtime is identical to a plain QuantizedLinear (no rotation kernel dispatch).
+nonisolated open class RotateQuantizedLinear: QuantizedLinear {
+
+    // Rotation parameters — discovered by Module reflection for update(parameters:)
+    let theta: MLXArray
+    let pairs: MLXArray
+    let channel_scales: MLXArray  // swiftlint:disable:this identifier_name
+
+    /// Pre-computed rotation data, lazily initialized on first forward pass.
+    private struct CachedRotation {
+        let cos: MLXArray
+        let sin: MLXArray
+        let packedPairs: MLXArray
+        let scalesFlat: MLXArray
+        let dim: Int
+        let halfGroup: Int
+        let numGroups: Int
+        let krot: Int
+    }
+
+    private var cached: CachedRotation?
+    private var cachedParams: MLXArray?
+    private var cachedBatch: Int = -1
+
+    /// When true, weights have been pre-rotated and callAsFunction skips the rotation kernel.
+    private var preRotated = false
+
+    public init(
+        inputDims: Int, outputDims: Int, hasBias: Bool,
+        groupSize: Int, bits: Int, krot: Int
+    ) {
+        self.theta = MLXArray.zeros([krot, inputDims / 2])
+        self.pairs = MLXArray.zeros([krot, inputDims], type: Int16.self)
+        self.channel_scales = MLXArray.ones([1, inputDims])
+
+        super.init(
+            weight: MLXArray.zeros([outputDims, inputDims * bits / 32], type: UInt32.self),
+            bias: hasBias ? MLXArray.zeros([outputDims]) : nil,
+            scales: MLXArray.zeros([outputDims, inputDims / groupSize]),
+            biases: MLXArray.zeros([outputDims, inputDims / groupSize]),
+            groupSize: groupSize,
+            bits: bits
+        )
+    }
+
+    private func ensureCached() -> CachedRotation {
+        if let c = cached { return c }
+        let dim = theta.dim(1) * 2
+        let cosTheta = MLX.cos(theta)
+        let sinTheta = MLX.sin(theta)
+        let packed = packPairs(pairs, groupSize: groupSize)
+        let flat = channel_scales.reshaped(-1)
+
+        // Force GPU materialization so rotation constants are resident
+        // and not recomputed as part of each forward pass graph.
+        eval(cosTheta, sinTheta, packed, flat)
+
+        let c = CachedRotation(
+            cos: cosTheta,
+            sin: sinTheta,
+            packedPairs: packed,
+            scalesFlat: flat,
+            dim: dim,
+            halfGroup: groupSize / 2,
+            numGroups: dim / groupSize,
+            krot: theta.dim(0)
+        )
+        cached = c
+        return c
+    }
+
+    private func rotate(_ x: MLXArray, cache c: CachedRotation) -> MLXArray {
+        let batch = x.dim(0)
+        let tile = batch <= 1 ? 1 : 4
+
+        // Cache params array — batch rarely changes during autoregressive generation
+        if batch != cachedBatch {
+            cachedParams = MLXArray([Int32(batch), Int32(c.dim), Int32(c.krot), Int32(groupSize)])
+            cachedBatch = batch
+        }
+
+        let gridX = ((batch + tile - 1) / tile) * c.halfGroup
+        return getRotationKernel(tile: tile)(
+            [x, c.packedPairs, c.cos, c.sin, c.scalesFlat, cachedParams!],
+            grid: (gridX, c.numGroups, 1),
+            threadGroup: (c.halfGroup, 1, 1),
+            outputShapes: [x.shape],
+            outputDTypes: [x.dtype]
+        )[0]
+    }
+
+    /// Pre-rotate weights at load time to eliminate per-token rotation kernel dispatches.
+    ///
+    /// Transforms: `y = quantizedMM(rotate(x), W)` → `y = quantizedMM(x, W_pre)`
+    /// where `W_pre` incorporates both channel_scales and the Givens rotation.
+    ///
+    /// The rotation matrix is block-diagonal (independent per group), so we build it
+    /// group-by-group to keep memory usage at O(group_size²) per group.
+    public func preRotateWeights() throws {
+        let c = ensureCached()
+        let dim = c.dim
+        let gs = groupSize
+        let numGroups = c.numGroups
+
+        // 1. Dequantize current weights to float16
+        let wFloat = dequantized(
+            weight, scales: scales, biases: biases,
+            groupSize: gs, bits: bits
+        )
+        // wFloat is [outputDims, inputDims] in float16
+
+        // 2. Build rotation matrix group-by-group and pre-rotate columns of W.
+        //    rotate(I_g) computes the rotation+scale block for group g.
+        //    W_pre[:, g] = wFloat[:, g] @ block_g^T
+        var preRotatedGroups = [MLXArray]()
+        preRotatedGroups.reserveCapacity(numGroups)
+
+        for g in 0 ..< numGroups {
+            let colStart = g * gs
+            let colEnd = colStart + gs
+
+            // Build [gs, dim] input: identity block at columns [colStart, colEnd), zeros elsewhere
+            let eye = MLXArray.identity(gs).asType(.float16)
+            if colStart == 0 && colEnd == dim {
+                // Single group spans entire dim
+                let rotated = rotate(eye, cache: c)
+                let wCols = wFloat[0..., colStart ..< colEnd]
+                preRotatedGroups.append(matmul(wCols, rotated.transposed()))
+            } else {
+                let leftPad =
+                    colStart > 0
+                    ? MLXArray.zeros([gs, colStart], dtype: .float16) : nil
+                let rightPad =
+                    colEnd < dim
+                    ? MLXArray.zeros([gs, dim - colEnd], dtype: .float16) : nil
+                var parts = [MLXArray]()
+                if let leftPad { parts.append(leftPad) }
+                parts.append(eye)
+                if let rightPad { parts.append(rightPad) }
+                let groupInput = concatenated(parts, axis: 1)
+
+                let rotated = rotate(groupInput, cache: c)
+                let block = rotated[0..., colStart ..< colEnd]
+
+                let wCols = wFloat[0..., colStart ..< colEnd]
+                preRotatedGroups.append(matmul(wCols, block.transposed()))
+            }
+
+            // Eval every few groups to bound computation graph size
+            if (g + 1) % 8 == 0 || g == numGroups - 1 {
+                eval(preRotatedGroups)
+            }
+        }
+
+        // 3. Reassemble the full pre-rotated weight matrix
+        let wPre = concatenated(preRotatedGroups, axis: 1)
+        eval(wPre)
+
+        // 4. Re-quantize
+        let (wq, sc, bi) = quantized(wPre, groupSize: gs, bits: bits)
+
+        // 5. Update the QuantizedLinear properties
+        let params: [String: MLXArray] = [
+            "weight": wq,
+            "scales": sc,
+            "biases": bi ?? MLXArray.zeros(scales.shape),
+        ]
+        try self.update(parameters: ModuleParameters.unflattened(params), verify: [])
+
+        preRotated = true
+    }
+
+    open override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        if preRotated {
+            // Fast path: weights already include rotation + channel_scales
+            var y = quantizedMM(
+                x, weight,
+                scales: scales, biases: biases,
+                transpose: true, groupSize: groupSize, bits: bits
+            )
+            if let bias { y = y + bias }
+            return y
+        }
+
+        // Standard path: apply rotation kernel then quantized matmul
+        let c = ensureCached()
+        let shape = x.shape
+        let rotated = rotate(x.reshaped(-1, c.dim), cache: c)
+
+        var y = quantizedMM(
+            rotated.reshaped(shape), weight,
+            scales: scales, biases: biases,
+            transpose: true, groupSize: groupSize, bits: bits
+        )
+        if let bias { y = y + bias }
+        return y
+    }
+}

--- a/Tests/MLXLMTests/ParoQuantTests.swift
+++ b/Tests/MLXLMTests/ParoQuantTests.swift
@@ -1,0 +1,285 @@
+// Copyright © 2025 INQTR. All rights reserved.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+public class ParoQuantTests: XCTestCase {
+
+    // MARK: - Pair Packing
+
+    func testPairPackingEncodesCorrectly() {
+        let groupSize = 8
+        let krot = 2
+        let dim = 16  // 2 groups of 8
+
+        // krot=0: [0,1,2,3,4,5,6,7, 0,1,2,3,4,5,6,7]
+        // krot=1: [7,6,5,4,3,2,1,0, 7,6,5,4,3,2,1,0]
+        let row0 = (0 ..< dim).map { Int16($0 % groupSize) }
+        let row1 = (0 ..< dim).map { Int16((groupSize - 1) - ($0 % groupSize)) }
+        let pairs = MLXArray(row0 + row1).reshaped(krot, dim)
+
+        let packed = packPairsForTesting(pairs, groupSize: groupSize)
+        XCTAssertEqual(packed.shape, [krot, dim / 2])
+
+        let values = packed.asArray(Int32.self)
+
+        // krot=0, group 0: pairs [0,1,2,3,4,5,6,7]
+        //   even=[0,2,4,6], odd=[1,3,5,7]  →  packed = lo | (hi << 16)
+        XCTAssertEqual(values[0] & 0xFFFF, 0)
+        XCTAssertEqual(values[0] >> 16, 1)
+        XCTAssertEqual(values[1] & 0xFFFF, 2)
+        XCTAssertEqual(values[1] >> 16, 3)
+        XCTAssertEqual(values[2] & 0xFFFF, 4)
+        XCTAssertEqual(values[2] >> 16, 5)
+        XCTAssertEqual(values[3] & 0xFFFF, 6)
+        XCTAssertEqual(values[3] >> 16, 7)
+
+        // krot=1, group 0: pairs [7,6,5,4,3,2,1,0]
+        //   even=[7,5,3,1], odd=[6,4,2,0]
+        let offset = dim / 2
+        XCTAssertEqual(values[offset + 0] & 0xFFFF, 7)
+        XCTAssertEqual(values[offset + 0] >> 16, 6)
+        XCTAssertEqual(values[offset + 1] & 0xFFFF, 5)
+        XCTAssertEqual(values[offset + 1] >> 16, 4)
+    }
+
+    func testPairPackingRoundTrip() {
+        let groupSize = 128
+        let krot = 8
+        let dim = 256
+
+        let pairs = makeRandomPairs(krot: krot, dim: dim, groupSize: groupSize)
+        let packed = packPairsForTesting(pairs, groupSize: groupSize)
+
+        let packedValues = packed.asArray(Int32.self)
+        let originalValues = pairs.asArray(Int16.self)
+
+        for k in 0 ..< krot {
+            for g in 0 ..< (dim / groupSize) {
+                for t in 0 ..< (groupSize / 2) {
+                    let packedIdx = k * (dim / 2) + g * (groupSize / 2) + t
+                    let lo = packedValues[packedIdx] & 0xFFFF
+                    let hi = packedValues[packedIdx] >> 16
+
+                    let evenIdx = k * dim + g * groupSize + t * 2
+                    let oddIdx = evenIdx + 1
+
+                    XCTAssertEqual(lo, Int32(originalValues[evenIdx]))
+                    XCTAssertEqual(hi, Int32(originalValues[oddIdx]))
+                }
+            }
+        }
+    }
+
+    // MARK: - AutoAWQ Conversion
+
+    /// Verifies bias = (-scales_f32 * zeros_f32).T.float16 using known values.
+    func testAWQBiasComputation() {
+        let outputDims = 4
+
+        // scales [4,1], NOT transposed yet (AWQ format)
+        let scalesData: [Float16] = [2.0, 4.0, 1.0, 0.5]
+        let scales = MLXArray(scalesData).reshaped(outputDims, 1)
+
+        // qzeros: all zero-points = 3 → packed as 0x33333333
+        let qzeros = MLXArray([UInt32(0x3333_3333)]).reshaped(1, 1)
+
+        let zeros = unpackAndReorderForTesting(qzeros).asType(.float32)
+        let zerosValues = zeros.asArray(Float.self)
+        for z in zerosValues {
+            XCTAssertEqual(z, 3.0, accuracy: 1e-6)
+        }
+
+        // biases = (-scales * zeros).T → [8, 4]
+        let biases = (-scales.asType(.float32) * zeros).transposed().asType(.float16)
+        XCTAssertEqual(biases.shape, [8, 4])
+
+        // biases[:, i] = -scales[i] * 3.0
+        let biasValues = biases.asArray(Float16.self)
+        let expected: [Float] = [-6.0, -12.0, -3.0, -1.5]
+        for j in 0 ..< 8 {
+            for (i, exp) in expected.enumerated() {
+                XCTAssertEqual(Float(biasValues[j * 4 + i]), exp, accuracy: 0.01)
+            }
+        }
+    }
+
+    func testAWQUnpackReorderPackRoundTrip() {
+        // All-zeros should unpack to all-zeros
+        let zeros = MLXArray([UInt32(0)]).reshaped(1, 1)
+        let unpackedValues = unpackAndReorderForTesting(zeros).asArray(UInt8.self)
+        for v in unpackedValues {
+            XCTAssertEqual(v, 0)
+        }
+
+        // AWQ stores nibbles in order [0,2,4,6,1,3,5,7].
+        // Pack sequential values 0..7 in that order and verify unpack recovers [0,1,2,...,7].
+        let awqPacked: UInt32 =
+            (0 << 0) | (2 << 4) | (4 << 8) | (6 << 12)
+            | (1 << 16) | (3 << 20) | (5 << 24) | (7 << 28)
+
+        let result = unpackAndReorderForTesting(MLXArray([awqPacked]).reshaped(1, 1))
+        let resultValues = result.asArray(UInt8.self)
+        XCTAssertEqual(resultValues.count, 8)
+        for i in 0 ..< 8 {
+            XCTAssertEqual(resultValues[i], UInt8(i), "Mismatch at index \(i)")
+        }
+    }
+
+    // MARK: - Rotation + Quantization Round-Trip
+
+    func testQuantizationRoundTrip() {
+        let w = MLXRandom.normal([32, 128]).asType(.float16)
+        let (wq, scales, biases) = quantized(w, groupSize: 64, bits: 4)
+        let wRecon = dequantized(wq, scales: scales, biases: biases, groupSize: 64, bits: 4)
+
+        let relError = relativeRMSError(w, wRecon)
+        XCTAssertLessThan(relError, 0.15, "Quantization round-trip error: \(relError)")
+    }
+
+    func testQuantizedMatmulApproximatesFullPrecision() {
+        let x = MLXRandom.normal([4, 128]).asType(.float16)
+        let w = MLXRandom.normal([64, 128]).asType(.float16)
+        eval(x, w)
+
+        let yRef = matmul(x, w.transposed())
+
+        let (wq, scales, biases) = quantized(w, groupSize: 64, bits: 4)
+        let yQuant = quantizedMM(
+            x, wq, scales: scales, biases: biases,
+            transpose: true, groupSize: 64, bits: 4
+        )
+
+        let relError = relativeRMSError(yRef, yQuant)
+        XCTAssertLessThan(relError, 0.15, "Quantized matmul error: \(relError)")
+    }
+
+    // MARK: - Pre-Rotation Equivalence
+
+    func testPreRotationEquivalence() throws {
+        let layer = try makeTestLayer(hasBias: false)
+        let x = MLXRandom.normal([4, 128]).asType(.float16)
+        eval(x)
+
+        // Output BEFORE pre-rotation (runtime rotation path)
+        let yBefore = layer(x)
+        eval(yBefore)
+
+        // Pre-rotate: bakes rotation into weights
+        try layer.preRotateWeights()
+        eval(layer)
+
+        // Output AFTER pre-rotation (fast path)
+        let yAfter = layer(x)
+        eval(yAfter)
+
+        // One extra quantization round → allow up to 25% relative error
+        let relError = relativeRMSError(yBefore, yAfter)
+        XCTAssertLessThan(relError, 0.25, "Pre-rotation equivalence error: \(relError)")
+    }
+
+    func testRotateQuantizedLinearProducesValidOutput() throws {
+        let layer = try makeTestLayer(hasBias: true)
+
+        let y1 = layer(MLXRandom.normal([1, 128]).asType(.float16))
+        eval(y1)
+        XCTAssertEqual(y1.shape, [1, 64])
+
+        let y1Values = y1.asType(.float32).asArray(Float.self)
+        XCTAssertTrue(y1Values.allSatisfy { $0.isFinite }, "Output contains non-finite values")
+        XCTAssertTrue(y1Values.contains { $0 != 0 }, "Output is all zeros")
+
+        let y4 = layer(MLXRandom.normal([4, 128]).asType(.float16))
+        eval(y4)
+        XCTAssertEqual(y4.shape, [4, 64])
+    }
+}
+
+// MARK: - Test Helpers
+
+private let testInDim = 128
+private let testOutDim = 64
+private let testGroupSize = 128
+private let testBits = 4
+private let testKrot = 2
+
+/// Creates a RotateQuantizedLinear layer with random weights and rotation parameters.
+private func makeTestLayer(hasBias: Bool) throws -> RotateQuantizedLinear {
+    let layer = RotateQuantizedLinear(
+        inputDims: testInDim, outputDims: testOutDim, hasBias: hasBias,
+        groupSize: testGroupSize, bits: testBits, krot: testKrot
+    )
+
+    let w = MLXRandom.normal([testOutDim, testInDim]).asType(.float16)
+    let (wq, scales, biases) = quantized(w, groupSize: testGroupSize, bits: testBits)
+
+    // Small rotation angles keep the rotation near identity
+    let theta = (MLXRandom.normal([testKrot, testInDim / 2]) * 0.1).asType(.float16)
+    let pairs = makeRandomPairs(krot: testKrot, dim: testInDim, groupSize: testGroupSize)
+    let channelScales = (MLXRandom.normal([1, testInDim]) * 0.1 + 1.0).asType(.float16)
+
+    var params: [String: MLXArray] = [
+        "theta": theta,
+        "pairs": pairs,
+        "channel_scales": channelScales,
+        "weight": wq,
+        "scales": scales,
+        "biases": biases ?? MLXArray.zeros(scales.shape),
+    ]
+    if hasBias {
+        params["bias"] = MLXRandom.normal([testOutDim]).asType(.float16)
+    }
+    try layer.update(parameters: ModuleParameters.unflattened(params), verify: [])
+    eval(layer)
+    return layer
+}
+
+/// Generates random permutation pair indices for Givens rotations within each group.
+private func makeRandomPairs(krot: Int, dim: Int, groupSize: Int) -> MLXArray {
+    var data = [Int16]()
+    data.reserveCapacity(krot * dim)
+    for _ in 0 ..< krot {
+        for _ in 0 ..< (dim / groupSize) {
+            var perm = Array(0 ..< groupSize).map { Int16($0) }
+            perm.shuffle()
+            data.append(contentsOf: perm)
+        }
+    }
+    return MLXArray(data).reshaped(krot, dim)
+}
+
+/// Relative RMS error between two arrays: sqrt(mean((a-b)²) / mean(a²)).
+private func relativeRMSError(_ a: MLXArray, _ b: MLXArray) -> Float {
+    let diff = (a - b).asType(.float32)
+    let ref = a.asType(.float32)
+    let mse = mean(diff * diff).item(Float.self)
+    let refVar = mean(ref * ref).item(Float.self)
+    return sqrt(mse / max(refVar, 1e-10))
+}
+
+/// Mirrors `packPairs` from RotateQuantizedLinear.swift (file-private in production).
+private func packPairsForTesting(_ pairs: MLXArray, groupSize: Int) -> MLXArray {
+    let krot = pairs.dim(0)
+    let numGroups = pairs.dim(1) / groupSize
+    let p = pairs.reshaped(krot, numGroups, groupSize).asType(.int32)
+    let lo = p[0..., 0..., .stride(by: 2)]
+    let hi = p[0..., 0..., .stride(from: 1, by: 2)]
+    return (lo | (hi << 16)).reshaped(krot, -1)
+}
+
+/// Mirrors `unpackAndReorder` from ParoQuantLoader.swift (file-private in production).
+private func unpackAndReorderForTesting(_ packed: MLXArray) -> MLXArray {
+    let rows = packed.dim(0)
+    let cols = packed.dim(1)
+    let shifts = MLXArray([0, 4, 8, 12, 16, 20, 24, 28].map { Int64($0) }).reshaped(1, 1, 8)
+    let mask: Int64 = 0xF
+    let inverseReorder = MLXArray([0, 4, 1, 5, 2, 6, 3, 7].map { Int32($0) })
+
+    let expanded = packed.asType(.int64).expandedDimensions(axis: 2)
+    let raw = ((expanded >> shifts) & mask).asType(.uint8)
+    let reordered = raw.take(inverseReorder, axis: 2)
+    return reordered.reshaped(rows, cols * 8)
+}

--- a/Tests/MLXLMTests/ParoQuantTests.swift
+++ b/Tests/MLXLMTests/ParoQuantTests.swift
@@ -170,6 +170,54 @@ public class ParoQuantTests: XCTestCase {
         eval(y4)
         XCTAssertEqual(y4.shape, [4, 64])
     }
+
+    /// Regression gate for PR #164 C1 + C4 — the old implementation had a
+    /// `nonisolated(unsafe)` kernel cache and an eval-time `CachedRotation?`
+    /// field that mutated on the first forward pass. Both are unsafe under
+    /// the multi-threaded usage that `ModelContainer.perform { ... }`
+    /// allows in production.
+    ///
+    /// Uses `DispatchQueue.concurrentPerform` (the same dispatch primitive
+    /// the model container path ends up on via its worker queue) so the
+    /// layer is hit from several threads simultaneously without any
+    /// isolation in between. Mixes batch=1 and batch=4 so both tile sizes
+    /// race into the kernel cache on the first iteration.
+    func testRotateQuantizedLinearConcurrentSafe() throws {
+        let layer = try makeTestLayer(hasBias: true)
+        let numTasks = 8
+        let buffer = SynchronizedShapeBuffer()
+
+        DispatchQueue.concurrentPerform(iterations: numTasks) { i in
+            let batch = i % 2 == 0 ? 1 : 4
+            let x = MLXRandom.normal([batch, 128]).asType(.float16)
+            let y = layer(x)
+            eval(y)
+            buffer.append(y.shape)
+        }
+
+        let shapes = buffer.snapshot()
+        XCTAssertEqual(shapes.count, numTasks)
+        for shape in shapes {
+            XCTAssertTrue(
+                shape == [1, 64] || shape == [4, 64],
+                "Unexpected output shape under concurrent load: \(shape)")
+        }
+    }
+}
+
+/// Thread-safe `[[Int]]` accumulator used by `testRotateQuantizedLinearConcurrentSafe`.
+/// `@unchecked Sendable` because all mutation is serialised by the internal lock.
+private final class SynchronizedShapeBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var shapes: [[Int]] = []
+
+    func append(_ shape: [Int]) {
+        lock.withLock { shapes.append(shape) }
+    }
+
+    func snapshot() -> [[Int]] {
+        lock.withLock { shapes }
+    }
 }
 
 // MARK: - Test Helpers
@@ -207,6 +255,9 @@ private func makeTestLayer(hasBias: Bool) throws -> RotateQuantizedLinear {
         params["bias"] = MLXRandom.normal([testOutDim]).asType(.float16)
     }
     try layer.update(parameters: ModuleParameters.unflattened(params), verify: [])
+    // Mirror the loader contract: derive rotation state after the checkpoint
+    // params are loaded, before any forward pass.
+    layer.prepareDerivedRotationState()
     eval(layer)
     return layer
 }

--- a/Tests/MLXLMTests/ParoQuantTests.swift
+++ b/Tests/MLXLMTests/ParoQuantTests.swift
@@ -157,30 +157,6 @@ public class ParoQuantTests: XCTestCase {
         XCTAssertLessThan(relError, 0.15, "Quantized matmul error: \(relError)")
     }
 
-    // MARK: - Pre-Rotation Equivalence
-
-    func testPreRotationEquivalence() throws {
-        let layer = try makeTestLayer(hasBias: false)
-        let x = MLXRandom.normal([4, 128]).asType(.float16)
-        eval(x)
-
-        // Output BEFORE pre-rotation (runtime rotation path)
-        let yBefore = layer(x)
-        eval(yBefore)
-
-        // Pre-rotate: bakes rotation into weights
-        try layer.preRotateWeights()
-        eval(layer)
-
-        // Output AFTER pre-rotation (fast path)
-        let yAfter = layer(x)
-        eval(yAfter)
-
-        // One extra quantization round → allow up to 25% relative error
-        let relError = relativeRMSError(yBefore, yAfter)
-        XCTAssertLessThan(relError, 0.25, "Pre-rotation equivalence error: \(relError)")
-    }
-
     func testRotateQuantizedLinearProducesValidOutput() throws {
         let layer = try makeTestLayer(hasBias: true)
 

--- a/Tests/MLXLMTests/ParoQuantTests.swift
+++ b/Tests/MLXLMTests/ParoQuantTests.swift
@@ -1,5 +1,3 @@
-// Copyright © 2025 INQTR. All rights reserved.
-
 import Foundation
 import MLX
 import MLXLMCommon


### PR DESCRIPTION
## Summary

Adds support for [ParoQuant](https://arxiv.org/abs/2511.10645) (ICLR 2026) INT4-quantized models. ParoQuant uses learned pairwise Givens rotations to suppress weight outliers before quantization, achieving ~2.4% accuracy improvement over standard AWQ on reasoning tasks.

**What's included:**

- `RotateQuantizedLinear` — applies channel-scaling + pairwise Givens rotation to activations at runtime via Metal kernel, then feeds into standard `quantizedMatmul`
- `ParoQuantLoader` — loads AutoAWQ-format checkpoints, converts weight layout, and patches rotation layers with their learned parameters (theta, pairs, channel_scales)
- Qwen 3.5 fixes — `in_proj_ba` split in sanitize for PARO checkpoint compatibility, hybrid cache handling for mixed attention/Mamba layers
- 7 unit tests (pair packing, AWQ conversion, quantization round-trip)

## Agent benchmark results

We run a 14-scenario tool-calling benchmark (file reads, edits, multi-step instructions, clarification requests) on Apple Silicon. Results are multi-run averages.

| Model | Runs | Passed | Tool Acc | Dup Rate | tok/s | Peak Mem |
|---|---|---|---|---|---|---|
| **Qwen3.5-9B PARO (INT4)** | 4 | **7.2/14** | **85.7%** | **0.9%** | 51 | 9.0 GB |
| Qwen3.5-9B OptiQ (4.5-bit) | 4 | 6.2/14 | 84.3% | 3.1% | 40 | 8.3 GB |
| Qwen3.5-4B PARO (INT4) | 7 | 5.6/14 | 77.5% | 9.7% | 67 | 4.2 GB |
| Qwen3.5-4B (8-bit) | 7 | 4.3/14 | 79.6% | 12.3% | 58 | 5.6 GB |

The 9B PARO outperforms 4.5-bit mixed-precision (OptiQ) on scenarios passed, duplicate rate, and throughput while using comparable memory.

**Key finding:** an earlier version pre-baked rotations into quantized weights for +23% throughput. This degraded structured output quality on the 9B model (5/14 passed, 11% dups). Applying rotation to activations at runtime instead — keeping weights in their original INT4 form — restored accuracy at a small throughput cost.

## Test plan

- [x] Unit tests pass
- [x] End-to-end inference with Qwen3.5-4B-PARO and Qwen3.5-9B-PARO
- [x] Non-PARO Qwen 3.5 models still load correctly (regression check)
- [x] Agent benchmark on 4 model variants (table above)