### PR TITLE
Fix inaccuracies in (and possibly remove) "skills"

### DIFF
--- a/skills/mlx-swift-lm/SKILL.md
+++ b/skills/mlx-swift-lm/SKILL.md
@@ -65,12 +65,11 @@ MLXEmbedders    - Embedding models and pooling utilities
 ```swift
 import MLXLLM
 import MLXLMCommon
-import MLXLMHuggingFace  // from swift-huggingface-mlx
-import MLXLMTokenizers   // from swift-tokenizers-mlx
+import MLXHuggingFace  // provides #hubDownloader() and #huggingFaceTokenizerLoader()
 
 let modelContainer = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: #hubDownloader(),
+    using: #huggingFaceTokenizerLoader(),
     configuration: .init(id: "mlx-community/Qwen3-4B-4bit")
 )
 
@@ -89,12 +88,11 @@ for try await chunk in session.streamResponse(to: "Explain structured concurrenc
 ```swift
 import MLXVLM
 import MLXLMCommon
-import MLXLMHuggingFace  // from swift-huggingface-mlx
-import MLXLMTokenizers   // from swift-tokenizers-mlx
+import MLXHuggingFace  // provides #hubDownloader() and #huggingFaceTokenizerLoader()
 
 let modelContainer = try await VLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: #hubDownloader(),
+    using: #huggingFaceTokenizerLoader(),
     configuration: .init(id: "mlx-community/Qwen2-VL-2B-Instruct-4bit")
 )
 
