### PR TITLE
Fix Qwen2-VL chat template: emit vision tokens before text

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -909,18 +909,17 @@ public struct Qwen2VLMessageGenerator: MessageGenerator {
     public init() {}
 
     public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        // Image content MUST come BEFORE text in the content array, matching
+        // HuggingFace's apply_chat_template output for Qwen2.5-VL which emits
+        // <|vision_start|><|image_pad|><|vision_end|>{text}. Putting text first
+        // shifts image-token positions and skews MROPE position IDs, producing
+        // a deterministic ~9 px bbox offset vs the Python mlx-vlm reference.
         [
             "role": message.role.rawValue,
-            "content": [
-                ["type": "text", "text": message.content]
-            ]
-                // Messages format for Qwen 2 VL, Qwen 2.5 VL. May need to be adapted for other models.
-                + message.images.map { _ in
-                    ["type": "image"]
-                }
-                + message.videos.map { _ in
-                    ["type": "video"]
-                },
+            "content":
+                message.images.map { _ in ["type": "image"] }
+                + message.videos.map { _ in ["type": "video"] }
+                + [["type": "text", "text": message.content]],
         ]
     }
 }

--- a/Tests/MLXLMTests/UserInputTests.swift
+++ b/Tests/MLXLMTests/UserInputTests.swift
@@ -241,11 +241,11 @@ public class UserInputTests: XCTestCase {
                 "role": "user",
                 "content": [
                     [
-                        "type": "text",
-                        "text": "What is this?",
+                        "type": "image"
                     ],
                     [
-                        "type": "image"
+                        "type": "text",
+                        "text": "What is this?",
                     ],
                 ],
             ],


### PR DESCRIPTION
Splits one fix out of #222 per @vade's earlier suggestion.

Qwen2VLMessageGenerator emitted content as `[text, image]`, but HuggingFace's `apply_chat_template` for Qwen2.5-VL emits `<|vision_start|><|image_pad|><|vision_end|>{text}` — image content first. Swapping the order removes a deterministic +9 / +8 / +5 px bbox-coordinate offset on left/top/bottom edges vs the Python `mlx-vlm` 0.4.3 reference.

**Effect on three canonical test images** (Qwen2.5-VL-7B-4bit, temperature=0):

| Image | Before (text-first) | After (image-first) | Python reference |
|---|---|---|---|
| LeetCode A (3078×2114 → 1260×868) | Q [10,154,421,631] / E [421,154,881,631] | Q [1,146,421,628] / E [421,146,881,628] | Q [1,146,421,626] / E [421,146,881,626] |
| LeetCode B (3600×2338 → 1260×812) | (drift) | Q [24,161,352,556] / E [364,161,749,556] | identical (0 px) |
| Layout test (3600×2338 → 1260×812) | (drift) | Q [106,24,1091,536] / E [16,556,464,794] | identical (0 px) |

After the fix: ≤2 px on every edge of every panel, bit-exact (0 px) on 2 of 3 images.

Reproducer (clones upstream, applies a complete patch, builds with xcodebuild, runs a strict ≤2 px gate against saved Python references — aborts loudly on any edge >2 px on any image): https://github.com/NivDvir/screen-overlay-toolkit/tree/main/scripts/parity

Diff: 1 file (`Qwen2VL.swift`), 1 function (`Qwen2VLMessageGenerator.generate`), +9/-10.