### PR TITLE
Fix Gemma4Text quantized KV cache attention

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -175,6 +175,53 @@ private class ScaledLinear: Module {
     }
 }
 
+private enum Gemma4PositionOffset {
+    case scalar(Int)
+    case batch(MLXArray)
+}
+
+private enum Gemma4TextKVState {
+    case regular(keys: MLXArray, values: MLXArray)
+    case quantized(
+        keys: (MLXArray, MLXArray, MLXArray?),
+        values: (MLXArray, MLXArray, MLXArray?),
+        groupSize: Int,
+        bits: Int,
+        mode: QuantizationMode
+    )
+
+    var sequenceLength: Int {
+        switch self {
+        case .regular(let keys, _):
+            keys.dim(2)
+        case .quantized(let keys, _, _, _, _):
+            keys.0.dim(-2)
+        }
+    }
+}
+
+private func gemma4CapturePositionOffset(from cache: KVCache?) -> Gemma4PositionOffset {
+    if let batchCache = cache as? BatchPositionedKVCache {
+        // Snapshot the per-sequence offsets before cache.update(...) advances them.
+        .batch(batchCache.batchOffset + 0)
+    } else {
+        .scalar(cache?.offset ?? 0)
+    }
+}
+
+private func gemma4ApplyRotaryPosition<R: RoPELayer>(
+    _ rope: R,
+    to x: MLXArray,
+    offset: Gemma4PositionOffset
+) -> MLXArray {
+    switch offset {
+    case .scalar(let value):
+        rope(x, offset: value)
+    case .batch(let values):
+        rope(x, offset: values)
+    }
+}
+
 // MARK: - Attention
 
 private class Gemma4Attention: Module {
@@ -255,27 +302,25 @@ private class Gemma4Attention: Module {
         _ x: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
-        sharedKV: (MLXArray, MLXArray)? = nil,
-        positionOffset: RoPEOffset? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), RoPEOffset?) {
+        sharedKV: Gemma4TextKVState? = nil,
+        positionOffset: Gemma4PositionOffset? = nil
+    ) -> (MLXArray, Gemma4TextKVState, Gemma4PositionOffset) {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x).reshaped(B, L, nHeads, effectiveHeadDim)
         queries = qNorm(queries)
 
-        let keys: MLXArray
-        let values: MLXArray
-        let activePositionOffset = positionOffset ?? cache?.ropeOffset
+        let activePositionOffset = positionOffset ?? gemma4CapturePositionOffset(from: cache)
+        let kvState: Gemma4TextKVState
 