@@ -112,12 +110,11 @@ let response = try await session.respond(
 
 ```swift
 import MLXEmbedders
-import MLXEmbeddersHuggingFace  // from swift-huggingface-mlx
-import MLXLMTokenizers          // from swift-tokenizers-mlx
+import MLXHuggingFace  // provides #hubDownloader() and #huggingFaceTokenizerLoader()
 
 let container = try await loadModelContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: #hubDownloader(),
+    using: #huggingFaceTokenizerLoader(),
     configuration: ModelConfiguration(id: "mlx-community/bge-small-en-v1.5-mlx")
 )
 
@@ -234,10 +231,16 @@ let params = GenerateParameters(
     kvBits: 4,                  // Quantized cache (4 or 8)
     kvGroupSize: 64,            // Quantization group size
     quantizedKVStart: 0,        // Token index to start KV quantization
-    temperature: 0.7,           // 0 = greedy / argmax
+    temperature: 0.6,           // 0 = greedy / argmax
     topP: 0.9,                  // Nucleus sampling
+    topK: 0,                    // Top-k sampling (0 disables)
+    minP: 0.0,                  // Min-p threshold (0 disables)
     repetitionPenalty: 1.1,     // Penalize repeats
     repetitionContextSize: 20,  // Penalty window
+    presencePenalty: nil,        // Additive presence penalty
+    presenceContextSize: 20,    // Presence penalty window
+    frequencyPenalty: nil,       // Additive frequency penalty
+    frequencyContextSize: 20,   // Frequency penalty window
     prefillStepSize: 512        // Prompt prefill chunk size
 )
 ```

--- a/skills/mlx-swift-lm/references/concurrency.md
+++ b/skills/mlx-swift-lm/references/concurrency.md
@@ -11,8 +11,6 @@ mlx-swift-lm uses Swift concurrency with specialized utilities to handle the uni
 | Type | Purpose |
 |------|---------|
 | `SerialAccessContainer<T>` | Exclusive async access to wrapped state |
-| `AsyncMutex` | Lock that works with async blocks |
-| `SendableBox<T>` | Transfer non-Sendable values across isolation |
 | `ModelContainer` | Thread-safe model wrapper (uses SerialAccessContainer) |
 | `ChatSession` | NOT thread-safe (single task only) |
 
@@ -23,8 +21,8 @@ Provides exclusive access to state across `async` calls:
 ```swift
 // Unlike actors, this guarantees exclusive access for entire async operation
 final class SerialAccessContainer<T>: @unchecked Sendable {
-    func read<R>(_ body: (T) async throws -> R) async rethrows -> R
-    func update<R>(_ body: (inout T) async throws -> R) async rethrows -> R
+    func read<R>(_ body: @Sendable (T) async throws -> sending R) async rethrows -> sending R
+    func update<R>(_ body: @Sendable (inout T) async throws -> sending R) async rethrows -> sending R
 }
 ```
 
@@ -69,9 +67,11 @@ await container.update { state in
 }
 ```
 
-## SendableBox
+## SendableBox (Internal)
 
-Transfer non-Sendable values across isolation boundaries:
+`SendableBox<T>` is an internal utility for transferring non-Sendable values across isolation
+boundaries. It is not part of the public API, but is used extensively in the implementation
+of `ModelContainer` and generation functions.
 
 ```swift
 // Problem: LMInput is not Sendable
@@ -80,33 +80,12 @@ Task {
     use(input)  // Compiler error!
 }
 
-// Solution: Use SendableBox
+// Inside the library, SendableBox wraps the value:
 let box = SendableBox(input)
 Task {
-    let input = box.consume()  // Transfer ownership
+    let input = box.consume()  // Transfer ownership (single use)
     use(input)
 }
-```
-
-### Pattern: Consuming Parameters
-
-```swift
-func processAsync(input: consuming LMInput) async throws -> Result {
-    let boxed = SendableBox(input)
-
-    return try await container.read { context in
-        let input = boxed.consume()  // Consume inside closure
-        return try process(input, context: context)
-    }
-}
-```
-
-### Important: Single Consume
-
-```swift
-let box = SendableBox(value)
-let v1 = box.consume()  // OK
-let v2 = box.consume()  // fatalError: "value already consumed"
 ```
 
 ## ModelContainer Thread Safety
@@ -119,8 +98,8 @@ public final class ModelContainer: Sendable {
 
     // Thread-safe access
     public func perform<R: Sendable>(
-        _ action: @Sendable (ModelContext) async throws -> R
-    ) async rethrows -> R
+        _ action: @Sendable (ModelContext) async throws -> sending R
+    ) async rethrows -> sending R
 }
 ```
 
@@ -129,8 +108,8 @@ public final class ModelContainer: Sendable {
 ```swift
 // Multiple tasks can call perform() safely
 let container = try await loadModelContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,        // any Downloader (e.g. #hubDownloader() from MLXHuggingFace)
+    using: tokenizerLoader,  // any TokenizerLoader (e.g. #huggingFaceTokenizerLoader())
     id: "mlx-community/Qwen3-4B-4bit"
 )
 

--- a/skills/mlx-swift-lm/references/embeddings.md
+++ b/skills/mlx-swift-lm/references/embeddings.md
@@ -50,10 +50,13 @@ The Embedders library provides text embedding models for semantic search, RAG, c
 ```swift
 import MLXEmbedders
 
+// Requires a Downloader and TokenizerLoader — e.g. from MLXHuggingFace:
+//   let downloader = #hubDownloader()
+//   let tokenizerLoader = #huggingFaceTokenizerLoader()
 let config = ModelConfiguration.bge_small
 let container = try await loadModelContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,
+    using: tokenizerLoader,
     configuration: config
 )
 ```
@@ -63,8 +66,8 @@ let container = try await loadModelContainer(
 ```swift
 let config = ModelConfiguration(id: "BAAI/bge-small-en-v1.5")
 let container = try await loadModelContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: downloader,
+    using: tokenizerLoader,
     configuration: config
 )
 ```
@@ -74,7 +77,7 @@ let container = try await loadModelContainer(
 ```swift
 let container = try await loadModelContainer(
     from: localModelURL,
-    using: TokenizersLoader()
+    using: tokenizerLoader
 )
 ```
 
@@ -82,12 +85,13 @@ let container = try await loadModelContainer(
 
 ```swift
 let container = try await loadModelContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
