### PR TITLE
Add coherence integration tests

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/CoherenceIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/CoherenceIntegrationTests.swift
@@ -1,0 +1,112 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import HuggingFace
+import IntegrationTestHelpers
+import MLXHuggingFace
+import MLXLLM
+import MLXLMCommon
+import Testing
+import Tokenizers
+
+private let models = IntegrationTestModels(
+    downloader: #hubDownloader(),
+    tokenizerLoader: #huggingFaceTokenizerLoader()
+)
+
+@Suite(.serialized)
+struct CoherenceIntegrationTests {
+
+    @Test func bitnet_b1_58_2B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.bitnet_b1_58_2b_4t_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func exaone_4_0_1_2B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.exaone_4_0_1_2b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func gemma3_1B_qat() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.gemma3_1B_qat_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func gemma3n_E2B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.gemma3n_E2B_it_lm_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func gemma4_e2b() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.gemma4_e2b_it_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func glm4_9B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.glm4_9b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func granite3_3_2B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.granite3_3_2b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func granite4_0_H_tiny() async throws {
+        let container = try await models.llmContainer(
+            for: LLMRegistry.granite_4_0_h_tiny_4bit_dwq)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func jamba_3B_4bit() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.jamba_3b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func lfm2_1_2B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.lfm2_1_2b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func llama3_2_1B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.llama3_2_1B_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func mistral_7B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.mistral7B4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func olmo2_7B() async throws {
+        let container = try await models.llmContainer(
+            for: LLMRegistry.olmo_2_1124_7B_Instruct_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func olmoe_1B_7B() async throws {
+        let container = try await models.llmContainer(
+            for: LLMRegistry.olmoe_1b_7b_0125_instruct_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func phi3_5() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.phi3_5_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func qwen3_1_7B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.qwen3_1_7b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func qwen3_5_2B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.qwen3_5_2b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+
+    @Test func smollm3_3B() async throws {
+        let container = try await models.llmContainer(for: LLMRegistry.smollm3_3b_4bit)
+        try await ChatSessionTests.planetsCoherence(container: container)
+    }
+}

--- a/IntegrationTesting/IntegrationTestingTests/ToolCallIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/ToolCallIntegrationTests.swift
@@ -19,75 +19,84 @@ struct ToolCallIntegrationTests {
     // MARK: - LFM2
 
     @Test func lfm2FormatAutoDetection() async throws {
-        let container = try await models.lfm2Container()
+        let container = try await models.llmContainer(for: .init(id: IntegrationTestModelIDs.lfm2))
         try await ToolCallTests.lfm2FormatAutoDetection(container: container)
     }
 
     @Test func lfm2EndToEnd() async throws {
-        let container = try await models.lfm2Container()
+        let container = try await models.llmContainer(for: .init(id: IntegrationTestModelIDs.lfm2))
         try await ToolCallTests.lfm2EndToEndGeneration(container: container)
     }
 
     // MARK: - GLM4
 
     @Test func glm4FormatAutoDetection() async throws {
-        let container = try await models.glm4Container()
+        let container = try await models.llmContainer(for: .init(id: IntegrationTestModelIDs.glm4))
         try await ToolCallTests.glm4FormatAutoDetection(container: container)
     }
 
     @Test func glm4EndToEnd() async throws {
-        let container = try await models.glm4Container()
+        let container = try await models.llmContainer(for: .init(id: IntegrationTestModelIDs.glm4))
         try await ToolCallTests.glm4EndToEndGeneration(container: container)
     }
 
     // MARK: - Mistral3
 
     @Test func mistral3FormatAutoDetection() async throws {
-        let container = try await models.mistral3Container()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.mistral3))
         try await ToolCallTests.mistral3FormatAutoDetection(container: container)
     }
 
     @Test func mistral3EndToEnd() async throws {
-        let container = try await models.mistral3Container()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.mistral3))
         try await ToolCallTests.mistral3EndToEndGeneration(container: container)
     }
 
     @Test func mistral3MultiTool() async throws {
-        let container = try await models.mistral3Container()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.mistral3))
         try await ToolCallTests.mistral3MultiToolGeneration(container: container)
     }
 
     // MARK: - Nemotron
 
     @Test func nemotronFormatAutoDetection() async throws {
-        let container = try await models.nemotronContainer()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.nemotron))
         try await ToolCallTests.nemotronFormatAutoDetection(container: container)
     }
 
     @Test func nemotronEndToEnd() async throws {
-        let container = try await models.nemotronContainer()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.nemotron))
         try await ToolCallTests.nemotronEndToEndGeneration(container: container)
     }
 
     @Test func nemotronMultiTool() async throws {
-        let container = try await models.nemotronContainer()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.nemotron))
         try await ToolCallTests.nemotronMultiToolGeneration(container: container)
     }
 
     // MARK: - Qwen3.5
 
     @Test func qwen35FormatAutoDetection() async throws {
-        let container = try await models.qwen35Container()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.qwen35))
         try await ToolCallTests.qwen35FormatAutoDetection(container: container)
     }
 
     @Test func qwen35EndToEnd() async throws {
-        let container = try await models.qwen35Container()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.qwen35))
         try await ToolCallTests.qwen35EndToEndGeneration(container: container)
     }
 
     @Test func qwen35MultiTool() async throws {
-        let container = try await models.qwen35Container()
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.qwen35))
         try await ToolCallTests.qwen35MultiToolGeneration(container: container)
     }
 }

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -54,6 +54,7 @@ public actor IntegrationTestModels {
     private var mistral3Task: Task<LLModelContainer, Error>?
     private var nemotronTask: Task<LLModelContainer, Error>?
     private var qwen35Task: Task<LLModelContainer, Error>?
+    private var llmTasksByName: [String: Task<LLModelContainer, Error>] = [:]
 
     public init(downloader: any Downloader, tokenizerLoader: any TokenizerLoader) {
         self.downloader = downloader
@@ -204,6 +205,31 @@ public actor IntegrationTestModels {
             return container
         }
         qwen35Task = task
+        return try await task.value
+    }
+
+    /// Load an arbitrary LLM container, cached by `configuration.name` so the same
+    /// model is only loaded once per test run.
+    public func llmContainer(for configuration: ModelConfiguration) async throws
+        -> LLModelContainer
+    {
+        let key = configuration.name
+        if let task = llmTasksByName[key] {
+            return try await task.value
+        }
+        let downloader = self.downloader
+        let tokenizerLoader = self.tokenizerLoader
+        let task = Task {
+            print("Loading LLM: \(key)")
+            let container = try await LLMModelFactory.shared.loadContainer(
+                from: downloader, using: tokenizerLoader,
+                configuration: configuration,
+                progressHandler: logProgress(key)
+            )
+            print("Loaded LLM: \(key)")
+            return container
+        }
+        llmTasksByName[key] = task
         return try await task.value
     }
 
@@ -367,6 +393,26 @@ public enum ChatSessionTests {
         try check(
             result.lowercased().contains("wed") || result.lowercased().contains("wednesday"),
             "Expected 'Wed' or 'Wednesday' in response, got: \(result)"
+        )
+    }
+
+    public static func planetsCoherence(container: LLModelContainer) async throws {
+        let session = ChatSession(
+            container,
+            generateParameters: GenerateParameters(maxTokens: 3000, temperature: 0))
+        let result = try await streamAndCollect(
+            session.streamResponse(
+                to: "List all the planets in our solar system in order from the Sun."),
+            label: "Response")
+
+        let expected = [
+            "Mercury", "Venus", "Earth", "Mars",
+            "Jupiter", "Saturn", "Uranus", "Neptune",
+        ]
+        let missing = expected.filter { !result.contains($0) }
+        try check(
+            missing.isEmpty,
+            "Expected all planets in response, missing: \(missing). Got: \(result)"
         )
     }
 

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -47,169 +47,17 @@ public actor IntegrationTestModels {
     private let downloader: any Downloader
     private let tokenizerLoader: any TokenizerLoader
 
-    private var llmTask: Task<LLModelContainer, Error>?
-    private var vlmTask: Task<LLModelContainer, Error>?
-    private var lfm2Task: Task<LLModelContainer, Error>?
-    private var glm4Task: Task<LLModelContainer, Error>?
-    private var mistral3Task: Task<LLModelContainer, Error>?
-    private var nemotronTask: Task<LLModelContainer, Error>?
-    private var qwen35Task: Task<LLModelContainer, Error>?
     private var llmTasksByName: [String: Task<LLModelContainer, Error>] = [:]
+    private var vlmTasksByName: [String: Task<LLModelContainer, Error>] = [:]
+    private var embeddingTask: Task<EmbeddingModelContainer, Error>?
 
     public init(downloader: any Downloader, tokenizerLoader: any TokenizerLoader) {
         self.downloader = downloader
         self.tokenizerLoader = tokenizerLoader
     }
 
-    public func llmContainer() async throws -> LLModelContainer {
-        if let task = llmTask {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.llm
-        let task = Task {
-            print("Loading LLM: \(id)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded LLM: \(id)")
-            return container
-        }
-        llmTask = task
-        return try await task.value
-    }
-
-    public func vlmContainer() async throws -> LLModelContainer {
-        if let task = vlmTask {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.vlm
-        let task = Task {
-            print("Loading VLM: \(id)")
-            let container = try await VLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded VLM: \(id)")
-            return container
-        }
-        vlmTask = task
-        return try await task.value
-    }
-
-    public func lfm2Container() async throws -> LLModelContainer {
-        if let task = lfm2Task {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.lfm2
-        let task = Task {
-            print("Loading LFM2: \(id)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded LFM2: \(id)")
-            return container
-        }
-        lfm2Task = task
-        return try await task.value
-    }
-
-    public func glm4Container() async throws -> LLModelContainer {
-        if let task = glm4Task {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.glm4
-        let task = Task {
-            print("Loading GLM4: \(id)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded GLM4: \(id)")
-            return container
-        }
-        glm4Task = task
-        return try await task.value
-    }
-
-    public func mistral3Container() async throws -> LLModelContainer {
-        if let task = mistral3Task {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.mistral3
-        let task = Task {
-            print("Loading Mistral3: \(id)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded Mistral3: \(id)")
-            return container
-        }
-        mistral3Task = task
-        return try await task.value
-    }
-
-    public func nemotronContainer() async throws -> LLModelContainer {
-        if let task = nemotronTask {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.nemotron
-        let task = Task {
-            print("Loading Nemotron: \(id)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded Nemotron: \(id)")
-            return container
-        }
-        nemotronTask = task
-        return try await task.value
-    }
-
-    public func qwen35Container() async throws -> LLModelContainer {
-        if let task = qwen35Task {
-            return try await task.value
-        }
-        let downloader = self.downloader
-        let tokenizerLoader = self.tokenizerLoader
-        let id = IntegrationTestModelIDs.qwen35
-        let task = Task {
-            print("Loading Qwen3.5: \(id)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: .init(id: id),
-                progressHandler: logProgress(id)
-            )
-            print("Loaded Qwen3.5: \(id)")
-            return container
-        }
-        qwen35Task = task
-        return try await task.value
-    }
-
     /// Load an arbitrary LLM container, cached by `configuration.name` so the same
-    /// model is only loaded once per test run.
+    /// model is only loaded once per `IntegrationTestModels` instance.
     public func llmContainer(for configuration: ModelConfiguration) async throws
         -> LLModelContainer
     {
@@ -233,18 +81,50 @@ public actor IntegrationTestModels {
         return try await task.value
     }
 
+    /// Load an arbitrary VLM container, cached by `configuration.name` so the same
+    /// model is only loaded once per `IntegrationTestModels` instance.
+    public func vlmContainer(for configuration: ModelConfiguration) async throws
+        -> LLModelContainer
+    {
+        let key = configuration.name
+        if let task = vlmTasksByName[key] {
+            return try await task.value
+        }
+        let downloader = self.downloader
+        let tokenizerLoader = self.tokenizerLoader
+        let task = Task {
+            print("Loading VLM: \(key)")
+            let container = try await VLMModelFactory.shared.loadContainer(
+                from: downloader, using: tokenizerLoader,
+                configuration: configuration,
+                progressHandler: logProgress(key)
+            )
+            print("Loaded VLM: \(key)")
+            return container
+        }
+        vlmTasksByName[key] = task
+        return try await task.value
+    }
+
     public func embeddingContainer() async throws -> EmbeddingModelContainer {
+        if let task = embeddingTask {
+            return try await task.value
+        }
         let downloader = self.downloader
         let tokenizerLoader = self.tokenizerLoader
         let id = "nomic_text_v1_5"
-        print("Loading embedding model: \(id)")
-        let container = try await EmbedderModelFactory.shared.loadContainer(
-            from: downloader, using: tokenizerLoader,
-            configuration: EmbedderRegistry.nomic_text_v1_5,
-            progressHandler: logProgress(id)
-        )
-        print("Loaded embedding model: \(id)")
-        return container
+        let task = Task {
+            print("Loading embedding model: \(id)")
+            let container = try await EmbedderModelFactory.shared.loadContainer(
+                from: downloader, using: tokenizerLoader,
+                configuration: EmbedderRegistry.nomic_text_v1_5,
+                progressHandler: logProgress(id)
+            )
+            print("Loaded embedding model: \(id)")
+            return container
+        }
+        embeddingTask = task
+        return try await task.value
     }
 }
 

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -73,7 +73,7 @@ public enum LLMTypeRegistry {
         "nanochat": create(NanoChatConfiguration.self, NanoChatModel.init),
         "nemotron_h": create(NemotronHConfiguration.self, NemotronHModel.init),
         "afmoe": create(AfMoEConfiguration.self, AfMoEModel.init),
-        "jamba_3b": create(JambaConfiguration.self, JambaModel.init),
+        "jamba": create(JambaConfiguration.self, JambaModel.init),
         "mistral3": create(Mistral3TextConfiguration.self, Mistral3TextModel.init),
         "apertus": create(ApertusConfiguration.self, ApertusModel.init),
     ])
@@ -237,6 +237,16 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         defaultPrompt: "Why is the sky blue?"
     )
 
+    static public let qwen3_5_2b_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.5-2B-4bit",
+        defaultPrompt: "Why is the sky blue?"
+    )
+
+    static public let qwen3_6_27b_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.6-27B-4bit",
+        defaultPrompt: "Why is the sky blue?"
+    )
+
     static public let openelm270m4bit = ModelConfiguration(
         id: "mlx-community/OpenELM-270M-Instruct",
         // https://huggingface.co/apple/OpenELM
@@ -361,8 +371,8 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         defaultPrompt: "Why is the sky blue?"
     )
 
-    static public let jamba_3b = ModelConfiguration(
-        id: "mlx-community/AI21-Jamba-Reasoning-3B-bf16",
+    static public let jamba_3b_4bit = ModelConfiguration(
+        id: "mlx-community/AI21-Jamba-Reasoning-3B-4bit",
         defaultPrompt: ""
     )
 
@@ -400,6 +410,8 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
             qwen3_4b_4bit,
             qwen3_8b_4bit,
             qwen3MoE_30b_a3b_4bit,
+            qwen3_5_2b_4bit,
+            qwen3_6_27b_4bit,
             smolLM_135M_4bit,
             deepseek_r1_4bit,
             mimo_7b_sft_4bit,
@@ -418,7 +430,7 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
             lfm2_8b_a1b_3bit_mlx,
             nanochat_d20_mlx,
             gpt_oss_20b_MXFP4_Q8,
-            jamba_3b,
+            jamba_3b_4bit,
         ]
     }
 


### PR DESCRIPTION
I've added an integration test suite that checks for coherent responses from a representative sample of models. The suite can be run whenever wide-ranging changes such as #178 are made to catch regressions such as the one noted in #233.

The test suite uses smaller models (≤9B) so that they can run on machines with 16 GB of RAM.

The new suite already caught a latent bug: `LLMTypeRegistry` had Jamba registered under the key `"jamba_3b"`, but actual Jamba configs specify `model_type: "jamba"`. I fixed that here as well.

It also surfaced a second issue: loading OLMoE (or any model using `GPTNeoXTokenizer`) fails because Swift Transformers doesn't register that class. My [Swift Tokenizers](https://github.com/DePasqualeOrg/swift-tokenizers) package already works correctly, because the class is registered there.

There are also two failing tool-calling integration tests that are outside the scope of this PR.

## Changes

- Added new `CoherenceIntegrationTests` suite
- Refactored `IntegrationTestModels` around generic `llmContainer(for:)` / `vlmContainer(for:)` accessors and reduced boilerplate code
- Added `LLMRegistry.qwen3_5_2b_4bit` (used by the new suite) and `qwen3_6_27b_4bit`
- Renamed `LLMRegistry.jamba_3b` to `jamba_3b_4bit` and pointed it at the 4-bit variant (1.7 GB vs 6.1 GB bf16)
- Fixed `LLMTypeRegistry` Jamba creator key: `"jamba_3b"` → `"jamba"`