### PR TITLE
Qwen2/2.5-VL: default to the model card's recommended image budget

### DIFF
--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -151,8 +151,18 @@ public struct UserInput {
 
         public var audio = AudioProcessing()
 
-        public init(resize: CGSize? = nil) {
+        /// Optional per-call overrides for the image resize budget. When set,
+        /// they replace the model's configured `min_pixels` / `max_pixels` for
+        /// this request; when `nil` the model configuration is used. This lets
+        /// a caller request the resolution a model was tuned for without
+        /// hard-coding pixel counts in the processor.
+        public var minPixels: Int?
+        public var maxPixels: Int?
+
+        public init(resize: CGSize? = nil, minPixels: Int? = nil, maxPixels: Int? = nil) {
             self.resize = resize
+            self.minPixels = minPixels
+            self.maxPixels = maxPixels
         }
     }
 

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -798,10 +798,15 @@ public struct Qwen25VLProcessor: UserInputProcessor {
 
         // image_processing_qwen2_vl._preprocess
         let size = images[0].extent.size
+        let factor = config.patchSize * config.mergeSize
+        // Qwen2.5-VL ships a very large max_pixels; default to the budget the
+        // model card recommends (1280 * 28 * 28), override-able via `processing`.
+        let maxPixels = processing?.maxPixels ?? min(config.size.maxPixels, 1280 * factor * factor)
         let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
             height: Int(size.height), width: Int(size.width),
-            factor: config.patchSize * config.mergeSize,
-            minPixels: config.size.minPixels, maxPixels: config.size.maxPixels)
+            factor: factor,
+            minPixels: processing?.minPixels ?? config.size.minPixels,
+            maxPixels: maxPixels)
         let resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
 
         let processedImages =

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -540,12 +540,16 @@ public struct Qwen2VLProcessor: UserInputProcessor {
         let images = images.map { MediaProcessing.apply($0, processing: processing) }
 
         // image_processing_qwen2_vl._preprocess
-
         let size = images[0].extent.size
+        let factor = config.patchSize * config.mergeSize
+        // Default to the image budget the model card recommends
+        // (1280 * 28 * 28), override-able via `processing`.
+        let maxPixels = processing?.maxPixels ?? min(config.maxPixels, 1280 * factor * factor)
         let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
             height: Int(size.height), width: Int(size.width),
-            factor: config.patchSize * config.mergeSize,
-            minPixels: config.minPixels, maxPixels: config.maxPixels)
+            factor: factor,
+            minPixels: processing?.minPixels ?? config.minPixels,
+            maxPixels: maxPixels)
         let resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
 
         let processedImages = images.map { image in

--- a/Tests/MLXLMTests/QwenImageBudgetTests.swift
+++ b/Tests/MLXLMTests/QwenImageBudgetTests.swift
@@ -1,0 +1,39 @@
+// Copyright © 2024 Apple Inc.
+
+import XCTest
+
+@testable import MLXVLM
+
+/// The Qwen processors resize to the image budget the model card recommends
+/// (`1280 * 28 * 28`), override-able per request via `UserInput.Processing`.
+/// Both feed `QwenVL.targetSize`, so this exercises the budget: the recommended
+/// cap must produce a smaller, factor-aligned grid than the config's large
+/// `max_pixels`, and never exceed the budget.
+final class QwenImageBudgetTests: XCTestCase {
+
+    func testMaxPixelsBudgetShrinksGrid() throws {
+        let factor = 28  // patchSize (14) * mergeSize (2)
+        let (w, h) = (2000, 1500)
+
+        // Model default (Qwen2.5-VL ships max_pixels = 12,845,056).
+        let large = try QwenVL.targetSize(
+            height: h, width: w, factor: factor,
+            minPixels: 256 * 28 * 28, maxPixels: 12_845_056)
+        XCTAssertEqual(large.0, 1512)
+        XCTAssertEqual(large.1, 1988)
+
+        // Caller-supplied recommended budget (the override path).
+        let capped = try QwenVL.targetSize(
+            height: h, width: w, factor: factor,
+            minPixels: 256 * 28 * 28, maxPixels: 1280 * 28 * 28)
+        XCTAssertEqual(capped.0, 840)
+        XCTAssertEqual(capped.1, 1148)
+
+        // The override shrinks the grid, stays within budget, and both
+        // dimensions remain multiples of the patch factor.
+        XCTAssertLessThan(capped.0 * capped.1, large.0 * large.1)
+        XCTAssertLessThanOrEqual(capped.0 * capped.1, 1280 * 28 * 28)
+        XCTAssertEqual(capped.0 % factor, 0)
+        XCTAssertEqual(capped.1 % factor, 0)
+    }
+}


### PR DESCRIPTION
Qwen2.5-VL's `preprocessor_config.json` ships `max_pixels = 12,845,056` — about 12× the `1280*28*28` budget its model card recommends for image tasks. Grounding is noticeably sharper at the documented size, so this defaults there. Callers can still set any budget via `UserInput.Processing.minPixels` / `maxPixels`. ([#1175](https://github.com/Blaizzy/mlx-vlm/issues/1175) tracked the same finding for the Python side.)