### PR TITLE
Fix sporadic JSON tool-call detection and add parser hardening for mixed text/tool outputs

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -421,7 +421,8 @@ public final class ChatSession {
                             promptTokenCount: input.text.tokens.size,
                             modelConfiguration: modelConfiguration,
                             tokenizer: tokenizer,
-                            iterator: iterator
+                            iterator: iterator,
+                            tools: tools
                         )
 
                         var pendingToolCalls: [ToolCall] = []

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1478,6 +1478,7 @@ public func generate(
 ///   - modelConfiguration: model configuration (for EOS/extra EOS tokens and tool-call format)
 ///   - tokenizer: tokenizer (for EOS id, unknown token id, and detokenization)
 ///   - iterator: token iterator
+///   - tools: Optional tool schemas used to validate emitted tool names.
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
 /// - Returns: An `AsyncStream` that emits `Generation` values and a `Task`
 public func generateTask(
@@ -1485,6 +1486,7 @@ public func generateTask(
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
     iterator: consuming TokenIterator,
+    tools: [[String: any Sendable]]?,
     wiredMemoryTicket: WiredMemoryTicket? = nil
 ) -> (AsyncStream<Generation>, Task<Void, Never>) {
     generateLoopTask(
@@ -1495,8 +1497,30 @@ public func generateTask(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: tokenizer,
-            format: modelConfiguration.toolCallFormat ?? .json
+            format: modelConfiguration.toolCallFormat ?? .json,
+            tools: tools
         )
+    )
+}
+
+/// Compatibility overload that preserves the original public signature.
+///
+/// This forwards to ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:tools:wiredMemoryTicket:)``
+/// with `tools` unset.
+public func generateTask(
+    promptTokenCount: Int,
+    modelConfiguration: ModelConfiguration,
+    tokenizer: Tokenizer,
+    iterator: consuming TokenIterator,
+    wiredMemoryTicket: WiredMemoryTicket? = nil
+) -> (AsyncStream<Generation>, Task<Void, Never>) {
+    generateTask(
+        promptTokenCount: promptTokenCount,
+        modelConfiguration: modelConfiguration,
+        tokenizer: tokenizer,
+        iterator: iterator,
+        tools: nil,
+        wiredMemoryTicket: wiredMemoryTicket
     )
 }
 
@@ -1957,9 +1981,9 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     var detokenizer: NaiveStreamingDetokenizer
     let toolCallProcessor: ToolCallProcessor
 
-    init(tokenizer: Tokenizer, format: ToolCallFormat) {
+    init(tokenizer: Tokenizer, format: ToolCallFormat, tools: [[String: any Sendable]]? = nil) {
         detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
-        toolCallProcessor = ToolCallProcessor(format: format)
+        toolCallProcessor = ToolCallProcessor(format: format, tools: tools)
     }
 
     mutating func onToken(
@@ -1975,8 +1999,8 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
                 }
             }
 
-            // Check if we have a complete tool call.
-            if let toolCall = toolCallProcessor.toolCalls.popLast() {
+            // Emit all complete tool calls in parse order.
+            for toolCall in toolCallProcessor.drainToolCalls() {
                 if case .terminated = emit(.toolCall(toolCall)) {
                     return false
                 }
@@ -1996,9 +2020,15 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     mutating func onGenerationEnd(
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
     ) {
-        toolCallProcessor.processEOS()
+        if let bufferedText = toolCallProcessor.processEOS(returnBufferedText: true),
+            !bufferedText.isEmpty
+        {
+            if case .terminated = emit(.chunk(bufferedText)) {
+                return
+            }
+        }
 
-        for toolCall in toolCallProcessor.toolCalls {
+        for toolCall in toolCallProcessor.drainToolCalls() {
             if case .terminated = emit(.toolCall(toolCall)) {
                 break
             }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1986,8 +1986,8 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
                 }
             }
 
-            // Check if we have a complete tool call.
-            if let toolCall = toolCallProcessor.toolCalls.popLast() {
+            // Emit all complete tool calls in parse order.
+            for toolCall in toolCallProcessor.drainToolCalls() {
                 if case .terminated = emit(.toolCall(toolCall)) {
                     return false
                 }
@@ -2007,9 +2007,15 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
     mutating func onGenerationEnd(
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
     ) {
-        toolCallProcessor.processEOS()
+        if let bufferedText = toolCallProcessor.processEOS(returnBufferedText: true),
+            !bufferedText.isEmpty
+        {
+            if case .terminated = emit(.chunk(bufferedText)) {
+                return
+            }
+        }
 
-        for toolCall in toolCallProcessor.toolCalls {
+        for toolCall in toolCallProcessor.drainToolCalls() {
             if case .terminated = emit(.toolCall(toolCall)) {
                 break
             }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -33,6 +33,22 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
             let function = try? JSONDecoder().decode(ToolCall.Function.self, from: data)
         else { return nil }
 
+        // If tool schemas are provided, only accept calls to declared tools.
+        if let tools, !tools.isEmpty {
+            var isDeclaredTool = false
+            for tool in tools {
+                let functionSpec = tool["function"] as? [String: any Sendable]
+                if functionSpec?["name"] as? String == function.name {
+                    isDeclaredTool = true
+                    break
+                }
+            }
+
+            guard isDeclaredTool else {
+                return nil
+            }
+        }
+
         return ToolCall(function: function)
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -35,6 +35,22 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
             let function = try? JSONDecoder().decode(ToolCall.Function.self, from: normalizedData)
         else { return nil }
 
+        // If tool schemas are provided, only accept calls to declared tools.
+        if let tools, !tools.isEmpty {
+            var isDeclaredTool = false
+            for tool in tools {
+                let functionSpec = tool["function"] as? [String: any Sendable]
+                if functionSpec?["name"] as? String == function.name {
+                    isDeclaredTool = true
+                    break
+                }
+            }
+
+            guard isDeclaredTool else {
+                return nil
+            }
+        }
+
         return ToolCall(function: function)
     }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -28,6 +28,9 @@ public class ToolCallProcessor {
 
     private let parser: any ToolCallParser
     private let tools: [[String: any Sendable]]?
+    private let supportsBareJSONFallback: Bool
+    private let maxJSONFallbackBufferLength = 32_768
+    private let jsonObjectScanner = JSONLeadingObjectScanner(startCharacter: "{")
     private var state = State.normal
     private var toolCallBuffer = ""
 
@@ -40,6 +43,13 @@ public class ToolCallProcessor {
         case normal
         case potentialToolCall
         case collectingToolCall
+        case collectingJSONToolCall
+    }
+
+    private enum TaggedStartMode {
+        case none
+        case tagged
+        case bareJSON
     }
 
     // MARK: - Initialization
@@ -51,6 +61,7 @@ public class ToolCallProcessor {
     public init(format: ToolCallFormat = .json, tools: [[String: any Sendable]]? = nil) {
         self.parser = format.createParser()
         self.tools = tools
+        self.supportsBareJSONFallback = format == .json
     }
 
     // MARK: - Computed Properties
@@ -77,6 +88,17 @@ public class ToolCallProcessor {
         return processTaggedChunk(chunk)
     }
 
+    /// Drain queued tool calls in parse order.
+    ///
+    /// This is useful for streaming consumers that need deterministic FIFO dispatch
+    /// of all complete calls discovered while processing a token chunk.
+    func drainToolCalls() -> [ToolCall] {
+        guard !toolCalls.isEmpty else { return [] }
+        let drained = toolCalls
+        toolCalls.removeAll(keepingCapacity: true)
+        return drained
+    }
+
     /// Process end-of-sequence, parsing any buffered content as tool call(s).
     ///
     /// Call this when generation ends (e.g., on EOS token) to handle formats
@@ -86,16 +108,38 @@ public class ToolCallProcessor {
     /// For formats with end tags that appear in the text stream, the buffer
     /// will already be empty at generation end, making this a no-op.
     public func processEOS() {
-        guard state == .collectingToolCall || state == .potentialToolCall else { return }
+        _ = processEOS(returnBufferedText: false)
+    }
+
+    /// Process end-of-sequence and optionally return residual buffered text.
+    ///
+    /// Use this overload when callers need to preserve non-tool trailing content
+    /// that remained buffered until generation end.
+    ///
+    /// - Parameter returnBufferedText: When `true`, returns residual text if no
+    ///   tool call was parsed from the buffered content.
+    /// - Returns: Residual buffered text that should be emitted as regular output,
+    ///   or `nil` when the buffer was fully parsed as tool call content (or when
+    ///   `returnBufferedText` is `false`).
+    @discardableResult
+    public func processEOS(returnBufferedText: Bool = true) -> String? {
+        guard
+            state == .collectingToolCall || state == .potentialToolCall
+                || state == .collectingJSONToolCall
+        else { return nil }
         guard !toolCallBuffer.isEmpty else {
             state = .normal
-            return
+            return nil
         }
 
-        toolCalls.append(contentsOf: parser.parseEOS(toolCallBuffer, tools: tools))
+        let buffered = toolCallBuffer
+        let parsedCalls = parser.parseEOS(buffered, tools: tools)
+        toolCalls.append(contentsOf: parsedCalls)
 
         toolCallBuffer = ""
         state = .normal
+
+        return returnBufferedText && parsedCalls.isEmpty ? buffered : nil
     }
 
     // MARK: - Private Methods
@@ -137,7 +181,7 @@ public class ToolCallProcessor {
             // No brace seen — pass through as regular text
             return chunk
 
-        case .potentialToolCall, .collectingToolCall:
+        case .potentialToolCall, .collectingToolCall, .collectingJSONToolCall:
             toolCallBuffer += chunk
 
             if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
@@ -177,7 +221,11 @@ public class ToolCallProcessor {
             return chunk
         }
 
-        guard (state == .normal && chunk.contains(startChar)) || state != .normal else {
+        let startMode =
+            state == .normal
+            ? taggedStartMode(in: chunk, startChar: startChar)
+            : .none
+        guard startMode != .none || state != .normal else {
             return chunk
         }
 
@@ -186,13 +234,35 @@ public class ToolCallProcessor {
 
         switch state {
         case .normal:
-            // Change state to potential tool call
+            if startMode == .bareJSON {
+                // Fallback for models that sporadically emit bare JSON tool calls.
+                state = .collectingJSONToolCall
+
+                leadingToken = separateToken(
+                    from: &toolCallBuffer,
+                    separator: String(jsonObjectScanner.startCharacter),
+                    returnLeading: true
+                )
+
+                return processCollectingJSONToolCall(
+                    startTag: startTag,
+                    startChar: startChar,
+                    leadingToken: leadingToken
+                )
+            }
+
+            guard startMode == .tagged else {
+                return chunk
+            }
+
+            // Change state to potential tagged tool call.
             state = .potentialToolCall
 
             leadingToken = separateToken(
                 from: &toolCallBuffer, separator: String(startChar), returnLeading: true)
 
             fallthrough
+
         case .potentialToolCall:
             if partialMatch(buffer: toolCallBuffer, tag: startTag) {
                 if toolCallBuffer.starts(with: startTag) {
@@ -202,43 +272,169 @@ public class ToolCallProcessor {
                     return nil
                 }
             } else {
-                // Otherwise, return the collected text and reset the state
+                // Otherwise, return the collected text and reset the state.
                 state = .normal
                 let buffer = toolCallBuffer
                 toolCallBuffer = ""
                 return (leadingToken ?? "") + buffer
             }
+
         case .collectingToolCall:
             guard let endTag = parser.endTag else {
                 return nil
             }
 
             if toolCallBuffer.contains(endTag) {
-                // Separate the trailing token
+                // Separate the trailing token.
                 let trailingToken = separateToken(
                     from: &toolCallBuffer, separator: endTag, returnLeading: false)
 
-                // Parse the tool call using the parser
-                if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
+                let bufferedToolCall = toolCallBuffer
+
+                // Parse the tool call using the parser.
+                if let toolCall = parser.parse(content: bufferedToolCall, tools: tools) {
                     toolCalls.append(toolCall)
+                    state = .normal
+                    toolCallBuffer = ""
+
+                    // If trailing content may contain another tool call, recurse.
+                    if let trailingToken,
+                        tokenCouldContainToolStart(trailingToken, startChar: startChar)
+                    {
+                        return combine(leadingToken, processChunk(trailingToken))
+                    }
+
+                    // Otherwise, return trailing text if non-empty.
+                    let trailingText = trailingToken?.isEmpty ?? true ? nil : trailingToken
+                    return combine(leadingToken, trailingText)
                 }
 
+                // Preserve unparsed tagged payload as plain text, then continue scanning.
                 state = .normal
                 toolCallBuffer = ""
-
-                // If the token contains the start character, there may be more tool calls to come
-                if let trailingToken, let startChar = startTagFirstChar,
-                    trailingToken.contains(startChar)
+                if let trailingToken,
+                    tokenCouldContainToolStart(trailingToken, startChar: startChar)
                 {
-                    return processChunk(trailingToken)
-                } else {
-                    // Otherwise, return the collected token, or nil if it's empty
-                    return trailingToken?.isEmpty ?? true ? nil : trailingToken
+                    return combine(
+                        leadingToken,
+                        combine(bufferedToolCall, processChunk(trailingToken))
+                    )
                 }
-            } else {
-                return nil
+                return combine(leadingToken, combine(bufferedToolCall, trailingToken))
             }
+
+            return nil
+
+        case .collectingJSONToolCall:
+            return processCollectingJSONToolCall(
+                startTag: startTag,
+                startChar: startChar,
+                leadingToken: leadingToken
+            )
         }
+    }
+
+    private func processCollectingJSONToolCall(
+        startTag: String,
+        startChar: Character,
+        leadingToken: String?
+    ) -> String? {
+        if toolCallBuffer.count > maxJSONFallbackBufferLength {
+            // Safety valve: flush pathological unmatched JSON-like buffers as text.
+            state = .normal
+            let buffered = toolCallBuffer
+            toolCallBuffer = ""
+            return combine(leadingToken, buffered)
+        }
+
+        switch jsonObjectScanner.evaluatePrefix(in: toolCallBuffer) {
+        case .invalidObject:
+            state = .normal
+            let buffered = toolCallBuffer
+            toolCallBuffer = ""
+            // vLLM-style recovery: if a tagged tool call exists later, retry tagged parsing.
+            if buffered.contains(startTag) {
+                return combine(leadingToken, processChunk(buffered))
+            }
+            return combine(leadingToken, buffered)
+        case .needsMore, .validObject:
+            break
+        }
+
+        guard let split = jsonObjectScanner.splitLeadingObject(from: toolCallBuffer) else {
+            // Continue buffering until a complete top-level JSON object is available.
+            return leadingToken?.isEmpty ?? true ? nil : leadingToken
+        }
+
+        let jsonCandidate = split.object
+        let trailingToken = split.trailing
+
+        if let toolCall = parser.parse(content: jsonCandidate, tools: tools) {
+            toolCalls.append(toolCall)
+
+            state = .normal
+            toolCallBuffer = ""
+
+            if trailingToken.isEmpty {
+                return leadingToken?.isEmpty ?? true ? nil : leadingToken
+            }
+
+            if tokenCouldContainToolStart(trailingToken, startChar: startChar) {
+                return combine(leadingToken, processChunk(trailingToken))
+            }
+
+            return combine(leadingToken, trailingToken)
+        }
+
+        // If it looked like JSON but is not a valid tool call payload,
+        // flush it back as normal text while still scanning trailing content.
+        state = .normal
+        toolCallBuffer = ""
+        if tokenCouldContainToolStart(trailingToken, startChar: startChar) {
+            return combine(leadingToken, combine(jsonCandidate, processChunk(trailingToken)))
+        }
+        return combine(leadingToken, combine(jsonCandidate, trailingToken))
+    }
+
+    private func taggedStartMode(
+        in chunk: String,
+        startChar: Character
+    ) -> TaggedStartMode {
+        let taggedStartIndex = chunk.firstIndex(of: startChar)
+        let jsonStartIndex =
+            supportsBareJSONFallback
+            ? chunk.firstIndex(of: jsonObjectScanner.startCharacter)
+            : nil
+
+        switch (taggedStartIndex, jsonStartIndex) {
+        case (nil, nil):
+            return .none
+        case (.some, nil):
+            return .tagged
+        case (nil, .some):
+            return .bareJSON
+        case (.some(let tagged), .some(let json)):
+            if json >= tagged {
+                return .tagged
+            }
+
+            // If the earlier `{` cannot begin a JSON object, prefer tagged parsing.
+            if case .invalidObject = jsonObjectScanner.evaluatePrefix(in: chunk, from: json) {
+                return .tagged
+            }
+
+            return .bareJSON
+        }
+    }
+
+    private func tokenCouldContainToolStart(_ token: String, startChar: Character) -> Bool {
+        token.contains(startChar)
+            || (supportsBareJSONFallback && token.contains(jsonObjectScanner.startCharacter))
+    }
+
+    private func combine(_ first: String?, _ second: String?) -> String? {
+        let merged = (first ?? "") + (second ?? "")
+        return merged.isEmpty ? nil : merged
     }
 
     /// Separates a token from a string buffer based on a separator
@@ -272,5 +468,101 @@ public class ToolCallProcessor {
         }
 
         return true
+    }
+}
+
+private struct JSONLeadingObjectScanner {
+    enum PrefixState {
+        case needsMore
+        case validObject
+        case invalidObject
+    }
+
+    let startCharacter: Character
+
+    func evaluatePrefix(in buffer: String) -> PrefixState {
+        guard let start = buffer.firstIndex(where: { !$0.isWhitespace }) else {
+            return .invalidObject
+        }
+        return evaluatePrefix(in: buffer, from: start)
+    }
+
+    func evaluatePrefix(in buffer: String, from start: String.Index) -> PrefixState {
+        var openingIndex = start
+        while openingIndex < buffer.endIndex, buffer[openingIndex].isWhitespace {
+            openingIndex = buffer.index(after: openingIndex)
+        }
+
+        guard openingIndex < buffer.endIndex, buffer[openingIndex] == startCharacter else {
+            return .invalidObject
+        }
+
+        var index = buffer.index(after: openingIndex)
+        while index < buffer.endIndex, buffer[index].isWhitespace {
+            index = buffer.index(after: index)
+        }
+
+        guard index < buffer.endIndex else {
+            return .needsMore
+        }
+
+        let firstToken = buffer[index]
+        if firstToken == "\"" || firstToken == "}" {
+            return .validObject
+        }
+
+        return .invalidObject
+    }
+
+    /// Splits a buffer that starts with optional whitespace + startCharacter into:
+    /// 1) the first complete top-level JSON object
+    /// 2) trailing remainder after that object
+    func splitLeadingObject(from buffer: String) -> (object: String, trailing: String)? {
+        guard let start = buffer.firstIndex(where: { !$0.isWhitespace }),
+            buffer[start] == startCharacter
+        else { return nil }
+
+        var depth = 0
+        var inString = false
+        var isEscaped = false
+
+        var index = start
+        while index < buffer.endIndex {
+            let character = buffer[index]
+
+            if inString {
+                if isEscaped {
+                    isEscaped = false
+                } else if character == "\\" {
+                    isEscaped = true
+                } else if character == "\"" {
+                    inString = false
+                }
+            } else {
+                switch character {
+                case "\"":
+                    inString = true
+                case "{":
+                    depth += 1
+                case "}":
+                    depth -= 1
+                    if depth == 0 {
+                        let object = String(buffer[start ... index])
+                        let trailingStart = buffer.index(after: index)
+                        let trailing =
+                            trailingStart < buffer.endIndex
+                            ? String(buffer[trailingStart...])
+                            : ""
+                        return (object, trailing)
+                    }
+                default:
+                    break
+                }
+            }
+
+            index = buffer.index(after: index)
+        }
+
+        return nil
     }
 }

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -113,6 +113,317 @@ struct ToolTests {
         #expect(toolCall.function.arguments["query"] == .string("swift programming"))
     }
 
+    @Test("Test JSON Format via ToolCallProcessor - Bare JSON Fallback")
+    func testJSONFormatProcessorBareJSONFallback() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunks: [String] = [
+            "{\"name\": \"get_weather\", ",
+            "\"arguments\": {\"location\": \"Rome\"}}",
+        ]
+
+        var emittedText = ""
+        for chunk in chunks {
+            if let text = processor.processChunk(chunk) {
+                emittedText += text
+            }
+        }
+
+        if let text = processor.processEOS(returnBufferedText: true) {
+            emittedText += text
+        }
+
+        #expect(emittedText.isEmpty)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Rome"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Bare JSON With Leading Text")
+    func testJSONFormatProcessorBareJSONWithLeadingText() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "Let me check that.\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Milan\"}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == "Let me check that.\n")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Milan"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Tagged JSON In Single Chunk")
+    func testJSONFormatProcessorTaggedSingleChunk() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "<tool_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Tokyo\"}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Tokyo"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Multiple Tagged Calls Preserve Order")
+    func testJSONFormatProcessorMultipleTaggedCallsPreserveOrder() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "<tool_call>{\"name\":\"first_call\",\"arguments\":{}}</tool_call><tool_call>{\"name\":\"second_call\",\"arguments\":{}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 2)
+        #expect(processor.toolCalls[0].function.name == "first_call")
+        #expect(processor.toolCalls[1].function.name == "second_call")
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Tagged JSON With Leading Text")
+    func testJSONFormatProcessorTaggedWithLeadingText() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "Let me check that.\n<tool_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Osaka\"}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == "Let me check that.\n")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Osaka"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Invalid Bare JSON Flushes At EOS")
+    func testJSONFormatProcessorInvalidBareJSONFlushesAtEOS() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk = "{\"name\": \"get_weather\", \"arguments\": "
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == chunk)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Non Tool JSON Stays Text")
+    func testJSONFormatProcessorNonToolJSONStaysText() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk = "{\"status\": \"ok\", \"data\": {\"value\": 42}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == chunk)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Split Non Tool JSON Stays Text")
+    func testJSONFormatProcessorSplitNonToolJSONStaysText() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunks = ["{\"status\": ", "\"ok\", \"data\": {\"value\": 42}}"]
+
+        var emittedText = ""
+        for chunk in chunks {
+            if let output = processor.processChunk(chunk) {
+                emittedText += output
+            }
+        }
+
+        if let eosOutput = processor.processEOS(returnBufferedText: true) {
+            emittedText += eosOutput
+        }
+
+        #expect(emittedText == "{\"status\": \"ok\", \"data\": {\"value\": 42}}")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Missing Arguments Stays Text")
+    func testJSONFormatProcessorMissingArgumentsStaysText() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk = "{\"name\": \"not_a_tool_call_payload\"}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == chunk)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Brace Text Is Not Treated As JSON Tool Call")
+    func testJSONFormatProcessorBraceTextNotToolCall() {
+        let processor = ToolCallProcessor(format: .json)
+
+        let first = processor.processChunk("Use {")
+        let second = processor.processChunk("x} notation")
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(first == "Use ")
+        #expect(second == "{x} notation")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Unknown Tool Name Stays Text When Tools Are Provided"
+    )
+    func testJSONFormatProcessorUnknownToolNameStaysTextWithTools() {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk = "{\"name\": \"not_declared\", \"arguments\": {}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == chunk)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Recovers Tagged Tool Call After Brace Text")
+    func testJSONFormatProcessorRecoversTaggedToolCallAfterBraceText() throws {
+        let processor = ToolCallProcessor(format: .json)
+        var emittedText = ""
+
+        if let output = processor.processChunk("note {x") {
+            emittedText += output
+        }
+        if let output = processor.processChunk(
+            "} <tool_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Paris\"}}</tool_call>"
+        ) {
+            emittedText += output
+        }
+        if let eosOutput = processor.processEOS(returnBufferedText: true) {
+            emittedText += eosOutput
+        }
+
+        #expect(emittedText == "note {x} ")
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool Preserved And Continues Parsing"
+    )
+    func testJSONFormatProcessorUnknownTaggedToolPreservedAndContinuesParsing() throws {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk =
+            "<tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call><tool_call>{\"name\":\"get_weather\",\"arguments\":{}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == "<tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call>")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool With Leading Text Preserved"
+    )
+    func testJSONFormatProcessorUnknownTaggedToolWithLeadingTextPreserved() throws {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk =
+            "Preface <tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call><tool_call>{\"name\":\"get_weather\",\"arguments\":{}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(
+            output == "Preface <tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call>")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Declared Tool Name Parses When Tools Are Provided"
+    )
+    func testJSONFormatProcessorDeclaredToolNameParsesWithTools() throws {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk = "{\"name\": \"get_weather\", \"arguments\": {}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+    }
+
     // MARK: - Pythonic Format Tests (LFM2/LFM2.5)
 
     @Test("Test Pythonic Tool Call Parser - Basic")
@@ -740,7 +1051,6 @@ struct ToolTests {
 
         // End tag never arrives in text, so tool call stays buffered until processEOS
         #expect(processor.toolCalls.count == 0)
-
         processor.processEOS()
 
         #expect(processor.toolCalls.count == 1)
@@ -788,7 +1098,6 @@ struct ToolTests {
 
         // No tool calls before processEOS
         #expect(processor.toolCalls.count == 0)
-
         processor.processEOS()
 
         // Both tool calls should be extracted

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -152,6 +152,317 @@ struct ToolTests {
             toolCall.function.arguments["queries"] == .array([.string("swift"), .string("mlx")]))
     }
 
+    @Test("Test JSON Format via ToolCallProcessor - Bare JSON Fallback")
+    func testJSONFormatProcessorBareJSONFallback() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunks: [String] = [
+            "{\"name\": \"get_weather\", ",
+            "\"arguments\": {\"location\": \"Rome\"}}",
+        ]
+
+        var emittedText = ""
+        for chunk in chunks {
+            if let text = processor.processChunk(chunk) {
+                emittedText += text
+            }
+        }
+
+        if let text = processor.processEOS(returnBufferedText: true) {
+            emittedText += text
+        }
+
+        #expect(emittedText.isEmpty)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Rome"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Bare JSON With Leading Text")
+    func testJSONFormatProcessorBareJSONWithLeadingText() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "Let me check that.\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Milan\"}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == "Let me check that.\n")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Milan"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Tagged JSON In Single Chunk")
+    func testJSONFormatProcessorTaggedSingleChunk() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "<tool_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Tokyo\"}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Tokyo"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Multiple Tagged Calls Preserve Order")
+    func testJSONFormatProcessorMultipleTaggedCallsPreserveOrder() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "<tool_call>{\"name\":\"first_call\",\"arguments\":{}}</tool_call><tool_call>{\"name\":\"second_call\",\"arguments\":{}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 2)
+        #expect(processor.toolCalls[0].function.name == "first_call")
+        #expect(processor.toolCalls[1].function.name == "second_call")
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Tagged JSON With Leading Text")
+    func testJSONFormatProcessorTaggedWithLeadingText() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk =
+            "Let me check that.\n<tool_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Osaka\"}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == "Let me check that.\n")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Osaka"))
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Invalid Bare JSON Flushes At EOS")
+    func testJSONFormatProcessorInvalidBareJSONFlushesAtEOS() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk = "{\"name\": \"get_weather\", \"arguments\": "
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == chunk)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Non Tool JSON Stays Text")
+    func testJSONFormatProcessorNonToolJSONStaysText() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk = "{\"status\": \"ok\", \"data\": {\"value\": 42}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == chunk)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Split Non Tool JSON Stays Text")
+    func testJSONFormatProcessorSplitNonToolJSONStaysText() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunks = ["{\"status\": ", "\"ok\", \"data\": {\"value\": 42}}"]
+
+        var emittedText = ""
+        for chunk in chunks {
+            if let output = processor.processChunk(chunk) {
+                emittedText += output
+            }
+        }
+
+        if let eosOutput = processor.processEOS(returnBufferedText: true) {
+            emittedText += eosOutput
+        }
+
+        #expect(emittedText == "{\"status\": \"ok\", \"data\": {\"value\": 42}}")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Missing Arguments Stays Text")
+    func testJSONFormatProcessorMissingArgumentsStaysText() {
+        let processor = ToolCallProcessor(format: .json)
+        let chunk = "{\"name\": \"not_a_tool_call_payload\"}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == chunk)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Brace Text Is Not Treated As JSON Tool Call")
+    func testJSONFormatProcessorBraceTextNotToolCall() {
+        let processor = ToolCallProcessor(format: .json)
+
+        let first = processor.processChunk("Use {")
+        let second = processor.processChunk("x} notation")
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(first == "Use ")
+        #expect(second == "{x} notation")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Unknown Tool Name Stays Text When Tools Are Provided"
+    )
+    func testJSONFormatProcessorUnknownToolNameStaysTextWithTools() {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk = "{\"name\": \"not_declared\", \"arguments\": {}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == chunk)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Recovers Tagged Tool Call After Brace Text")
+    func testJSONFormatProcessorRecoversTaggedToolCallAfterBraceText() throws {
+        let processor = ToolCallProcessor(format: .json)
+        var emittedText = ""
+
+        if let output = processor.processChunk("note {x") {
+            emittedText += output
+        }
+        if let output = processor.processChunk(
+            "} <tool_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Paris\"}}</tool_call>"
+        ) {
+            emittedText += output
+        }
+        if let eosOutput = processor.processEOS(returnBufferedText: true) {
+            emittedText += eosOutput
+        }
+
+        #expect(emittedText == "note {x} ")
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool Preserved And Continues Parsing"
+    )
+    func testJSONFormatProcessorUnknownTaggedToolPreservedAndContinuesParsing() throws {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk =
+            "<tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call><tool_call>{\"name\":\"get_weather\",\"arguments\":{}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == "<tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call>")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool With Leading Text Preserved"
+    )
+    func testJSONFormatProcessorUnknownTaggedToolWithLeadingTextPreserved() throws {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk =
+            "Preface <tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call><tool_call>{\"name\":\"get_weather\",\"arguments\":{}}</tool_call>"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(
+            output == "Preface <tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call>")
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Declared Tool Name Parses When Tools Are Provided"
+    )
+    func testJSONFormatProcessorDeclaredToolNameParsesWithTools() throws {
+        struct EmptyInput: Codable {}
+        struct EmptyOutput: Codable { let ok: Bool }
+
+        let tool = Tool<EmptyInput, EmptyOutput>(
+            name: "get_weather",
+            description: "Gets weather",
+            parameters: []
+        ) { _ in
+            EmptyOutput(ok: true)
+        }
+
+        let processor = ToolCallProcessor(format: .json, tools: [tool.schema])
+        let chunk = "{\"name\": \"get_weather\", \"arguments\": {}}"
+
+        let output = processor.processChunk(chunk)
+        let eosOutput = processor.processEOS(returnBufferedText: true)
+
+        #expect(output == nil)
+        #expect(eosOutput == nil)
+        #expect(processor.toolCalls.count == 1)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+    }
+
     // MARK: - Pythonic Format Tests (LFM2/LFM2.5)
 
     @Test("Test Pythonic Tool Call Parser - Basic")
@@ -788,7 +1099,6 @@ struct ToolTests {
 
         // End tag never arrives in text, so tool call stays buffered until processEOS
         #expect(processor.toolCalls.count == 0)
-
         processor.processEOS()
 
         #expect(processor.toolCalls.count == 1)
@@ -836,7 +1146,6 @@ struct ToolTests {
 
         // No tool calls before processEOS
         #expect(processor.toolCalls.count == 0)
-
         processor.processEOS()
 
         // Both tool calls should be extracted


### PR DESCRIPTION
## Proposed changes

This PR fixes sporadic cases where models output raw JSON tool calls (without wrapper tags) and the stream showed raw JSON instead of emitting a toolCall. It also hardens parser behavior to avoid regressions with normal text/JSON and mixed tagged + untagged content.
ToolCallProcessor primarily relied on tagged boundaries for streaming detection. When models (e.g. Qwen2.5 Instruct) occasionally emitted bare JSON tool calls, the content could bypass tool extraction and appear as raw text.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
