### PR TITLE
Forward tools and additionalContext in GlmOcr and SmolVLM2 processors

### DIFF
--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -831,7 +831,8 @@ public struct GlmOcrProcessor: UserInputProcessor {
     public func prepare(input: UserInput) async throws -> LMInput {
         let messages = GlmOcrMessageGenerator().generate(from: input)
 
-        var promptTokens = try tokenizer.applyChatTemplate(messages: messages)
+        var promptTokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: input.tools, additionalContext: input.additionalContext)
 
         // Text-only input
         if input.images.isEmpty, input.videos.isEmpty {

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -306,7 +306,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
 
             // Unfortunately we don't have a "render" option in Tokenizers yet, so decoding
             let promptTokens = try tokenizer.applyChatTemplate(
-                messages: messagesWithSystem(messages))
+                messages: messagesWithSystem(messages), tools: input.tools,
+                additionalContext: input.additionalContext)
             let decoded = tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
 
             let video = input.videos[0]


### PR DESCRIPTION
Follow-up to #140. GlmOcr was added after that fix and missed the pattern entirely. SmolVLM2's video path was also missed while its other two branches were fixed.

Separately, `ModelContainer.generate()` also doesn't forward `tools` to the underlying `generate()` call — anyone using that convenience method instead of `ChatSession` won't get type-aware tool call parsing. Not sure if that's worth adding a parameter for or if the expectation is that tool-aware callers use `ChatSession` or the lower-level `perform { }` API. Happy to add it if you want.