### PR TITLE
Doc corrections for v3

### DIFF
--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -10,8 +10,8 @@ let model = try await loadModel(
     id: "mlx-community/Qwen3-4B-4bit"
 )
 let session = ChatSession(model)
-print(try await session.respond(to: "What are two things to see in San Francisco?")
-print(try await session.respond(to: "How about a great place to eat?")
+print(try await session.respond(to: "What are two things to see in San Francisco?"))
+print(try await session.respond(to: "How about a great place to eat?"))
 ```
 
 The second question actually refers to information (the location) from the first
@@ -54,7 +54,7 @@ let model = try await loadModel(
 let session = ChatSession(model)
 
 let answer1 = try await session.respond(
-    to: "what kind of creature is in the picture?"
+    to: "what kind of creature is in the picture?",
     image: .url(URL(fileURLWithPath: "support/test.jpg"))
 )
 print(answer1)

--- a/Libraries/MLXLLM/README.md
+++ b/Libraries/MLXLLM/README.md
@@ -73,6 +73,7 @@ Using LLMs and VLMs from MLXLMCommon is as easy as:
 
 ```swift
 import MLXLLM
+import MLXLMCommon
 import MLXLMHuggingFace
 import MLXLMTokenizers
 

--- a/Libraries/MLXLMCommon/Documentation.docc/upgrade.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/upgrade.md
@@ -179,8 +179,8 @@ Add your preferred tokenizer and downloader adapters:
 
 // After (3.x) – core + adapters
 .package(url: "https://github.com/ml-explore/mlx-swift-lm/", from: "3.0.0"),
-.package(url: "https://github.com/DePasqualeOrg/swift-tokenizers-mlx/", from: "0.1.0"),
-.package(url: "https://github.com/DePasqualeOrg/swift-hf-api-mlx/", from: "0.1.0"),
+.package(url: "https://github.com/DePasqualeOrg/swift-tokenizers-mlx/", from: "0.2.0", traits: ["Swift"]),
+.package(url: "https://github.com/DePasqualeOrg/swift-hf-api-mlx/", from: "0.2.0"),
 ```
 
 And add their products to your target:

--- a/Libraries/MLXLMCommon/Documentation.docc/using.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/using.md
@@ -243,8 +243,8 @@ You can use the <doc:#MLXHuggingFace-Macros> like this:
 or one of the integration packages:
 
 ```swift
-.package(url: "https://github.com/DePasqualeOrg/swift-tokenizers-mlx", from: "0.1.0"),
-.package(url: "https://github.com/DePasqualeOrg/swift-hf-api-mlx", from: "0.1.0"),
+.package(url: "https://github.com/DePasqualeOrg/swift-tokenizers-mlx", from: "0.2.0", traits: ["Swift"]),
+.package(url: "https://github.com/DePasqualeOrg/swift-hf-api-mlx", from: "0.2.0"),
 ```
 
 ```swift
@@ -253,6 +253,6 @@ or one of the integration packages:
     dependencies: [
         .product(name: "MLXLLM", package: "mlx-swift-lm"),
         .product(name: "MLXLMTokenizers", package: "swift-tokenizers-mlx"),
-        .product(name: "MLXLMHuggingFace", package: "swift-hf-api-mlx"),
+        .product(name: "MLXLMHFAPI", package: "swift-hf-api-mlx"),
     ]),
 ```

--- a/Libraries/MLXLMCommon/README.md
+++ b/Libraries/MLXLMCommon/README.md
@@ -13,6 +13,7 @@ Using LLMs and VLMs is as easy as:
 
 ```swift
 import MLXLLM
+import MLXLMCommon
 import MLXLMHuggingFace
 import MLXLMTokenizers
 

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -13,6 +13,7 @@ Using LLMs and VLMs from MLXLMCommon is as easy as:
 
 ```swift
 import MLXVLM
+import MLXLMCommon
 import MLXLMHuggingFace
 import MLXLMTokenizers
 

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Then chose one of the methods below to select download and tokenizer implementat
 Then add your preferred tokenizer and downloader integrations, see [how to integrate mlx-swift-lm and downloaders/tokenizers](https://swiftpackageindex.com/ml-explore/mlx-swift-lm/main/documentation/mlxlmcommon/using#Integration-Packages):
 
 ```swift
-.package(url: "https://github.com/DePasqualeOrg/swift-tokenizers-mlx", from: "0.1.0"),
-.package(url: "https://github.com/DePasqualeOrg/swift-hf-api-mlx", from: "0.1.0"),
+.package(url: "https://github.com/DePasqualeOrg/swift-tokenizers-mlx", from: "0.2.0", traits: ["Swift"]),
+.package(url: "https://github.com/DePasqualeOrg/swift-hf-api-mlx", from: "0.2.0"),
 ```
 
 And add the libraries to your target:
@@ -59,7 +59,7 @@ And add the libraries to your target:
     dependencies: [
         .product(name: "MLXLLM", package: "mlx-swift-lm"),
         .product(name: "MLXLMTokenizers", package: "swift-tokenizers-mlx"),
-        .product(name: "MLXLMHuggingFace", package: "swift-hf-api-mlx"),
+        .product(name: "MLXLMHFAPI", package: "swift-hf-api-mlx"),
     ]),
 ```
 
@@ -70,8 +70,8 @@ This preserves parity with mlx-swift-lm 2.x.  Simply reference the huggingface p
 Add these to your dependencies:
 
 ```swift
-.package(url: "https://github.com/huggingface/swift-huggingface", upToNextMajor(from: "0.9.0")),
-.package(url: "https://github.com/huggingface/swift-transformers", upToNextMajor(from: "1.3.0")),
+.package(url: "https://github.com/huggingface/swift-huggingface", .upToNextMajor(from: "0.9.0")),
+.package(url: "https://github.com/huggingface/swift-transformers", .upToNextMajor(from: "1.3.0")),
 ```
 
 And add the libraries to your target:


### PR DESCRIPTION
I made a few corrections and updates to the docs.

I also expanded the version range for swift-syntax, since I ran into a conflict with another project that uses that package. I think this should just make this package more compatible with others.

I'm wondering if the usage examples for the integration packages could be confusing to users. It might be better to instead just link to the readmes of the integration packages, each of which shows the usage specific to that package. The issue is that any example has to show specific usage for one package or set or packages.

I don't want to favor my own packages. I just want to avoid confusion for users, and I'm thinking a less-is-more approach could be better.

Even with the current docs, Claude Code was able to set up a new project and get inference working without directions from me, but it stumbled over some of the errors that I fixed here.