-    configuration: config
-) { progress in
-    print("Download progress: \(progress.fractionCompleted)")
-}
+    from: downloader,
+    using: tokenizerLoader,
+    configuration: config,
+    progressHandler: { progress in
+        print("Download progress: \(progress.fractionCompleted)")
+    }
+)
 ```
 
 ## Generating Embeddings
@@ -168,8 +172,8 @@ public enum Strategy {
 // Create custom pooler
 let pooler = Pooling(strategy: .mean, dimension: 384)
 
-// Or from configuration file
-let pooler = loadPooling(modelDirectory: modelDir)
+// Or from configuration file (falls back to model's built-in strategy)
+let pooler = loadPooling(modelDirectory: modelDir, model: model)
 // Reads from 1_Pooling/config.json
 ```
 
@@ -189,6 +193,7 @@ let pooled = pooler(
 ```swift
 public protocol EmbeddingModel: Module {
     var vocabularySize: Int { get }
+    var poolingStrategy: Pooling.Strategy? { get }  // nil by default
 
     func callAsFunction(
         _ inputs: MLXArray,
@@ -257,31 +262,32 @@ print("Similarity: \(similarity)")  // ~0.85
 
 ## Model Configuration
 
+Note: `MLXEmbedders` defines its own `ModelConfiguration` type, separate from `MLXLMCommon.ModelConfiguration`.
+
 ```swift
 public struct ModelConfiguration: Sendable {
     public enum Identifier: Sendable {
-        case id(String)          // HuggingFace ID
-        case directory(URL)      // Local path
+        case id(String, revision: String = "main")  // Hub ID with optional revision
+        case directory(URL)                          // Local path
     }
 
     public var id: Identifier
     public var name: String
-    public let tokenizerId: String?       // Alternate tokenizer
-    public let overrideTokenizer: String? // Override tokenizer class
+    public let tokenizerSource: TokenizerSource?    // Alternate tokenizer source
 }
 ```
 
 ### Registry
 
 ```swift
-// Get registered model
-let config = await ModelConfiguration.configuration(id: "bge-small")
+// Get registered model (@MainActor)
+let config = ModelConfiguration.configuration(id: "bge-small")
 
-// List all models
-let models = await ModelConfiguration.models
+// List all models (@MainActor)
+let models = ModelConfiguration.models
 
-// Register custom model
-await ModelConfiguration.register(configurations: [myConfig])
+// Register custom model (@MainActor)
+ModelConfiguration.register(configurations: [myConfig])
 ```
 
 ## Supported Architectures
@@ -289,8 +295,14 @@ await ModelConfiguration.register(configurations: [myConfig])
 | Architecture | model_type |
 |-------------|------------|
 | BERT | `bert` |
+| RoBERTa | `roberta` |
+| XLM-RoBERTa | `xlm-roberta` |
+| DistilBERT | `distilbert` |
 | Nomic BERT | `nomic_bert` |
 | Qwen3 | `qwen3` |
+| Gemma3 | `gemma3` |
+| Gemma3 Text | `gemma3_text` |
+| Gemma3n | `gemma3n` |
 
 ## Memory Considerations
 

--- a/skills/mlx-swift-lm/references/generation.md
+++ b/skills/mlx-swift-lm/references/generation.md
@@ -25,8 +25,10 @@ Primary implementation lives in `Libraries/MLXLMCommon/Evaluate.swift`.
 import MLXLLM
 import MLXLMCommon
 
-let context = try await LLMModelFactory.shared.load(
-    configuration: .init(id: "mlx-community/Qwen3-4B-4bit")
+let context = try await loadModel(
+    from: downloader,        // any Downloader (e.g. #hubDownloader() from MLXHuggingFace)
+    using: tokenizerLoader,  // any TokenizerLoader (e.g. #huggingFaceTokenizerLoader())
+    id: "mlx-community/Qwen3-4B-4bit"
 )
 
 let userInput = UserInput(prompt: "Explain actor isolation in Swift.")

--- a/skills/mlx-swift-lm/references/kv-cache.md
+++ b/skills/mlx-swift-lm/references/kv-cache.md
@@ -66,7 +66,7 @@ let params = GenerateParameters(
     quantizedKVStart: 0  // Start quantizing after N tokens
 )
 
-// Or create directly
+// Or create directly (default bits is 8; toQuantized() defaults to 4)
 let cache = QuantizedKVCache(
     groupSize: 64,
     bits: 4,

--- a/skills/mlx-swift-lm/references/lora-adapters.md
+++ b/skills/mlx-swift-lm/references/lora-adapters.md
@@ -230,8 +230,8 @@ public protocol LoRALayer: Module {
 ```swift
 // Load base model
 let container = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,        // any Downloader (e.g. #hubDownloader() from MLXHuggingFace)
+    using: tokenizerLoader,  // any TokenizerLoader (e.g. #huggingFaceTokenizerLoader())
     configuration: .init(id: "mlx-community/Llama-3.2-3B-Instruct-4bit")
 )
 
