### PR TITLE
Optimize Gemma 4 text decode: compile-fused RMSNorm-add and gelu-mul (+23.8%)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -9,6 +9,33 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+// MARK: - Compiled fusion fragments
+//
+// Gemma 4 uses a single rms_norm_eps (1e-6) for every RMSNorm in the model
+// (see Gemma4TextConfiguration.rmsNormEps default — all upstream Gemma 4
+// weights ship with this value). Hardcoding lets one compiled graph serve
+// every layer without per-layer specialization.
+//
+// Mirrors the upstream mlx-lm Python optimization
+// (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/gemma4_text.py)
+// which fuses (residual + RMSNorm(x) * weight) and gelu(g) * other into a
+// single compiled graph. Measured ~+2.4% decode tps on M4 Max for
+// gemma-4-e2b-it-4bit at batch=1.
+
+private let kRMSEps: Float = 1e-6
+
+private let _addRMSNorm: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { residual, x, weight in
+    residual + MLXFast.rmsNorm(x, weight: weight, eps: kRMSEps)
+}
+
+private let _geluMul: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { gate, other in
+    geluApproximate(gate) * other
+}
+
 // MARK: - Configuration
 
 public struct Gemma4TextConfiguration: Codable, Sendable {
@@ -417,14 +444,14 @@ private class Gemma4DecoderLayer: Module {
         let h = inputLayernorm(x)
         let (attnOut, kvPair, attnPositionOffset) = selfAttn(
             h, mask: mask, cache: cache, sharedKV: sharedKV, positionOffset: positionOffset)
-        let postAttn = postAttentionLayernorm(attnOut)
-        var out = residual + postAttn
+        // Fused: residual + RMSNorm(attnOut) * weight
+        var out = _addRMSNorm(residual, attnOut, postAttentionLayernorm.weight)
 
         let residual2 = out
         out = preFeedforwardLayernorm(out)
         out = mlp(out)
-        out = postFeedforwardLayernorm(out)
-        out = residual2 + out
+        // Fused: residual + RMSNorm(out) * weight
+        out = _addRMSNorm(residual2, out, postFeedforwardLayernorm.weight)
 
         // PLE gating
         if let gate = perLayerInputGate,
@@ -434,11 +461,11 @@ private class Gemma4DecoderLayer: Module {
         {
             let residual3 = out
             var g = gate(out)
-            g = geluApproximate(g)
-            g = g * perLayerInput
+            // Fused: gelu_approx(g) * perLayerInput
+            g = _geluMul(g, perLayerInput)
             g = proj(g)
-            g = norm(g)
-            out = residual3 + g
+            // Fused: residual + RMSNorm(g) * weight
+            out = _addRMSNorm(residual3, g, norm.weight)
         }
 
         out = out * layerScalar

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -11,16 +11,21 @@ import MLXNN
 
 // MARK: - Compiled fusion fragments
 //
-// Gemma 4 uses a single rms_norm_eps (1e-6) for every RMSNorm in the model
-// (see Gemma4TextConfiguration.rmsNormEps default — all upstream Gemma 4
-// weights ship with this value). Hardcoding lets one compiled graph serve
-// every layer without per-layer specialization.
+// Gemma 4 ships with a single rms_norm_eps (1e-6) on every RMSNorm in the
+// model (see Gemma4TextConfiguration.rmsNormEps default — all upstream
+// Gemma 4 weights use this value). Hardcoding the constant lets one compiled
+// graph serve every layer without per-layer specialization. `Gemma4DecoderLayer.init`
+// asserts the config matches so a future checkpoint with a different eps fails
+// loudly instead of silently using the wrong value.
 //
 // Mirrors the upstream mlx-lm Python optimization
 // (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/gemma4_text.py)
 // which fuses (residual + RMSNorm(x) * weight) and gelu(g) * other into a
-// single compiled graph. Measured ~+2.4% decode tps on M4 Max for
-// gemma-4-e2b-it-4bit at batch=1.
+// single compiled graph. The Python equivalent measured ~+2.4% decode tps on
+// M4 Max for gemma-4-e2b-it-4bit at batch=1; the Swift gain is larger
+// (~+23.8% on the same model and hardware) because Swift's per-op MLX
+// dispatch has more overhead, so consolidating ops via compile() recovers
+// more of that overhead. See PR description for the per-trial numbers.
 
 private let kRMSEps: Float = 1e-6
 
@@ -400,6 +405,14 @@ private class Gemma4DecoderLayer: Module {
     @ModuleInfo(key: "layer_scalar") var layerScalar: MLXArray
 
     init(_ config: Gemma4TextConfiguration, layerIdx: Int) {
+        // _addRMSNorm bakes kRMSEps into its compiled graph. Catch a future
+        // checkpoint that ships a different rms_norm_eps before it reaches
+        // the fused path with the wrong constant.
+        precondition(
+            config.rmsNormEps == kRMSEps,
+            "Gemma4 fused decode path requires rmsNormEps == \(kRMSEps), got \(config.rmsNormEps)"
+        )
+
         self.config = config
         self.layerIdx = layerIdx
         self.layerType = config.layerTypes[layerIdx]

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -9,6 +9,33 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+// MARK: - Compiled fusion fragments
+//
+// Gemma 4 uses a single rms_norm_eps (1e-6) for every RMSNorm in the model
+// (see Gemma4TextConfiguration.rmsNormEps default — all upstream Gemma 4
+// weights ship with this value). Hardcoding lets one compiled graph serve
+// every layer without per-layer specialization.
+//
+// Mirrors the upstream mlx-lm Python optimization
+// (https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/gemma4_text.py)
+// which fuses (residual + RMSNorm(x) * weight) and gelu(g) * other into a
+// single compiled graph. Measured ~+2.4% decode tps on M4 Max for
+// gemma-4-e2b-it-4bit at batch=1.
+
+private let kRMSEps: Float = 1e-6
+
+private let _addRMSNorm: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { residual, x, weight in
+    residual + MLXFast.rmsNorm(x, weight: weight, eps: kRMSEps)
+}
+
+private let _geluMul: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { gate, other in
+    geluApproximate(gate) * other
+}
+
 // MARK: - Configuration
 
 public struct Gemma4TextConfiguration: Codable, Sendable {
@@ -442,14 +469,14 @@ private class Gemma4DecoderLayer: Module {
         let h = inputLayernorm(x)
         let (attnOut, kvPair, attnPositionOffset) = selfAttn(
             h, mask: mask, cache: cache, sharedKV: sharedKV, positionOffset: positionOffset)
-        let postAttn = postAttentionLayernorm(attnOut)
-        var out = residual + postAttn
+        // Fused: residual + RMSNorm(attnOut) * weight
+        var out = _addRMSNorm(residual, attnOut, postAttentionLayernorm.weight)
 
         let residual2 = out
         out = preFeedforwardLayernorm(out)
         out = mlp(out)
-        out = postFeedforwardLayernorm(out)
-        out = residual2 + out
+        // Fused: residual + RMSNorm(out) * weight
+        out = _addRMSNorm(residual2, out, postFeedforwardLayernorm.weight)
 
         // PLE gating
         if let gate = perLayerInputGate,
@@ -459,11 +486,11 @@ private class Gemma4DecoderLayer: Module {
         {
             let residual3 = out
             var g = gate(out)
-            g = geluApproximate(g)
-            g = g * perLayerInput
+            // Fused: gelu_approx(g) * perLayerInput
+            g = _geluMul(g, perLayerInput)
             g = proj(g)
-            g = norm(g)
-            out = residual3 + g
+            // Fused: residual + RMSNorm(g) * weight
+            out = _addRMSNorm(residual3, g, norm.weight)
         }
 
         out = out * layerScalar


### PR DESCRIPTION
## Summary

Fuse three small graph fragments in `Gemma4DecoderLayer` into `compile()` helpers so each compiled graph spans `add+norm` or `gelu+mul` instead of emitting them as separate ops:

- Post-attention residual: `residual + RMSNorm(attnOut)`
- Post-MLP residual: `residual + RMSNorm(out)`
- PLE gating: `gelu_approx(g) * perLayerInput`, `residual + RMSNorm(g)`

The eps is hardcoded to `1e-6` to keep the compiled graph shapeless and single-instance. Every shipping Gemma 4 weight uses this value (it is the `Gemma4TextConfiguration.rmsNormEps` default).

## Numerical equivalence

`compile()` preserves graph semantics; fusion is a scheduling-level optimization, no algebraic rewrite. Output values should be bit-identical to the previous code path. Greedy output parity verified by visual inspection across all benchmark trials.

## Benchmark

Apple M4 Max (128 GB), `mlx-community/gemma-4-e2b-it-4bit`, prompt 183 tok, decode 64 tok, temperature 0, seed 42. Eight in-process trials per branch using `llm-tool` with a local `--repeat 8` flag. Trial 1 dropped as warm-up (compile lazy phase / Metal pipeline build).

Decode throughput, trials 2-8 (tok/s):

| | trials 2-8 (sorted) | median |
|---|---|---:|
| `main` | 48.2, 48.7, 50.5, 51.2, 55.4, 58.0, 59.1 | **51.2** |
| this PR | 51.9, 60.9, 61.7, 63.4, 63.8, 65.0, 66.4 | **63.4** |

→ **+23.8% decode throughput**

Prefill is unchanged (~1300-1500 tok/s in both branches), as expected — the fusions live on the per-token decode path.

The Python equivalent of these fusions on `mlx-lm` measures +2.4% on the same hardware/model. The Swift gain is larger because Swift's per-op MLX dispatch has more overhead than Python's, so consolidating ops via `compile()` recovers more of that overhead.

## Test plan

- [x] `swift build --target MLXLLM` passes (358/358, no warnings).
- [x] Decode tps measured on M4 Max as above.
- [x] Greedy output parity verified.
- [ ] Reviewers running `gemma-4-e2b-it-4bit` or `gemma-4-e4b-it-4bit` should observe similar relative speedups.