### PR TITLE
Handle stringified JSON tool call arguments

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -29,10 +29,29 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
 
         let jsonStr = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard let data = jsonStr.data(using: .utf8),
-            let function = try? JSONDecoder().decode(ToolCall.Function.self, from: data)
+        guard
+            let data = jsonStr.data(using: .utf8),
+            let normalizedData = normalizedToolCallData(from: data),
+            let function = try? JSONDecoder().decode(ToolCall.Function.self, from: normalizedData)
         else { return nil }
 
         return ToolCall(function: function)
+    }
+
+    private func normalizedToolCallData(from data: Data) -> Data? {
+        guard var jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        if let stringifiedArguments = jsonObject["arguments"] as? String {
+            guard
+                let argumentsData = stringifiedArguments.data(using: .utf8),
+                let argumentsObject = try? JSONSerialization.jsonObject(with: argumentsData)
+                    as? [String: Any]
+            else { return nil }
+            jsonObject["arguments"] = argumentsObject
+        }
+
+        return try? JSONSerialization.data(withJSONObject: jsonObject)
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -39,7 +39,8 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
     }
 
     private func normalizedToolCallData(from data: Data) -> Data? {
-        guard var jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard var jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
             return nil
         }
 

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -113,6 +113,44 @@ struct ToolTests {
         #expect(toolCall.function.arguments["query"] == .string("swift programming"))
     }
 
+    @Test("Test JSON Tool Call Parser - Stringified Arguments")
+    func testJSONParserStringifiedArguments() throws {
+        let parser = JSONToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content =
+            #"<tool_call>{"name":"get_weather","arguments":"{\"location\":\"Paris\",\"unit\":\"celsius\"}"}</tool_call>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+        #expect(toolCall.function.arguments["unit"] == .string("celsius"))
+    }
+
+    @Test("Test JSON Tool Call Parser - Stringified Empty Arguments")
+    func testJSONParserStringifiedEmptyArguments() throws {
+        let parser = JSONToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content =
+            #"<tool_call>{"name":"current_time","arguments":"{}"}</tool_call>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "current_time")
+        #expect(toolCall.function.arguments.isEmpty)
+    }
+
+    @Test("Test JSON Tool Call Parser - Stringified Array Arguments")
+    func testJSONParserStringifiedArrayArguments() throws {
+        let parser = JSONToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content =
+            #"<tool_call>{"name":"search_many","arguments":"{\"queries\":[\"swift\",\"mlx\"],\"limit\":2}"}</tool_call>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "search_many")
+        #expect(toolCall.function.arguments["limit"] == .int(2))
+        #expect(toolCall.function.arguments["queries"] == .array([.string("swift"), .string("mlx")]))
+    }
+
     // MARK: - Pythonic Format Tests (LFM2/LFM2.5)
 
     @Test("Test Pythonic Tool Call Parser - Basic")

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -148,7 +148,8 @@ struct ToolTests {
 
         #expect(toolCall.function.name == "search_many")
         #expect(toolCall.function.arguments["limit"] == .int(2))
-        #expect(toolCall.function.arguments["queries"] == .array([.string("swift"), .string("mlx")]))
+        #expect(
+            toolCall.function.arguments["queries"] == .array([.string("swift"), .string("mlx")]))
     }
 
     // MARK: - Pythonic Format Tests (LFM2/LFM2.5)


### PR DESCRIPTION
Fixes #169.

## Problem

`JSONToolCallParser` assumes `arguments` is always a JSON object, but some models emit it as a JSON-encoded string instead.

That means payloads like this fail to parse today:

```json
{"name":"get_weather","arguments":"{\"location\":\"Paris\"}"}
```

As a result, Swift drops the tool call entirely.

## Fix

Normalize the outer JSON payload before decoding `ToolCall.Function`:

- decode the top-level object with `JSONSerialization`
- if `arguments` is a string, parse that string as JSON
- replace `arguments` with the parsed value
- decode the normalized payload using the existing `JSONDecoder`

This preserves the current behavior for object-shaped arguments while adding compatibility for stringified arguments.

## Testing

- `swift test --filter ToolTests`
- added regression tests for stringified object arguments
- added regression tests for stringified empty arguments
- added regression tests for stringified array arguments

I also verified locally with Granite tool calling that the original parser emitted no parsed tool call while the patched parser successfully emitted `get_weather(location: "Tokyo", unit: "celsius")`.