@@ -311,7 +311,7 @@ After training, save adapter weights:
 let params = model.trainableParameters()
 
 // Save to safetensors
-try save(arrays: params.flattened(), url: weightsURL)
+try save(arrays: Dictionary(uniqueKeysWithValues: params.flattened()), url: weightsURL)
 
 // Save configuration
 let encoder = JSONEncoder()

--- a/skills/mlx-swift-lm/references/model-container.md
+++ b/skills/mlx-swift-lm/references/model-container.md
@@ -24,24 +24,19 @@
 
 ```swift
 // Via factory (recommended)
+// Requires a Downloader and TokenizerLoader — e.g. from MLXHuggingFace:
+//   let downloader = #hubDownloader()
+//   let tokenizerLoader = #huggingFaceTokenizerLoader()
 let container = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,
+    using: tokenizerLoader,
     configuration: .init(id: "mlx-community/Qwen3-4B-4bit")
-)
-
-// With custom hub (from MLXLMHuggingFace)
-let hub = HubClient(token: "hf_...")
-let container = try await LLMModelFactory.shared.loadContainer(
-    from: hub,
-    using: TokenizersLoader(),
-    configuration: .init(id: "private/model")
 )
 
 // With progress tracking
 let container = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: downloader,
+    using: tokenizerLoader,
     configuration: config,
     progressHandler: { progress in
         print("Downloaded: \(progress.fractionCompleted)")
@@ -92,12 +87,7 @@ let streamWithTicket = try await container.generate(
 
 // Encode/decode
 let tokens = await container.encode("Hello world")
-let text = await container.decode(tokens: [1, 2, 3])
-
-// Apply chat template
-let tokens = try await container.applyChatTemplate(messages: [
-    ["role": "user", "content": "Hello"]
-])
+let text = await container.decode(tokenIds: [1, 2, 3])
 ```
 
 ### Generation + Wired Memory
@@ -160,10 +150,9 @@ let config = ModelConfiguration(
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `id` | `Identifier` | `.id(String)` or `.directory(URL)` |
+| `id` | `Identifier` | `.id(String, revision:)` or `.directory(URL)` |
 | `name` | `String` | Human-readable name |
-| `tokenizerId` | `String?` | Pull tokenizer from different repo |
-| `overrideTokenizer` | `String?` | Force tokenizer class |
+| `tokenizerSource` | `TokenizerSource?` | Alternate tokenizer source (`.id`, `.directory`, or `nil` for model dir) |
 | `defaultPrompt` | `String` | Default prompt for testing |
 | `extraEOSTokens` | `Set<String>` | Additional stop tokens (as strings) |
 | `eosTokenIds` | `Set<Int>` | EOS token IDs (loaded from config) |
@@ -179,8 +168,8 @@ let factory = LLMModelFactory.shared
 
 // Load container
 let container = try await factory.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: downloader,
+    using: tokenizerLoader,
     configuration: LLMRegistry.llama3_2_3B_4bit
 )
 
@@ -197,8 +186,8 @@ let customFactory = LLMModelFactory(
 let factory = VLMModelFactory.shared
 
 let container = try await factory.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),
+    from: downloader,
+    using: tokenizerLoader,
     configuration: VLMRegistry.qwen2VL2BInstruct4Bit
 )
 ```
@@ -227,12 +216,14 @@ Map `model_type` from config.json to model initializers:
 
 ```swift
 // LLMTypeRegistry supports (partial list):
