### PR TITLE
Remove temporal coupling in `applyRotaryPosition`

### DIFF
--- a/Libraries/MLXLLM/Models/AfMoE.swift
+++ b/Libraries/MLXLLM/Models/AfMoE.swift
@@ -197,8 +197,9 @@ class AfMoEAttention: Module {
 
         // Apply RoPE only for local (sliding window) attention
         if isLocalAttention, let rope = rope {
-            queries = applyRotaryPosition(rope, to: queries, cache: cache)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+            queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+            keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
         }
 
         var output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/Apertus.swift
+++ b/Libraries/MLXLLM/Models/Apertus.swift
@@ -223,8 +223,9 @@ private class ApertusAttention: Module {
         values = values.transposed(0, 2, 1, 3)
 
         // 4. RoPE
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         if let cache = cache {
             // Update cache (expects [B, H, L, D])

--- a/Libraries/MLXLLM/Models/BaichuanM1.swift
+++ b/Libraries/MLXLLM/Models/BaichuanM1.swift
@@ -130,8 +130,9 @@ class BaichuanM1Attention: Module {
         keys = customConvolution(keys, convK, state: lastK)
         values = customConvolution(values, convV, state: lastV)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: kvSubCache)
-        keys = applyRotaryPosition(rope, to: keys, cache: kvSubCache)
+        let ropeOffset = kvSubCache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         if let cache = cache as? CacheList {
             let kvCache = cache[1]

--- a/Libraries/MLXLLM/Models/BailingMoe.swift
+++ b/Libraries/MLXLLM/Models/BailingMoe.swift
@@ -145,8 +145,9 @@ class BailingMoeAttention: Module {
         keys = keys.transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Bitnet.swift
+++ b/Libraries/MLXLLM/Models/Bitnet.swift
@@ -315,8 +315,9 @@ class BitnetAttention: Module {
         keys = keys.reshaped(B, L, args.resolvedKvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.resolvedKvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         if let cache {
             (keys, values) = cache.update(keys: keys, values: values)

--- a/Libraries/MLXLLM/Models/Cohere.swift
+++ b/Libraries/MLXLLM/Models/Cohere.swift
@@ -50,8 +50,9 @@ class CohereAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -197,8 +197,9 @@ class DeepseekV3Attention: Module {
 
         var (kNope, values) = (splitKv[0], splitKv[1])
 
-        qPe = applyRotaryPosition(rope, to: qPe, cache: cache)
-        kPe = applyRotaryPosition(rope, to: kPe, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        qPe = applyRotaryPosition(rope, to: qPe, offset: ropeOffset)
+        kPe = applyRotaryPosition(rope, to: kPe, offset: ropeOffset)
         kPe = repeated(kPe, count: numHeads, axis: 1)
 
         var keys: MLXArray

--- a/Libraries/MLXLLM/Models/Ernie4_5.swift
+++ b/Libraries/MLXLLM/Models/Ernie4_5.swift
@@ -104,8 +104,9 @@ class Ernie45Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Exaone4.swift
+++ b/Libraries/MLXLLM/Models/Exaone4.swift
@@ -72,8 +72,9 @@ class Exaone4Attention: Module {
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
         if useRope, let rope {
-            queries = applyRotaryPosition(rope, to: queries, cache: cache)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+            queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+            keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
         }
 
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -302,8 +302,9 @@ class FalconH1Attention: Module {
         keys = keys.reshaped(B, L, numKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, numKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         if let cache {
             (keys, values) = cache.update(keys: keys, values: values)

--- a/Libraries/MLXLLM/Models/GLM4.swift
+++ b/Libraries/MLXLLM/Models/GLM4.swift
@@ -55,8 +55,9 @@ class GLM4Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/GLM4MOE.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOE.swift
@@ -70,8 +70,9 @@ class GLM4MoEAttention: Module {
         keys = keys.transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/GLM4MOELite.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOELite.swift
@@ -254,8 +254,9 @@ class GLM4MoELiteAttention: Module {
         kPe = kPe.reshaped(B, L, 1, qkRopeHeadDim).transposed(0, 2, 1, 3)
         var kvLatent = kvALayerNorm(compressedKv)
 
-        qPe = applyRotaryPosition(rope, to: qPe, cache: cache)
-        kPe = applyRotaryPosition(rope, to: kPe, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        qPe = applyRotaryPosition(rope, to: qPe, offset: ropeOffset)
+        kPe = applyRotaryPosition(rope, to: kPe, offset: ropeOffset)
 
         // Expand kvLatent for attention: [B, L, kvLoraRank] -> [B, 1, L, kvLoraRank]
         kvLatent = expandedDimensions(kvLatent, axis: 1)

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -212,6 +212,7 @@ class AttentionBlock: Module {
     ) -> MLXArray {
         let (B, L) = (x.dim(0), x.dim(1))
         let D = headDim
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
 
         var q = qProj(x).reshaped(B, L, -1, D).swappedAxes(1, 2)
         var k = kProj(x).reshaped(B, L, -1, D).swappedAxes(1, 2)
@@ -229,8 +230,8 @@ class AttentionBlock: Module {
             if sinksActive {
                 fatalError("Quantized attention does not support non-zero sinks.")
             }
-            q = applyRotaryPosition(rope, to: q, cache: cache)
-            k = applyRotaryPosition(rope, to: k, cache: cache)
+            q = applyRotaryPosition(rope, to: q, offset: ropeOffset)
+            k = applyRotaryPosition(rope, to: k, offset: ropeOffset)
 
             let (qKeys, qValues) = qcache.updateQuantized(keys: k, values: v)
             let vHat = quantizedScaledDotProductAttention(
@@ -247,8 +248,8 @@ class AttentionBlock: Module {
             return oProj(vHat.swappedAxes(1, 2).reshaped(B, L, -1))
         }
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        q = applyRotaryPosition(rope, to: q, offset: ropeOffset)
+        k = applyRotaryPosition(rope, to: k, offset: ropeOffset)
 
         if let cache {
             (k, v) = cache.update(keys: k, values: v)

--- a/Libraries/MLXLLM/Models/Gemma.swift
+++ b/Libraries/MLXLLM/Models/Gemma.swift
@@ -68,8 +68,9 @@ class GemmaAttention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Gemma2.swift
+++ b/Libraries/MLXLLM/Models/Gemma2.swift
@@ -54,8 +54,9 @@ class Gemma2Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         if let cache {
             (keys, values) = cache.update(keys: keys, values: values)

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -197,8 +197,9 @@ class Gemma3Attention: Module {
         queries = queryNorm(queries)
         keys = keyNorm(keys)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Gemma3nText.swift
+++ b/Libraries/MLXLLM/Models/Gemma3nText.swift
@@ -258,10 +258,13 @@ class Gemma3nAttention: Module {
         cache: KVCache? = nil
     ) -> MLXArray {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
 
         var queries = qProj(x)
         queries = queries.reshaped(B, L, -1, headDim)
         queries = qNorm(queries)
+        queries = queries.transposed(0, 2, 1, 3)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
 
         var keys: MLXArray
         var values: MLXArray
@@ -275,7 +278,7 @@ class Gemma3nAttention: Module {
                 keys = kProj(x).reshaped(B, L, -1, headDim)
                 keys = kNorm(keys)
                 keys = keys.transposed(0, 2, 1, 3)
-                keys = applyRotaryPosition(rope, to: keys, cache: cache)
+                keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
                 values = vProj(x).reshaped(B, L, -1, headDim)
                 values = vNorm(values)
@@ -289,7 +292,7 @@ class Gemma3nAttention: Module {
             keys = kProj(x).reshaped(B, L, -1, headDim)
             keys = kNorm(keys)
             keys = keys.transposed(0, 2, 1, 3)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
             values = vProj(x).reshaped(B, L, -1, headDim)
             values = vNorm(values)
@@ -299,9 +302,6 @@ class Gemma3nAttention: Module {
                 (keys, values) = cache.update(keys: keys, values: values)
             }
         }
-
-        queries = queries.transposed(0, 2, 1, 3)
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
 
         var adjustedMask = mask
         if case .array(let maskArray) = mask {

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -175,33 +175,6 @@ private class ScaledLinear: Module {
     }
 }
 
-private enum Gemma4PositionOffset {
-    case scalar(Int)
-    case batch(MLXArray)
-}
-
-private func gemma4CapturePositionOffset(from cache: KVCache?) -> Gemma4PositionOffset {
-    if let batchCache = cache as? BatchPositionedKVCache {
-        // Snapshot the per-sequence offsets before cache.update(...) advances them.
-        .batch(batchCache.batchOffset + 0)
-    } else {
-        .scalar(cache?.offset ?? 0)
-    }
-}
-
-private func gemma4ApplyRotaryPosition<R: RoPELayer>(
-    _ rope: R,
-    to x: MLXArray,
-    offset: Gemma4PositionOffset
-) -> MLXArray {
-    switch offset {
-    case .scalar(let value):
-        rope(x, offset: value)
-    case .batch(let values):
-        rope(x, offset: values)
-    }
-}
-
 // MARK: - Attention
 
 private class Gemma4Attention: Module {
@@ -283,8 +256,8 @@ private class Gemma4Attention: Module {
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
         sharedKV: (MLXArray, MLXArray)? = nil,
-        positionOffset: Gemma4PositionOffset? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), Gemma4PositionOffset) {
+        positionOffset: RoPEOffset? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray), RoPEOffset) {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x).reshaped(B, L, nHeads, effectiveHeadDim)
@@ -292,7 +265,7 @@ private class Gemma4Attention: Module {
 
         let keys: MLXArray
         let values: MLXArray
-        let activePositionOffset = positionOffset ?? gemma4CapturePositionOffset(from: cache)
+        let activePositionOffset = positionOffset ?? (cache?.ropeOffset ?? .scalar(0))
 
         if let (sharedK, sharedV) = sharedKV {
             // KV-shared layers use pre-computed KV from an earlier layer
@@ -302,7 +275,7 @@ private class Gemma4Attention: Module {
             var k = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             k = kNorm(k)
             k = k.transposed(0, 2, 1, 3)
-            k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
+            k = applyRotaryPosition(rope, to: k, offset: activePositionOffset)
 
             var v: MLXArray
             if let vProj {
@@ -324,7 +297,7 @@ private class Gemma4Attention: Module {
         }
 
         queries = queries.transposed(0, 2, 1, 3)
-        queries = gemma4ApplyRotaryPosition(rope, to: queries, offset: activePositionOffset)
+        queries = applyRotaryPosition(rope, to: queries, offset: activePositionOffset)
 
         // Adjust mask if cache size differs from mask size
         var adjustedMask = mask
@@ -435,8 +408,8 @@ private class Gemma4DecoderLayer: Module {
         cache: KVCache? = nil,
         perLayerInput: MLXArray? = nil,
         sharedKV: (MLXArray, MLXArray)? = nil,
-        positionOffset: Gemma4PositionOffset? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), Gemma4PositionOffset) {
+        positionOffset: RoPEOffset? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray), RoPEOffset) {
         let residual = x
 
         let h = inputLayernorm(x)
@@ -605,7 +578,7 @@ private class Gemma4TextModelInner: Module {
         }
 
         // Forward through layers, tracking intermediate KV pairs for sharing
-        var intermediates = [(kv: (MLXArray, MLXArray)?, positionOffset: Gemma4PositionOffset?)](
+        var intermediates = [(kv: (MLXArray, MLXArray)?, positionOffset: RoPEOffset?)](
             repeating: (nil, nil), count: config.numHiddenLayers)
 
         for (idx, layer) in layers.enumerated() {

--- a/Libraries/MLXLLM/Models/Granite.swift
+++ b/Libraries/MLXLLM/Models/Granite.swift
@@ -59,8 +59,9 @@ class GraniteAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -245,8 +245,9 @@ class GraniteMoeHybridAttention: Module {
         values = values.reshaped(B, L, args.kvHeads, headDim).transposed(0, 2, 1, 3)
 
         if let rope {
-            queries = applyRotaryPosition(rope, to: queries, cache: cache)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+            queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+            keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
         }
 
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/Internlm2.swift
+++ b/Libraries/MLXLLM/Models/Internlm2.swift
@@ -119,8 +119,9 @@ class Internlm2Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -157,8 +157,9 @@ class LFM2Attention: Module {
         keys = kLayerNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -154,8 +154,9 @@ class LFM2MoEAttention: Module {
         keys = kLayerNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Lille130m.swift
+++ b/Libraries/MLXLLM/Models/Lille130m.swift
@@ -65,9 +65,9 @@ final class Lille130mAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        // Apply RoPE with cache-aware offset if available
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -55,8 +55,9 @@ class LlamaAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/MiMo.swift
+++ b/Libraries/MLXLLM/Models/MiMo.swift
@@ -59,8 +59,9 @@ class MiMoAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -169,8 +169,9 @@ class MiMoV2FlashAttention: Module {
         var k = keys.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
         let v = values.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        q = applyRotaryPosition(rope, to: q, offset: ropeOffset)
+        k = applyRotaryPosition(rope, to: k, offset: ropeOffset)
 
         let output = attentionWithCacheUpdateAndSinks(
             queries: q,

--- a/Libraries/MLXLLM/Models/MiniCPM.swift
+++ b/Libraries/MLXLLM/Models/MiniCPM.swift
@@ -54,8 +54,9 @@ final class MiniCPMAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/MiniMax.swift
+++ b/Libraries/MLXLLM/Models/MiniMax.swift
@@ -77,8 +77,9 @@ class MiniMaxAttention: Module {
         var k = keys.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
         let v = values.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        q = applyRotaryPosition(rope, to: q, offset: ropeOffset)
+        k = applyRotaryPosition(rope, to: k, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: q,

--- a/Libraries/MLXLLM/Models/Mistral3Text.swift
+++ b/Libraries/MLXLLM/Models/Mistral3Text.swift
@@ -87,8 +87,9 @@ class Mistral3Attention: Module {
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
         // Apply RoPE
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         // Apply attention scaling
         queries = queries * attnScale

--- a/Libraries/MLXLLM/Models/NanoChat.swift
+++ b/Libraries/MLXLLM/Models/NanoChat.swift
@@ -112,8 +112,9 @@ final class NanoChatAttention: Module {
         keys = keys.reshaped(batchSize, sequenceLength, numKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(batchSize, sequenceLength, numKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         queries = functionalRMSNorm(queries, eps: config.rmsNormEps)
         keys = functionalRMSNorm(keys, eps: config.rmsNormEps)

--- a/Libraries/MLXLLM/Models/Olmo2.swift
+++ b/Libraries/MLXLLM/Models/Olmo2.swift
@@ -68,8 +68,9 @@ class Olmo2Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Olmo3.swift
+++ b/Libraries/MLXLLM/Models/Olmo3.swift
@@ -78,8 +78,9 @@ class Olmo3Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/OlmoE.swift
+++ b/Libraries/MLXLLM/Models/OlmoE.swift
@@ -67,8 +67,9 @@ class OlmoEAttention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/OpenELM.swift
+++ b/Libraries/MLXLLM/Models/OpenELM.swift
@@ -78,8 +78,9 @@ class MultiHeadCausalAttention: Module {
             keys = kNorm(keys)
         }
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Phi.swift
+++ b/Libraries/MLXLLM/Models/Phi.swift
@@ -57,8 +57,9 @@ class PhiAttention: Module {
         values = values.reshaped(B, L, args.kvHeads, headDim).transposed(0, 2, 1, 3)
 
         // Add RoPE to the queries and keys and combine them with the cache
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         // Finally perform the attention computation
         let scale = sqrt(1 / Float(queries.dim(-1)))

--- a/Libraries/MLXLLM/Models/Phi3.swift
+++ b/Libraries/MLXLLM/Models/Phi3.swift
@@ -82,8 +82,9 @@ class Phi3Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/PhiMoE.swift
+++ b/Libraries/MLXLLM/Models/PhiMoE.swift
@@ -91,8 +91,9 @@ class PhiMoEAttention: Module {
         var k = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         let v = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        q = applyRotaryPosition(rope, to: q, offset: ropeOffset)
+        k = applyRotaryPosition(rope, to: k, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: q,

--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -70,8 +70,9 @@ class Qwen2Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -77,8 +77,9 @@ class Qwen3Attention: Module {
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
         // Apply RoPE positioning
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         // Use the automatic attention router that handles both quantized and regular caches
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -359,8 +359,9 @@ final class Qwen35Attention: Module {
         keys = kNorm(keys.reshaped(B, L, kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -76,8 +76,9 @@ class Qwen3MoEAttention: Module {
         keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -99,8 +99,9 @@ public final class Qwen3NextAttention: Module {
         keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/SmolLM3.swift
+++ b/Libraries/MLXLLM/Models/SmolLM3.swift
@@ -71,8 +71,9 @@ class SmolLM3Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Starcoder2.swift
+++ b/Libraries/MLXLLM/Models/Starcoder2.swift
@@ -55,8 +55,9 @@ class Starcoder2Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+        queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+        keys = applyRotaryPosition(rope, to: keys, offset: ropeOffset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLMCommon/RoPEApplication.swift
+++ b/Libraries/MLXLMCommon/RoPEApplication.swift
@@ -15,29 +15,79 @@ public protocol BatchPositionedKVCache: KVCache {
     var batchOffset: MLXArray { get }
 }
 
+// MARK: - RoPEOffset
+
+/// Positional offset for RoPE. Polymorphic so single-sequence and batched
+/// inference share the same call site.
+///
+/// Snapshot once per forward pass via ``KVCache/ropeOffset`` before any
+/// `cache.update` call, then reuse the value for every RoPE application in
+/// the layer. Reading `cache.offset` at each RoPE call is unsafe because
+/// `cache.update` advances the offset mid-pass.
+public enum RoPEOffset {
+    /// Single-sequence offset.
+    case scalar(Int)
+    /// Per-sequence offsets with shape `[B]`.
+    case array(MLXArray)
+}
+
+extension KVCache {
+    /// Snapshot of the current RoPE offset suitable for passing to
+    /// ``applyRotaryPosition(_:to:offset:)``.
+    ///
+    /// Read once at the top of `callAsFunction` and reuse for every RoPE
+    /// call in that layer. Do not re-read across a `cache.update` — the
+    /// offset advances and a later read will not match an earlier one.
+    ///
+    /// The batched form defensively copies `batchOffset` (via `+ 0`) so the
+    /// returned value is decoupled from any in-place mutation that
+    /// `cache.update` may perform on the cache's stored offset array.
+    public var ropeOffset: RoPEOffset {
+        if let batched = self as? BatchPositionedKVCache {
+            return .array(batched.batchOffset + 0)
+        } else {
+            return .scalar(offset)
+        }
+    }
+}
+
 // MARK: - applyRotaryPosition Helper
 
-/// Apply rotary position embeddings, using the cache offset when available.
+/// Apply rotary position embeddings at an explicit offset.
 ///
-/// This function enables models to use a single call site instead of
-/// repeating conditional offset handling:
 /// ```swift
-/// queries = applyRotaryPosition(rope, to: queries, cache: cache)
-/// keys = applyRotaryPosition(rope, to: keys, cache: cache)
+/// let ropeOffset = cache?.ropeOffset ?? .scalar(0)
+/// queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
+/// keys    = applyRotaryPosition(rope, to: keys,    offset: ropeOffset)
 /// ```
 ///
 /// - Parameters:
 ///   - rope: A RoPE layer conforming to both `OffsetLayer` and `ArrayOffsetLayer`.
 ///   - x: The input tensor to apply RoPE to.
-///   - cache: The KV cache (determines scalar or per-sequence offset), or `nil`
-///     for offset 0.
+///   - offset: The positional offset, typically produced by ``KVCache/ropeOffset``.
 /// - Returns: The input with rotary positional encoding applied.
+public func applyRotaryPosition<R: RoPELayer>(
+    _ rope: R, to x: MLXArray, offset: RoPEOffset
+) -> MLXArray {
+    switch offset {
+    case .scalar(let i): return rope(x, offset: i)
+    case .array(let a): return rope(x, offset: a)
+    }
+}
+
+/// Apply rotary position embeddings, reading the offset from the cache.
+///
+/// - Warning: This overload reads `cache.offset` at call time and is unsafe
+///   when `cache.update` runs between RoPE calls in the same layer. Snapshot
+///   the offset once via ``KVCache/ropeOffset`` and use
+///   ``applyRotaryPosition(_:to:offset:)`` instead.
+@available(
+    *, deprecated,
+    message:
+        "Snapshot `cache?.ropeOffset ?? .scalar(0)` once before any `cache.update` and use `applyRotaryPosition(_:to:offset:)`."
+)
 public func applyRotaryPosition<R: RoPELayer>(_ rope: R, to x: MLXArray, cache: KVCache?)
     -> MLXArray
 {
-    if let batchCache = cache as? BatchPositionedKVCache {
-        return rope(x, offset: batchCache.batchOffset)
-    } else {
-        return rope(x, offset: cache?.offset ?? 0)
-    }
+    applyRotaryPosition(rope, to: x, offset: cache?.ropeOffset ?? .scalar(0))
 }


### PR DESCRIPTION
`applyRotaryPosition(_:to:cache:)`, which was introduced in [#178](https://github.com/ml-explore/mlx-swift-lm/pull/178) (cc [@ronaldmannak](https://github.com/ronaldmannak)), reads `cache.offset` implicitly. Because `cache.update(...)` advances the offset, the helper's result depends on call ordering relative to cache updates, and that dependency is invisible at the call site.

44 of the 45 attention layers using this helper call it for queries and keys back to back before any `cache.update`, so both reads return the same value and the coupling stays hidden. Gemma 3n is the exception: its KV-sharing branch calls `cache.update` between the key and query RoPE calls, so queries get rotated at `cache.offset + L` while keys use `cache.offset`. That mismatch produces garbled output (see [#233](https://github.com/ml-explore/mlx-swift-lm/issues/233)).

Gemma 4 had the same interleaving and worked around it with file-local helpers that corresponded to this PR's API, which is now uniformly applied.

MLX LM in Python avoids this by making `offset` an explicit argument to `nn.RoPE`. Callers that interleave `cache.update_and_fetch` snapshot `offset = cache.offset` first, making the timing visible.

## Solution

Make the offset explicit in Swift too. Preserve the batch polymorphism the helper was introduced for, but move the cache read out of the helper and into a one-line snapshot at the top of each `callAsFunction`.

### New API (additive)

In `Libraries/MLXLMCommon/RoPEApplication.swift`, add a `RoPEOffset` enum (`.scalar(Int)` / `.array(MLXArray)`), a `KVCache.ropeOffset` snapshot property that defensively copies the batched variant, and a new `applyRotaryPosition(_:to:offset:)` overload.

### Deprecated shim

Mark the existing `applyRotaryPosition(_:to:cache:)` `@available(*, deprecated)` and forward it to the new overload via `cache?.ropeOffset ?? .scalar(0)`, so downstream callers get a warning, not a compile error, during migration.

### Call site example

Before:
```swift
queries = applyRotaryPosition(rope, to: queries, cache: cache)
keys    = applyRotaryPosition(rope, to: keys,    cache: cache)
```

After:
```swift
let ropeOffset = cache?.ropeOffset ?? .scalar(0)
...
queries = applyRotaryPosition(rope, to: queries, offset: ropeOffset)
keys    = applyRotaryPosition(rope, to: keys,    offset: ropeOffset)
```

The snapshot goes at the top of `callAsFunction`, or at the narrowest scope containing the RoPE calls when branches or conditionals require it (Gemma 3n, GPTOSS, and AfMoE).