### PR TITLE
Fix: tolerate 1D token inputs in Gemma 4 VLM forward pass

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -970,6 +970,18 @@ private final class Gemma4TextBackbone: Module {
         cache: [KVCache?]? = nil,
         perLayerInputs: MLXArray? = nil
     ) -> MLXArray {
+        // Tolerate callers that hand us a 1D `(L,)` token array instead
+        // of the canonical 2D `(B, L)` produced by `Gemma4Processor.prepare`.
+        // The downstream `perLayerInputs` indexing path (`finalPerLayerInputs[
+        // 0..., 0..., idx, 0...]`) requires 4D shapes; with 1D inputs the
+        // model otherwise crashes inside `MLXArray.subscript.getter`
+        // → `mlx_array_dim` → `_mlx_error`. This expansion is zero-copy
+        // and behaves identically when the caller already passed 2D.
+        let inputs = inputs.map { $0.ndim == 1 ? $0.expandedDimensions(axis: 0) : $0 }
+        let inputsEmbeds = inputsEmbeds.map {
+            $0.ndim == 2 ? $0.expandedDimensions(axis: 0) : $0
+        }
+
         let h0: MLXArray
         if let inputsEmbeds {
             h0 = inputsEmbeds

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -968,6 +968,18 @@ private final class Gemma4TextBackbone: Module {
         cache: [KVCache?]? = nil,
         perLayerInputs: MLXArray? = nil
     ) -> MLXArray {
+        // Tolerate callers that hand us a 1D `(L,)` token array instead
+        // of the canonical 2D `(B, L)` produced by `Gemma4Processor.prepare`.
+        // The downstream `perLayerInputs` indexing path (`finalPerLayerInputs[
+        // 0..., 0..., idx, 0...]`) requires 4D shapes; with 1D inputs the
+        // model otherwise crashes inside `MLXArray.subscript.getter`
+        // → `mlx_array_dim` → `_mlx_error`. This expansion is zero-copy
+        // and behaves identically when the caller already passed 2D.
+        let inputs = inputs.map { $0.ndim == 1 ? $0.expandedDimensions(axis: 0) : $0 }
+        let inputsEmbeds = inputsEmbeds.map {
+            $0.ndim == 2 ? $0.expandedDimensions(axis: 0) : $0
+        }
+
         let h0: MLXArray
         if let inputsEmbeds {
             h0 = inputsEmbeds


### PR DESCRIPTION
Fixes #240.

## Summary

`Gemma4TextBackbone.callAsFunction` indexes `finalPerLayerInputs` with `[0..., 0..., idx, 0...]` (4D), which silently requires the input to have arrived through `Gemma4Processor.prepare(input:)` — that path always expands to 2D `(1, L)` via `MLXArray(promptTokens).expandedDimensions(axis: 0)`. Callers that construct `LMInput` directly with raw token IDs (e.g. for manual KV-cache prefix reuse across requests) end up handing the model a 1D `(L,)` shape; `embedTokens` produces 2D `(L, D)`; `processedPerLayerInputs` becomes 3D; and the 4D subscript crashes inside `MLXArray.subscript.getter` → `mlx_array_dim` → `_mlx_error`.

The first request happens to work because the iterator's autoregressive `step` adds `.newAxis` to each generated token, so the 2D path is hit. The crash shows up on the *initial prefill* of a continuation request when prefix-cache reuse leaves only a short tail to feed.

## Fix

At the top of `callAsFunction`, expand 1D `inputs` and 2D `inputsEmbeds` to add a leading batch dim. Zero-copy reshape; identical behavior when the caller already passed the canonical 2D shape:

```swift
let inputs = inputs.map { $0.ndim == 1 ? $0.expandedDimensions(axis: 0) : $0 }
let inputsEmbeds = inputsEmbeds.map {
    $0.ndim == 2 ? $0.expandedDimensions(axis: 0) : $0
}
```

This matches Python `mlx-vlm`'s tolerance for 1D inputs in similar paths, and matches what `LLMModel.prepare` already does implicitly via `y[.newAxis, ..<prefillStepSize]` for chunked prefill.

## Validation

End-to-end via a standalone CLI reproducer that loads `mlx-community/gemma-4-e4b-it-4bit` and runs a 2-turn manual KV-cache flow:
- **Without this patch**: turn 1 generates "ok" then turn 2 prefill crashes inside `Gemma4TextBackbone.callAsFunction` with `_mlx_error` from `mlx_array_dim`.
- **With this patch**: turn 1 generates "ok", turn 2 generates "yes", cache offset advances `0 → 19 → 38` correctly. Cache reuse cuts TTFT from ~14 s to ~1 s on a 3000-token system prompt in real usage (Lloyd app, M-series).

The full reproduction code is inline in #240.

## Notes

The alternative considered (Option B in the issue) was a `precondition(input.text.tokens.ndim >= 2, ...)` at the public `MLXLMCommon.generateTokens` entry point, but that turns a sharp edge into a louder sharp edge rather than removing it. Option A here removes the trap entirely with a single zero-copy reshape per forward pass.