-// "llama", "mistral", "qwen2", "qwen3", "gemma", "gemma2", "gemma3",
-// "phi", "phi3", "deepseek_v3", "glm4", "lfm2", ...
+// "llama", "mistral", "qwen2", "qwen3", "qwen3_moe", "qwen3_5",
+// "gemma", "gemma2", "gemma3", "gemma3n", "phi", "phi3",
+// "deepseek_v3", "glm4", "lfm2", "lfm2_moe", ...
 
 // VLMTypeRegistry supports:
-// "qwen2_vl", "qwen2_5_vl", "qwen3_vl", "paligemma", "gemma3",
-// "idefics3", "smolvlm", "pixtral", "mistral3", ...
+// "qwen2_vl", "qwen2_5_vl", "qwen3_vl", "qwen3_5", "paligemma",
+// "gemma3", "idefics3", "smolvlm", "pixtral", "mistral3",
+// "lfm2_vl", "glm_ocr", ...
 ```
 
 ## Loading Flow
@@ -249,11 +240,11 @@ Map `model_type` from config.json to model initializers:
 // Download location
 let resolved = try await resolve(
     configuration: configuration,
-    from: HubClient.default,
+    from: downloader,
+    useLatest: false,
     progressHandler: { _ in }
 )
 let modelDir = resolved.modelDirectory
-// ~/.cache/huggingface/hub/models--mlx-community--Model-Name/...
 ```
 
 ## Memory Management

--- a/skills/mlx-swift-lm/references/model-porting.md
+++ b/skills/mlx-swift-lm/references/model-porting.md
@@ -365,8 +365,8 @@ If you need custom keys, override `loraDefaultKeys`.
 
 ```swift
 let modelContainer = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,        // any Downloader (e.g. #hubDownloader() from MLXHuggingFace)
+    using: tokenizerLoader,  // any TokenizerLoader (e.g. #huggingFaceTokenizerLoader())
     configuration: ModelConfiguration(id: "mlx-community/YourModel-4bit")
 )
 

--- a/skills/mlx-swift-lm/references/supported-models.md
+++ b/skills/mlx-swift-lm/references/supported-models.md
@@ -32,7 +32,7 @@ LLMRegistry.mistralNeMo4bit       // mlx-community/Mistral-Nemo-Instruct-2407-4b
 ### Qwen
 
 ```swift
-// model_type: "qwen2", "qwen3", "qwen3_moe"
+// model_type: "qwen2", "qwen3", "qwen3_moe", "qwen3_next", "qwen3_5", "qwen3_5_moe", "qwen3_5_text"
 LLMRegistry.qwen2_5_7b            // mlx-community/Qwen2.5-7B-Instruct-4bit
 LLMRegistry.qwen2_5_1_5b          // mlx-community/Qwen2.5-1.5B-Instruct-4bit
 LLMRegistry.qwen3_4b_4bit         // mlx-community/Qwen3-4B-4bit
@@ -103,6 +103,12 @@ LLMRegistry.glm4_9b_4bit          // mlx-community/GLM-4-9B-0414-4bit
 | `bailing_moe` | Bailing MoE |
 | `gpt_oss` | GPT OSS |
 | `minicpm` | MiniCPM |
+| `acereason` | AceReason (uses Qwen2 architecture) |
+| `baichuan_m1` | Baichuan M1 |
+| `qwen3_next` | Qwen3 Next |
+| `qwen3_5`, `qwen3_5_moe`, `qwen3_5_text` | Qwen3.5 |
+| `mistral3` | Mistral 3 (text-only) |
+| `lille-130m` | Lille 130M |
 
 ## VLM Families
 
@@ -141,6 +147,8 @@ VLMRegistry.paligemma3bMix448_8bit // mlx-community/paligemma-3b-mix-448-8bit
 | `pixtral` | Pixtral |
 | `mistral3` | Mistral 3 VLM |
 | `lfm2_vl`, `lfm2-vl` | LFM2 VL |
