### PR TITLE
fix: Gemma4 attention_k_eq_v double transpose crashes KV cache

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -307,11 +307,13 @@ private class Gemma4Attention: Module {
             var v: MLXArray
             if let vProj {
                 v = vProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
+                v = vNorm(v)
+                v = v.transposed(0, 2, 1, 3)
             } else {
-                v = k
+                // k is already [B, nKV, L, HD] after transpose + RoPE;
+                // only apply vNorm, skip redundant transpose
+                v = vNorm(k)
             }
-            v = vNorm(v)
-            v = v.transposed(0, 2, 1, 3)
 
             if let cache {
                 let (updatedK, updatedV) = cache.update(keys: k, values: v)


### PR DESCRIPTION
## Summary

- Fixes a fatal crash (`mlx_slice_update` → `EXC_BREAKPOINT`) on all Gemma 4 models with `attention_k_eq_v: true` (gemma-4-31b-it-4bit, gemma-4-e2b-it-4bit, gemma-4-e4b-it-4bit)
- Root cause: when `vProj` is nil (keqv path), `v = k` copies the already-transposed key tensor `[B, nKV, L, HD]`, then `v.transposed(0, 2, 1, 3)` produces `[B, L, nKV, HD]` — a shape mismatch when `KVCacheSimple.update` writes both into identically-shaped cache slices
- Fix: apply `vNorm` directly to `k` and skip the redundant transpose in the keqv branch

## Reproduction

1. Load any Gemma 4 model with `attention_k_eq_v: true` in the HF config (e.g. `mlx-community/gemma-4-31b-it-4bit`)
2. Run inference (even a single token generation)
3. Crash in `KVCacheSimple.update` → `mlx_slice_update` → `_mlx_error` → `fatalError`

## Test plan

- [x] Verified fix on gemma-4-31b-it-4bit — inference runs without crash
- [ ] Existing tests should pass (no behavioral change for models without keqv)