### PR TITLE
Fix Swift 6 Sendable error in Llama3ToolCallParser

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/Llama3ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Llama3ToolCallParser.swift
@@ -35,7 +35,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
 
             let function = ToolCall.Function(
                 name: llamaFunc.name,
-                arguments: args.mapValues { $0.anyValue }
+                arguments: args
             )
             return ToolCall(function: function)
         }
@@ -65,7 +65,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
                 let args = llamaFunc.parameters ?? llamaFunc.arguments ?? [:]
                 let function = ToolCall.Function(
                     name: llamaFunc.name,
-                    arguments: args.mapValues { $0.anyValue }
+                    arguments: args
                 )
                 return ToolCall(function: function)
             }
@@ -76,7 +76,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
             let args = llamaFunc.parameters ?? llamaFunc.arguments ?? [:]
             let function = ToolCall.Function(
                 name: llamaFunc.name,
-                arguments: args.mapValues { $0.anyValue }
+                arguments: args
             )
             return [ToolCall(function: function)]
         }

--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -11,6 +11,11 @@ public struct ToolCall: Hashable, Codable, Sendable {
         /// The arguments passed to the function
         public let arguments: [String: JSONValue]
 
+        public init(name: String, arguments: [String: JSONValue]) {
+            self.name = name
+            self.arguments = arguments
+        }
+
         public init(name: String, arguments: [String: any Sendable]) {
             self.name = name
             self.arguments = arguments.mapValues { JSONValue.from($0) }


### PR DESCRIPTION
## Summary
- preserve decoded JSON arguments as `JSONValue` when building `ToolCall.Function`
- add a direct `ToolCall.Function` initializer for `[String: JSONValue]`
- fix Swift 6 `Sendable` build failures in `Llama3ToolCallParser`

## Testing
- `xcodebuild -workspace FlowDown.xcworkspace -scheme FlowDown -configuration Release -destination 'generic/platform=iOS' build | xcbeautify -qq`

Written by Codex.
