### PR TITLE
Fix Gemma 4 system message and modality order

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1768,6 +1768,32 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
 
 // MARK: - Processor
 
+public struct Gemma4MessageGenerator: MessageGenerator {
+    public init() {}
+
+    public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        if message.role == .system {
+            [
+                "role": message.role.rawValue,
+                "content": message.content,
+            ]
+        } else {
+            [
+                "role": message.role.rawValue,
+                "content": [
+                    ["type": "text", "text": message.content]
+                ]
+                    + message.images.map { _ in
+                        ["type": "image"]
+                    }
+                    + message.videos.map { _ in
+                        ["type": "video"]
+                    },
+            ]
+        }
+    }
+}
+
 public struct Gemma4Processor: UserInputProcessor {
     private let config: Gemma4ProcessorConfiguration
     private let tokenizer: any Tokenizer
@@ -1804,7 +1830,7 @@ public struct Gemma4Processor: UserInputProcessor {
     }
 
     public func prepare(input: UserInput) async throws -> LMInput {
-        let messages = Qwen2VLMessageGenerator().generate(from: input)
+        let messages = Gemma4MessageGenerator().generate(from: input)
 
         var promptTokens = try tokenizer.applyChatTemplate(
             messages: messages, tools: input.tools,

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1780,15 +1780,15 @@ public struct Gemma4MessageGenerator: MessageGenerator {
         } else {
             [
                 "role": message.role.rawValue,
-                "content": [
-                    ["type": "text", "text": message.content]
-                ]
-                    + message.images.map { _ in
-                        ["type": "image"]
-                    }
+                "content": message.images.map { _ in
+                    ["type": "image"]
+                }
                     + message.videos.map { _ in
                         ["type": "video"]
-                    },
+                    }
+                    + [
+                        ["type": "text", "text": message.content]
+                    ],
             ]
         }
     }

--- a/Tests/MLXLMTests/UserInputTests.swift
+++ b/Tests/MLXLMTests/UserInputTests.swift
@@ -281,11 +281,11 @@ public class UserInputTests: XCTestCase {
                 "role": "user",
                 "content": [
                     [
-                        "type": "text",
-                        "text": "What is this?",
+                        "type": "image"
                     ],
                     [
-                        "type": "image"
+                        "type": "text",
+                        "text": "What is this?",
                     ],
                 ],
             ],

--- a/Tests/MLXLMTests/UserInputTests.swift
+++ b/Tests/MLXLMTests/UserInputTests.swift
@@ -95,6 +95,33 @@ public class UserInputTests: XCTestCase {
         assertEqual(expected, messages)
     }
 
+    public func testGemma4ConversionText() {
+        let chat: [Chat.Message] = [
+            .system("You are a useful agent."),
+            .user("Tell me a story."),
+        ]
+
+        let messages = Gemma4MessageGenerator().generate(messages: chat)
+
+        let expected: [[String: any Sendable]] = [
+            [
+                "role": "system",
+                "content": "You are a useful agent.",
+            ],
+            [
+                "role": "user",
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "Tell me a story.",
+                    ]
+                ],
+            ],
+        ]
+
+        assertEqual(expected, messages)
+    }
+
     // MARK: - Mistral3 Message Generator Tests
 
     public func testMistral3ConversionText() {
@@ -228,6 +255,43 @@ public class UserInputTests: XCTestCase {
 
         let userInput = UserInput(chat: chat)
         XCTAssertEqual(userInput.images.count, 1)
+    }
+
+    public func testGemma4ConversionImage() {
+        let chat: [Chat.Message] = [
+            .system("You are a useful agent."),
+            .user(
+                "What is this?",
+                images: [
+                    .url(
+                        URL(
+                            string: "https://opensource.apple.com/images/projects/mlx.f5c59d8b.png")!
+                    )
+                ]),
+        ]
+
+        let messages = Gemma4MessageGenerator().generate(messages: chat)
+
+        let expected: [[String: any Sendable]] = [
+            [
+                "role": "system",
+                "content": "You are a useful agent.",
+            ],
+            [
+                "role": "user",
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "What is this?",
+                    ],
+                    [
+                        "type": "image"
+                    ],
+                ],
+            ],
+        ]
+
+        assertEqual(expected, messages)
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Gemma 4 system message in `MLXVLM` is currently ignored since wrongly formatted with `Qwen2VLMessageGenerator`, this PR introduce `Gemma4MessageGenerator` handling the system message correctly for the chat template.
Also optimize modality order as recommended in the Gemma 4 model card.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works