### PR TITLE
Fix EmbeddingGemma init-order crash + dense head hidden size

### DIFF
--- a/Libraries/MLXEmbedders/Models/Gemma3.swift
+++ b/Libraries/MLXEmbedders/Models/Gemma3.swift
@@ -474,17 +474,36 @@ public class EmbeddingGemma: Module, EmbeddingModel {
 
         // Initialize projection head if weights are present.
         //
-        // We cannot use `self._dense.wrappedValue = [...]`: after init
-        // ran, `_dense.module` is non-nil (set to `[]`), and re-assigning
-        // the wrapped value routes through `@ModuleInfo.wrappedValue.set`,
-        // which `fatalError`s in that case to keep the module's item cache
+        // The dense head's hidden dimension is NOT `config.intermediateSize`
+        // (which is the MLP hidden size for the backbone). For
+        // `embeddinggemma-300m` the dense head expands to `4 * hiddenSize`
+        // (3072 for a 768-hidden model) and the checkpoint does not declare
+        // it in `config.json`. Read it off `dense.0.weight` so the shape is
+        // always correct whatever the upstream publishes. `.weight` first
+        // dim is the output dim for both float and 4-bit quantized layers.
+        //
+        // We cannot use `self._dense.wrappedValue = [...]`: after init ran,
+        // `_dense.module` is non-nil (set to `[]`), and re-assigning the
+        // wrapped value routes through `@ModuleInfo.wrappedValue.set`, which
+        // `fatalError`s in that case to keep the module's item cache
         // consistent. `update(modules:)` goes through `TypeErasedSetter`,
         // which accepts `[Module]` and updates the cache in lockstep.
         if processedWeights.keys.contains(where: { $0.hasPrefix("dense.") }) {
+            guard let dense0Weight = processedWeights["dense.0.weight"] else {
+                // Malformed checkpoint: `dense.*` keys exist but no
+                // `dense.0.weight` to read the hidden dim from. Skip
+                // dense-head setup and let `loadWeights` raise a shape
+                // mismatch against the (still-empty) `_dense` array.
+                return processedWeights.filter { (key, _) in
+                    !key.contains("self_attn.rotary_emb.inv_freq")
+                        && !key.contains("lm_head")
+                }
+            }
+            let denseHiddenSize = dense0Weight.dim(0)
             update(
                 modules: .unflattened([
-                    ("dense.0", Linear(config.hiddenSize, config.intermediateSize, bias: false)),
-                    ("dense.1", Linear(config.intermediateSize, config.hiddenSize, bias: false)),
+                    ("dense.0", Linear(config.hiddenSize, denseHiddenSize, bias: false)),
+                    ("dense.1", Linear(denseHiddenSize, config.hiddenSize, bias: false)),
                 ])
             )
         }

--- a/Libraries/MLXEmbedders/Models/Gemma3.swift
+++ b/Libraries/MLXEmbedders/Models/Gemma3.swift
@@ -472,12 +472,21 @@ public class EmbeddingGemma: Module, EmbeddingModel {
             processedWeights = Dictionary(uniqueKeysWithValues: lm.flattened())
         }
 
-        // Initialize projection head if weights are present
+        // Initialize projection head if weights are present.
+        //
+        // We cannot use `self._dense.wrappedValue = [...]`: after init
+        // ran, `_dense.module` is non-nil (set to `[]`), and re-assigning
+        // the wrapped value routes through `@ModuleInfo.wrappedValue.set`,
+        // which `fatalError`s in that case to keep the module's item cache
+        // consistent. `update(modules:)` goes through `TypeErasedSetter`,
+        // which accepts `[Module]` and updates the cache in lockstep.
         if processedWeights.keys.contains(where: { $0.hasPrefix("dense.") }) {
-            self._dense.wrappedValue = [
-                Linear(config.hiddenSize, config.intermediateSize, bias: false),
-                Linear(config.intermediateSize, config.hiddenSize, bias: false),
-            ]
+            update(
+                modules: .unflattened([
+                    ("dense.0", Linear(config.hiddenSize, config.intermediateSize, bias: false)),
+                    ("dense.1", Linear(config.intermediateSize, config.hiddenSize, bias: false)),
+                ])
+            )
         }
 
         // Truncate vocab if weights were trained with extra padding tokens

--- a/Libraries/MLXEmbedders/Models/Gemma3.swift
+++ b/Libraries/MLXEmbedders/Models/Gemma3.swift
@@ -472,33 +472,9 @@ public class EmbeddingGemma: Module, EmbeddingModel {
             processedWeights = Dictionary(uniqueKeysWithValues: lm.flattened())
         }
 
-        // Initialize projection head if weights are present.
-        //
-        // The dense head's hidden dimension is NOT `config.intermediateSize`
-        // (which is the MLP hidden size for the backbone). For
-        // `embeddinggemma-300m` the dense head expands to `4 * hiddenSize`
-        // (3072 for a 768-hidden model) and the checkpoint does not declare
-        // it in `config.json`. Read it off `dense.0.weight` so the shape is
-        // always correct whatever the upstream publishes. `.weight` first
-        // dim is the output dim for both float and 4-bit quantized layers.
-        //
-        // We cannot use `self._dense.wrappedValue = [...]`: after init ran,
-        // `_dense.module` is non-nil (set to `[]`), and re-assigning the
-        // wrapped value routes through `@ModuleInfo.wrappedValue.set`, which
-        // `fatalError`s in that case to keep the module's item cache
-        // consistent. `update(modules:)` goes through `TypeErasedSetter`,
-        // which accepts `[Module]` and updates the cache in lockstep.
-        if processedWeights.keys.contains(where: { $0.hasPrefix("dense.") }) {
-            guard let dense0Weight = processedWeights["dense.0.weight"] else {
-                // Malformed checkpoint: `dense.*` keys exist but no
-                // `dense.0.weight` to read the hidden dim from. Skip
-                // dense-head setup and let `loadWeights` raise a shape
-                // mismatch against the (still-empty) `_dense` array.
-                return processedWeights.filter { (key, _) in
-                    !key.contains("self_attn.rotary_emb.inv_freq")
-                        && !key.contains("lm_head")
-                }
-            }
+        // Dense head hidden dim is not in config, infer from checkpoint weight.
+        // Use update(modules:) to replace values with correct shape.
+        if let dense0Weight = processedWeights["dense.0.weight"] {
             let denseHiddenSize = dense0Weight.dim(0)
             update(
                 modules: .unflattened([


### PR DESCRIPTION
## Summary

Loading any `mlx-community/embeddinggemma-*` checkpoint on HEAD crashes with:

```
MLXNN/Module.swift:1530: Fatal error: please use Model.update(modules:)
rather than mutating the Module property directly
```

Root cause is a re-assignment to `@ModuleInfo`-wrapped `_dense` after the `EmbeddingGemma` initializer has already seeded it. The `@ModuleInfo.wrappedValue.set` path `fatalError`s when `module != nil`, which is the setter's way of refusing assignments that would desync the wrapped value from the parent `Module`'s item cache. Routing the second assignment through `update(modules:)` gets us past the guard and keeps the cache consistent — that helper hops through `TypeErasedSetter.updateModule(_:)`, which accepts `[Module]` and updates both sides together.

While verifying the first fix end-to-end, a second latent bug surfaced in the same code path: the dense head was being created with `config.intermediateSize` (the backbone's MLP hidden size, `1152` for `embeddinggemma-300m`) as the hidden dim. The real checkpoint's dense head expands `4x` (`3072` for a `768`-hidden model) and that dimension is not declared in `config.json`. Reading the hidden dim off `dense.0.weight.dim(0)` stays agnostic to whatever the upstream ships.

## Commits

- **Fix EmbeddingGemma init-order crash in sanitize(weights:)** — replaces `self._dense.wrappedValue = [...]` with `update(modules: .unflattened([...]))`. Surgical, keeps the existing (wrong) dimensions for reviewability.
- **Fix EmbeddingGemma dense head hidden size** — computes the dense hidden size from the weights dict instead of from `config.intermediateSize`.

Happy to split into two PRs if maintainers prefer.

## Reproduction

```swift
// throwaway target, Package.swift depends on mlx-swift-lm at HEAD + swift-tokenizers-mlx

import MLXEmbedders
import MLXEmbeddersTokenizers

let dir = URL(fileURLWithPath: ".../embeddinggemma-300m-4bit")
let container = try await MLXEmbeddersTokenizers.loadModelContainer(from: dir)
// ^ crashes on HEAD in EmbeddingGemma.sanitize with
//   "please use Model.update(modules:) rather than mutating the Module property directly"
```

## Test plan

- [x] Added a standalone Swift target that constructs `EmbeddingGemma` and calls `sanitize(weights:)` with a synthetic `dense.*` weight dict. Confirms the fatal error reproduces on HEAD and is gone after commit 1.
- [x] Loaded `mlx-community/embeddinggemma-300m-4bit` end-to-end after both commits. Encoded a Russian + English input and got a `768`-dim L2-normalized vector back — the first three components from a representative run were `[-0.07890581, 0.009463381, 0.040300827]`.
- [ ] No existing tests exercise this path (`IntegrationTesting/` has no `gemma3` / `EmbeddingGemma` case), so there are no regressions to check here. An integration test for `EmbedderModelFactory` on `embeddinggemma-300m` would be a sensible follow-up but is out of scope for this PR.

## Context

Discovered while wiring `EmbeddingGemma` into Second Brain, an on-device PKM app that leans on `MLXEmbedders` for hybrid search. Happy to iterate if the maintainers want a different structure, or to extract a minimum-viable test case into the repo.
