### PR TITLE
Adopt GemmaFunctionParser to accomodate Gemma4 tool calls.

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -5,21 +5,28 @@ import Foundation
 /// Parser for Gemma format: call:name{key:value,k:<escape>str<escape>}
 /// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/function_gemma.py
 public struct GemmaFunctionParser: ToolCallParser, Sendable {
-    public let startTag: String? = "<start_function_call>"
-    public let endTag: String? = "<end_function_call>"
+    public let startTag: String?
+    public let endTag: String?
+    public let escapeMarker: String?
 
-    private let escapeMarker = "<escape>"
-
-    public init() {}
+    public init(startTag: String, endTag: String, escapeMarker: String) {
+        self.startTag = startTag
+        self.endTag = endTag
+        self.escapeMarker = escapeMarker
+    }
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        // Unwrap
+        guard let start = startTag, let end = endTag else { return nil }
+        guard let marker = escapeMarker else { return nil }
+
         // Strip tags if present
         var text = content
-        if let start = startTag {
-            text = text.replacingOccurrences(of: start, with: "")
+        if let startRange = text.range(of: start) {
+            text = String(text[startRange.upperBound...])
         }
-        if let end = endTag {
-            text = text.replacingOccurrences(of: end, with: "")
+        if let endRange = text.range(of: end) {
+            text = String(text[..<endRange.lowerBound])
         }
 
         // Pattern: call:(\w+)\{(.*?)\}
@@ -48,9 +55,9 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
             argsStr = String(argsStr[argsStr.index(after: colonIdx)...])
 
             // Handle escaped strings
-            if argsStr.hasPrefix(escapeMarker) {
-                argsStr = String(argsStr.dropFirst(escapeMarker.count))
-                guard let endEscape = argsStr.range(of: escapeMarker) else { break }
+            if argsStr.hasPrefix(marker) {
+                argsStr = String(argsStr.dropFirst(marker.count))
+                guard let endEscape = argsStr.range(of: marker) else { break }
                 let value = String(argsStr[..<endEscape.lowerBound])
                 arguments[key] = value
                 argsStr = String(argsStr[endEscape.upperBound...])

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -79,8 +79,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     case glm4
 
     /// Gemma function call format.
-    /// Example: `call:name{key:value,k:<escape>str<escape>}`
+    /// Example: `<start_function_call>call:name{key:value,k:<escape>str<escape>}<end_function_call>`
     case gemma
+
+    /// Gemma4 function call format.
+    /// Example: `<|tool_call>call:name{key:[<|"|>value<|"|>]}<tool_call|>`
+    case gemma4
 
     /// Kimi K2 format with functions prefix.
     /// Example: `functions.name:0<|tool_call_argument_begin|>{"key": "value"}`
@@ -110,7 +114,9 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         case .glm4:
             return GLM4ToolCallParser()
         case .gemma:
-            return GemmaFunctionParser()
+            return GemmaFunctionParser(startTag: "<start_function_call>", endTag: "<end_function_call>", escapeMarker: "<escape>")
+        case .gemma4:
+            return GemmaFunctionParser(startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
         case .kimiK2:
             return KimiK2ToolCallParser()
         case .minimaxM2:
@@ -138,6 +144,11 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // GLM4 family (glm4, glm4_moe, glm4_moe_lite, etc.)
         if type.hasPrefix("glm4") {
             return .glm4
+        }
+
+        // Gemma4
+        if type.hasPrefix("gemma4") {
+            return .gemma4
         }
 
         // Gemma

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -83,7 +83,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     case gemma
 
     /// Gemma4 function call format.
-    /// Example: `<|tool_call>call:name{key:[<|"|>value<|"|>]}<tool_call|>`
+    /// Example: `<|tool_call>call:name{key:<|"|>value<|"|>}<tool_call|>`
     case gemma4
 
     /// Kimi K2 format with functions prefix.
@@ -114,9 +114,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         case .glm4:
             return GLM4ToolCallParser()
         case .gemma:
-            return GemmaFunctionParser(startTag: "<start_function_call>", endTag: "<end_function_call>", escapeMarker: "<escape>")
+            return GemmaFunctionParser(
+                startTag: "<start_function_call>", endTag: "<end_function_call>",
+                escapeMarker: "<escape>")
         case .gemma4:
-            return GemmaFunctionParser(startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
+            return GemmaFunctionParser(
+                startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
         case .kimiK2:
             return KimiK2ToolCallParser()
         case .minimaxM2:

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -79,8 +79,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     case glm4
 
     /// Gemma function call format.
-    /// Example: `call:name{key:value,k:<escape>str<escape>}`
+    /// Example: `<start_function_call>call:name{key:value,k:<escape>str<escape>}<end_function_call>`
     case gemma
+
+    /// Gemma4 function call format.
+    /// Example: `<|tool_call>call:name{key:[<|"|>value<|"|>]}<tool_call|>`
+    case gemma4
 
     /// Kimi K2 format with functions prefix.
     /// Example: `functions.name:0<|tool_call_argument_begin|>{"key": "value"}`
@@ -114,7 +118,9 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         case .glm4:
             return GLM4ToolCallParser()
         case .gemma:
-            return GemmaFunctionParser()
+            return GemmaFunctionParser(startTag: "<start_function_call>", endTag: "<end_function_call>", escapeMarker: "<escape>")
+        case .gemma4:
+            return GemmaFunctionParser(startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
         case .kimiK2:
             return KimiK2ToolCallParser()
         case .minimaxM2:
@@ -168,6 +174,11 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // GLM4 family (glm4, glm4_moe, glm4_moe_lite, etc.)
         if type.hasPrefix("glm4") {
             return .glm4
+        }
+
+        // Gemma4
+        if type.hasPrefix("gemma4") {
+            return .gemma4
         }
 
         // Gemma

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -83,7 +83,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     case gemma
 
     /// Gemma4 function call format.
-    /// Example: `<|tool_call>call:name{key:[<|"|>value<|"|>]}<tool_call|>`
+    /// Example: `<|tool_call>call:name{key:<|"|>value<|"|>}<tool_call|>`
     case gemma4
 
     /// Kimi K2 format with functions prefix.
@@ -118,9 +118,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         case .glm4:
             return GLM4ToolCallParser()
         case .gemma:
-            return GemmaFunctionParser(startTag: "<start_function_call>", endTag: "<end_function_call>", escapeMarker: "<escape>")
+            return GemmaFunctionParser(
+                startTag: "<start_function_call>", endTag: "<end_function_call>",
+                escapeMarker: "<escape>")
         case .gemma4:
-            return GemmaFunctionParser(startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
+            return GemmaFunctionParser(
+                startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
         case .kimiK2:
             return KimiK2ToolCallParser()
         case .minimaxM2:

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -468,7 +468,9 @@ struct ToolTests {
 
     @Test("Test Gemma Function Parser")
     func testGemmaParser() throws {
-        let parser = GemmaFunctionParser()
+        let parser = GemmaFunctionParser(
+            startTag: "<start_function_call>", endTag: "<end_function_call>",
+            escapeMarker: "<escape>")
         let content =
             "<start_function_call>call:get_weather{location:Paris,unit:celsius}<end_function_call>"
 
@@ -481,7 +483,9 @@ struct ToolTests {
 
     @Test("Test Gemma Function Parser - Escaped Strings")
     func testGemmaParserEscapedStrings() throws {
-        let parser = GemmaFunctionParser()
+        let parser = GemmaFunctionParser(
+            startTag: "<start_function_call>", endTag: "<end_function_call>",
+            escapeMarker: "<escape>")
         // Note: Gemma uses <escape> for both start and end markers (not </escape>)
         let content =
             "<start_function_call>call:search{query:<escape>hello, world!<escape>}<end_function_call>"


### PR DESCRIPTION
## Proposed changes

I see #180 by @drgrondin is already looking good, this complements Gemma 4 with tool calling.
It reuses **GemmaFunctionParser**, and initializes it with three parameters:
- startTag
- endTag
- escapeMarker

To distinguish between the different flavors of tool calling.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