+| `qwen3_5`, `qwen3_5_moe` | Qwen3.5 VLM |
+| `glm_ocr` | GLM OCR |
 
 ## Loading Any Model
 
@@ -150,8 +158,8 @@ Models not in registries can be loaded by ID:
 // Any mlx-community model
 let config = ModelConfiguration(id: "mlx-community/SomeModel-4bit")
 let container = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,        // any Downloader (e.g. #hubDownloader() from MLXHuggingFace)
+    using: tokenizerLoader,  // any TokenizerLoader (e.g. #huggingFaceTokenizerLoader())
     configuration: config
 )
 
@@ -207,19 +215,19 @@ let config = ModelConfiguration(
 // Most models use default .json format (auto-detected)
 ```
 
-### Tokenizer Overrides
+### Tokenizer Source
 
 ```swift
-// Override tokenizer class
-let config = ModelConfiguration(
-    id: "...",
-    overrideTokenizer: "PreTrainedTokenizer"
-)
-
-// Use tokenizer from different model
+// Use tokenizer from a different model repository
 let config = ModelConfiguration(
     id: "model-without-tokenizer",
-    tokenizerId: "different-model-with-tokenizer"
+    tokenizerSource: .id("different-model-with-tokenizer")
+)
+
+// Use tokenizer from a local directory
+let config = ModelConfiguration(
+    id: "...",
+    tokenizerSource: .directory(URL(filePath: "/path/to/tokenizer"))
 )
 ```
 

--- a/skills/mlx-swift-lm/references/tokenizer-chat.md
+++ b/skills/mlx-swift-lm/references/tokenizer-chat.md
@@ -7,18 +7,7 @@ Tokenizers convert text to/from token IDs and apply chat templates for multi-tur
 **Files:**
 - `Libraries/MLXLMCommon/Tokenizer.swift`
 - `Libraries/MLXLMCommon/Chat.swift`
-
-## Quick Reference
-
-| Type | Purpose |
-|------|---------|
-| `Tokenizer` | Protocol from swift-transformers |
-| `PreTrainedTokenizer` | Standard tokenizer implementation |
-| `Chat.Message` | Structured chat message |
-| `Chat.Message.Role` | user, assistant, system, tool |
-| `MessageGenerator` | Convert Chat.Message to raw dicts |
-| `StreamingDetokenizer` | Incremental token-to-text |
-| `NaiveStreamingDetokenizer` | Default streaming implementation |
+- `Libraries/MLXLMCommon/ChatSession.swift`
 
 ## Tokenizer Loading
 
@@ -27,9 +16,12 @@ Tokenizers convert text to/from token IDs and apply chat templates for multi-tur
 Tokenizers are loaded automatically by model factories:
 
 ```swift
+// Requires a Downloader and TokenizerLoader — e.g. from MLXHuggingFace:
+//   let downloader = #hubDownloader()
+//   let tokenizerLoader = #huggingFaceTokenizerLoader()
 let container = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,
+    using: tokenizerLoader,
     configuration: config
 )
 let tokenizer = await container.tokenizer
@@ -41,8 +33,8 @@ Tokenizer loading is handled by the `TokenizerLoader` protocol. Each integration
 package provides a concrete loader:
 
 ```swift
-// Using TokenizersLoader from MLXLMTokenizers (swift-tokenizers-mlx)
-let loader = TokenizersLoader()
+// Implement the TokenizerLoader protocol or use a macro from MLXHuggingFace:
+let loader = #huggingFaceTokenizerLoader()  // from MLXHuggingFace
 let tokenizer = try await loader.load(from: modelDirectory)
 ```
 
@@ -55,7 +47,7 @@ let tokenizer = try await loader.load(from: modelDirectory)
 let tokens: [Int] = tokenizer.encode(text: "Hello, world!")
 
 // Decode tokens to text
-let text: String = tokenizer.decode(tokens: tokens)
+let text: String = tokenizer.decode(tokenIds: tokens)
 ```
 
 ### Chat Template
@@ -63,7 +55,7 @@ let text: String = tokenizer.decode(tokens: tokens)
 Apply model-specific chat formatting:
 
 ```swift
