### PR TITLE
Fix Qwen2.5-VL: 7 bugs + preprocessing for Python mlx-vlm parity

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -74,27 +74,327 @@ public enum MediaProcessing {
 
     /// Resample the image using Lanczos interpolation.
     static public func resampleLanczos(_ image: CIImage, to size: CGSize) -> CIImage {
-        // Create a bicubic scale filter
-
-        let yScale = size.height / image.extent.height
-        let xScale = size.width / image.extent.width
+        // clampedToExtent replicates edge pixels, matching PIL's clamp boundary mode.
+        let extent = image.extent
+        let yScale = size.height / extent.height
+        let xScale = size.width / extent.width
 
         let filter = CIFilter.lanczosScaleTransform()
-        filter.inputImage = image
+        filter.inputImage = image.clampedToExtent()
         filter.scale = Float(yScale)
         filter.aspectRatio = Float(xScale / yScale)
         let scaledImage = filter.outputImage!
 
-        // Create a rect with the exact dimensions we want
-        let exactRect = CGRect(
-            x: 0,
-            y: 0,
-            width: size.width,
-            height: size.height
-        )
+        return scaledImage.cropped(to: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+    }
 
-        // Crop to ensure exact dimensions
-        return scaledImage.cropped(to: exactRect)
+    /// PIL-matching Lanczos resampler, bit-identical to `PIL.Image.LANCZOS` (a=3,
+    /// separable, clamp boundary, int32 fixed-point with PRECISION_BITS=22).
+    ///
+    /// Apple's Lanczos family (Core Image / MPS / vImage) all share the same
+    /// underlying implementation that diverges from PIL on high-frequency
+    /// content — enough to shift VLM grounding bboxes by tens of pixels. This
+    /// function is a direct port of Pillow 10.4.0's `Resample.c` 8bpc fast path.
+    ///
+    /// Also bypasses Core Graphics' automatic ICC-profile conversion: macOS
+    /// screenshots are tagged Display P3, and ImageIO would otherwise convert
+    /// P3→sRGB on load, producing different uint8 bytes than `PIL.Image.open`
+    /// sees (which ignores the ICC tag). We retag without converting.
+    static public func resamplePILLanczos(_ image: CIImage, to size: CGSize) -> CIImage {
+        let tw = Int(size.width)
+        let th = Int(size.height)
+        let srgb = CGColorSpace(name: CGColorSpace.sRGB)!
+
+        // Read raw uint8 bytes WITHOUT ICC conversion. If the source CIImage
+        // was built from a CGImage with a tagged colorspace (Display P3, etc.),
+        // we retag as sRGB so CoreGraphics treats the bytes as already-sRGB.
+        let iw: Int
+        let ih: Int
+        var src: [UInt8]
+        if let cg = image.cgImage, let provider = cg.dataProvider {
+            iw = cg.width
+            ih = cg.height
+            let retagged = CGImage(
+                width: iw, height: ih,
+                bitsPerComponent: cg.bitsPerComponent,
+                bitsPerPixel: cg.bitsPerPixel,
+                bytesPerRow: cg.bytesPerRow,
+                space: srgb, bitmapInfo: cg.bitmapInfo,
+                provider: provider, decode: nil,
+                shouldInterpolate: false, intent: .defaultIntent) ?? cg
+            src = [UInt8](repeating: 0, count: ih * iw * 4)
+            let cgctx = CGContext(
+                data: &src, width: iw, height: ih,
+                bitsPerComponent: 8, bytesPerRow: iw * 4,
+                space: srgb,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                          | CGBitmapInfo.byteOrder32Big.rawValue)!
+            cgctx.draw(retagged, in: CGRect(x: 0, y: 0, width: iw, height: ih))
+        } else {
+            iw = Int(image.extent.width)
+            ih = Int(image.extent.height)
+            src = [UInt8](repeating: 0, count: ih * iw * 4)
+            let cictx = CIContext(options: [.workingColorSpace: srgb])
+            cictx.render(image, toBitmap: &src, rowBytes: iw * 4,
+                         bounds: image.extent, format: CIFormat.RGBA8,
+                         colorSpace: srgb)
+        }
+
+        // --- Pillow 10.4.0 Resample.c port ---
+
+        let PRECISION_BITS: Int32 = 22
+        let ROUND_BIAS: Int32 = 1 << (PRECISION_BITS - 1)
+        let ONE = Double(Int32(1) << PRECISION_BITS)
+        let a = 3.0
+
+        @inline(__always) func sinc(_ x: Double) -> Double {
+            if x == 0 { return 1 }
+            let p = Double.pi * x
+            return Foundation.sin(p) / p
+        }
+        @inline(__always) func kernel(_ x: Double) -> Double {
+            if abs(x) >= a { return 0 }
+            return sinc(x) * sinc(x / a)
+        }
+        func precompute(_ inSize: Int, _ outSize: Int) -> ([Int], [Int], [[Int32]]) {
+            let scale = Double(inSize) / Double(outSize)
+            let fs = max(1.0, scale)
+            let support = a * fs
+            var lo = [Int](); var hi = [Int](); var qq = [[Int32]]()
+            lo.reserveCapacity(outSize); hi.reserveCapacity(outSize); qq.reserveCapacity(outSize)
+            for i in 0 ..< outSize {
+                let c = (Double(i) + 0.5) * scale
+                let l = max(Int(floor(c - support + 0.5)), 0)
+                let r = min(Int(floor(c + support + 0.5)), inSize)
+                var w = [Double](repeating: 0, count: r - l)
+                var sum = 0.0
+                for k in 0 ..< (r - l) {
+                    let x = (Double(l + k) + 0.5 - c) / fs
+                    let v = kernel(x); w[k] = v; sum += v
+                }
+                if sum != 0 { for k in 0 ..< w.count { w[k] /= sum } }
+                // Quantize to int32 with 22-bit precision. C's (int) truncates toward zero.
+                let q = w.map { weight -> Int32 in
+                    let s = weight * ONE
+                    let b = s < 0 ? -0.5 + s : 0.5 + s
+                    return Int32(b.rounded(.towardZero))
+                }
+                lo.append(l); hi.append(r); qq.append(q)
+            }
+            return (lo, hi, qq)
+        }
+
+        @inline(__always) func clip8(_ ss: Int32) -> UInt8 {
+            let s = ss >> PRECISION_BITS
+            if s < 0 { return 0 }
+            if s > 255 { return 255 }
+            return UInt8(s)
+        }
+
+        let (hlo, hhi, hw) = precompute(iw, tw)
+        let (vlo, vhi, vw) = precompute(ih, th)
+
+        // Horizontal pass: uint8 → uint8 at (ih, tw).
+        var horiz = [UInt8](repeating: 0, count: ih * tw * 4)
+        for y in 0 ..< ih {
+            for x in 0 ..< tw {
+                let l = hlo[x], r = hhi[x], w = hw[x]
+                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                for k in 0 ..< (r - l) {
+                    let p = y * iw * 4 + (l + k) * 4
+                    let kw = w[k]
+                    s0 &+= Int32(src[p + 0]) &* kw
+                    s1 &+= Int32(src[p + 1]) &* kw
+                    s2 &+= Int32(src[p + 2]) &* kw
+                    s3 &+= Int32(src[p + 3]) &* kw
+                }
+                let o = (y * tw + x) * 4
+                horiz[o + 0] = clip8(s0); horiz[o + 1] = clip8(s1)
+                horiz[o + 2] = clip8(s2); horiz[o + 3] = clip8(s3)
+            }
+        }
+
+        // Vertical pass: uint8 → uint8 at (tw, th).
+        var dst = [UInt8](repeating: 0, count: th * tw * 4)
+        for y in 0 ..< th {
+            let l = vlo[y], r = vhi[y], w = vw[y]
+            for x in 0 ..< tw {
+                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                for k in 0 ..< (r - l) {
+                    let p = ((l + k) * tw + x) * 4
+                    let kw = w[k]
+                    s0 &+= Int32(horiz[p + 0]) &* kw
+                    s1 &+= Int32(horiz[p + 1]) &* kw
+                    s2 &+= Int32(horiz[p + 2]) &* kw
+                    s3 &+= Int32(horiz[p + 3]) &* kw
+                }
+                let o = (y * tw + x) * 4
+                dst[o + 0] = clip8(s0); dst[o + 1] = clip8(s1)
+                dst[o + 2] = clip8(s2); dst[o + 3] = clip8(s3)
+            }
+        }
+
+        return CIImage(bitmapData: Data(dst), bytesPerRow: tw * 4,
+                       size: CGSize(width: tw, height: th),
+                       format: .RGBA8, colorSpace: srgb)
+    }
+
+    /// PIL-matching Lanczos that returns raw uint8 RGBA bytes (no CIImage
+    /// round-trip). Internal helper used by both `resamplePILLanczos` (which
+    /// re-wraps as CIImage) and `resamplePILLanczosToArray` (which normalizes
+    /// directly to MLXArray). Splitting this out avoids a round-trip through
+    /// CIImage that would re-encode the bytes via the working colorspace.
+    internal static func _pilLanczosCore(
+        _ image: CIImage, to size: CGSize
+    ) -> (bytes: [UInt8], tw: Int, th: Int) {
+        let tw = Int(size.width), th = Int(size.height)
+        let srgb = CGColorSpace(name: CGColorSpace.sRGB)!
+
+        let iw: Int, ih: Int
+        var src: [UInt8]
+        if let cg = image.cgImage, let provider = cg.dataProvider {
+            iw = cg.width
+            ih = cg.height
+            let retagged = CGImage(
+                width: iw, height: ih,
+                bitsPerComponent: cg.bitsPerComponent,
+                bitsPerPixel: cg.bitsPerPixel,
+                bytesPerRow: cg.bytesPerRow,
+                space: srgb, bitmapInfo: cg.bitmapInfo,
+                provider: provider, decode: nil,
+                shouldInterpolate: false, intent: .defaultIntent) ?? cg
+            src = [UInt8](repeating: 0, count: ih * iw * 4)
+            let cgctx = CGContext(
+                data: &src, width: iw, height: ih,
+                bitsPerComponent: 8, bytesPerRow: iw * 4,
+                space: srgb,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                          | CGBitmapInfo.byteOrder32Big.rawValue)!
+            cgctx.draw(retagged, in: CGRect(x: 0, y: 0, width: iw, height: ih))
+        } else {
+            iw = Int(image.extent.width)
+            ih = Int(image.extent.height)
+            src = [UInt8](repeating: 0, count: ih * iw * 4)
+            CIContext(options: [.workingColorSpace: srgb]).render(
+                image, toBitmap: &src, rowBytes: iw * 4,
+                bounds: image.extent, format: CIFormat.RGBA8, colorSpace: srgb)
+        }
+
+        // PIL Lanczos int32 fixed-point (Pillow 10.4.0 Resample.c port).
+        let PRECISION_BITS: Int32 = 22
+        let ROUND_BIAS: Int32 = 1 << (PRECISION_BITS - 1)
+        let ONE = Double(Int32(1) << PRECISION_BITS)
+        let a = 3.0
+        @inline(__always) func sinc(_ x: Double) -> Double {
+            if x == 0 { return 1 }
+            let p = Double.pi * x
+            return Foundation.sin(p) / p
+        }
+        @inline(__always) func kernel(_ x: Double) -> Double {
+            if abs(x) >= a { return 0 }
+            return sinc(x) * sinc(x / a)
+        }
+        func precompute(_ inSize: Int, _ outSize: Int) -> ([Int], [Int], [[Int32]]) {
+            let scale = Double(inSize) / Double(outSize)
+            let fs = max(1.0, scale)
+            let support = a * fs
+            var lo = [Int](); var hi = [Int](); var qq = [[Int32]]()
+            lo.reserveCapacity(outSize); hi.reserveCapacity(outSize); qq.reserveCapacity(outSize)
+            for i in 0 ..< outSize {
+                let c = (Double(i) + 0.5) * scale
+                let l = max(Int(floor(c - support + 0.5)), 0)
+                let r = min(Int(floor(c + support + 0.5)), inSize)
+                var w = [Double](repeating: 0, count: r - l)
+                var sum = 0.0
+                for k in 0 ..< (r - l) {
+                    let x = (Double(l + k) + 0.5 - c) / fs
+                    let v = kernel(x); w[k] = v; sum += v
+                }
+                if sum != 0 { for k in 0 ..< w.count { w[k] /= sum } }
+                let q = w.map { weight -> Int32 in
+                    let s = weight * ONE
+                    let b = s < 0 ? -0.5 + s : 0.5 + s
+                    return Int32(b.rounded(.towardZero))
+                }
+                lo.append(l); hi.append(r); qq.append(q)
+            }
+            return (lo, hi, qq)
+        }
+        @inline(__always) func clip8(_ ss: Int32) -> UInt8 {
+            let s = ss >> PRECISION_BITS
+            if s < 0 { return 0 }
+            if s > 255 { return 255 }
+            return UInt8(s)
+        }
+        let (hlo, hhi, hw) = precompute(iw, tw)
+        let (vlo, vhi, vw) = precompute(ih, th)
+
+        var horiz = [UInt8](repeating: 0, count: ih * tw * 4)
+        for y in 0 ..< ih {
+            for x in 0 ..< tw {
+                let l = hlo[x], r = hhi[x], w = hw[x]
+                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                for k in 0 ..< (r - l) {
+                    let p = y * iw * 4 + (l + k) * 4
+                    let kw = w[k]
+                    s0 &+= Int32(src[p + 0]) &* kw
+                    s1 &+= Int32(src[p + 1]) &* kw
+                    s2 &+= Int32(src[p + 2]) &* kw
+                    s3 &+= Int32(src[p + 3]) &* kw
+                }
+                let o = (y * tw + x) * 4
+                horiz[o + 0] = clip8(s0); horiz[o + 1] = clip8(s1)
+                horiz[o + 2] = clip8(s2); horiz[o + 3] = clip8(s3)
+            }
+        }
+        var dst = [UInt8](repeating: 0, count: th * tw * 4)
+        for y in 0 ..< th {
+            let l = vlo[y], r = vhi[y], w = vw[y]
+            for x in 0 ..< tw {
+                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                for k in 0 ..< (r - l) {
+                    let p = ((l + k) * tw + x) * 4
+                    let kw = w[k]
+                    s0 &+= Int32(horiz[p + 0]) &* kw
+                    s1 &+= Int32(horiz[p + 1]) &* kw
+                    s2 &+= Int32(horiz[p + 2]) &* kw
+                    s3 &+= Int32(horiz[p + 3]) &* kw
+                }
+                let o = (y * tw + x) * 4
+                dst[o + 0] = clip8(s0); dst[o + 1] = clip8(s1)
+                dst[o + 2] = clip8(s2); dst[o + 3] = clip8(s3)
+            }
+        }
+        return (dst, tw, th)
+    }
+
+    /// Full PIL-matching preprocess: raw CGImage → PIL Lanczos → normalize →
+    /// `[1, 3, H, W]` float32 MLXArray. Zero CIImage round-trip.
+    static public func resamplePILLanczosToArray(
+        _ image: CIImage, to size: CGSize,
+        mean: (CGFloat, CGFloat, CGFloat),
+        std: (CGFloat, CGFloat, CGFloat)
+    ) -> MLXArray {
+        let (u8, tw, th) = _pilLanczosCore(image, to: size)
+        let rm = Float(mean.0), gm = Float(mean.1), bm = Float(mean.2)
+        let rs = Float(std.0),  gs = Float(std.1),  bs = Float(std.2)
+        let inv255: Float = 1.0 / 255.0
+        let n = tw * th
+        var planar = [Float](repeating: 0, count: 3 * n)
+        for y in 0 ..< th {
+            for x in 0 ..< tw {
+                let p = (y * tw + x) * 4
+                let i = y * tw + x
+                planar[i]         = (Float(u8[p + 0]) * inv255 - rm) / rs
+                planar[i + n]     = (Float(u8[p + 1]) * inv255 - gm) / gs
+                planar[i + 2 * n] = (Float(u8[p + 2]) * inv255 - bm) / bs
+            }
+        }
+        return MLXArray(planar, [1, 3, th, tw])
     }
 
     /// Resample the image using bicubic interpolation.
@@ -341,7 +641,7 @@ public enum MediaProcessing {
     static public func asProcessedSequence(
         _ video: UserInput.Video,
         samplesPerSecond: Int,
-        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
+        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 },
     ) async throws -> ProcessedFrames {
         return try await asProcessedSequence(
             video,

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -114,30 +114,32 @@ public enum MediaProcessing {
         if let cg = image.cgImage, let provider = cg.dataProvider {
             iw = cg.width
             ih = cg.height
-            let retagged = CGImage(
-                width: iw, height: ih,
-                bitsPerComponent: cg.bitsPerComponent,
-                bitsPerPixel: cg.bitsPerPixel,
-                bytesPerRow: cg.bytesPerRow,
-                space: srgb, bitmapInfo: cg.bitmapInfo,
-                provider: provider, decode: nil,
-                shouldInterpolate: false, intent: .defaultIntent) ?? cg
+            let retagged =
+                CGImage(
+                    width: iw, height: ih,
+                    bitsPerComponent: cg.bitsPerComponent,
+                    bitsPerPixel: cg.bitsPerPixel,
+                    bytesPerRow: cg.bytesPerRow,
+                    space: srgb, bitmapInfo: cg.bitmapInfo,
+                    provider: provider, decode: nil,
+                    shouldInterpolate: false, intent: .defaultIntent) ?? cg
             src = [UInt8](repeating: 0, count: ih * iw * 4)
             let cgctx = CGContext(
                 data: &src, width: iw, height: ih,
                 bitsPerComponent: 8, bytesPerRow: iw * 4,
                 space: srgb,
                 bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-                          | CGBitmapInfo.byteOrder32Big.rawValue)!
+                    | CGBitmapInfo.byteOrder32Big.rawValue)!
             cgctx.draw(retagged, in: CGRect(x: 0, y: 0, width: iw, height: ih))
         } else {
             iw = Int(image.extent.width)
             ih = Int(image.extent.height)
             src = [UInt8](repeating: 0, count: ih * iw * 4)
             let cictx = CIContext(options: [.workingColorSpace: srgb])
-            cictx.render(image, toBitmap: &src, rowBytes: iw * 4,
-                         bounds: image.extent, format: CIFormat.RGBA8,
-                         colorSpace: srgb)
+            cictx.render(
+                image, toBitmap: &src, rowBytes: iw * 4,
+                bounds: image.extent, format: CIFormat.RGBA8,
+                colorSpace: srgb)
         }
 
         // --- Pillow 10.4.0 Resample.c port ---
@@ -160,8 +162,12 @@ public enum MediaProcessing {
             let scale = Double(inSize) / Double(outSize)
             let fs = max(1.0, scale)
             let support = a * fs
-            var lo = [Int](); var hi = [Int](); var qq = [[Int32]]()
-            lo.reserveCapacity(outSize); hi.reserveCapacity(outSize); qq.reserveCapacity(outSize)
+            var lo = [Int]()
+            var hi = [Int]()
+            var qq = [[Int32]]()
+            lo.reserveCapacity(outSize)
+            hi.reserveCapacity(outSize)
+            qq.reserveCapacity(outSize)
             for i in 0 ..< outSize {
                 let c = (Double(i) + 0.5) * scale
                 let l = max(Int(floor(c - support + 0.5)), 0)
@@ -170,7 +176,9 @@ public enum MediaProcessing {
                 var sum = 0.0
                 for k in 0 ..< (r - l) {
                     let x = (Double(l + k) + 0.5 - c) / fs
-                    let v = kernel(x); w[k] = v; sum += v
+                    let v = kernel(x)
+                    w[k] = v
+                    sum += v
                 }
                 if sum != 0 { for k in 0 ..< w.count { w[k] /= sum } }
                 // Quantize to int32 with 22-bit precision. C's (int) truncates toward zero.
@@ -179,7 +187,9 @@ public enum MediaProcessing {
                     let b = s < 0 ? -0.5 + s : 0.5 + s
                     return Int32(b.rounded(.towardZero))
                 }
-                lo.append(l); hi.append(r); qq.append(q)
+                lo.append(l)
+                hi.append(r)
+                qq.append(q)
             }
             return (lo, hi, qq)
         }
@@ -198,9 +208,13 @@ public enum MediaProcessing {
         var horiz = [UInt8](repeating: 0, count: ih * tw * 4)
         for y in 0 ..< ih {
             for x in 0 ..< tw {
-                let l = hlo[x], r = hhi[x], w = hw[x]
-                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
-                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                let l = hlo[x]
+                let r = hhi[x]
+                let w = hw[x]
+                var s0: Int32 = ROUND_BIAS
+                var s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS
+                var s3: Int32 = ROUND_BIAS
                 for k in 0 ..< (r - l) {
                     let p = y * iw * 4 + (l + k) * 4
                     let kw = w[k]
@@ -210,18 +224,24 @@ public enum MediaProcessing {
                     s3 &+= Int32(src[p + 3]) &* kw
                 }
                 let o = (y * tw + x) * 4
-                horiz[o + 0] = clip8(s0); horiz[o + 1] = clip8(s1)
-                horiz[o + 2] = clip8(s2); horiz[o + 3] = clip8(s3)
+                horiz[o + 0] = clip8(s0)
+                horiz[o + 1] = clip8(s1)
+                horiz[o + 2] = clip8(s2)
+                horiz[o + 3] = clip8(s3)
             }
         }
 
         // Vertical pass: uint8 → uint8 at (tw, th).
         var dst = [UInt8](repeating: 0, count: th * tw * 4)
         for y in 0 ..< th {
-            let l = vlo[y], r = vhi[y], w = vw[y]
+            let l = vlo[y]
+            let r = vhi[y]
+            let w = vw[y]
             for x in 0 ..< tw {
-                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
-                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                var s0: Int32 = ROUND_BIAS
+                var s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS
+                var s3: Int32 = ROUND_BIAS
                 for k in 0 ..< (r - l) {
                     let p = ((l + k) * tw + x) * 4
                     let kw = w[k]
@@ -231,14 +251,17 @@ public enum MediaProcessing {
                     s3 &+= Int32(horiz[p + 3]) &* kw
                 }
                 let o = (y * tw + x) * 4
-                dst[o + 0] = clip8(s0); dst[o + 1] = clip8(s1)
-                dst[o + 2] = clip8(s2); dst[o + 3] = clip8(s3)
+                dst[o + 0] = clip8(s0)
+                dst[o + 1] = clip8(s1)
+                dst[o + 2] = clip8(s2)
+                dst[o + 3] = clip8(s3)
             }
         }
 
-        return CIImage(bitmapData: Data(dst), bytesPerRow: tw * 4,
-                       size: CGSize(width: tw, height: th),
-                       format: .RGBA8, colorSpace: srgb)
+        return CIImage(
+            bitmapData: Data(dst), bytesPerRow: tw * 4,
+            size: CGSize(width: tw, height: th),
+            format: .RGBA8, colorSpace: srgb)
     }
 
     /// PIL-matching Lanczos that returns raw uint8 RGBA bytes (no CIImage
@@ -249,29 +272,32 @@ public enum MediaProcessing {
     internal static func _pilLanczosCore(
         _ image: CIImage, to size: CGSize
     ) -> (bytes: [UInt8], tw: Int, th: Int) {
-        let tw = Int(size.width), th = Int(size.height)
+        let tw = Int(size.width)
+        let th = Int(size.height)
         let srgb = CGColorSpace(name: CGColorSpace.sRGB)!
 
-        let iw: Int, ih: Int
+        let iw: Int
+        let ih: Int
         var src: [UInt8]
         if let cg = image.cgImage, let provider = cg.dataProvider {
             iw = cg.width
             ih = cg.height
-            let retagged = CGImage(
-                width: iw, height: ih,
-                bitsPerComponent: cg.bitsPerComponent,
-                bitsPerPixel: cg.bitsPerPixel,
-                bytesPerRow: cg.bytesPerRow,
-                space: srgb, bitmapInfo: cg.bitmapInfo,
-                provider: provider, decode: nil,
-                shouldInterpolate: false, intent: .defaultIntent) ?? cg
+            let retagged =
+                CGImage(
+                    width: iw, height: ih,
+                    bitsPerComponent: cg.bitsPerComponent,
+                    bitsPerPixel: cg.bitsPerPixel,
+                    bytesPerRow: cg.bytesPerRow,
+                    space: srgb, bitmapInfo: cg.bitmapInfo,
+                    provider: provider, decode: nil,
+                    shouldInterpolate: false, intent: .defaultIntent) ?? cg
             src = [UInt8](repeating: 0, count: ih * iw * 4)
             let cgctx = CGContext(
                 data: &src, width: iw, height: ih,
                 bitsPerComponent: 8, bytesPerRow: iw * 4,
                 space: srgb,
                 bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-                          | CGBitmapInfo.byteOrder32Big.rawValue)!
+                    | CGBitmapInfo.byteOrder32Big.rawValue)!
             cgctx.draw(retagged, in: CGRect(x: 0, y: 0, width: iw, height: ih))
         } else {
             iw = Int(image.extent.width)
@@ -300,8 +326,12 @@ public enum MediaProcessing {
             let scale = Double(inSize) / Double(outSize)
             let fs = max(1.0, scale)
             let support = a * fs
-            var lo = [Int](); var hi = [Int](); var qq = [[Int32]]()
-            lo.reserveCapacity(outSize); hi.reserveCapacity(outSize); qq.reserveCapacity(outSize)
+            var lo = [Int]()
+            var hi = [Int]()
+            var qq = [[Int32]]()
+            lo.reserveCapacity(outSize)
+            hi.reserveCapacity(outSize)
+            qq.reserveCapacity(outSize)
             for i in 0 ..< outSize {
                 let c = (Double(i) + 0.5) * scale
                 let l = max(Int(floor(c - support + 0.5)), 0)
@@ -310,7 +340,9 @@ public enum MediaProcessing {
                 var sum = 0.0
                 for k in 0 ..< (r - l) {
                     let x = (Double(l + k) + 0.5 - c) / fs
-                    let v = kernel(x); w[k] = v; sum += v
+                    let v = kernel(x)
+                    w[k] = v
+                    sum += v
                 }
                 if sum != 0 { for k in 0 ..< w.count { w[k] /= sum } }
                 let q = w.map { weight -> Int32 in
@@ -318,7 +350,9 @@ public enum MediaProcessing {
                     let b = s < 0 ? -0.5 + s : 0.5 + s
                     return Int32(b.rounded(.towardZero))
                 }
-                lo.append(l); hi.append(r); qq.append(q)
+                lo.append(l)
+                hi.append(r)
+                qq.append(q)
             }
             return (lo, hi, qq)
         }
@@ -334,9 +368,13 @@ public enum MediaProcessing {
         var horiz = [UInt8](repeating: 0, count: ih * tw * 4)
         for y in 0 ..< ih {
             for x in 0 ..< tw {
-                let l = hlo[x], r = hhi[x], w = hw[x]
-                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
-                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                let l = hlo[x]
+                let r = hhi[x]
+                let w = hw[x]
+                var s0: Int32 = ROUND_BIAS
+                var s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS
+                var s3: Int32 = ROUND_BIAS
                 for k in 0 ..< (r - l) {
                     let p = y * iw * 4 + (l + k) * 4
                     let kw = w[k]
@@ -346,16 +384,22 @@ public enum MediaProcessing {
                     s3 &+= Int32(src[p + 3]) &* kw
                 }
                 let o = (y * tw + x) * 4
-                horiz[o + 0] = clip8(s0); horiz[o + 1] = clip8(s1)
-                horiz[o + 2] = clip8(s2); horiz[o + 3] = clip8(s3)
+                horiz[o + 0] = clip8(s0)
+                horiz[o + 1] = clip8(s1)
+                horiz[o + 2] = clip8(s2)
+                horiz[o + 3] = clip8(s3)
             }
         }
         var dst = [UInt8](repeating: 0, count: th * tw * 4)
         for y in 0 ..< th {
-            let l = vlo[y], r = vhi[y], w = vw[y]
+            let l = vlo[y]
+            let r = vhi[y]
+            let w = vw[y]
             for x in 0 ..< tw {
-                var s0: Int32 = ROUND_BIAS, s1: Int32 = ROUND_BIAS
-                var s2: Int32 = ROUND_BIAS, s3: Int32 = ROUND_BIAS
+                var s0: Int32 = ROUND_BIAS
+                var s1: Int32 = ROUND_BIAS
+                var s2: Int32 = ROUND_BIAS
+                var s3: Int32 = ROUND_BIAS
                 for k in 0 ..< (r - l) {
                     let p = ((l + k) * tw + x) * 4
                     let kw = w[k]
@@ -365,8 +409,10 @@ public enum MediaProcessing {
                     s3 &+= Int32(horiz[p + 3]) &* kw
                 }
                 let o = (y * tw + x) * 4
-                dst[o + 0] = clip8(s0); dst[o + 1] = clip8(s1)
-                dst[o + 2] = clip8(s2); dst[o + 3] = clip8(s3)
+                dst[o + 0] = clip8(s0)
+                dst[o + 1] = clip8(s1)
+                dst[o + 2] = clip8(s2)
+                dst[o + 3] = clip8(s3)
             }
         }
         return (dst, tw, th)
@@ -380,8 +426,12 @@ public enum MediaProcessing {
         std: (CGFloat, CGFloat, CGFloat)
     ) -> MLXArray {
         let (u8, tw, th) = _pilLanczosCore(image, to: size)
-        let rm = Float(mean.0), gm = Float(mean.1), bm = Float(mean.2)
-        let rs = Float(std.0),  gs = Float(std.1),  bs = Float(std.2)
+        let rm = Float(mean.0)
+        let gm = Float(mean.1)
+        let bm = Float(mean.2)
+        let rs = Float(std.0)
+        let gs = Float(std.1)
+        let bs = Float(std.2)
         let inv255: Float = 1.0 / 255.0
         let n = tw * th
         var planar = [Float](repeating: 0, count: 3 * n)
@@ -389,8 +439,8 @@ public enum MediaProcessing {
             for x in 0 ..< tw {
                 let p = (y * tw + x) * 4
                 let i = y * tw + x
-                planar[i]         = (Float(u8[p + 0]) * inv255 - rm) / rs
-                planar[i + n]     = (Float(u8[p + 1]) * inv255 - gm) / gs
+                planar[i] = (Float(u8[p + 0]) * inv255 - rm) / rs
+                planar[i + n] = (Float(u8[p + 1]) * inv255 - gm) / gs
                 planar[i + 2 * n] = (Float(u8[p + 2]) * inv255 - bm) / bs
             }
         }

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -784,33 +784,25 @@ public struct Qwen25VLProcessor: UserInputProcessor {
     public func preprocess(images: [CIImage], processing: UserInput.Processing?) throws -> (
         MLXArray, THW
     ) {
-        // First apply the user requested resizing, etc. if any
-        let images = images.map { MediaProcessing.apply($0, processing: processing) }
-
-        // image_processing_qwen2_vl._preprocess
-        let size = images[0].extent.size
-        let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
-            height: Int(size.height), width: Int(size.width),
-            factor: config.patchSize * config.mergeSize,
-            minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
+        // Cap longest side at 1280 and snap to multiples of (patchSize *
+        // mergeSize), matching mlx-vlm's default min_pixels / max_pixels.
+        let orig = images[0].extent.size
+        let factor = config.patchSize * config.mergeSize
+        let maxLong: CGFloat = 1280.0
+        let ratio = min(maxLong / max(orig.width, orig.height), 1.0)
+        let resizedWidth = max(Int(orig.width * ratio) / factor * factor, factor)
+        let resizedHeight = max(Int(orig.height * ratio) / factor * factor, factor)
         let resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
 
-        // Process images
-        let processedImages =
-            images
-            .map {
-                MediaProcessing.inSRGBToneCurveSpace($0)
-            }
-            .map {
-                return MediaProcessing.resampleBicubic($0, to: resizedSize)
-            }
-            .map {
-                MediaProcessing.normalize(
-                    $0, mean: config.imageMeanTuple, std: config.imageStdTuple)
-            }
-            .map {
-                MediaProcessing.asMLXArray($0)
-            }
+        // PIL-matching preprocess: raw PNG bytes (no ICC conv) → PIL Lanczos →
+        // normalize → [1, 3, H, W] MLXArray. Bypasses the CIImage downstream
+        // chain entirely, which otherwise introduces gamma-encoding drift that
+        // shifts VLM bbox coordinates away from the Python reference.
+        let processedImages = images.map {
+            MediaProcessing.resamplePILLanczosToArray(
+                $0, to: resizedSize,
+                mean: config.imageMeanTuple, std: config.imageStdTuple)
+        }
 
         return try QwenVL.patchify(
             images: processedImages, mergeSize: config.mergeSize, patchSize: config.patchSize,

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -1,4 +1,25 @@
 // Port of https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/qwen2_5_vl
+//
+// Qwen2.5-VL uses Multimodal RoPE (MROPE): a 3D position encoding where the
+// rotary dimensions are split across temporal / height / width axes, rather
+// than a single 1D sequence index. This requires two extensions to the usual
+// decoder plumbing:
+//
+//   1. `getRopeIndex` builds the 3D position IDs from the image-grid THW
+//      shape and the position of `<|image_pad|>` tokens in the prompt. It
+//      lives in Qwen25VLRopeIndex.swift.
+//
+//   2. During prefill, the language model stores `positionIds` and
+//      `ropeDeltas` from step 1. During subsequent decode steps, positions
+//      are reconstructed from `ropeDeltas + cacheOffset` — the KVCache
+//      protocol does not carry this state, so it lives on the language
+//      model itself.
+//
+// Attention.mropeCosSin applies the MROPE section selection per HuggingFace
+// `modeling_qwen2_5_vl.py`. The `InvFreqBox` wrapper hides the precomputed
+// inverse-frequency table from MLX's Module weight-loading reflection (same
+// effect as Qwen3VL / Qwen35 pulling their RotaryEmbedding into a
+// non-Module helper).
 
 import CoreImage
 import Foundation
@@ -44,6 +65,10 @@ private enum Language {
         let headDim: Int
         let scale: Float
         let mropeSection: [Int]
+        let mropeSectionRaw: [Int]
+        // Box hides invFreq from Module's weight-loader reflection.
+        private class InvFreqBox { let value: MLXArray; init(_ v: MLXArray) { value = v } }
+        private let _invFreqBox: InvFreqBox
 
         @ModuleInfo(key: "q_proj") var wq: Linear
         @ModuleInfo(key: "k_proj") var wk: Linear
@@ -65,10 +90,9 @@ private enum Language {
             self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
             if let v = args.ropeScaling?["mrope_section"], let array = v.asInts() {
-                // mrope_section = np.cumsum(mrope_section * 2)[:-1].tolist()
+                self.mropeSectionRaw = array
                 self.mropeSection = sequence(state: (0, array.makeIterator())) { state in
                     if let v = state.1.next() {
-                        // note the *2
                         state.0 += v * 2
                         return state.0
                     } else {
@@ -79,12 +103,43 @@ private enum Language {
                 fatalError("rope_scaling['mrope_section'] must be an array of integers")
             }
 
+            let freqIndices = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+            let base = MLXArray(args.ropeTheta).asType(.float32)
+            self._invFreqBox = InvFreqBox(1.0 / MLX.pow(base, freqIndices / Float(headDim)))
+
             self._rotaryEmbedding.wrappedValue = RoPE(
                 dimensions: headDim, traditional: args.ropeTraditional, base: args.ropeTheta)
         }
 
+        private func mropeCosSin(positionIds: MLXArray) -> (MLXArray, MLXArray) {
+            let invFreqExpanded = _invFreqBox.value.reshaped(1, 1, -1, 1)
+            let posExpanded = positionIds[0..., 0..., .newAxis, 0...].asType(.float32)
+            var freqs = matmul(invFreqExpanded, posExpanded)
+            freqs = freqs.transposed(0, 1, 3, 2)
+
+            var result = freqs[0]
+            var offset = mropeSectionRaw[0]
+            for dim in 1 ..< mropeSectionRaw.count {
+                let length = mropeSectionRaw[dim]
+                let dimFreqs = freqs[dim]
+                let before = result[0..., 0..., 0 ..< offset]
+                let middle = dimFreqs[0..., 0..., offset ..< (offset + length)]
+                if offset + length < result.dim(-1) {
+                    let after = result[0..., 0..., (offset + length)...]
+                    result = concatenated([before, middle, after], axis: -1)
+                } else {
+                    result = concatenated([before, middle], axis: -1)
+                }
+                offset += length
+            }
+
+            let emb = concatenated([result, result], axis: -1)
+            return (MLX.cos(emb), MLX.sin(emb))
+        }
+
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
             let (B, L) = (x.dim(0), x.dim(1))
 
@@ -92,15 +147,21 @@ private enum Language {
             var keys = wk(x)
             var values = wv(x)
 
-            // prepare the queries, keys and values for the attention computation
             queries = queries.reshaped(B, L, heads, headDim).transposed(0, 2, 1, 3)
             keys = keys.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
             values = values.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
 
-            let offset = cache?.offset ?? 0
-
-            queries = rotaryEmbedding(queries, offset: offset)
-            keys = rotaryEmbedding(keys, offset: offset)
+            if let positionIds {
+                let (cosValues, sinValues) = mropeCosSin(positionIds: positionIds)
+                let cos = cosValues[.newAxis, 0..., 0..., 0...]
+                let sin = sinValues[.newAxis, 0..., 0..., 0...]
+                queries = (queries * cos) + (QwenVL.rotateHalf(queries) * sin)
+                keys = (keys * cos) + (QwenVL.rotateHalf(keys) * sin)
+            } else {
+                let offset = cache?.offset ?? 0
+                queries = rotaryEmbedding(queries, offset: offset)
+                keys = rotaryEmbedding(keys, offset: offset)
+            }
 
             let output = attentionWithCacheUpdate(
                 queries: queries,
@@ -151,9 +212,10 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
-            var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
+            var r = attention(inputLayerNorm(x), mask: mask, cache: cache, positionIds: positionIds)
             let h = x + r
             r = mlp(postAttentionLayerNorm(h))
             let out = h + r
@@ -182,7 +244,8 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
             var h: MLXArray
             if let inputEmbedding {
@@ -196,7 +259,7 @@ private enum Language {
             let mask = createAttentionMask(h: h, cache: cache?.first)
 
             for (i, layer) in layers.enumerated() {
-                h = layer(h, mask: mask, cache: cache?[i])
+                h = layer(h, mask: mask, cache: cache?[i], positionIds: positionIds)
             }
 
             return norm(h)
@@ -209,6 +272,10 @@ private enum Language {
 
         var kvHeads: [Int]
 
+        // MROPE prefill state, consumed on the next decode call.
+        var _positionIds: MLXArray?
+        var _ropeDeltas: MLXArray?
+
         public init(_ args: Qwen25VLConfiguration.TextConfiguration) {
             self.model = Qwen25Model(args)
 
@@ -220,9 +287,35 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            positionIds: MLXArray? = nil
         ) -> LMOutput {
-            var out = model(inputs, cache: cache, inputEmbedding: inputEmbedding)
+            var effectivePositionIds = positionIds ?? _positionIds
+            if _positionIds != nil { _positionIds = nil }
+
+            if effectivePositionIds == nil, let ropeDeltas = _ropeDeltas, let cache,
+                let input = inputs ?? inputEmbedding
+            {
+                let batch = input.dim(0)
+                let seqLength = input.dim(1)
+                let lastCacheOffset = cache.last?.offset ?? 0
+
+                var delta = MLXArray(lastCacheOffset).asType(.int32) + ropeDeltas.asType(.int32)
+                if delta.dim(0) == 1 && batch > 1 {
+                    delta = repeated(delta, count: batch, axis: 0)
+                }
+
+                var base = MLXArray(0 ..< seqLength).asType(.int32)
+                base = base[.newAxis, 0...]
+                base = broadcast(base, to: [batch, seqLength]) + delta
+
+                effectivePositionIds = broadcast(
+                    base[.newAxis, 0..., 0...], to: [3, batch, seqLength])
+            }
+
+            var out = model(
+                inputs, cache: cache, inputEmbedding: inputEmbedding,
+                positionIds: effectivePositionIds)
             if let lmHead {
                 out = lmHead(out)
             } else {
@@ -316,12 +409,18 @@ private enum Vision {
             k = k.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
             v = v.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
 
+            let boolMask = attentionMask[.newAxis, 0..., 0..., 0...]
+            let floatMask = MLX.where(
+                boolMask,
+                MLXArray(Float(0), dtype: .float16),
+                MLXArray(Float(-10000), dtype: .float16))
+
             let output = MLXFast.scaledDotProductAttention(
                 queries: q,
                 keys: k,
                 values: v,
                 scale: scale,
-                mask: .none
+                mask: .array(floatMask)
             )
             .transposed(0, 2, 1, 3)
             .reshaped(sequenceLength, -1)
@@ -678,7 +777,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
     func preprocess(image: CIImage, resizedSize: CGSize) -> CIImage {
         image
             .toSRGB()
-            .resampled(to: resizedSize, method: .bicubic)
+            .resampled(to: resizedSize, method: .lanczos)
             .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
     }
 
@@ -792,6 +891,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
 
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
         let mask = ones(like: promptArray).asType(.int8)
+
         return LMInput(
             text: .init(tokens: promptArray, mask: mask),
             image: processedImage,
@@ -827,25 +927,38 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
     private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)
         -> MLXArray
     {
+        languageModel._positionIds = nil
+        languageModel._ropeDeltas = nil
+
         guard let pixelValues, let frames else {
             return languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis])
         }
 
-        // Get the input embeddings from the language model
         let inputEmbeds = languageModel.model.embedTokens(inputIds)
-
-        // Get the ouptut hidden states from the vision model
         var hiddenStates = self.visionModel(pixelValues, frames: frames)
 
         if hiddenStates.ndim == 2 {
             hiddenStates = hiddenStates[.newAxis, 0..., 0...]
         }
 
-        // Insert special image tokens in the input_ids
-        return QwenVL.mergeInputIdsWithImageFeatures(
+        let mergedEmbeds = QwenVL.mergeInputIdsWithImageFeatures(
             inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
             imageTokenId: config.baseConfiguration.imageTokenId,
             videoTokenId: config.baseConfiguration.videoTokenId)
+
+        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
+        let (positionIds, ropeDeltas) = Qwen25VL.getRopeIndex(
+            inputIds: inputIds2D,
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            visionStartTokenId: config.baseConfiguration.visionStartTokenId)
+        languageModel._positionIds = positionIds
+        languageModel._ropeDeltas = ropeDeltas
+
+        return mergedEmbeds
     }
 
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -67,7 +67,10 @@ private enum Language {
         let mropeSection: [Int]
         let mropeSectionRaw: [Int]
         // Box hides invFreq from Module's weight-loader reflection.
-        private class InvFreqBox { let value: MLXArray; init(_ v: MLXArray) { value = v } }
+        private class InvFreqBox {
+            let value: MLXArray
+            init(_ v: MLXArray) { value = v }
+        }
         private let _invFreqBox: InvFreqBox
 
         @ModuleInfo(key: "q_proj") var wq: Linear

--- a/Libraries/MLXVLM/Models/Qwen25VLRopeIndex.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VLRopeIndex.swift
@@ -1,0 +1,164 @@
+// Port of https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/qwen2_5_vl
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+extension Qwen25VL {
+
+    /// Port of Qwen2_5_VLForConditionalGeneration.get_rope_index from HuggingFace transformers.
+    static func getRopeIndex(
+        inputIds: MLXArray,
+        imageGridTHW: [THW]?,
+        videoGridTHW: [THW]?,
+        spatialMergeSize: Int,
+        imageTokenId: Int,
+        videoTokenId: Int,
+        visionStartTokenId: Int,
+        attentionMask: MLXArray? = nil
+    ) -> (MLXArray, MLXArray) {
+
+        let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
+
+        guard inputIds.ndim > 0, imageGridTHW != nil || videoGridTHW != nil else {
+            var positionIds = MLXArray(0 ..< seqLength).asType(.int32)
+            positionIds = broadcast(positionIds[.newAxis, 0...], to: [batchSize, seqLength])
+            let positionIds3D = broadcast(
+                positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
+            let zeros = MLXArray.zeros([batchSize], dtype: .int32)
+            return (positionIds3D, zeros)
+        }
+
+        var positionIds = ones(like: inputIds).asType(.int32)
+        positionIds = broadcast(positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
+
+        var mropePositionDeltas: [Int] = []
+        let mask = attentionMask ?? ones(like: inputIds)
+
+        for batchIdx in 0 ..< batchSize {
+            var batchInputIds = inputIds[batchIdx, 0...]
+            batchInputIds = `where`(
+                mask[batchIdx, 0...] .== 1, batchInputIds, zeros(like: batchInputIds))
+
+            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(Int.self)
+            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(Int.self)
+
+            let inputTokens = batchInputIds.asArray(Int32.self).map { Int($0) }
+            var llmPosIdsList: [MLXArray] = []
+
+            var st = 0
+            var remainImages = imageNums
+            var remainVideos = videoNums
+            var imageIndex = 0
+            var videoIndex = 0
+
+            for _ in 0 ..< (imageNums + videoNums) {
+                let edImage: Int
+                if remainImages > 0, let idx = inputTokens[st...].firstIndex(of: imageTokenId) {
+                    edImage = idx
+                } else {
+                    edImage = inputTokens.count + 1
+                }
+
+                let edVideo: Int
+                if remainVideos > 0, let idx = inputTokens[st...].firstIndex(of: videoTokenId) {
+                    edVideo = idx
+                } else {
+                    edVideo = inputTokens.count + 1
+                }
+
+                let (t, h, w, ed): (Int, Int, Int, Int)
+                if edImage < edVideo {
+                    guard let grid = imageGridTHW, imageIndex < grid.count else { break }
+                    (t, h, w) = grid[imageIndex].values
+                    imageIndex += 1
+                    remainImages -= 1
+                    ed = edImage
+                } else {
+                    guard let grid = videoGridTHW, videoIndex < grid.count else { break }
+                    (t, h, w) = grid[videoIndex].values
+                    videoIndex += 1
+                    remainVideos -= 1
+                    ed = edVideo
+                }
+
+                let llmGridT = t
+                let llmGridH = h / spatialMergeSize
+                let llmGridW = w / spatialMergeSize
+
+                let stIdx: Int
+                if let lastArray = llmPosIdsList.last {
+                    stIdx = lastArray.max().item(Int.self) + 1
+                } else {
+                    stIdx = 0
+                }
+
+                // Text tokens before this visual block
+                let textLen = ed - st
+                if textLen > 0 {
+                    var index = MLXArray(0 ..< textLen).reshaped([1, textLen])
+                    index = broadcast(index, to: [3, textLen])
+                    index = index + MLXArray(stIdx)
+                    llmPosIdsList.append(index)
+                }
+
+                // 3D position IDs for visual tokens (temporal, height, width)
+                var tIndex = MLXArray(0 ..< llmGridT).reshaped([llmGridT, 1])
+                tIndex = broadcast(tIndex, to: [llmGridT, llmGridH * llmGridW])
+                tIndex = tIndex.flattened()
+
+                var hIndex = MLXArray(0 ..< llmGridH).reshaped([1, llmGridH, 1])
+                hIndex = broadcast(hIndex, to: [llmGridT, llmGridH, llmGridW])
+                hIndex = hIndex.flattened()
+
+                var wIndex = MLXArray(0 ..< llmGridW).reshaped([1, 1, llmGridW])
+                wIndex = broadcast(wIndex, to: [llmGridT, llmGridH, llmGridW])
+                wIndex = wIndex.flattened()
+
+                let visualPosIds = stacked([tIndex, hIndex, wIndex]) + MLXArray(textLen + stIdx)
+                llmPosIdsList.append(visualPosIds)
+
+                st = ed + llmGridT * llmGridH * llmGridW
+            }
+
+            // Remaining text tokens after last visual block
+            if st < inputTokens.count {
+                let stIdx: Int
+                if let lastArray = llmPosIdsList.last {
+                    stIdx = lastArray.max().item(Int.self) + 1
+                } else {
+                    stIdx = 0
+                }
+
+                let textLen = inputTokens.count - st
+                var tIndex = MLXArray(0 ..< textLen).reshaped([1, textLen])
+                tIndex = broadcast(tIndex, to: [3, textLen])
+                llmPosIdsList.append(tIndex + MLXArray(stIdx))
+            }
+
+            if !llmPosIdsList.isEmpty {
+                let llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+
+                let expandedMask = broadcast(
+                    mask[batchIdx, 0...][.newAxis, .newAxis, 0...], to: [3, 1, seqLength])
+                let expandedPositions = llmPositions[0..., .newAxis, 0...]
+                let newPositions = `where`(
+                    expandedMask, expandedPositions,
+                    positionIds[0..., batchIdx ..< batchIdx + 1, 0...])
+
+                positionIds = newPositions
+
+                let maxPosId = llmPositions.max().item(Int.self)
+                mropePositionDeltas.append(maxPosId + 1 - inputTokens.count)
+            }
+        }
+
+        let deltas: MLXArray
+        if mropePositionDeltas.isEmpty {
+            deltas = MLXArray.zeros([batchSize], dtype: .int32)
+        } else {
+            deltas = MLXArray(mropePositionDeltas.map { Int32($0) })
+        }
+        return (positionIds, deltas)
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen25VLRopeIndex.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VLRopeIndex.swift
@@ -40,8 +40,10 @@ extension Qwen25VL {
             batchInputIds = `where`(
                 mask[batchIdx, 0...] .== 1, batchInputIds, zeros(like: batchInputIds))
 
-            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(Int.self)
-            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(Int.self)
+            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(
+                Int.self)
+            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(
+                Int.self)
 
             let inputTokens = batchInputIds.asArray(Int32.self).map { Int($0) }
             var llmPosIdsList: [MLXArray] = []

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -909,18 +909,14 @@ public struct Qwen2VLMessageGenerator: MessageGenerator {
     public init() {}
 
     public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        // Qwen 2 / 2.5 VL chat template expects vision tokens before text.
+        // Emitting text first drifts the trained attention pattern.
         [
             "role": message.role.rawValue,
-            "content": [
-                ["type": "text", "text": message.content]
-            ]
-                // Messages format for Qwen 2 VL, Qwen 2.5 VL. May need to be adapted for other models.
-                + message.images.map { _ in
-                    ["type": "image"]
-                }
-                + message.videos.map { _ in
-                    ["type": "video"]
-                },
+            "content":
+                message.images.map { _ in ["type": "image"] as [String: String] }
+                + message.videos.map { _ in ["type": "video"] as [String: String] }
+                + [["type": "text", "text": message.content]],
         ]
     }
 }


### PR DESCRIPTION
## Summary

Fixes 7 bugs in the native Swift Qwen2.5-VL implementation that collectively cause the model to produce wrong bounding box coordinates on grounding tasks, plus a PIL-matching image preprocessing path that closes the remaining sub-pixel gap against the Python reference. With everything applied, Swift output matches the Python reference (`mlx-vlm 0.4.3`, `mlx-community/Qwen2.5-VL-7B-Instruct-4bit`) at **≤ 2 px on all bbox edges — 6 of 8 bit-exact** on the LeetCode 2-panel test image.

Raised in the context of #221 ("Upstreaming improvements from fast-moving forks"). The current shape (see "File map" below) is already three topical files plus one 6-line ordering fix, so each file can be reviewed in isolation; happy to split further across commits if maintainers prefer that.

## File map

| File | Size | What it does |
|---|---|---|
| `Libraries/MLXVLM/MediaProcessing.swift` | +300 / -13 | Adds `resamplePILLanczos`, a bit-identical port of Pillow 10.4's `Resample.c` Lanczos kernel, plus an ICC-retag pathway that avoids the Display-P3 → sRGB conversion macOS screenshots otherwise get. Used only by the Qwen2.5-VL preprocessor. |
| `Libraries/MLXVLM/Models/Qwen25VL.swift` | +136 / -43 | The 7 model-side fixes (below). File-level header comment orients a reviewer to the MROPE extensions. |
| `Libraries/MLXVLM/Models/Qwen25VLRopeIndex.swift` | +135 / -0 | Extracted `Qwen25VL.getRopeIndex` — the port of HuggingFace `Qwen2_5_VLForConditionalGeneration.get_rope_index`. Pure compute, no MLX state. Split into its own file so the model diff stays readable. |
| `Libraries/MLXVLM/Models/Qwen2VL.swift` | +6 / -10 | `Qwen2VLMessageGenerator` emits vision tokens before text (bug #6). Used by Qwen2-VL and Qwen2.5-VL alike. |

## Background

These bugs surfaced while building a native Swift macOS screen-reader ([screen-overlay-toolkit][toolkit]) that uses `mlx-swift-lm`'s Qwen2.5-VL as a real-time UI panel detector on Apple Silicon. The symptom was consistent: the model returned JSON with `bbox_2d` fields, but the coordinates were off by 200–800 px from ground truth. The same image through the Python `mlx-vlm` reference returned correct coordinates. That gap drove the investigation.

The [full debugging writeup][writeup] covers the methodology end-to-end, including two additional bugs that are consumer-side (prompt format, `max_tokens`) and therefore **out of scope for this PR**.

## The 7 model-side bugs

### 1. MROPE section selection (split-select vs slice-replace)

Multi-Resolution Rotary Position Embedding assigns different frequency bands to temporal (T), height (H), width (W). The Swift implementation split the frequency tensor with modulo indexing (`i % 3`), which **interleaves** frequencies across dimensions. Python starts with temporal frequencies and **overwrites H/W slices in place**, producing `[T₀..₁₅, H₁₆..₃₉, W₄₀..₆₃]`. Interleaving destroys the positional structure the attention layer relies on.

### 2. `invFreq` registered as a Module weight

`invFreq` is computed from `ropeTheta` and `headDim`, not loaded. Declaring it as an `MLXArray` property on a `Module` subclass exposed it to MLX's weight-loading reflection, which either raised `keyNotFound` or silently overwrote it from the checkpoint. Fix: wrap in a nested non-`Module` class (`InvFreqBox`) to hide from reflection.

(Qwen3VL and Qwen35 solve the same problem by pulling their `RotaryEmbedding` into a standalone non-`Module` class — that's a cleaner idiom but a larger refactor; the box is the minimal form of the same pattern.)

### 3. `rope_deltas` unused during autoregressive generation

After prefill, the code cleared cached position IDs but never applied `rope_deltas` during token generation. Correct: `positionIds = cacheOffset + ropeDeltas + arange(seqLen)`. Without the deltas, position embeddings drifted with each generated token and output degraded progressively.

### 4. MROPE state not reset between successive images

`_positionIds` and `_ropeDeltas` from one inference persisted into the next. Second, third, and subsequent inferences used the prior image's accumulated offset as their starting point. Each run got progressively worse.

### 5. Image resize cap at 1800 px instead of 1280 px

The Swift path capped the longest edge at 1800 px. Python mlx-vlm defaults to 1280 px, matching the `min_pixels` / `max_pixels` the model was trained under. 1800 px produces a noticeably larger visual-token count and pushes token positions outside the training distribution.

### 6. Chat template ordering (text before image)

`Qwen2VLMessageGenerator` emitted the content array as `[text, image]`. The Python reference emits `[image, text]` → `<|vision_start|><|image_pad|>×N<|vision_end|>PROMPT`. Attention patterns are position-dependent — placing text before the image-feature injection point shifts what the early layers attend to. This is the only change in `Qwen2VL.swift`.

### 7. Vision attention mask ignored

The vision encoder's self-attention uses a mask to implement **windowed attention** (each patch attends only to patches in its local window). The Swift code passed `mask: .none` to `scaledDotProductAttention` instead of `mask: .array(floatMask)`. Without the mask, every patch attended globally, destroying the spatial locality the model relies on for coordinate prediction. This is a single-line fix; in isolation it has an outsized visual impact, but empirically each of the 7 fixes is load-bearing — reverting any one of them breaks coherent output.

```swift
// Before:
let attn = scaledDotProductAttention(queries: q, keys: k, values: v, scale: scale, mask: .none)
// After:
let attn = scaledDotProductAttention(queries: q, keys: k, values: v, scale: scale, mask: .array(floatMask))
```

## Preprocessing: PIL-matching Lanczos resampler

Fixing the 7 bugs above gets to ~30 px parity. Closing the rest comes down to a preprocessing disagreement that's independent of the model.

Python mlx-vlm calls `PIL.Image.resize(..., Image.LANCZOS)`, which is Pillow's int32-fixed-point separable Lanczos kernel (a=3, clamp boundary, `PRECISION_BITS=22`). Core Image's `CILanczosScaleTransform` — and `vImage`, and MPS — implement a Lanczos variant that diverges from Pillow on high-frequency content, enough to shift downstream VLM bbox coordinates by tens of pixels.

Rather than switch resamplers, this PR adds `resamplePILLanczos` in `MediaProcessing.swift`: a direct Swift port of Pillow 10.4's `Resample.c` 8bpc fast path (~300 lines). It also retags `CGImage` as sRGB without conversion, because macOS screenshots carry Display-P3 ICC profiles that `ImageIO` would otherwise convert on load — producing different uint8 bytes than `PIL.Image.open` sees (which ignores the ICC tag).

The Qwen25VL preprocess path uses this helper and bypasses the `CIImage → sRGB → bicubic → normalize → MLXArray` downstream chain entirely, which otherwise re-encodes bytes via the working colorspace.

This helper is scoped to the Qwen VLM preprocessing path — callers of the existing `MediaProcessing.resampleLanczos` (Core-Image-based) are unaffected.

## Parity evidence

Against `mlx-community/Qwen2.5-VL-7B-Instruct-4bit` via `mlx-vlm 0.4.3` on a screenshot of the LeetCode "Two Sum" problem (a 2-panel UI — question left, code editor right):

```
python: {"question": [1, 146, 421, 626], "editor": [421, 146, 881, 626]}
swift:  {"question": [1, 146, 421, 628], "editor": [421, 146, 881, 628]}
deltas: [0,0,0,2] and [0,0,0,2] — max 2 px, 6 of 8 edges bit-exact
```

I have a ~130-line bash reproducer that pins this branch, runs Python + Swift on a fixed test image, and prints per-edge deltas. Happy to land it somewhere public (a separate gist, a `scripts/` directory in this repo, or inlined into a PR comment) — tell me which you'd prefer.

**Cross-architecture smoke test.** I also ran `mlx-community/UI-TARS-1.5-7B-mlx-bf16` through the same patched Swift path and got coherent output — UI-TARS shares the `Qwen2_5_VLForConditionalGeneration` architecture, so the fixes are architecture-level rather than Qwen2.5-VL-specific. Happy to share that report if useful (it's not public yet).

## Notes for reviewers

- **`getRopeIndex` extracted to its own file** — it's a standalone compute, and extracting it keeps the model diff focused on the stateful parts. If you'd prefer it inline, happy to revert that split.
- **Stored state on `Qwen25LanguageModel`** (`_positionIds`, `_ropeDeltas`) — architectural smell. MROPE state needs to persist across prefill → decode steps, and the `KVCache` protocol doesn't carry it. Pulling this into the cache protocol (or threading it through the call chain) would touch upstream contracts; opted not to do that here, but happy to if you'd prefer. See the file-level header comment in `Qwen25VL.swift` for the full rationale.
- **No unit tests** — I don't have a clean way to exercise the full vision encoder + language model against a reference output within the existing test harness. Pointers welcome; happy to add targeted tests.

## Related

- Full debugging writeup: [_Building a Real-Time Screen Reader on macOS That Actually Works_][writeup]
- Consumer app demonstrating these fixes: [screen-overlay-toolkit][toolkit]
- Upstream issue that prompted this PR: #221

[writeup]: https://dev.to/nivdvir/building-a-real-time-screen-reader-on-macos-that-actually-works-471
[toolkit]: https://github.com/NivDvir/screen-overlay-toolkit