-        if let (sharedK, sharedV) = sharedKV {
-            // KV-shared layers use pre-computed KV from an earlier layer
-            keys = sharedK
-            values = sharedV
+        if let sharedKV {
+            // KV-shared layers use pre-computed KV from an earlier layer.
+            kvState = sharedKV
         } else {
-            var k = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
-            k = kNorm(k)
+            let kRaw = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
+            var k = kNorm(kRaw)
             k = k.transposed(0, 2, 1, 3)
-            k = applyRotaryPosition(rope, to: k, offset: activePositionOffset)
+            k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
 
             var v: MLXArray
             if let vProj {
@@ -283,44 +328,69 @@ private class Gemma4Attention: Module {
                 v = vNorm(v)
                 v = v.transposed(0, 2, 1, 3)
             } else {
-                // k is already transposed to (B, nKvHeads, L, head_dim);
-                // skip the second transpose to avoid reversing it.
-                v = vNorm(k)
+                v = vNorm(kRaw)
+                v = v.transposed(0, 2, 1, 3)
             }
 
-            if let cache {
+            if let quantizedCache = cache as? QuantizedKVCacheProtocol {
+                let (quantizedKeys, quantizedValues) = quantizedCache.updateQuantized(
+                    keys: k, values: v)
+                kvState = .quantized(
+                    keys: quantizedKeys,
+                    values: quantizedValues,
+                    groupSize: quantizedCache.groupSize,
+                    bits: quantizedCache.bits,
+                    mode: quantizedCache.mode
+                )
+            } else if let cache {
                 let (updatedK, updatedV) = cache.update(keys: k, values: v)
-                keys = updatedK
-                values = updatedV
+                kvState = .regular(keys: updatedK, values: updatedV)
             } else {
-                keys = k
-                values = v
+                kvState = .regular(keys: k, values: v)
             }
         }
 
         queries = queries.transposed(0, 2, 1, 3)
-        queries = applyRotaryPosition(rope, to: queries, offset: activePositionOffset)
+        queries = gemma4ApplyRotaryPosition(rope, to: queries, offset: activePositionOffset)
 
         // Adjust mask if cache size differs from mask size
         var adjustedMask = mask
         if case .array(let maskArray) = mask {
-            let keysSeqLen = keys.dim(2)
+            let keysSeqLen = kvState.sequenceLength
             if maskArray.dim(-1) != keysSeqLen {
                 adjustedMask = .array(maskArray[.ellipsis, 0 ..< keysSeqLen])
             }
         }
 
-        let output = MLXFast.scaledDotProductAttention(
-            queries: queries,
-            keys: keys,
-            values: values,
-            scale: scale,
-            mask: adjustedMask ?? .none
-        )
-        .transposed(0, 2, 1, 3)
-        .reshaped(B, L, -1)
+        let attentionOutput: MLXArray =
+            switch kvState {
+            case .regular(let keys, let values):
+                MLXFast.scaledDotProductAttention(
+                    queries: queries,
+                    keys: keys,
+                    values: values,
+                    scale: scale,
+                    mask: adjustedMask ?? .none
+                )
+            case .quantized(let keys, let values, let groupSize, let bits, let mode):
+                quantizedScaledDotProductAttention(
+                    queries: queries,
+                    quantizedKeys: keys,
+                    quantizedValues: values,
+                    scale: scale,
+                    mask: adjustedMask ?? .none,
+                    groupSize: groupSize,
+                    bits: bits,
+                    mode: mode
+                )
+            }
 
-        return (oProj(output), (keys, values), activePositionOffset)
+        let output =
+            attentionOutput
+            .transposed(0, 2, 1, 3)
+            .reshaped(B, L, -1)
+
+        return (oProj(output), kvState, activePositionOffset)
     }
 }
 
@@ -409,9 +479,9 @@ private class Gemma4DecoderLayer: Module {
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
         perLayerInput: MLXArray? = nil,
-        sharedKV: (MLXArray, MLXArray)? = nil,
-        positionOffset: RoPEOffset? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), RoPEOffset?) {
+        sharedKV: Gemma4TextKVState? = nil,
+        positionOffset: Gemma4PositionOffset? = nil
+    ) -> (MLXArray, Gemma4TextKVState, Gemma4PositionOffset) {
         let residual = x
 
         let h = inputLayernorm(x)
@@ -580,7 +650,7 @@ private class Gemma4TextModelInner: Module {
         }
 
         // Forward through layers, tracking intermediate KV pairs for sharing
-        var intermediates = [(kv: (MLXArray, MLXArray)?, positionOffset: RoPEOffset?)](
+        var intermediates = [(kv: Gemma4TextKVState?, positionOffset: Gemma4PositionOffset?)](
             repeating: (nil, nil), count: config.numHiddenLayers)
 
         for (idx, layer) in layers.enumerated() {

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -175,53 +175,6 @@ private class ScaledLinear: Module {
     }
 }
 
-private enum Gemma4PositionOffset {
-    case scalar(Int)
-    case batch(MLXArray)
-}
-
-private enum Gemma4TextKVState {
-    case regular(keys: MLXArray, values: MLXArray)
-    case quantized(
-        keys: (MLXArray, MLXArray, MLXArray?),
-        values: (MLXArray, MLXArray, MLXArray?),
-        groupSize: Int,
-        bits: Int,
-        mode: QuantizationMode
-    )
-
-    var sequenceLength: Int {
-        switch self {
-        case .regular(let keys, _):
-            keys.dim(2)
-        case .quantized(let keys, _, _, _, _):
-            keys.0.dim(-2)
-        }
-    }
-}
-
-private func gemma4CapturePositionOffset(from cache: KVCache?) -> Gemma4PositionOffset {
-    if let batchCache = cache as? BatchPositionedKVCache {
-        // Snapshot the per-sequence offsets before cache.update(...) advances them.
-        .batch(batchCache.batchOffset + 0)
-    } else {
-        .scalar(cache?.offset ?? 0)
-    }
-}
-
-private func gemma4ApplyRotaryPosition<R: RoPELayer>(
-    _ rope: R,
-    to x: MLXArray,
-    offset: Gemma4PositionOffset
-) -> MLXArray {
-    switch offset {
-    case .scalar(let value):
-        rope(x, offset: value)
-    case .batch(let values):
-        rope(x, offset: values)
-    }
-}
-
 // MARK: - Attention
 
 private class Gemma4Attention: Module {
@@ -302,16 +255,16 @@ private class Gemma4Attention: Module {
         _ x: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
-        sharedKV: Gemma4TextKVState? = nil,
-        positionOffset: Gemma4PositionOffset? = nil
-    ) -> (MLXArray, Gemma4TextKVState, Gemma4PositionOffset) {
+        sharedKV: Gemma4SharedKVState? = nil,
+        positionOffset: RoPEOffset? = nil
+    ) -> (MLXArray, Gemma4SharedKVState, RoPEOffset?) {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x).reshaped(B, L, nHeads, effectiveHeadDim)
         queries = qNorm(queries)
 
-        let activePositionOffset = positionOffset ?? gemma4CapturePositionOffset(from: cache)
-        let kvState: Gemma4TextKVState
+        let activePositionOffset = positionOffset ?? cache?.ropeOffset
+        let kvState: Gemma4SharedKVState
 
         if let sharedKV {
             // KV-shared layers use pre-computed KV from an earlier layer.
@@ -320,7 +273,7 @@ private class Gemma4Attention: Module {
             let kRaw = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             var k = kNorm(kRaw)
             k = k.transposed(0, 2, 1, 3)
-            k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
+            k = applyRotaryPosition(rope, to: k, offset: activePositionOffset)
 
             var v: MLXArray
             if let vProj {
@@ -351,7 +304,7 @@ private class Gemma4Attention: Module {
         }
 
         queries = queries.transposed(0, 2, 1, 3)
-        queries = gemma4ApplyRotaryPosition(rope, to: queries, offset: activePositionOffset)
+        queries = applyRotaryPosition(rope, to: queries, offset: activePositionOffset)
 
         // Adjust mask if cache size differs from mask size
         var adjustedMask = mask
@@ -479,9 +432,9 @@ private class Gemma4DecoderLayer: Module {
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
         perLayerInput: MLXArray? = nil,
-        sharedKV: Gemma4TextKVState? = nil,
-        positionOffset: Gemma4PositionOffset? = nil
-    ) -> (MLXArray, Gemma4TextKVState, Gemma4PositionOffset) {
+        sharedKV: Gemma4SharedKVState? = nil,
+        positionOffset: RoPEOffset? = nil
+    ) -> (MLXArray, Gemma4SharedKVState, RoPEOffset?) {
         let residual = x
 
         let h = inputLayernorm(x)
@@ -650,7 +603,7 @@ private class Gemma4TextModelInner: Module {
         }
 
         // Forward through layers, tracking intermediate KV pairs for sharing
-        var intermediates = [(kv: Gemma4TextKVState?, positionOffset: Gemma4PositionOffset?)](
+        var intermediates = [(kv: Gemma4SharedKVState?, positionOffset: RoPEOffset?)](
             repeating: (nil, nil), count: config.numHiddenLayers)
 
         for (idx, layer) in layers.enumerated() {

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -422,24 +422,40 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     ///
     /// Use `updateQuantized()` and `quantizedScaledDotProductAttention()` for zero-overhead operation.
     public func toQuantized(groupSize: Int = 64, bits: Int = 4) -> QuantizedKVCache {
-        let quantizedCache = QuantizedKVCache(groupSize: groupSize, bits: bits)
-        quantizedCache.offset = self.offset
-
         if let keys = self.keys, let values = self.values {
             // Quantize the current keys and values
             let currentKeys = keys[.ellipsis, ..<offset, 0...]
             let currentValues = values[.ellipsis, ..<offset, 0...]
+            guard
+                let effectiveGroupSize = resolvedKVQuantizationGroupSize(
+                    requested: groupSize,
+                    keyHeadDim: currentKeys.dim(3),
+                    valueHeadDim: currentValues.dim(3)
+                )
+            else {
+                fatalError(
+                    "KV cache quantization requires head dimensions divisible by one of the supported group sizes (32, 64, 128). Requested group size: \(groupSize). Key head dim: \(currentKeys.dim(3)). Value head dim: \(currentValues.dim(3))."
+                )
+            }
+            let quantizedCache = QuantizedKVCache(groupSize: effectiveGroupSize, bits: bits)
+            quantizedCache.offset = self.offset
 
-            let quantizedKeys = quantized(currentKeys, groupSize: groupSize, bits: bits)
-            let quantizedValues = quantized(currentValues, groupSize: groupSize, bits: bits)
+            let quantizedKeys = quantized(
+                currentKeys, groupSize: effectiveGroupSize, bits: bits)
+            let quantizedValues = quantized(
+                currentValues, groupSize: effectiveGroupSize, bits: bits)
 
             // Set the quantized state
             quantizedCache.state = [
                 quantizedKeys.wq, quantizedKeys.scales, quantizedKeys.biases,
                 quantizedValues.wq, quantizedValues.scales, quantizedValues.biases,
             ].compactMap { $0 }
+
+            return quantizedCache
         }
 
+        let quantizedCache = QuantizedKVCache(groupSize: groupSize, bits: bits)
+        quantizedCache.offset = self.offset
         return quantizedCache
     }
 
@@ -741,12 +757,32 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 }
 
+private func resolvedKVQuantizationGroupSize(
+    requested: Int,
+    keyHeadDim: Int,
+    valueHeadDim: Int
+) -> Int? {
+    let requested = max(1, requested)
+    let compatible = [32, 64, 128].filter {
+        keyHeadDim.isMultiple(of: $0) && valueHeadDim.isMultiple(of: $0)
+    }
+    guard !compatible.isEmpty else { return nil }
+    return compatible.min { lhs, rhs in
+        let lhsDistance = abs(lhs - requested)
+        let rhsDistance = abs(rhs - requested)
+        if lhsDistance == rhsDistance {
+            return lhs < rhs
+        }
+        return lhsDistance < rhsDistance
+    }
+}
+
 /// Quantized KV cache for memory efficiency using MLX quantization
 public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     private var keys: (MLXArray, MLXArray, MLXArray?)?
     private var values: (MLXArray, MLXArray, MLXArray?)?
     private let step: Int
-    public let groupSize: Int
+    public private(set) var groupSize: Int
     public let bits: Int
     public let mode: QuantizationMode
 
@@ -839,6 +875,24 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
         let kHeadDim = keys.dim(3)
         let vHeadDim = values.dim(3)
         let prev = offset
+        let effectiveGroupSize = resolvedKVQuantizationGroupSize(
+            requested: groupSize,
+            keyHeadDim: kHeadDim,
+            valueHeadDim: vHeadDim
+        )
+        if let effectiveGroupSize,
+            effectiveGroupSize != groupSize,
+            self.keys == nil,
+            self.values == nil,
+            offset == 0
+        {
+            self.groupSize = effectiveGroupSize
+        }
+        guard effectiveGroupSize != nil else {
+            fatalError(
+                "KV cache quantization requires head dimensions divisible by one of the supported group sizes (32, 64, 128). Requested group size: \(groupSize). Key head dim: \(kHeadDim). Value head dim: \(vHeadDim)."
+            )
+        }
 
         // Check if we need to expand the cache
         if self.keys == nil || (prev + numSteps) > self.keys!.0.dim(-2) {
@@ -1812,6 +1866,20 @@ public func maybeQuantizeKVCache(
     for i in 0 ..< cache.count {
         // Handle cache types that support quantization
         if let simpleCache = cache[i] as? KVCacheSimple {
+            let state = simpleCache.state
+            if state.count == 2 {
+                let keyHeadDim = state[0].dim(3)
+                let valueHeadDim = state[1].dim(3)
+                guard
+                    resolvedKVQuantizationGroupSize(
+                        requested: kvGroupSize,
+                        keyHeadDim: keyHeadDim,
+                        valueHeadDim: valueHeadDim
+                    ) != nil
+                else {
+                    continue
+                }
+            }
             cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
         }
         // TODO: RotatingKVCache.toQuantized() is not implemented yet, like in Python.

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -783,7 +783,7 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     private var values: (MLXArray, MLXArray, MLXArray?)?
     private let step: Int
     public private(set) var groupSize: Int
-    public let bits: Int
+    public private(set) var bits: Int
     public let mode: QuantizationMode
 
     public init(groupSize: Int = 64, bits: Int = 8, mode: QuantizationMode = .affine) {
@@ -1009,8 +1009,17 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
             guard newValue.count == 4 else {
                 fatalError("QuantizedKVCache metaState must have exactly 4 values")
             }
+            guard
+                let offset = Int(newValue[1]),
+                let groupSize = Int(newValue[2]),
+                let bits = Int(newValue[3])
+            else {
+                fatalError("Failed to convert QuantizedKVCache metaState values to integers")
+            }
 
-            self.offset = Int(newValue[1]) ?? 0
+            self.offset = offset
+            self.groupSize = groupSize
+            self.bits = bits
         }
     }
 

--- a/Libraries/MLXLMCommon/Models/Gemma4.swift
+++ b/Libraries/MLXLMCommon/Models/Gemma4.swift
@@ -1,0 +1,21 @@
+import MLX
+
+package enum Gemma4SharedKVState {
+    case regular(keys: MLXArray, values: MLXArray)
+    case quantized(
+        keys: (MLXArray, MLXArray, MLXArray?),
+        values: (MLXArray, MLXArray, MLXArray?),
+        groupSize: Int,
+        bits: Int,
+        mode: QuantizationMode
+    )
+
+    package var sequenceLength: Int {
+        switch self {
+        case .regular(let keys, _):
+            keys.dim(2)
+        case .quantized(let keys, _, _, _, _):
+            keys.0.dim(-2)
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/RoPEApplication.swift
+++ b/Libraries/MLXLMCommon/RoPEApplication.swift
@@ -17,7 +17,8 @@ public protocol BatchPositionedKVCache: KVCache {
 
 extension BatchPositionedKVCache {
     public var ropeOffset: RoPEOffset {
-        .batch(batchOffset[.ellipsis])
+        // Snapshot the per-sequence offsets before cache.update(...) advances them.
+        .batch(batchOffset + 0)
     }
 }
 

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -185,26 +185,6 @@ private func gemma4EnsureFusedSDPA(
     )[.ellipsis, ..<d]
 }
 
-private enum Gemma4SharedKVState {
-    case regular(keys: MLXArray, values: MLXArray)
-    case quantized(
-        keys: (MLXArray, MLXArray, MLXArray?),
-        values: (MLXArray, MLXArray, MLXArray?),
-        groupSize: Int,
-        bits: Int,
-        mode: QuantizationMode
-    )
-
-    var sequenceLength: Int {
-        switch self {
-        case .regular(let keys, _):
-            return keys.dim(2)
-        case .quantized(let keys, _, _, _, _):
-            return keys.0.dim(-2)
-        }
-    }
-}
-
 private func gemma4AdjustAttentionMask(
     _ mask: MLXFast.ScaledDotProductAttentionMaskMode,
     keyLength: Int

--- a/Tests/MLXLMTests/Gemma4TextTests.swift
+++ b/Tests/MLXLMTests/Gemma4TextTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+struct Gemma4TextTests {
+    @Test("Gemma4Text handles quantized KV cache in shared full attention")
+    func quantizedKVCacheSupportsSharedFullAttention() throws {
+        let model = Gemma4TextModel(try Self.configuration(attentionKEqV: false))
+        eval(model)
+
+        var cache: [KVCache] = model.newCache(parameters: nil)
+        let promptLogits = model(MLXArray([1, 2, 3]).reshaped([1, 3]), cache: cache)
+        eval(promptLogits)
+        #expect(promptLogits.shape == [1, 3, 32])
+
+        maybeQuantizeKVCache(cache: &cache, kvBits: 4, kvGroupSize: 64, quantizedKVStart: 0)
+        #expect(cache.contains { $0 is QuantizedKVCache })
+        let quantizedCache = try #require(cache.first as? QuantizedKVCache)
+        #expect(quantizedCache.groupSize == 32)
+
+        let nextLogits = model(MLXArray([4]).reshaped([1, 1]), cache: cache)
+        eval(nextLogits)
+        #expect(nextLogits.shape == [1, 1, 32])
+    }
+
+    @Test("Gemma4Text handles K-equals-V full attention before and after KV quantization")
+    func quantizedKVCacheSupportsKEqVFullAttention() throws {
+        let model = Gemma4TextModel(try Self.configuration(attentionKEqV: true))
+        eval(model)
+
+        var cache: [KVCache] = model.newCache(parameters: nil)
+        let promptLogits = model(MLXArray([1, 2, 3]).reshaped([1, 3]), cache: cache)
+        eval(promptLogits)
+        #expect(promptLogits.shape == [1, 3, 32])
+
+        maybeQuantizeKVCache(cache: &cache, kvBits: 4, kvGroupSize: 64, quantizedKVStart: 0)
+        #expect(cache.contains { $0 is QuantizedKVCache })
+        let quantizedCache = try #require(cache.first as? QuantizedKVCache)
+        #expect(quantizedCache.groupSize == 32)
+
+        let nextLogits = model(MLXArray([4]).reshaped([1, 1]), cache: cache)
+        eval(nextLogits)
+        #expect(nextLogits.shape == [1, 1, 32])
+    }
+
+    private static func configuration(attentionKEqV: Bool) throws -> Gemma4TextConfiguration {
+        let json = """
+            {
+              "model_type": "gemma4_text",
+              "hidden_size": 16,
+              "num_hidden_layers": 2,
+              "intermediate_size": 32,
+              "num_attention_heads": 2,
+              "head_dim": 32,
+              "global_head_dim": 32,
+              "global_partial_rotary_factor": 0.25,
+              "rms_norm_eps": 0.000001,
+              "vocab_size": 32,
+              "vocab_size_per_layer_input": 32,
+              "num_key_value_heads": 1,
+              "num_global_key_value_heads": 1,
+              "num_kv_shared_layers": 1,
+              "hidden_size_per_layer_input": 0,
+              "sliding_window": 8,
+              "sliding_window_pattern": 1,
+              "max_position_embeddings": 64,
+              "attention_k_eq_v": \(attentionKEqV),
+              "final_logit_softcapping": 30.0,
+              "use_double_wide_mlp": false,
+              "layer_types": ["full_attention", "full_attention"],
+              "tie_word_embeddings": true
+            }
+            """
+        return try JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -65,6 +65,67 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     }
 }
 
+@Test func testQuantizedKVCacheRestoresNonDefaultQuantizationMetadata() throws {
+    let cache = QuantizedKVCache(groupSize: 64, bits: 4)
+    let keys = MLXArray.ones([1, 1, 4, 32], dtype: .bfloat16)
+    let values = MLXArray.ones([1, 1, 4, 32], dtype: .bfloat16)
+    _ = cache.updateQuantized(keys: keys, values: values)
+
+    #expect(cache.groupSize == 32)
+    #expect(cache.bits == 4)
+
+    let url = tempURL()
+    try savePromptCache(url: url, cache: [cache], metadata: [:])
+    let (loaded, _) = try loadPromptCache(url: url)
+
+    let restored = try #require(loaded[0] as? QuantizedKVCache)
+    #expect(restored.groupSize == 32)
+    #expect(restored.bits == 4)
+    #expect(restored.metaState == cache.metaState)
+
+    let moreKeys = MLXArray.zeros([1, 1, 1, 32], dtype: .bfloat16)
+    let moreValues = MLXArray.zeros([1, 1, 1, 32], dtype: .bfloat16)
+    _ = restored.updateQuantized(keys: moreKeys, values: moreValues)
+
+    #expect(restored.groupSize == 32)
+    #expect(restored.bits == 4)
+}
+
+@Test func testQuantizedKVCacheMetaStateRestoresQuantizationMetadataWithoutState() {
+    let cache = QuantizedKVCache()
+
+    cache.metaState = ["256", "11", "32", "4"]
+
+    #expect(cache.offset == 11)
+    #expect(cache.groupSize == 32)
+    #expect(cache.bits == 4)
+    #expect(cache.metaState == ["256", "11", "32", "4"])
+}
+
+@Test func testQuantizedKVCacheCopyPreservesRestoredQuantizationMetadata() throws {
+    let cache = QuantizedKVCache()
+    cache.metaState = ["256", "5", "32", "4"]
+
+    let copied = try #require(cache.copy() as? QuantizedKVCache)
+
+    #expect(copied.offset == 5)
+    #expect(copied.groupSize == 32)
+    #expect(copied.bits == 4)
+    #expect(copied.metaState == cache.metaState)
+}
+
+@Test func testEmptyKVCacheSimpleToQuantizedPreservesRequestedQuantizationMetadata() {
+    let cache = KVCacheSimple()
+    cache.offset = 7
+
+    let quantized = cache.toQuantized(groupSize: 128, bits: 4)
+
+    #expect(quantized.offset == 7)
+    #expect(quantized.groupSize == 128)
+    #expect(quantized.bits == 4)
+    #expect(quantized.metaState == ["256", "7", "128", "4"])
+}
+
 // MARK: - ArraysCache sparse slot round-trip
 
 @Test func testArraysCacheSparseSlots() throws {


### PR DESCRIPTION
## Proposed changes

Fix run of gemma-4-e4b-it-4bit which was causing: MLXLMCommon/KVCache.swift:894: Fatal error: update was called on QuantizedKVCache. Use updateQuantized instead.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