-let messages: [[String: String]] = [
+let messages: [[String: any Sendable]] = [
     ["role": "system", "content": "You are helpful"],
     ["role": "user", "content": "Hello"]
 ]
@@ -85,11 +77,11 @@ let tokens = try tokenizer.applyChatTemplate(
 
 ```swift
 // EOS token
-tokenizer.eosToken        // String, e.g., "</s>"
+tokenizer.eosToken        // String?, e.g., "</s>"
 tokenizer.eosTokenId      // Int?, e.g., 2
 
 // Unknown token
-tokenizer.unknownToken    // String
+tokenizer.unknownToken    // String?
 tokenizer.unknownTokenId  // Int?
 
 // Convert between tokens and IDs
@@ -274,20 +266,6 @@ if let chunk = detokenizer.next() {
     // Complete character(s) ready
 }
 // nil means waiting for more tokens
-```
-
-## Tokenizer Replacement Registry
-
-Override tokenizer classes for compatibility:
-
-```swift
-// Built-in replacements
-// "Qwen2Tokenizer" -> "PreTrainedTokenizer"
-// "InternLM2Tokenizer" -> "PreTrainedTokenizer"
-// etc.
-
-// Add custom replacement
-replacementTokenizers["CustomTokenizer"] = "PreTrainedTokenizer"
 ```
 
 ## Deprecated Patterns

--- a/skills/mlx-swift-lm/references/tool-calling.md
+++ b/skills/mlx-swift-lm/references/tool-calling.md
@@ -29,12 +29,13 @@ mlx-swift-lm supports function calling / tool use with multiple model-specific f
 | Format | Models | Example Output |
 |--------|--------|----------------|
 | `.json` | Llama, Qwen, most models | `<tool_call>{"name":"f","arguments":{...}}</tool_call>` |
-| `.lfm2` | LFM2 | `<\|tool_call_start\|>{"name":"f",...}<\|tool_call_end\|>` |
+| `.lfm2` | LFM2 | `<|tool_call_start|>[func(arg='value')]<|tool_call_end|>` |
 | `.xmlFunction` | Nemotron, Qwen3 Coder, Qwen3.5 | `<tool_call><function=name><parameter=k>v</parameter></function></tool_call>` |
 | `.glm4` | GLM4 | `func<arg_key>k</arg_key><arg_value>v</arg_value>` |
 | `.gemma` | Gemma | `call:name{key:value}` |
-| `.kimiK2` | Kimi K2 | `functions.name:0<\|tool_call_argument_begin\|>{...}` |
+| `.kimiK2` | Kimi K2 | `functions.name:0<|tool_call_argument_begin|>{...}` |
 | `.minimaxM2` | MiniMax M2 | `<invoke name="f"><parameter name="k">v</parameter></invoke>` |
+| `.mistral` | Mistral V11+ | `[TOOL_CALLS]get_weather [ARGS]{"location": "Tokyo"}` |
 
 ## Defining Tools
 
@@ -169,7 +170,10 @@ for chunk in generatedChunks {
     }
 }
 
-// After generation, check for tool calls
+// When generation ends, call processEOS() to extract any buffered tool calls
+processor.processEOS()
+
+// Check for detected tool calls
 for toolCall in processor.toolCalls {
     print("Detected tool call: \(toolCall.function.name)")
 }
@@ -190,9 +194,12 @@ Formats are auto-detected from model type:
 
 ```swift
 // Auto-detected based on model_type in config.json
-ToolCallFormat.infer(from: "lfm2")     // -> .lfm2
+ToolCallFormat.infer(from: "lfm2")      // -> .lfm2
 ToolCallFormat.infer(from: "glm4")     // -> .glm4
 ToolCallFormat.infer(from: "gemma")    // -> .gemma
+ToolCallFormat.infer(from: "nemotron") // -> .xmlFunction
+ToolCallFormat.infer(from: "qwen3_5")  // -> .xmlFunction
+ToolCallFormat.infer(from: "mistral3") // -> .mistral
 ToolCallFormat.infer(from: "llama")    // -> nil (use default .json)
 ```
 
@@ -276,20 +283,21 @@ public protocol ToolCallParser: Sendable {
     var startTag: String? { get }  // nil for inline formats
     var endTag: String? { get }
     func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall?
+    func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall]
 }
 ```
 
 ## Error Handling
 
 ```swift
