### PR TITLE
Make Gemma 4 ScaledLinear quantizable

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -160,7 +160,14 @@ private class RMSNormNoScale: Module {
     }
 }
 
-private class ScaledLinear: Module {
+/// `Linear`-equivalent that scales the matmul output by a fixed scalar.
+///
+/// Conforms to `Quantizable` so `nn.quantize(model:)` can swap it for a
+/// `QuantizedScaledLinear` at load time. Without this, a quantized Gemma 4
+/// `per_layer_model_projection` checkpoint (where the weight is stored in
+/// packed `[N, K/8]` uint32 form) would fail the load with a shape mismatch
+/// against the dequantized `[N, K]` shape declared here.
+private class ScaledLinear: Module, Quantizable {
     let weight: MLXArray
     let scalar: Float
 
@@ -170,8 +177,50 @@ private class ScaledLinear: Module {
         super.init()
     }
 
+    /// Subclass entry point — used by `QuantizedScaledLinear`.
+    fileprivate init(weight: MLXArray, scalar: Float) {
+        self.weight = weight
+        self.scalar = scalar
+        super.init()
+    }
+
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         matmul(x, weight.T) * scalar
+    }
+
+    func toQuantized(groupSize: Int, bits: Int, mode: QuantizationMode) -> Module {
+        QuantizedScaledLinear(self, groupSize: groupSize, bits: bits, mode: mode)
+    }
+}
+
+/// Quantized counterpart of `ScaledLinear`. Same `output * scalar` shape,
+/// but the matmul runs against a quantized weight via `quantizedMM`.
+private class QuantizedScaledLinear: ScaledLinear, Quantized {
+    let groupSize: Int
+    let bits: Int
+    let mode: QuantizationMode
+    let scales: MLXArray
+    let biases: MLXArray?
+
+    init(_ other: ScaledLinear, groupSize: Int, bits: Int, mode: QuantizationMode) {
+        self.groupSize = groupSize
+        self.bits = bits
+        self.mode = mode
+        let (qw, scales, biases) = MLX.quantized(
+            other.weight, groupSize: groupSize, bits: bits, mode: mode)
+        self.scales = scales
+        self.biases = biases
+        super.init(weight: qw, scalar: other.scalar)
+        freeze()
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let y = MLX.quantizedMM(
+            x, weight,
+            scales: scales, biases: biases,
+            transpose: true,
+            groupSize: groupSize, bits: bits, mode: mode)
+        return y * scalar
     }
 }
 


### PR DESCRIPTION
## Summary

`Gemma4Text.ScaledLinear` (the inner `Linear`-equivalent that multiplies the matmul output by a fixed scalar — used by `per_layer_model_projection`) had no quantization-aware loading path. This PR makes it conform to `Quantizable` and adds a `QuantizedScaledLinear` counterpart, mirroring the existing `Linear` → `QuantizedLinear` pattern in `MLXNN`.

## Problem

Every quantized Gemma 4 Text checkpoint in the wild fails Swift load with a shape mismatch:

```
Mismatched parameter model.per_layer_model_projection.weight in
Gemma4TextModel.Gemma4TextModelInner.ScaledLinear shape.
Actual [N, K/8], expected [N, K]
```

(numbers are E2B; same shape pattern applies to E4B / 26B / 31B)

The packed `(N, K/8)` uint32 shape from a 4-bit-quantized `Linear` is being compared against the dequantized `(N, K)` shape that `ScaledLinear` declares. Because `ScaledLinear` was a plain `Module` wrapping a raw `MLXArray`, `nn.quantize(model:)` had no hook to substitute a quantized variant — so the load fails.

This affects:

- Every `mlx-community/Gemma4-*-Text-int4` (and `-int8` etc.) release
- Any user-quantized fine-tune produced by `mlx_lm.fuse` + `mlx_lm.convert --q-bits N`
- Any future quantized Gemma 4 Text checkpoint

## Fix

`ScaledLinear` now conforms to `Quantizable`. `nn.quantize` swaps it for `QuantizedScaledLinear` at load time, which runs the matmul through `quantizedMM` with the packed weight + scales + biases and applies the fixed scalar to the output:

```swift
private class ScaledLinear: Module, Quantizable {
    // ... unchanged storage + non-quantized callAsFunction ...

    func toQuantized(groupSize: Int, bits: Int, mode: QuantizationMode) -> Module {
        QuantizedScaledLinear(self, groupSize: groupSize, bits: bits, mode: mode)
    }
}

private class QuantizedScaledLinear: ScaledLinear, Quantized {
    let groupSize: Int
    let bits: Int
    let mode: QuantizationMode
    let scales: MLXArray
    let biases: MLXArray?

    init(_ other: ScaledLinear, groupSize: Int, bits: Int, mode: QuantizationMode) {
        // ... store metadata, run MLX.quantized on other.weight, super.init ...
    }

    override func callAsFunction(_ x: MLXArray) -> MLXArray {
        let y = MLX.quantizedMM(x, weight, scales: scales, biases: biases,
                                transpose: true,
                                groupSize: groupSize, bits: bits, mode: mode)
        return y * scalar
    }
}
```

Pattern is identical to `Linear` → `QuantizedLinear` in `mlx-swift/Source/MLXNN/Linear.swift` and `Quantized.swift`. `QuantizedScaledLinear` subclasses `ScaledLinear` so the `@ModuleInfo` typed property `perLayerModelProjection: ScaledLinear?` continues to type-check after `nn.quantize` swaps the instance.

No checkpoint key changes — `model.per_layer_model_projection.{weight,scales,biases}` stay where they were.

## Companion fix

Filed alongside [ml-explore/mlx-lm#1209](https://github.com/ml-explore/mlx-lm/pull/1209) (one-line, low-risk) which skips quantizing this layer when generating new checkpoints from the Python side. The two fixes are complementary: this one rescues every checkpoint already in the wild; the Python one keeps newly converted checkpoints loadable on Swift even on older mlx-swift-lm releases.

## Test plan

- [x] `swift build --target MLXLLM` clean
- [x] `swift test --filter Gemma4` — existing Gemma 4 chat-conversion tests pass
- [ ] (manual) Load a quantized Gemma 4 Text checkpoint via `LLMModelFactory.shared.loadContainer` and confirm it now succeeds where it previously raised the shape mismatch above
- [ ] (manual) Confirm a non-quantized Gemma 4 Text checkpoint still loads (no regression on the unquantized path)

## Repro of the original bug (for reviewers)

```swift
import MLXLLM
import MLXLMCommon
import MLXHuggingFace

let model = try await LLMModelFactory.shared.loadContainer(
    from: #hubDownloader(),
    using: #huggingFaceTokenizerLoader(),
    configuration: ModelConfiguration(id: "mlx-community/Gemma4-E2B-IT-Text-int4")
)
// before this PR: throws "Mismatched parameter ... ScaledLinear shape"
// after this PR: loads successfully
```