### PR TITLE
fix: flatten prompt in TokenRing.loadPrompt to handle 2D inputs

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -334,19 +334,19 @@ struct TokenRing {
 
     /// Bulk-load from a prompt. Keeps the last `capacity` tokens.
     mutating func loadPrompt(_ prompt: MLXArray) {
-        let n = prompt.dim(0)
-        let promptTokens = prompt.asType(.int32)
+        let promptTokens = prompt.asType(.int32).flattened()
+        let n = promptTokens.count
         if n <= capacity {
             if n < capacity {
                 let padding = MLXArray.zeros([capacity - n], type: Int32.self)
-                buffer = concatenated([promptTokens.reshaped(-1), padding])
+                buffer = concatenated([promptTokens, padding])
             } else {
-                buffer = promptTokens.reshaped(-1)
+                buffer = promptTokens
             }
             count = n
             writeIndex = n % capacity
         } else {
-            buffer = promptTokens[(-capacity)...].reshaped(-1)
+            buffer = promptTokens[(-capacity)...]
             count = capacity
             writeIndex = 0
         }

--- a/Tests/MLXLMTests/SampleTests.swift
+++ b/Tests/MLXLMTests/SampleTests.swift
@@ -204,4 +204,82 @@ public class SampleTests: XCTestCase {
         XCTAssertEqual(values[2], 0.0, accuracy: 1e-4)
         XCTAssertEqual(values[3], -0.5, accuracy: 1e-4)
     }
+
+    // MARK: - Repetition penalty
+
+    func testRepetitionContextPenalizesSeenTokens() {
+        var processor = RepetitionContext(repetitionPenalty: 2.0, repetitionContextSize: 20)
+        processor.prompt(MLXArray([1, 1, 3]))
+
+        let logits =
+            MLXArray([1.0 as Float, 2.0 as Float, 3.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 2.0, accuracy: 1e-6)
+    }
+
+    // MARK: - 2D prompt shape tests (issue #168)
+
+    func testRepetitionContextWith2DPrompt() {
+        var processor = RepetitionContext(repetitionPenalty: 2.0, repetitionContextSize: 20)
+        processor.prompt(MLXArray([1, 1, 3]).reshaped(1, -1))
+
+        let logits =
+            MLXArray([1.0 as Float, 2.0 as Float, 3.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 2.0, accuracy: 1e-6)
+
+        // Exercise the append path where the original crash occurred
+        processor.didSample(token: MLXArray(Int32(2)))
+        let afterAppend = processor.process(logits: logits)
+        let valuesAfter = afterAppend[0].asArray(Float.self)
+        XCTAssertEqual(valuesAfter[2], 1.5, accuracy: 1e-6)
+    }
+
+    func testPresencePenaltyContextWith2DPrompt() {
+        var processor = PresencePenaltyContext(presencePenalty: 0.5, presenceContextSize: 20)
+        processor.prompt(MLXArray([1, 1, 3]).reshaped(1, -1))
+
+        let logits =
+            MLXArray([1.0 as Float, 2.0 as Float, 3.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 1.5, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 3.5, accuracy: 1e-6)
+
+        // Exercise the append path where the original crash occurred
+        processor.didSample(token: MLXArray(Int32(2)))
+        let afterAppend = processor.process(logits: logits)
+        let valuesAfter = afterAppend[0].asArray(Float.self)
+        XCTAssertEqual(valuesAfter[2], 2.5, accuracy: 1e-6)
+    }
+
+    func testFrequencyPenaltyContextWith2DPrompt() {
+        var processor = FrequencyPenaltyContext(frequencyPenalty: 0.5, frequencyContextSize: 20)
+        processor.prompt(MLXArray([1, 1, 3]).reshaped(1, -1))
+
+        let logits =
+            MLXArray([1.0 as Float, 2.0 as Float, 3.0 as Float, 4.0 as Float])[.newAxis, .ellipsis]
+        let processed = processor.process(logits: logits)
+        let values = processed[0].asArray(Float.self)
+        XCTAssertEqual(values[0], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 1.0, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(values[3], 3.5, accuracy: 1e-6)
+
+        // Exercise the append path where the original crash occurred
+        processor.didSample(token: MLXArray(Int32(2)))
+        let afterAppend = processor.process(logits: logits)
+        let valuesAfter = afterAppend[0].asArray(Float.self)
+        XCTAssertEqual(valuesAfter[2], 2.5, accuracy: 1e-6)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #168.

- `TokenRing.loadPrompt` used `prompt.dim(0)` to count tokens, which returns `1` for VLM models that pass `[1, n]`-shaped prompts (via `.expandedDimensions(axis: 0)`). This caused the ring buffer to be incorrectly sized, leading to a broadcast shape crash on the next `append` call during token generation.
- Flatten the prompt to 1D upfront with `.flattened()` so the token count and all downstream slicing work correctly regardless of input shape.
- Added regression tests that exercise the full prompt → process → didSample → process cycle with 2D prompts, covering the exact crash path.

## Test plan

- [x] `swift test --filter SampleTests` — all penalty processor tests pass, including the new 2D-prompt variants
- [x] Run inference with a VLM model (e.g. Qwen2VL) using repetition/presence/frequency penalty to verify the crash no longer occurs