-public enum ToolError: Error {
+public enum ToolError: Error, LocalizedError {
     case nameMismatch(toolName: String, functionName: String)
 }
 
 do {
     let result = try await toolCall.execute(with: myTool)
-} catch ToolError.nameMismatch(let expected, let got) {
-    print("Tool '\(got)' doesn't match expected '\(expected)'")
+} catch ToolError.nameMismatch(let toolName, let functionName) {
+    print("Tool name mismatch: expected '\(toolName)' but got '\(functionName)'")
 }
 ```
 

--- a/skills/mlx-swift-lm/references/training.md
+++ b/skills/mlx-swift-lm/references/training.md
@@ -49,9 +49,12 @@ import MLXLLM
 import MLXLMCommon
 
 // Load base model
+// Requires a Downloader and TokenizerLoader — e.g. from MLXHuggingFace:
+//   let downloader = #hubDownloader()
+//   let tokenizerLoader = #huggingFaceTokenizerLoader()
 let container = try await LLMModelFactory.shared.loadContainer(
-    from: HubClient.default,
-    using: TokenizersLoader(),  // TokenizersLoader() from MLXLMTokenizers (swift-tokenizers-mlx)
+    from: downloader,
+    using: tokenizerLoader,
     configuration: .init(id: "mlx-community/Llama-3.2-3B-Instruct-4bit")
 )
 
@@ -347,8 +350,8 @@ import MLXOptimizers
 func trainAdapter() async throws {
     // Load model
     let container = try await LLMModelFactory.shared.loadContainer(
-        from: HubClient.default,
-        using: TokenizersLoader(),
+        from: downloader,
+        using: tokenizerLoader,
         configuration: .init(id: "mlx-community/Llama-3.2-1B-Instruct-4bit")
     )
 

--- a/skills/mlx-swift-lm/references/wired-memory.md
+++ b/skills/mlx-swift-lm/references/wired-memory.md
@@ -64,7 +64,9 @@ Use `WiredMemoryUtils.tune(...)` to measure real runtime costs and then size pol
 ### Text-only Measurement
 
 ```swift
-let context = try await LLMModelFactory.shared.load(configuration: config)
+let context = try await loadModel(
+    from: downloader, using: tokenizerLoader, configuration: config
+)
 let parameters = GenerateParameters(maxTokens: 128, prefillStepSize: 512)
 
 let measurement = try await WiredMemoryUtils.tune(
@@ -88,29 +90,6 @@ let measurement = try await WiredMemoryUtils.tune(
     context: context,
     parameters: parameters
 )
-```
-
-## CPU and Unsupported Backends
-
-When wired limit control is unavailable, keep policy math and admission active:
-
-```swift
-await WiredMemoryManager.shared.updateConfiguration { configuration in
-    configuration.policyOnlyWhenUnsupported = true
-}
-```
-
-## Debug Event Stream
-
-In DEBUG builds, observe manager events for policy stacking and limit changes.
-In release builds, stream is a no-op.
-
-```swift
-Task {
-    for await event in WiredMemoryManager.shared.events() {
-        print(event)
-    }
-}
 ```
 
 ## Practical Guidance


### PR DESCRIPTION
While I was working on #118, I noticed many inaccuracies in the "skills" documents that were added by @ronaldmannak in #92. I corrected some of these in #118 and have corrected more here. However, I think it would be best to remove most of these documents for the following reasons:

- They appear to be mostly AI-generated summaries of source files. It's better for agents to directly read the source files, which should be self-documenting.
- They are liable to get out of sync with the codebase, as happened with the latest refactoring, and are thus detrimental to agents that use them.

A better use of skills is to record knowledge that isn't directly apparent from the codebase. Only the porting guide fits this criterion. I suggest that the other documents be removed.