### PR TITLE
Fix MROPE, rope_deltas, and invFreq loading in Qwen2.5-VL

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -43,7 +43,11 @@ private enum Language {
         let kvHeads: Int
         let headDim: Int
         let scale: Float
-        let mropeSection: [Int]
+        let mropeSection: [Int]      // cumulative section indices (for half-dim split)
+        let mropeSectionRaw: [Int]   // raw section sizes [16, 24, 24] (for full-dim split)
+        // Wrapped in a class to hide from Module's weight loading (not a trained weight)
+        private class InvFreqBox { let value: MLXArray; init(_ v: MLXArray) { value = v } }
+        private let _invFreqBox: InvFreqBox
 
         @ModuleInfo(key: "q_proj") var wq: Linear
         @ModuleInfo(key: "k_proj") var wk: Linear
@@ -65,6 +69,8 @@ private enum Language {
             self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
             if let v = args.ropeScaling?["mrope_section"], let array = v.asInts() {
+                // Raw sections e.g. [16, 24, 24] — used for splitting full-dim cos/sin
+                self.mropeSectionRaw = array
                 // mrope_section = np.cumsum(mrope_section * 2)[:-1].tolist()
                 self.mropeSection = sequence(state: (0, array.makeIterator())) { state in
                     if let v = state.1.next() {
@@ -79,12 +85,54 @@ private enum Language {
                 fatalError("rope_scaling['mrope_section'] must be an array of integers")
             }
 
+            // Compute inv_freq for MROPE (same formula as Python)
+            // inv_freq = 1.0 / (theta ^ (arange(0, dim, 2) / dim))
+            let freqIndices = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+            let base = MLXArray(args.ropeTheta)
+            self._invFreqBox = InvFreqBox(1.0 / pow(base, freqIndices / Float(headDim)))
+
             self._rotaryEmbedding.wrappedValue = RoPE(
                 dimensions: headDim, traditional: args.ropeTraditional, base: args.ropeTheta)
         }
 
+        /// Compute cos/sin for MROPE from 3D position IDs
+        /// Matches Python apply_mrope: start with temporal, overwrite H/W ranges
+        private func mropeCosSin(positionIds: MLXArray) -> (MLXArray, MLXArray) {
+            // positionIds: [3, batch, seq]
+            let invFreqExpanded = _invFreqBox.value.reshaped(1, 1, -1, 1)  // [1, 1, dim/2, 1]
+            let posExpanded = positionIds[0..., 0..., .newAxis, 0...].asType(.float32)  // [3, batch, 1, seq]
+            var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
+            freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]
+
+            // Python apply_mrope: start with temporal (freqs[0]), overwrite H/W slices
+            // mropeSectionRaw = [16, 24, 24]
+            // dims 0..15 → temporal, dims 16..39 → height, dims 40..63 → width
+            var result = freqs[0]  // [batch, seq, dim/2] — start with temporal
+            var offset = mropeSectionRaw[0]  // 16
+            for dim in 1 ..< mropeSectionRaw.count {
+                let length = mropeSectionRaw[dim]
+                // Replace slice [offset..<offset+length] with freqs from this dimension
+                let dimFreqs = freqs[dim]  // [batch, seq, dim/2]
+                // Use scatter or manual slice replacement
+                let before = result[0..., 0..., 0 ..< offset]
+                let middle = dimFreqs[0..., 0..., offset ..< (offset + length)]
+                let after: MLXArray
+                if offset + length < result.dim(-1) {
+                    after = result[0..., 0..., (offset + length)...]
+                    result = concatenated([before, middle, after], axis: -1)
+                } else {
+                    result = concatenated([before, middle], axis: -1)
+                }
+                offset += length
+            }
+
+            let emb = concatenated([result, result], axis: -1)  // [batch, seq, dim]
+            return (MLX.cos(emb), MLX.sin(emb))
+        }
+
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
             let (B, L) = (x.dim(0), x.dim(1))
 
@@ -97,10 +145,22 @@ private enum Language {
             keys = keys.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
             values = values.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
 
-            let offset = cache?.offset ?? 0
-
-            queries = rotaryEmbedding(queries, offset: offset)
-            keys = rotaryEmbedding(keys, offset: offset)
+            if let positionIds {
+                // MROPE path: compute 3D-aware cos/sin from position IDs
+                let (cosValues, sinValues) = mropeCosSin(positionIds: positionIds)
+                // Apply rotary embedding: expand dims for head broadcasting
+                let cos = cosValues[.newAxis, 0..., 0..., 0...]  // [1, batch, seq, dim]
+                let sin = sinValues[.newAxis, 0..., 0..., 0...]
+                let qEmbed = (queries * cos) + (QwenVL.rotateHalf(queries) * sin)
+                let kEmbed = (keys * cos) + (QwenVL.rotateHalf(keys) * sin)
+                queries = qEmbed
+                keys = kEmbed
+            } else {
+                // Simple sequential RoPE for autoregressive generation
+                let offset = cache?.offset ?? 0
+                queries = rotaryEmbedding(queries, offset: offset)
+                keys = rotaryEmbedding(keys, offset: offset)
+            }
 
             let output = attentionWithCacheUpdate(
                 queries: queries,
@@ -151,9 +211,10 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
-            var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
+            var r = attention(inputLayerNorm(x), mask: mask, cache: cache, positionIds: positionIds)
             let h = x + r
             r = mlp(postAttentionLayerNorm(h))
             let out = h + r
@@ -182,7 +243,8 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
             var h: MLXArray
             if let inputEmbedding {
@@ -196,7 +258,7 @@ private enum Language {
             let mask = createAttentionMask(h: h, cache: cache?.first)
 
             for (i, layer) in layers.enumerated() {
-                h = layer(h, mask: mask, cache: cache?[i])
+                h = layer(h, mask: mask, cache: cache?[i], positionIds: positionIds)
             }
 
             return norm(h)
@@ -209,6 +271,10 @@ private enum Language {
 
         var kvHeads: [Int]
 
+        // MROPE state: stored position IDs from prefill, reused during autoregressive generation
+        var _positionIds: MLXArray?
+        var _ropeDeltas: MLXArray?
+
         public init(_ args: Qwen25VLConfiguration.TextConfiguration) {
             self.model = Qwen25Model(args)
 
@@ -220,9 +286,40 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            positionIds: MLXArray? = nil
         ) -> LMOutput {
-            var out = model(inputs, cache: cache, inputEmbedding: inputEmbedding)
+            var effectivePositionIds = positionIds ?? _positionIds
+
+            // Clear stored position IDs after first use (prefill done)
+            if _positionIds != nil { _positionIds = nil }
+
+            // During autoregressive generation after multimodal prefill:
+            // compute position IDs using rope_deltas so MROPE offsets are correct
+            if effectivePositionIds == nil, let ropeDeltas = _ropeDeltas, let cache {
+                let input = inputs ?? inputEmbedding!
+                let batch = input.dim(0)
+                let seqLength = input.dim(1)
+                let lastCacheOffset = cache.last?.offset ?? 0
+
+                var delta = MLXArray(lastCacheOffset).asType(.int32) + ropeDeltas.asType(.int32)
+
+                var base = MLXArray(0 ..< seqLength).asType(.int32)
+                base = base[.newAxis, 0...]
+                base = broadcast(base, to: [batch, seqLength])
+
+                if delta.dim(0) == 1 && batch > 1 {
+                    delta = repeated(delta, count: batch, axis: 0)
+                }
+
+                base = base + delta
+
+                effectivePositionIds = base[.newAxis, 0..., 0...]
+                effectivePositionIds = broadcast(effectivePositionIds!, to: [3, batch, seqLength])
+            }
+
+            var out = model(inputs, cache: cache, inputEmbedding: inputEmbedding,
+                           positionIds: effectivePositionIds)
             if let lmHead {
                 out = lmHead(out)
             } else {
@@ -316,12 +413,19 @@ private enum Vision {
             k = k.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
             v = v.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
 
+            // Apply attention mask (window or full attention)
+            // attentionMask is [1, seqLen, seqLen] boolean — convert to float16 mask for SDPA
+            let boolMask = attentionMask[.newAxis, 0..., 0..., 0...]  // [1, 1, seqLen, seqLen]
+            let floatMask = MLX.where(boolMask,
+                                       MLXArray(Float16(0)),
+                                       MLXArray(Float16(-10000)))
+
             let output = MLXFast.scaledDotProductAttention(
                 queries: q,
                 keys: k,
                 values: v,
                 scale: scale,
-                mask: .none
+                mask: .array(floatMask)
             )
             .transposed(0, 2, 1, 3)
             .reshaped(sequenceLength, -1)
@@ -678,40 +782,32 @@ public struct Qwen25VLProcessor: UserInputProcessor {
     func preprocess(image: CIImage, resizedSize: CGSize) -> CIImage {
         image
             .toSRGB()
-            .resampled(to: resizedSize, method: .bicubic)
+            .resampled(to: resizedSize, method: .lanczos)
             .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
     }
 
     public func preprocess(images: [CIImage], processing: UserInput.Processing?) throws -> (
         MLXArray, THW
     ) {
-        // First apply the user requested resizing, etc. if any
-        let images = images.map { MediaProcessing.apply($0, processing: processing) }
+        // Compute target size from the original image before any processing, matching Python's
+        // single-step resize: ratio = max_size / max(w,h); new_w = int(w*ratio)//28*28
+        let origSize = images[0].extent.size
+        let factor = config.patchSize * config.mergeSize
+        let targetSize: CGSize
+        if let resize = processing?.resize {
+            targetSize = resize
+        } else {
+            let (h, w) = try QwenVL.targetSize(
+                height: Int(origSize.height), width: Int(origSize.width),
+                factor: factor, minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
+            targetSize = CGSize(width: w, height: h)
+        }
 
-        // image_processing_qwen2_vl._preprocess
-        let size = images[0].extent.size
-        let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
-            height: Int(size.height), width: Int(size.width),
-            factor: config.patchSize * config.mergeSize,
-            minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
-        let resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
-
-        // Process images
-        let processedImages =
-            images
-            .map {
-                MediaProcessing.inSRGBToneCurveSpace($0)
-            }
-            .map {
-                return MediaProcessing.resampleBicubic($0, to: resizedSize)
-            }
-            .map {
-                MediaProcessing.normalize(
-                    $0, mean: config.imageMeanTuple, std: config.imageStdTuple)
-            }
-            .map {
-                MediaProcessing.asMLXArray($0)
-            }
+        let processedImages = images
+            .map { MediaProcessing.inSRGBToneCurveSpace($0) }
+            .map { MediaProcessing.resampleBicubic($0, to: targetSize) }
+            .map { MediaProcessing.normalize($0, mean: config.imageMeanTuple, std: config.imageStdTuple) }
+            .map { MediaProcessing.asMLXArray($0) }
 
         return try QwenVL.patchify(
             images: processedImages, mergeSize: config.mergeSize, patchSize: config.patchSize,
@@ -828,13 +924,20 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         -> MLXArray
     {
         guard let pixelValues, let frames else {
+            // Text-only: reset MROPE state
+            languageModel._positionIds = nil
+            languageModel._ropeDeltas = nil
             return languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis])
         }
+
+        // Reset MROPE state when processing new image (matches Python)
+        languageModel._positionIds = nil
+        languageModel._ropeDeltas = nil
 
         // Get the input embeddings from the language model
         let inputEmbeds = languageModel.model.embedTokens(inputIds)
 
-        // Get the ouptut hidden states from the vision model
+        // Get the output hidden states from the vision model
         var hiddenStates = self.visionModel(pixelValues, frames: frames)
 
         if hiddenStates.ndim == 2 {
@@ -842,10 +945,26 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         // Insert special image tokens in the input_ids
-        return QwenVL.mergeInputIdsWithImageFeatures(
+        let mergedEmbeds = QwenVL.mergeInputIdsWithImageFeatures(
             inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
             imageTokenId: config.baseConfiguration.imageTokenId,
             videoTokenId: config.baseConfiguration.videoTokenId)
+
+        // Compute MROPE 3D position IDs for spatial awareness
+        let spatialMergeSize = config.visionConfiguration.spatialMergeSize
+        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
+        let (positionIds, ropeDeltas) = Qwen25VL.getRopeIndex(
+            inputIds: inputIds2D,
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            visionStartTokenId: config.baseConfiguration.visionStartTokenId)
+        languageModel._positionIds = positionIds
+        languageModel._ropeDeltas = ropeDeltas
+
+        return mergedEmbeds
     }
 
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
@@ -878,6 +997,163 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings)
 
         return .logits(result)
+    }
+
+    /// Compute MROPE 3D position IDs for image/video spatial encoding
+    /// Ported from Qwen3VL.swift getRopeIndex() and Python get_rope_index()
+    static func getRopeIndex(
+        inputIds: MLXArray,
+        imageGridTHW: [THW]?,
+        videoGridTHW: [THW]?,
+        spatialMergeSize: Int,
+        imageTokenId: Int,
+        videoTokenId: Int,
+        visionStartTokenId: Int,
+        attentionMask: MLXArray? = nil
+    ) -> (MLXArray, MLXArray) {
+
+        let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
+
+        guard inputIds.ndim > 0, imageGridTHW != nil || videoGridTHW != nil else {
+            var positionIds = MLXArray(0 ..< seqLength).asType(.int32)
+            positionIds = broadcast(positionIds[.newAxis, 0...], to: [batchSize, seqLength])
+            let positionIds3D = broadcast(
+                positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
+            let zeros = MLXArray.zeros([batchSize], dtype: .int32)
+            return (positionIds3D, zeros)
+        }
+
+        var positionIds = ones(like: inputIds).asType(.int32)
+        positionIds = broadcast(positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
+
+        var mropePositionDeltas: [Int] = []
+        let mask = attentionMask ?? ones(like: inputIds)
+
+        for batchIdx in 0 ..< batchSize {
+            var batchInputIds = inputIds[batchIdx, 0...]
+            batchInputIds = `where`(
+                mask[batchIdx, 0...] .== 1, batchInputIds, zeros(like: batchInputIds))
+
+            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(Int.self)
+            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(Int.self)
+
+            let inputTokens = batchInputIds.asArray(Int32.self).map { Int($0) }
+            var llmPosIdsList: [MLXArray] = []
+
+            var st = 0
+            var remainImages = imageNums
+            var remainVideos = videoNums
+            var imageIndex = 0
+            var videoIndex = 0
+
+            for _ in 0 ..< (imageNums + videoNums) {
+                let edImage: Int
+                if remainImages > 0, let idx = inputTokens[st...].firstIndex(of: imageTokenId) {
+                    edImage = idx
+                } else {
+                    edImage = inputTokens.count + 1
+                }
+
+                let edVideo: Int
+                if remainVideos > 0, let idx = inputTokens[st...].firstIndex(of: videoTokenId) {
+                    edVideo = idx
+                } else {
+                    edVideo = inputTokens.count + 1
+                }
+
+                let (t, h, w, ed): (Int, Int, Int, Int)
+                if edImage < edVideo {
+                    guard let grid = imageGridTHW, imageIndex < grid.count else { break }
+                    (t, h, w) = grid[imageIndex].values
+                    imageIndex += 1
+                    remainImages -= 1
+                    ed = edImage
+                } else {
+                    guard let grid = videoGridTHW, videoIndex < grid.count else { break }
+                    (t, h, w) = grid[videoIndex].values
+                    videoIndex += 1
+                    remainVideos -= 1
+                    ed = edVideo
+                }
+
+                let llmGridT = t
+                let llmGridH = h / spatialMergeSize
+                let llmGridW = w / spatialMergeSize
+
+                let stIdx: Int
+                if let lastArray = llmPosIdsList.last {
+                    stIdx = lastArray.max().item(Int.self) + 1
+                } else {
+                    stIdx = 0
+                }
+
+                // Text tokens before this visual block
+                let textLen = ed - st
+                if textLen > 0 {
+                    var index = MLXArray(0 ..< textLen).reshaped([1, textLen])
+                    index = broadcast(index, to: [3, textLen])
+                    index = index + MLXArray(stIdx)
+                    llmPosIdsList.append(index)
+                }
+
+                // 3D position IDs for visual tokens (temporal, height, width)
+                var tIndex = MLXArray(0 ..< llmGridT).reshaped([llmGridT, 1])
+                tIndex = broadcast(tIndex, to: [llmGridT, llmGridH * llmGridW])
+                tIndex = tIndex.flattened()
+
+                var hIndex = MLXArray(0 ..< llmGridH).reshaped([1, llmGridH, 1])
+                hIndex = broadcast(hIndex, to: [llmGridT, llmGridH, llmGridW])
+                hIndex = hIndex.flattened()
+
+                var wIndex = MLXArray(0 ..< llmGridW).reshaped([1, 1, llmGridW])
+                wIndex = broadcast(wIndex, to: [llmGridT, llmGridH, llmGridW])
+                wIndex = wIndex.flattened()
+
+                let visualPosIds = stacked([tIndex, hIndex, wIndex]) + MLXArray(textLen + stIdx)
+                llmPosIdsList.append(visualPosIds)
+
+                st = ed + llmGridT * llmGridH * llmGridW
+            }
+
+            // Remaining text tokens after last visual block
+            if st < inputTokens.count {
+                let stIdx: Int
+                if let lastArray = llmPosIdsList.last {
+                    stIdx = lastArray.max().item(Int.self) + 1
+                } else {
+                    stIdx = 0
+                }
+
+                let textLen = inputTokens.count - st
+                var tIndex = MLXArray(0 ..< textLen).reshaped([1, textLen])
+                tIndex = broadcast(tIndex, to: [3, textLen])
+                llmPosIdsList.append(tIndex + MLXArray(stIdx))
+            }
+
+            if !llmPosIdsList.isEmpty {
+                let llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+
+                let expandedMask = broadcast(
+                    mask[batchIdx, 0...][.newAxis, .newAxis, 0...], to: [3, 1, seqLength])
+                let expandedPositions = llmPositions[0..., .newAxis, 0...]
+                let newPositions = `where`(
+                    expandedMask, expandedPositions,
+                    positionIds[0..., batchIdx ..< batchIdx + 1, 0...])
+
+                positionIds = newPositions
+
+                let maxPosId = llmPositions.max().item(Int.self)
+                mropePositionDeltas.append(maxPosId + 1 - inputTokens.count)
+            }
+        }
+
+        let deltas: MLXArray
+        if mropePositionDeltas.isEmpty {
+            deltas = MLXArray.zeros([batchSize], dtype: .int32)
+        } else {
+            deltas = MLXArray(mropePositionDeltas.map { Int32($0) })
+        }
+        return (positionIds, deltas)
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -793,9 +793,16 @@ public struct Qwen25VLProcessor: UserInputProcessor {
     }
 
     func preprocess(image: CIImage, resizedSize: CGSize) -> CIImage {
+        // Bicubic matches the image-path resampler (the dedicated PIL-
+        // Lanczos port for images was reverted in PR #243 once parity
+        // was measured to not be load-bearing). This helper is only
+        // called from the video-frame map loop in
+        // VideoFrameProcessor; switching it to Lanczos in an earlier
+        // exploratory pass was accidental scope-creep (no video parity
+        // benchmark justifies it). Per davidkoski #239 review.
         image
             .toSRGB()
-            .resampled(to: resizedSize, method: .lanczos)
+            .resampled(to: resizedSize, method: .bicubic)
             .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
     }
 

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -939,8 +939,10 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         -> (embeds: MLXArray, positionIds: MLXArray?, ropeDeltas: MLXArray?)
     {
         guard let pixelValues, let frames else {
-            return (languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis]),
-                    nil, nil)
+            return (
+                languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis]),
+                nil, nil
+            )
         }
 
         // Get the input embeddings from the language model

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -43,8 +43,8 @@ private enum Language {
         let kvHeads: Int
         let headDim: Int
         let scale: Float
-        let mropeSection: [Int]      // cumulative section indices (for half-dim split)
-        let mropeSectionRaw: [Int]   // raw section sizes [16, 24, 24] (for full-dim split)
+        let mropeSection: [Int]  // cumulative section indices (for half-dim split)
+        let mropeSectionRaw: [Int]  // raw section sizes [16, 24, 24] (for full-dim split)
         // Leading underscore makes Module's weight loader skip this property —
         // invFreq is computed from ropeTheta+headDim, not a trained weight.
         // (See `parameterIsValid(_:)` in mlx-swift's Module.)
@@ -319,8 +319,9 @@ private enum Language {
                 effectivePositionIds = broadcast(effectivePositionIds!, to: [3, batch, seqLength])
             }
 
-            var out = model(inputs, cache: cache, inputEmbedding: inputEmbedding,
-                           positionIds: effectivePositionIds)
+            var out = model(
+                inputs, cache: cache, inputEmbedding: inputEmbedding,
+                positionIds: effectivePositionIds)
             if let lmHead {
                 out = lmHead(out)
             } else {
@@ -417,9 +418,10 @@ private enum Vision {
             // Apply attention mask (window or full attention)
             // attentionMask is [1, seqLen, seqLen] boolean — convert to float16 mask for SDPA
             let boolMask = attentionMask[.newAxis, 0..., 0..., 0...]  // [1, 1, seqLen, seqLen]
-            let floatMask = MLX.where(boolMask,
-                                       MLXArray(Float16(0)),
-                                       MLXArray(Float16(-10000)))
+            let floatMask = MLX.where(
+                boolMask,
+                MLXArray(Float16(0)),
+                MLXArray(Float16(-10000)))
 
             let output = MLXFast.scaledDotProductAttention(
                 queries: q,
@@ -814,10 +816,14 @@ public struct Qwen25VLProcessor: UserInputProcessor {
             targetSize = CGSize(width: w, height: h)
         }
 
-        let processedImages = images
+        let processedImages =
+            images
             .map { MediaProcessing.inSRGBToneCurveSpace($0) }
             .map { MediaProcessing.resampleBicubic($0, to: targetSize) }
-            .map { MediaProcessing.normalize($0, mean: config.imageMeanTuple, std: config.imageStdTuple) }
+            .map {
+                MediaProcessing.normalize(
+                    $0, mean: config.imageMeanTuple, std: config.imageStdTuple)
+            }
             .map { MediaProcessing.asMLXArray($0) }
 
         return try QwenVL.patchify(

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -6,6 +6,13 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+// Per-call decoder state is plumbed through `LMOutput.State` rather than
+// stored as instance vars on the model — see #283 for the pattern. The
+// model itself stays a pure function, so one instance can serve many
+// concurrent chat sessions without their state colliding.
+private let positionIdsKey = LMOutput.Key<MLXArray>("qwen25vl.positionIds")
+private let ropeDeltasKey = LMOutput.Key<MLXArray>("qwen25vl.ropeDeltas")
+
 // MARK: - Language
 
 private enum Language {
@@ -259,10 +266,6 @@ private enum Language {
 
         var kvHeads: [Int]
 
-        // MROPE state: stored position IDs from prefill, reused during autoregressive generation
-        var _positionIds: MLXArray?
-        var _ropeDeltas: MLXArray?
-
         public init(_ args: Qwen25VLConfiguration.TextConfiguration) {
             self.model = Qwen25Model(args)
 
@@ -274,18 +277,20 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            _ inputs: MLXArray?, cache: [KVCache]? = nil,
+            state: LMOutput.State?,
+            inputEmbedding: MLXArray? = nil,
             positionIds: MLXArray? = nil
         ) -> LMOutput {
-            var effectivePositionIds = positionIds ?? _positionIds
+            var state = state ?? .init()
+            var effectivePositionIds = positionIds ?? state[positionIdsKey]
+            if state[positionIdsKey] != nil {
+                state[positionIdsKey] = nil
+            }
 
-            // Clear stored position IDs after first use (prefill done)
-            if _positionIds != nil { _positionIds = nil }
-
-            // During autoregressive generation after multimodal prefill:
-            // compute position IDs using rope_deltas so MROPE offsets are correct
-            if effectivePositionIds == nil, let ropeDeltas = _ropeDeltas, let cache {
-                let input = inputs ?? inputEmbedding!
+            if effectivePositionIds == nil, let ropeDeltas = state[ropeDeltasKey],
+                let cache, let input = inputs ?? inputEmbedding
+            {
                 let batch = input.dim(0)
                 let seqLength = input.dim(1)
                 let lastCacheOffset = cache.last?.offset ?? 0
@@ -314,7 +319,7 @@ private enum Language {
             } else {
                 out = model.embedTokens.asLinear(out)
             }
-            return LMOutput(logits: out)
+            return LMOutput(logits: out, state: state)
         }
     }
 }
@@ -931,19 +936,20 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         self._languageModel.wrappedValue = Language.LanguageModel(config.textConfiguration)
     }
 
+    /// Builds the multimodal input embedding for one prefill step.
+    ///
+    /// Returns the embeddings paired with the prefill-only MROPE state
+    /// (positionIds + ropeDeltas) — both nil on the no-image path. The
+    /// caller seeds `LMOutput.State` with these so subsequent decode
+    /// steps can reconstruct positions from `ropeDeltas + cacheOffset`
+    /// without mutating the model.
     private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)
-        -> MLXArray
+        -> (embeds: MLXArray, positionIds: MLXArray?, ropeDeltas: MLXArray?)
     {
         guard let pixelValues, let frames else {
-            // Text-only: reset MROPE state
-            languageModel._positionIds = nil
-            languageModel._ropeDeltas = nil
-            return languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis])
+            return (languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis]),
+                    nil, nil)
         }
-
-        // Reset MROPE state when processing new image (matches Python)
-        languageModel._positionIds = nil
-        languageModel._ropeDeltas = nil
 
         // Get the input embeddings from the language model
         let inputEmbeds = languageModel.model.embedTokens(inputIds)
@@ -972,10 +978,8 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             imageTokenId: config.baseConfiguration.imageTokenId,
             videoTokenId: config.baseConfiguration.videoTokenId,
             visionStartTokenId: config.baseConfiguration.visionStartTokenId)
-        languageModel._positionIds = positionIds
-        languageModel._ropeDeltas = ropeDeltas
 
-        return mergedEmbeds
+        return (mergedEmbeds, positionIds, ropeDeltas)
     }
 
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
@@ -1001,17 +1005,28 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: videoFrames)
         }
 
-        let inputEmbeddings = self.inputEmbeddings(
+        let (embeds, positionIds, ropeDeltas) = self.inputEmbeddings(
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)
 
-        let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings)
+        // Seed per-call decoder state with the prefill-only MROPE
+        // positions + ropeDeltas (both nil on the no-image path). The
+        // LMOutput's `state` returned by this call is what subsequent
+        // decode steps consume via `callAsFunction(_:cache:state:)`.
+        var state = LMOutput.State()
+        if let positionIds {
+            state[positionIdsKey] = positionIds
+        }
+        if let ropeDeltas {
+            state[ropeDeltasKey] = ropeDeltas
+        }
+
+        let result = languageModel(
+            nil, cache: cache, state: state, inputEmbedding: embeds)
 
         return .logits(result)
     }
 
-    /// Compute MROPE 3D position IDs for image/video spatial encoding
-    /// Ported from Qwen3VL.swift getRopeIndex() and Python get_rope_index()
     static func getRopeIndex(
         inputIds: MLXArray,
         imageGridTHW: [THW]?,
@@ -1169,8 +1184,10 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         return (positionIds, deltas)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
-        languageModel(inputs, cache: cache).logits
+    public func callAsFunction(
+        _ input: LMInput.Text, cache: [any KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        languageModel(input.tokens, cache: cache, state: state)
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -45,9 +45,10 @@ private enum Language {
         let scale: Float
         let mropeSection: [Int]      // cumulative section indices (for half-dim split)
         let mropeSectionRaw: [Int]   // raw section sizes [16, 24, 24] (for full-dim split)
-        // Wrapped in a class to hide from Module's weight loading (not a trained weight)
-        private class InvFreqBox { let value: MLXArray; init(_ v: MLXArray) { value = v } }
-        private let _invFreqBox: InvFreqBox
+        // Leading underscore makes Module's weight loader skip this property —
+        // invFreq is computed from ropeTheta+headDim, not a trained weight.
+        // (See `parameterIsValid(_:)` in mlx-swift's Module.)
+        private let _invFreq: MLXArray
 
         @ModuleInfo(key: "q_proj") var wq: Linear
         @ModuleInfo(key: "k_proj") var wk: Linear
@@ -89,7 +90,7 @@ private enum Language {
             // inv_freq = 1.0 / (theta ^ (arange(0, dim, 2) / dim))
             let freqIndices = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
             let base = MLXArray(args.ropeTheta)
-            self._invFreqBox = InvFreqBox(1.0 / pow(base, freqIndices / Float(headDim)))
+            self._invFreq = 1.0 / pow(base, freqIndices / Float(headDim))
 
             self._rotaryEmbedding.wrappedValue = RoPE(
                 dimensions: headDim, traditional: args.ropeTraditional, base: args.ropeTheta)
@@ -99,7 +100,7 @@ private enum Language {
         /// Matches Python apply_mrope: start with temporal, overwrite H/W ranges
         private func mropeCosSin(positionIds: MLXArray) -> (MLXArray, MLXArray) {
             // positionIds: [3, batch, seq]
-            let invFreqExpanded = _invFreqBox.value.reshaped(1, 1, -1, 1)  // [1, 1, dim/2, 1]
+            let invFreqExpanded = _invFreq.reshaped(1, 1, -1, 1)  // [1, 1, dim/2, 1]
             let posExpanded = positionIds[0..., 0..., .newAxis, 0...].asType(.float32)  // [3, batch, 1, seq]
             var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
             freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -776,7 +776,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
         self.tokenizer = tokenizer
     }
 
-    func preprocess(image: CIImage, resizedSize: CGSize) -> CIImage {
+    func preprocessVideoFrame(image: CIImage, resizedSize: CGSize) -> CIImage {
         // Bicubic matches the image-path resampler (the dedicated PIL-
         // Lanczos port for images was reverted in PR #243 once parity
         // was measured to not be load-bearing). This helper is only
@@ -870,7 +870,8 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                             minPixels: config.minPixels, maxPixels: config.maxPixels)
                         resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
                     }
-                    let processedImage = preprocess(image: resizedImage, resizedSize: resizedSize)
+                    let processedImage = preprocessVideoFrame(
+                        image: resizedImage, resizedSize: resizedSize)
                     return VideoFrame(frame: processedImage, timeStamp: frame.timeStamp)
                 }
 

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -407,14 +407,6 @@ private enum Vision {
             k = k.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
             v = v.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
 
-            // Apply attention mask (window or full attention)
-            // attentionMask is [1, seqLen, seqLen] boolean — convert to float16 mask for SDPA
-            let boolMask = attentionMask[.newAxis, 0..., 0..., 0...]  // [1, 1, seqLen, seqLen]
-            let floatMask = MLX.where(
-                boolMask,
-                MLXArray(Float16(0)),
-                MLXArray(Float16(-10000)))
-
             let output = MLXFast.scaledDotProductAttention(
                 queries: q,
                 keys: k,

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -793,24 +793,21 @@ public struct Qwen25VLProcessor: UserInputProcessor {
     public func preprocess(images: [CIImage], processing: UserInput.Processing?) throws -> (
         MLXArray, THW
     ) {
-        // Compute target size from the original image before any processing, matching Python's
-        // single-step resize: ratio = max_size / max(w,h); new_w = int(w*ratio)//28*28
-        let origSize = images[0].extent.size
-        let factor = config.patchSize * config.mergeSize
-        let targetSize: CGSize
-        if let resize = processing?.resize {
-            targetSize = resize
-        } else {
-            let (h, w) = try QwenVL.targetSize(
-                height: Int(origSize.height), width: Int(origSize.width),
-                factor: factor, minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
-            targetSize = CGSize(width: w, height: h)
-        }
+        // First apply the user requested resizing, etc. if any
+        let images = images.map { MediaProcessing.apply($0, processing: processing) }
+
+        // image_processing_qwen2_vl._preprocess
+        let size = images[0].extent.size
+        let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
+            height: Int(size.height), width: Int(size.width),
+            factor: config.patchSize * config.mergeSize,
+            minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
+        let resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
 
         let processedImages =
             images
             .map { MediaProcessing.inSRGBToneCurveSpace($0) }
-            .map { MediaProcessing.resampleBicubic($0, to: targetSize) }
+            .map { MediaProcessing.resampleBicubic($0, to: resizedSize) }
             .map {
                 MediaProcessing.normalize(
                     $0, mean: config.imageMeanTuple, std: config.imageStdTuple)

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -43,7 +43,11 @@ private enum Language {
         let kvHeads: Int
         let headDim: Int
         let scale: Float
-        let mropeSection: [Int]
+        let mropeSection: [Int]      // cumulative section indices (for half-dim split)
+        let mropeSectionRaw: [Int]   // raw section sizes [16, 24, 24] (for full-dim split)
+        // Wrapped in a class to hide from Module's weight loading (not a trained weight)
+        private class InvFreqBox { let value: MLXArray; init(_ v: MLXArray) { value = v } }
+        private let _invFreqBox: InvFreqBox
 
         @ModuleInfo(key: "q_proj") var wq: Linear
         @ModuleInfo(key: "k_proj") var wk: Linear
@@ -65,6 +69,8 @@ private enum Language {
             self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
             if let v = args.ropeScaling?["mrope_section"], let array = v.asInts() {
+                // Raw sections e.g. [16, 24, 24] — used for splitting full-dim cos/sin
+                self.mropeSectionRaw = array
                 // mrope_section = np.cumsum(mrope_section * 2)[:-1].tolist()
                 self.mropeSection = sequence(state: (0, array.makeIterator())) { state in
                     if let v = state.1.next() {
@@ -79,12 +85,54 @@ private enum Language {
                 fatalError("rope_scaling['mrope_section'] must be an array of integers")
             }
 
+            // Compute inv_freq for MROPE (same formula as Python)
+            // inv_freq = 1.0 / (theta ^ (arange(0, dim, 2) / dim))
+            let freqIndices = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
+            let base = MLXArray(args.ropeTheta)
+            self._invFreqBox = InvFreqBox(1.0 / pow(base, freqIndices / Float(headDim)))
+
             self._rotaryEmbedding.wrappedValue = RoPE(
                 dimensions: headDim, traditional: args.ropeTraditional, base: args.ropeTheta)
         }
 
+        /// Compute cos/sin for MROPE from 3D position IDs
+        /// Matches Python apply_mrope: start with temporal, overwrite H/W ranges
+        private func mropeCosSin(positionIds: MLXArray) -> (MLXArray, MLXArray) {
+            // positionIds: [3, batch, seq]
+            let invFreqExpanded = _invFreqBox.value.reshaped(1, 1, -1, 1)  // [1, 1, dim/2, 1]
+            let posExpanded = positionIds[0..., 0..., .newAxis, 0...].asType(.float32)  // [3, batch, 1, seq]
+            var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
+            freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]
+
+            // Python apply_mrope: start with temporal (freqs[0]), overwrite H/W slices
+            // mropeSectionRaw = [16, 24, 24]
+            // dims 0..15 → temporal, dims 16..39 → height, dims 40..63 → width
+            var result = freqs[0]  // [batch, seq, dim/2] — start with temporal
+            var offset = mropeSectionRaw[0]  // 16
+            for dim in 1 ..< mropeSectionRaw.count {
+                let length = mropeSectionRaw[dim]
+                // Replace slice [offset..<offset+length] with freqs from this dimension
+                let dimFreqs = freqs[dim]  // [batch, seq, dim/2]
+                // Use scatter or manual slice replacement
+                let before = result[0..., 0..., 0 ..< offset]
+                let middle = dimFreqs[0..., 0..., offset ..< (offset + length)]
+                let after: MLXArray
+                if offset + length < result.dim(-1) {
+                    after = result[0..., 0..., (offset + length)...]
+                    result = concatenated([before, middle, after], axis: -1)
+                } else {
+                    result = concatenated([before, middle], axis: -1)
+                }
+                offset += length
+            }
+
+            let emb = concatenated([result, result], axis: -1)  // [batch, seq, dim]
+            return (MLX.cos(emb), MLX.sin(emb))
+        }
+
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
             let (B, L) = (x.dim(0), x.dim(1))
 
@@ -97,10 +145,22 @@ private enum Language {
             keys = keys.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
             values = values.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
 
-            let offset = cache?.offset ?? 0
-
-            queries = rotaryEmbedding(queries, offset: offset)
-            keys = rotaryEmbedding(keys, offset: offset)
+            if let positionIds {
+                // MROPE path: compute 3D-aware cos/sin from position IDs
+                let (cosValues, sinValues) = mropeCosSin(positionIds: positionIds)
+                // Apply rotary embedding: expand dims for head broadcasting
+                let cos = cosValues[.newAxis, 0..., 0..., 0...]  // [1, batch, seq, dim]
+                let sin = sinValues[.newAxis, 0..., 0..., 0...]
+                let qEmbed = (queries * cos) + (QwenVL.rotateHalf(queries) * sin)
+                let kEmbed = (keys * cos) + (QwenVL.rotateHalf(keys) * sin)
+                queries = qEmbed
+                keys = kEmbed
+            } else {
+                // Simple sequential RoPE for autoregressive generation
+                let offset = cache?.offset ?? 0
+                queries = rotaryEmbedding(queries, offset: offset)
+                keys = rotaryEmbedding(keys, offset: offset)
+            }
 
             let output = attentionWithCacheUpdate(
                 queries: queries,
@@ -151,9 +211,10 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+            _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
-            var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
+            var r = attention(inputLayerNorm(x), mask: mask, cache: cache, positionIds: positionIds)
             let h = x + r
             r = mlp(postAttentionLayerNorm(h))
             let out = h + r
@@ -182,7 +243,8 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            positionIds: MLXArray? = nil
         ) -> MLXArray {
             var h: MLXArray
             if let inputEmbedding {
@@ -196,7 +258,7 @@ private enum Language {
             let mask = createAttentionMask(h: h, cache: cache?.first)
 
             for (i, layer) in layers.enumerated() {
-                h = layer(h, mask: mask, cache: cache?[i])
+                h = layer(h, mask: mask, cache: cache?[i], positionIds: positionIds)
             }
 
             return norm(h)
@@ -209,6 +271,10 @@ private enum Language {
 
         var kvHeads: [Int]
 
+        // MROPE state: stored position IDs from prefill, reused during autoregressive generation
+        var _positionIds: MLXArray?
+        var _ropeDeltas: MLXArray?
+
         public init(_ args: Qwen25VLConfiguration.TextConfiguration) {
             self.model = Qwen25Model(args)
 
@@ -220,9 +286,40 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil,
+            positionIds: MLXArray? = nil
         ) -> LMOutput {
-            var out = model(inputs, cache: cache, inputEmbedding: inputEmbedding)
+            var effectivePositionIds = positionIds ?? _positionIds
+
+            // Clear stored position IDs after first use (prefill done)
+            if _positionIds != nil { _positionIds = nil }
+
+            // During autoregressive generation after multimodal prefill:
+            // compute position IDs using rope_deltas so MROPE offsets are correct
+            if effectivePositionIds == nil, let ropeDeltas = _ropeDeltas, let cache {
+                let input = inputs ?? inputEmbedding!
+                let batch = input.dim(0)
+                let seqLength = input.dim(1)
+                let lastCacheOffset = cache.last?.offset ?? 0
+
+                var delta = MLXArray(lastCacheOffset).asType(.int32) + ropeDeltas.asType(.int32)
+
+                var base = MLXArray(0 ..< seqLength).asType(.int32)
+                base = base[.newAxis, 0...]
+                base = broadcast(base, to: [batch, seqLength])
+
+                if delta.dim(0) == 1 && batch > 1 {
+                    delta = repeated(delta, count: batch, axis: 0)
+                }
+
+                base = base + delta
+
+                effectivePositionIds = base[.newAxis, 0..., 0...]
+                effectivePositionIds = broadcast(effectivePositionIds!, to: [3, batch, seqLength])
+            }
+
+            var out = model(inputs, cache: cache, inputEmbedding: inputEmbedding,
+                           positionIds: effectivePositionIds)
             if let lmHead {
                 out = lmHead(out)
             } else {
@@ -315,6 +412,13 @@ private enum Vision {
             q = q.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
             k = k.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
             v = v.reshaped(1, sequenceLength, numHeads, -1).transposed(0, 2, 1, 3)
+
+            // Apply attention mask (window or full attention)
+            // attentionMask is [1, seqLen, seqLen] boolean — convert to float16 mask for SDPA
+            let boolMask = attentionMask[.newAxis, 0..., 0..., 0...]  // [1, 1, seqLen, seqLen]
+            let floatMask = MLX.where(boolMask,
+                                       MLXArray(Float16(0)),
+                                       MLXArray(Float16(-10000)))
 
             let output = MLXFast.scaledDotProductAttention(
                 queries: q,
@@ -688,40 +792,32 @@ public struct Qwen25VLProcessor: UserInputProcessor {
     func preprocess(image: CIImage, resizedSize: CGSize) -> CIImage {
         image
             .toSRGB()
-            .resampled(to: resizedSize, method: .bicubic)
+            .resampled(to: resizedSize, method: .lanczos)
             .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
     }
 
     public func preprocess(images: [CIImage], processing: UserInput.Processing?) throws -> (
         MLXArray, THW
     ) {
-        // First apply the user requested resizing, etc. if any
-        let images = images.map { MediaProcessing.apply($0, processing: processing) }
+        // Compute target size from the original image before any processing, matching Python's
+        // single-step resize: ratio = max_size / max(w,h); new_w = int(w*ratio)//28*28
+        let origSize = images[0].extent.size
+        let factor = config.patchSize * config.mergeSize
+        let targetSize: CGSize
+        if let resize = processing?.resize {
+            targetSize = resize
+        } else {
+            let (h, w) = try QwenVL.targetSize(
+                height: Int(origSize.height), width: Int(origSize.width),
+                factor: factor, minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
+            targetSize = CGSize(width: w, height: h)
+        }
 
-        // image_processing_qwen2_vl._preprocess
-        let size = images[0].extent.size
-        let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
-            height: Int(size.height), width: Int(size.width),
-            factor: config.patchSize * config.mergeSize,
-            minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
-        let resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
-
-        // Process images
-        let processedImages =
-            images
-            .map {
-                MediaProcessing.inSRGBToneCurveSpace($0)
-            }
-            .map {
-                return MediaProcessing.resampleBicubic($0, to: resizedSize)
-            }
-            .map {
-                MediaProcessing.normalize(
-                    $0, mean: config.imageMeanTuple, std: config.imageStdTuple)
-            }
-            .map {
-                MediaProcessing.asMLXArray($0)
-            }
+        let processedImages = images
+            .map { MediaProcessing.inSRGBToneCurveSpace($0) }
+            .map { MediaProcessing.resampleBicubic($0, to: targetSize) }
+            .map { MediaProcessing.normalize($0, mean: config.imageMeanTuple, std: config.imageStdTuple) }
+            .map { MediaProcessing.asMLXArray($0) }
 
         return try QwenVL.patchify(
             images: processedImages, mergeSize: config.mergeSize, patchSize: config.patchSize,
@@ -838,13 +934,20 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         -> MLXArray
     {
         guard let pixelValues, let frames else {
+            // Text-only: reset MROPE state
+            languageModel._positionIds = nil
+            languageModel._ropeDeltas = nil
             return languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis])
         }
+
+        // Reset MROPE state when processing new image (matches Python)
+        languageModel._positionIds = nil
+        languageModel._ropeDeltas = nil
 
         // Get the input embeddings from the language model
         let inputEmbeds = languageModel.model.embedTokens(inputIds)
 
-        // Get the ouptut hidden states from the vision model
+        // Get the output hidden states from the vision model
         var hiddenStates = self.visionModel(pixelValues, frames: frames)
 
         if hiddenStates.ndim == 2 {
@@ -852,10 +955,26 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         // Insert special image tokens in the input_ids
-        return QwenVL.mergeInputIdsWithImageFeatures(
+        let mergedEmbeds = QwenVL.mergeInputIdsWithImageFeatures(
             inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
             imageTokenId: config.baseConfiguration.imageTokenId,
             videoTokenId: config.baseConfiguration.videoTokenId)
+
+        // Compute MROPE 3D position IDs for spatial awareness
+        let spatialMergeSize = config.visionConfiguration.spatialMergeSize
+        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
+        let (positionIds, ropeDeltas) = Qwen25VL.getRopeIndex(
+            inputIds: inputIds2D,
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            visionStartTokenId: config.baseConfiguration.visionStartTokenId)
+        languageModel._positionIds = positionIds
+        languageModel._ropeDeltas = ropeDeltas
+
+        return mergedEmbeds
     }
 
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
@@ -888,6 +1007,163 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings)
 
         return .logits(result)
+    }
+
+    /// Compute MROPE 3D position IDs for image/video spatial encoding
+    /// Ported from Qwen3VL.swift getRopeIndex() and Python get_rope_index()
+    static func getRopeIndex(
+        inputIds: MLXArray,
+        imageGridTHW: [THW]?,
+        videoGridTHW: [THW]?,
+        spatialMergeSize: Int,
+        imageTokenId: Int,
+        videoTokenId: Int,
+        visionStartTokenId: Int,
+        attentionMask: MLXArray? = nil
+    ) -> (MLXArray, MLXArray) {
+
+        let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
+
+        guard inputIds.ndim > 0, imageGridTHW != nil || videoGridTHW != nil else {
+            var positionIds = MLXArray(0 ..< seqLength).asType(.int32)
+            positionIds = broadcast(positionIds[.newAxis, 0...], to: [batchSize, seqLength])
+            let positionIds3D = broadcast(
+                positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
+            let zeros = MLXArray.zeros([batchSize], dtype: .int32)
+            return (positionIds3D, zeros)
+        }
+
+        var positionIds = ones(like: inputIds).asType(.int32)
+        positionIds = broadcast(positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
+
+        var mropePositionDeltas: [Int] = []
+        let mask = attentionMask ?? ones(like: inputIds)
+
+        for batchIdx in 0 ..< batchSize {
+            var batchInputIds = inputIds[batchIdx, 0...]
+            batchInputIds = `where`(
+                mask[batchIdx, 0...] .== 1, batchInputIds, zeros(like: batchInputIds))
+
+            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(Int.self)
+            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(Int.self)
+
+            let inputTokens = batchInputIds.asArray(Int32.self).map { Int($0) }
+            var llmPosIdsList: [MLXArray] = []
+
+            var st = 0
+            var remainImages = imageNums
+            var remainVideos = videoNums
+            var imageIndex = 0
+            var videoIndex = 0
+
+            for _ in 0 ..< (imageNums + videoNums) {
+                let edImage: Int
+                if remainImages > 0, let idx = inputTokens[st...].firstIndex(of: imageTokenId) {
+                    edImage = idx
+                } else {
+                    edImage = inputTokens.count + 1
+                }
+
+                let edVideo: Int
+                if remainVideos > 0, let idx = inputTokens[st...].firstIndex(of: videoTokenId) {
+                    edVideo = idx
+                } else {
+                    edVideo = inputTokens.count + 1
+                }
+
+                let (t, h, w, ed): (Int, Int, Int, Int)
+                if edImage < edVideo {
+                    guard let grid = imageGridTHW, imageIndex < grid.count else { break }
+                    (t, h, w) = grid[imageIndex].values
+                    imageIndex += 1
+                    remainImages -= 1
+                    ed = edImage
+                } else {
+                    guard let grid = videoGridTHW, videoIndex < grid.count else { break }
+                    (t, h, w) = grid[videoIndex].values
+                    videoIndex += 1
+                    remainVideos -= 1
+                    ed = edVideo
+                }
+
+                let llmGridT = t
+                let llmGridH = h / spatialMergeSize
+                let llmGridW = w / spatialMergeSize
+
+                let stIdx: Int
+                if let lastArray = llmPosIdsList.last {
+                    stIdx = lastArray.max().item(Int.self) + 1
+                } else {
+                    stIdx = 0
+                }
+
+                // Text tokens before this visual block
+                let textLen = ed - st
+                if textLen > 0 {
+                    var index = MLXArray(0 ..< textLen).reshaped([1, textLen])
+                    index = broadcast(index, to: [3, textLen])
+                    index = index + MLXArray(stIdx)
+                    llmPosIdsList.append(index)
+                }
+
+                // 3D position IDs for visual tokens (temporal, height, width)
+                var tIndex = MLXArray(0 ..< llmGridT).reshaped([llmGridT, 1])
+                tIndex = broadcast(tIndex, to: [llmGridT, llmGridH * llmGridW])
+                tIndex = tIndex.flattened()
+
+                var hIndex = MLXArray(0 ..< llmGridH).reshaped([1, llmGridH, 1])
+                hIndex = broadcast(hIndex, to: [llmGridT, llmGridH, llmGridW])
+                hIndex = hIndex.flattened()
+
+                var wIndex = MLXArray(0 ..< llmGridW).reshaped([1, 1, llmGridW])
+                wIndex = broadcast(wIndex, to: [llmGridT, llmGridH, llmGridW])
+                wIndex = wIndex.flattened()
+
+                let visualPosIds = stacked([tIndex, hIndex, wIndex]) + MLXArray(textLen + stIdx)
+                llmPosIdsList.append(visualPosIds)
+
+                st = ed + llmGridT * llmGridH * llmGridW
+            }
+
+            // Remaining text tokens after last visual block
+            if st < inputTokens.count {
+                let stIdx: Int
+                if let lastArray = llmPosIdsList.last {
+                    stIdx = lastArray.max().item(Int.self) + 1
+                } else {
+                    stIdx = 0
+                }
+
+                let textLen = inputTokens.count - st
+                var tIndex = MLXArray(0 ..< textLen).reshaped([1, textLen])
+                tIndex = broadcast(tIndex, to: [3, textLen])
+                llmPosIdsList.append(tIndex + MLXArray(stIdx))
+            }
+
+            if !llmPosIdsList.isEmpty {
+                let llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+
+                let expandedMask = broadcast(
+                    mask[batchIdx, 0...][.newAxis, .newAxis, 0...], to: [3, 1, seqLength])
+                let expandedPositions = llmPositions[0..., .newAxis, 0...]
+                let newPositions = `where`(
+                    expandedMask, expandedPositions,
+                    positionIds[0..., batchIdx ..< batchIdx + 1, 0...])
+
+                positionIds = newPositions
+
+                let maxPosId = llmPositions.max().item(Int.self)
+                mropePositionDeltas.append(maxPosId + 1 - inputTokens.count)
+            }
+        }
+
+        let deltas: MLXArray
+        if mropePositionDeltas.isEmpty {
+            deltas = MLXArray.zeros([batchSize], dtype: .int32)
+        } else {
+            deltas = MLXArray(mropePositionDeltas.map { Int32($0) })
+        }
+        return (positionIds, deltas)
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -105,29 +105,16 @@ private enum Language {
             var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
             freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]
 
-            // Python apply_mrope: start with temporal (freqs[0]), overwrite H/W slices
-            // mropeSectionRaw = [16, 24, 24]
-            // dims 0..15 → temporal, dims 16..39 → height, dims 40..63 → width
-            var result = freqs[0]  // [batch, seq, dim/2] — start with temporal
-            var offset = mropeSectionRaw[0]  // 16
+            var freqsT = freqs[0]
+            var offset = mropeSectionRaw[0]
             for dim in 1 ..< mropeSectionRaw.count {
                 let length = mropeSectionRaw[dim]
-                // Replace slice [offset..<offset+length] with freqs from this dimension
-                let dimFreqs = freqs[dim]  // [batch, seq, dim/2]
-                // Use scatter or manual slice replacement
-                let before = result[0..., 0..., 0 ..< offset]
-                let middle = dimFreqs[0..., 0..., offset ..< (offset + length)]
-                let after: MLXArray
-                if offset + length < result.dim(-1) {
-                    after = result[0..., 0..., (offset + length)...]
-                    result = concatenated([before, middle, after], axis: -1)
-                } else {
-                    result = concatenated([before, middle], axis: -1)
-                }
+                freqsT[0..., 0..., offset ..< (offset + length)] =
+                    freqs[dim][0..., 0..., offset ..< (offset + length)]
                 offset += length
             }
 
-            let emb = concatenated([result, result], axis: -1)  // [batch, seq, dim]
+            let emb = concatenated([freqsT, freqsT], axis: -1)
             return (MLX.cos(emb), MLX.sin(emb))
         }
 

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -1044,8 +1044,10 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             batchInputIds = `where`(
                 mask[batchIdx, 0...] .== 1, batchInputIds, zeros(like: batchInputIds))
 
-            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(Int.self)
-            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(Int.self)
+            let imageNums = ((batchInputIds .== MLXArray(imageTokenId)).asType(.int32).sum()).item(
+                Int.self)
+            let videoNums = ((batchInputIds .== MLXArray(videoTokenId)).asType(.int32).sum()).item(
+                Int.self)
 
             let inputTokens = batchInputIds.asArray(Int32.self).map { Int($0) }
             var llmPosIdsList: [MLXArray] = []

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["IntegrationTestHelpers"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
+        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.4")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Three coupled fixes for Qwen2.5-VL to match Python mlx-vlm: MROPE section slices are slice-replaced not modulo-interleaved; rope_deltas is reconstructed during autoregressive decode; invFreq is wrapped to hide it from MLX's weight loader.

Split out from #222. Coupled because parity requires all three together.