### PR TITLE
fix: disable CIContext intermediate caching to prevent IOSurface exha…

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -13,7 +13,12 @@ public struct ProcessedFrames {
     public let totalDuration: CMTime
 }
 
-private let context = CIContext()
+// `.cacheIntermediates: false` prevents CoreImage from holding IOSurface-backed
+// GPU textures between frames. With the default (caching) context, a large-library
+// scan accumulates thousands of cached intermediate surfaces and hits the
+// per-process IOSurface limit of 16384, crashing the render pipeline.
+// Batch-processing never re-renders the same frame twice, so the cache buys nothing.
+private let context = CIContext(options: [.cacheIntermediates: false])
 
 /// Collection of methods for processing media (images, video, etc.).
 ///


### PR DESCRIPTION
…ustion

CIContext() default options cache IOSurface-backed GPU textures for intermediate filter results. Each frame in the VLM image pipeline (tone-curve → bicubic resample → color-matrix normalize) allocates multiple IOSurfaces that are held in the context cache across calls.

Processing a large library (hundreds of videos, each yielding several frames) accumulates thousands of cached surfaces and hits the macOS per-process IOSurface kernel limit of 16384, causing render failures:

  IOSurface creation failed: e00002be (likely per client IOSurface limit of
  16384 reached)
  -[CIContext _startTaskToRender:...] Render failed because of failure to
  allocate intermediate.

Fix: pass `.cacheIntermediates: false` when constructing the shared context. Batch inference never re-renders the same CIImage twice, so the intermediate cache provides no benefit. The change eliminates the surface accumulation while leaving all functional behavior intact.

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
