### PR TITLE
Add tool-call id round-trip for OpenClaw / Hermes-style tool calling

### DIFF
--- a/Libraries/MLXLMCommon/Chat.swift
+++ b/Libraries/MLXLMCommon/Chat.swift
@@ -1,5 +1,7 @@
 // Copyright © 2025 Apple Inc.
 
+import Foundation
+
 public enum Chat {
     public struct Message {
         /// The role of the message sender.
@@ -14,14 +16,24 @@ public enum Chat {
         /// Array of video data associated with the message.
         public var videos: [UserInput.Video]
 
+        /// For `.tool` messages: the id of the tool call this message answers.
+        public var toolCallId: String?
+        
+        /// For `.assistant` messages: the tool calls this turn emitted.
+        public var toolCalls: [ToolCall]?
+        
         public init(
             role: Role, content: String, images: [UserInput.Image] = [],
-            videos: [UserInput.Video] = []
+            videos: [UserInput.Video] = [],
+            toolCallId: String? = nil,
+            toolCalls: [ToolCall]? = nil
         ) {
             self.role = role
             self.content = content
             self.images = images
             self.videos = videos
+            self.toolCallId = toolCallId
+            self.toolCalls = toolCalls
         }
 
         public static func system(
@@ -31,9 +43,9 @@ public enum Chat {
         }
 
         public static func assistant(
-            _ content: String, images: [UserInput.Image] = [], videos: [UserInput.Video] = []
+            _ content: String, images: [UserInput.Image] = [], videos: [UserInput.Video] = [], toolCalls: [ToolCall]? = nil
         ) -> Self {
-            Self(role: .assistant, content: content, images: images, videos: videos)
+            Self(role: .assistant, content: content, images: images, videos: videos, toolCalls: toolCalls)
         }
 
         public static func user(
@@ -42,8 +54,8 @@ public enum Chat {
             Self(role: .user, content: content, images: images, videos: videos)
         }
 
-        public static func tool(_ content: String) -> Self {
-            Self(role: .tool, content: content)
+        public static func tool(_ content: String, id: String? = nil) -> Self {
+            Self(role: .tool, content: content, toolCallId: id)
         }
 
         public enum Role: String, Sendable {
@@ -81,10 +93,27 @@ public protocol MessageGenerator: Sendable {
 extension MessageGenerator {
 
     public func generate(message: Chat.Message) -> Message {
-        [
+        var dict: Message = [
             "role": message.role.rawValue,
             "content": message.content,
         ]
+        if let id = message.toolCallId {
+            dict["tool_call_id"] = id
+        }
+        if let calls = message.toolCalls {
+            dict["tool_calls"] = calls.map { call -> [String: any Sendable] in
+                var entry: [String: any Sendable] = [
+                    "type": "function",
+                    "function": [
+                        "name": call.function.name,
+                        "arguments": call.function.arguments.mapValues { $0.sendableValue },
+                    ] as [String: any Sendable],
+                ]
+                if let id = call.id { entry["id"] = id }
+                return entry
+            }
+        }
+        return dict
     }
 
     public func generate(messages: [Chat.Message]) -> [Message] {
@@ -111,7 +140,7 @@ extension MessageGenerator {
 }
 
 /// Default implementation of ``MessageGenerator`` that produces a
-/// `role` and `content`.
+/// `role`, `content`, `tool_call_id`, and `tool_calls` using default implementation.
 ///
 /// ```swift
 /// [
@@ -121,13 +150,6 @@ extension MessageGenerator {
 /// ```
 public struct DefaultMessageGenerator: MessageGenerator {
     public init() {}
-
-    public func generate(message: Chat.Message) -> Message {
-        [
-            "role": message.role.rawValue,
-            "content": message.content,
-        ]
-    }
 }
 
 /// Implementation of ``MessageGenerator`` that produces a

--- a/Libraries/MLXLMCommon/Chat.swift
+++ b/Libraries/MLXLMCommon/Chat.swift
@@ -18,10 +18,10 @@ public enum Chat {
 
         /// For `.tool` messages: the id of the tool call this message answers.
         public var toolCallId: String?
-        
+
         /// For `.assistant` messages: the tool calls this turn emitted.
         public var toolCalls: [ToolCall]?
-        
+
         public init(
             role: Role, content: String, images: [UserInput.Image] = [],
             videos: [UserInput.Video] = [],
@@ -43,9 +43,12 @@ public enum Chat {
         }
 
         public static func assistant(
-            _ content: String, images: [UserInput.Image] = [], videos: [UserInput.Video] = [], toolCalls: [ToolCall]? = nil
+            _ content: String, images: [UserInput.Image] = [], videos: [UserInput.Video] = [],
+            toolCalls: [ToolCall]? = nil
         ) -> Self {
-            Self(role: .assistant, content: content, images: images, videos: videos, toolCalls: toolCalls)
+            Self(
+                role: .assistant, content: content, images: images, videos: videos,
+                toolCalls: toolCalls)
         }
 
         public static func user(

--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -21,12 +21,17 @@ public struct ToolCall: Hashable, Codable, Sendable {
             self.arguments = arguments.mapValues { JSONValue.from($0) }
         }
     }
-
+    
     /// The function to be called
     public let function: Function
+    
+    /// An optional id used to correlate tool calls with their corresponding
+    /// tool responses across multi-call turns.
+    public let id: String?
 
-    public init(function: Function) {
+    public init(function: Function, id: String? = nil) {
         self.function = function
+        self.id = id
     }
 }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -21,10 +21,10 @@ public struct ToolCall: Hashable, Codable, Sendable {
             self.arguments = arguments.mapValues { JSONValue.from($0) }
         }
     }
-    
+
     /// The function to be called
     public let function: Function
-    
+
     /// An optional id used to correlate tool calls with their corresponding
     /// tool responses across multi-call turns.
     public let id: String?

--- a/Libraries/MLXLMCommon/Tool/Value.swift
+++ b/Libraries/MLXLMCommon/Tool/Value.swift
@@ -128,7 +128,7 @@ public enum JSONValue: Hashable, Codable, Sendable {
             return ["type": "object", "properties": props]
         }
     }
-    
+
     /// Convert to a `Sendable`-typed value suitable for use in
     /// `[String: any Sendable]` dictionaries (e.g. ``Message``).
     public var sendableValue: any Sendable {

--- a/Libraries/MLXLMCommon/Tool/Value.swift
+++ b/Libraries/MLXLMCommon/Tool/Value.swift
@@ -128,4 +128,25 @@ public enum JSONValue: Hashable, Codable, Sendable {
             return ["type": "object", "properties": props]
         }
     }
+    
+    /// Convert to a `Sendable`-typed value suitable for use in
+    /// `[String: any Sendable]` dictionaries (e.g. ``Message``).
+    public var sendableValue: any Sendable {
+        switch self {
+        case .null:
+            return NSNull()
+        case .bool(let value):
+            return value
+        case .int(let value):
+            return value
+        case .double(let value):
+            return value
+        case .string(let value):
+            return value
+        case .array(let value):
+            return value.map { $0.sendableValue }
+        case .object(let value):
+            return value.mapValues { $0.sendableValue }
+        }
+    }
 }

--- a/Tests/MLXLMTests/ToolCallIdTests.swift
+++ b/Tests/MLXLMTests/ToolCallIdTests.swift
@@ -1,0 +1,99 @@
+//
+//  File.swift
+//  mlx-swift-lm
+//
+//  Created by Ronald Mannak on 4/28/26.
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+struct ToolCallIdTests {
+    @Test("Tool message round-trips tool_call_id through DefaultMessageGenerator")
+    func testToolMessageRoundTripsId() throws {
+        let generator = DefaultMessageGenerator()
+        let message = Chat.Message.tool("ok", id: "call_1")
+
+        let dict = generator.generate(message: message)
+
+        #expect(dict["role"] as? String == "tool")
+        #expect(dict["content"] as? String == "ok")
+        #expect(dict["tool_call_id"] as? String == "call_1")
+    }
+
+    @Test("Assistant message round-trips tool_calls through DefaultMessageGenerator")
+    func testAssistantMessageRoundTripsToolCalls() throws {
+        let tc1 = ToolCall(
+            function: .init(
+                name: "get_weather",
+                arguments: ["location": .string("Paris")]
+            ),
+            id: "call_a"
+        )
+        let tc2 = ToolCall(
+            function: .init(
+                name: "get_time",
+                arguments: ["timezone": .string("UTC")]
+            ),
+            id: "call_b"
+        )
+
+        let generator = DefaultMessageGenerator()
+        let message = Chat.Message.assistant("", toolCalls: [tc1, tc2])
+
+        let dict = generator.generate(message: message)
+
+        #expect(dict["role"] as? String == "assistant")
+
+        let calls = try #require(dict["tool_calls"] as? [[String: any Sendable]])
+        #expect(calls.count == 2)
+
+        let first = calls[0]
+        #expect(first["id"] as? String == "call_a")
+        #expect(first["type"] as? String == "function")
+        let firstFn = try #require(first["function"] as? [String: any Sendable])
+        #expect(firstFn["name"] as? String == "get_weather")
+        let firstArgs = try #require(firstFn["arguments"] as? [String: any Sendable])
+        #expect(firstArgs["location"] as? String == "Paris")
+
+        let second = calls[1]
+        #expect(second["id"] as? String == "call_b")
+        #expect(second["type"] as? String == "function")
+        let secondFn = try #require(second["function"] as? [String: any Sendable])
+        #expect(secondFn["name"] as? String == "get_time")
+        let secondArgs = try #require(secondFn["arguments"] as? [String: any Sendable])
+        #expect(secondArgs["timezone"] as? String == "UTC")
+    }
+
+    @Test("Plain user message does not emit tool_call_id or tool_calls keys")
+    func testPlainMessageDoesNotEmitToolKeys() throws {
+        let generator = DefaultMessageGenerator()
+        let message = Chat.Message.user("hi")
+
+        let dict = generator.generate(message: message)
+
+        #expect(dict["tool_call_id"] == nil)
+        #expect(dict["tool_calls"] == nil)
+    }
+
+    @Test("ToolCallProcessor leaves id nil when the parser does not provide one")
+    func testToolCallProcessorLeavesIdNil() throws {
+        let processor = ToolCallProcessor(format: .json)
+        let content = "<tool_call>{\"name\":\"x\",\"arguments\":{}}</tool_call>"
+
+        _ = processor.processChunk(content)
+        processor.processEOS()
+
+        #expect(processor.toolCalls.count == 1)
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "x")
+        #expect(toolCall.id == nil)
+    }
+
+    @Test("ToolCall initialized without id stays nil (source compatibility)")
+    func testToolCallDefaultIdIsNil() throws {
+        let tc = ToolCall(function: .init(name: "noop", arguments: [:]))
+        #expect(tc.id == nil)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Multi-turn tool calling needs each tool result to reference the call it answers. This PR adds an optional id end-to-end.

Calling application supplies its own id (e.g. a UUID) and threads it through `ToolCall(id:, function:)` and `Chat.Message.tool(_:id:)`. 

All new fields default to `nil` and all new initializer parameters have `nil` defaults to maintain compatibility.

Example:
```swift
// 1. Model generates a turn that ends in a tool call.
//    ToolCallProcessor parses it; today id is always nil because no parser
//    extracts one from model output.
let parsed = processor.toolCalls.first!
//   ToolCall(id: nil, function: .init(name: "get_weather",
//                                     arguments: ["location": .string("Paris")]))

// 2. App synthesizes a correlation id and runs the tool.
let callId = UUID().uuidString
let result = try await runTool(parsed.function)   // e.g. "{\"tempC\":18}"

// 3. Build the next turn. The id threads from the assistant echo
//    (tool_calls[*].id) to the tool result (tool_call_id), so the model
//    can match the result to the call.
let nextTurn: [Chat.Message] = [
    .assistant("", toolCalls: [
        ToolCall(function: parsed.function, id: callId)
    ]),
    .tool(result, id: callId),
]
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
