### PR TITLE
Fix Gemma4 attention crash when vProj is nil (attentionKeqV)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -307,11 +307,13 @@ private class Gemma4Attention: Module {
             var v: MLXArray
             if let vProj {
                 v = vProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
+                v = vNorm(v)
+                v = v.transposed(0, 2, 1, 3)
             } else {
-                v = k
+                // k is already transposed to (B, nKvHeads, L, head_dim);
+                // skip the second transpose to avoid reversing it.
+                v = vNorm(k)
             }
-            v = vNorm(v)
-            v = v.transposed(0, 2, 1, 3)
 
             if let cache {
                 let (updatedK, updatedV) = cache.update(keys: k, values: v)

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -280,11 +280,13 @@ private class Gemma4Attention: Module {
             var v: MLXArray
             if let vProj {
                 v = vProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
+                v = vNorm(v)
+                v = v.transposed(0, 2, 1, 3)
             } else {
-                v = k
+                // k is already transposed to (B, nKvHeads, L, head_dim);
+                // skip the second transpose to avoid reversing it.
+                v = vNorm(k)
             }
-            v = vNorm(v)
-            v = v.transposed(0, 2, 1, 3)
 
             if let cache {
                 let (updatedK, updatedV) = cache.update(keys: k, values: v)


### PR DESCRIPTION
## Bug

`Gemma4Attention.callAsFunction` crashes in `broadcast_shapes` when running models that share K and V (`attentionKeqV: true`, `vProj` nil). Reproduces reliably with [`mlx-community/gemma-4-31b-it-4bit`](https://huggingface.co/mlx-community/gemma-4-31b-it-4bit).

## Cause

`k` is transposed to `(B, nKvHeads, L, head_dim)` earlier in the method. In the `vProj == nil` branch the code did:

```swift
v = k
// ...
v = vNorm(v)
v = v.transposed(0, 2, 1, 3)
```

That second transpose reversed `k`'s layout back to `(B, L, nKvHeads, head_dim)`, which doesn't match the shape the attention call expects, producing the `broadcast_shapes` fatal error.

## Fix

Move `vNorm` + transpose into the `vProj` branch (where `v` actually starts as `(B, L, nKvHeads, effectiveHeadDim)` and needs both), and in the nil-`vProj` branch apply `vNorm` directly to the already-transposed `k`.

The `vProj` branch is behaviorally unchanged.

## Verification

- Tested locally with `gemma-4-31b-it-4bit` — generation runs without crashing.
- Models that have a separate `v_proj` (e.g. `gemma-4-e2b/e4b`) hit the unchanged branch and continue to work.