### PR TITLE
Fix Gemma 4 text K-eq-V attention: don't double-process v from already-transposed k (#231)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -300,16 +300,22 @@ private class Gemma4Attention: Module {
             values = sharedV
         } else {
             var k = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
-            k = kNorm(k)
-            k = k.transposed(0, 2, 1, 3)
-            k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
 
+            // K-eq-V (attention_k_eq_v=true): values come from the raw k_proj
+            // output, BEFORE k_norm and the (B, H, L, D) transpose / RoPE.
+            // v_norm is then applied to that raw k_proj output, matching the
+            // Python reference (mlx_lm/models/gemma4_text.py).
             var v: MLXArray
             if let vProj {
                 v = vProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             } else {
                 v = k
             }
+
+            k = kNorm(k)
+            k = k.transposed(0, 2, 1, 3)
+            k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
+
             v = vNorm(v)
             v = v.transposed(0, 2, 1, 3)
 

--- a/Tests/MLXLMTests/Gemma4KeqVTests.swift
+++ b/Tests/MLXLMTests/Gemma4KeqVTests.swift
@@ -1,0 +1,80 @@
+// Copyright © 2026 Apple Inc.
+//
+// Verifies the #231 fix: Gemma 4 Text attention with `attention_k_eq_v=true`
+// must produce keys and values with matching shapes. Pre-fix the code took
+// `v = k` AFTER `k_norm` + transpose + RoPE had been applied to k, then ran
+// v through its own `vNorm` + transpose, so values ended up in
+// `(B, L, H, D)` while keys were in `(B, H, L, D)` — `scaledDotProductAttention`
+// crashes with `broadcast_shapes (B, H, L, D) vs (B, L, H, D)`.
+
+import Foundation
+import MLX
+@testable import MLXLLM
+import MLXLMCommon
+import XCTest
+
+final class Gemma4KeqVTests: XCTestCase {
+
+    /// Build a tiny Gemma 4 Text config (1 layer, hidden_size=64) with
+    /// `attention_k_eq_v: true`. Defaults handle every other field.
+    private func makeConfig() throws -> Gemma4TextConfiguration {
+        let json = """
+            {
+                "model_type": "gemma4_text",
+                "hidden_size": 64,
+                "num_hidden_layers": 1,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "head_dim": 16,
+                "global_head_dim": 32,
+                "num_key_value_heads": 2,
+                "vocab_size": 64,
+                "vocab_size_per_layer_input": 64,
+                "hidden_size_per_layer_input": 16,
+                "num_kv_shared_layers": 0,
+                "sliding_window": 16,
+                "sliding_window_pattern": 2,
+                "max_position_embeddings": 128,
+                "tie_word_embeddings": true,
+                "use_double_wide_mlp": true,
+                "attention_k_eq_v": true,
+                "layer_types": ["full_attention"]
+            }
+            """
+        return try JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// The bug manifested as a `broadcast_shapes` fatal during the very first
+    /// forward pass when `attention_k_eq_v=true`. A successful forward + a
+    /// non-NaN logits output is sufficient evidence the k / v shapes now
+    /// agree.
+    func testForwardWithKeqV() throws {
+        let config = try makeConfig()
+        let model = Gemma4TextModel(config)
+
+        // Single-token batch decode — this is the path that crashed.
+        let input = MLXArray([Int32(1)], [1, 1])
+        let logits = model(input, cache: nil)
+
+        XCTAssertEqual(logits.dim(0), 1)
+        XCTAssertEqual(logits.dim(1), 1)
+        XCTAssertEqual(logits.dim(2), config.vocabSize)
+        // Sanity: forward returned without crashing — k/v shapes are now
+        // consistent under `attention_k_eq_v=true`.
+        XCTAssertEqual(logits.ndim, 3)
+    }
+
+    /// Same forward at sequence length > 1 (prefill path). The shape mismatch
+    /// also fired here.
+    func testPrefillWithKeqV() throws {
+        let config = try makeConfig()
+        let model = Gemma4TextModel(config)
+
+        let input = MLXArray([Int32](1...8), [1, 8])
+        let logits = model(input, cache: nil)
+
+        XCTAssertEqual(logits.dim(1), 8)
+        XCTAssertEqual(logits.dim(2), config.vocabSize)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #231.

When \`attention_k_eq_v: true\` (used by \`mlx-community/gemma-4-26b-a4b-it-4bit\` and \`mlx-community/gemma-4-31b-it-4bit\`), \`v_proj\` is omitted and values are sourced from the raw \`k_proj\` output. The previous code took \`v = k\` *after* \`k_norm\`, the \`(B, H, L, D)\` transpose, and RoPE had already been applied to \`k\`, then re-applied \`v_norm\` and another transpose. The result was that \`keys\` ended up as \`(B, H, L, D)\` while \`values\` ended up as \`(B, L, H, D)\`, which \`scaledDotProductAttention\` cannot broadcast:

\`\`\`
Fatal error: [broadcast_shapes] Shapes (B, H, L, D) and (B, L, H, D) cannot be broadcast.
\`\`\`

The fix moves \`v = k\` to before \`k_norm\` / transpose / RoPE so v's subsequent \`vNorm\` + transpose lands it in \`(B, H, L, D)\` to match keys, matching the upstream Python (\`mlx_lm/models/gemma4_text.py\`).

## Verification (M4 Max)

\`Tests/MLXLMTests/Gemma4KeqVTests.swift\` builds a tiny Gemma 4 Text model (1 layer, hidden_size=64, head_dim=16) with \`attention_k_eq_v: true\` and runs a forward pass at both T=1 (decode) and T=8 (prefill) — the two paths the broadcast crash fired in.

\`\`\`
Test Case 'testForwardWithKeqV' passed (0.021 seconds)
Test Case 'testPrefillWithKeqV' passed (0.002 seconds)
\`\`\`

Pre-fix, both tests fatal-error inside the first \`scaledDotProductAttention\` call. The tests use random-init weights (no checkpoint download needed) since the bug is purely a shape mismatch.

Run via:

\`\`\`bash
xcodebuild test -scheme mlx-swift-lm-Package \\
  -destination 'platform=macOS,arch=arm64' \\
  -only-testing:MLXLMTests/Gemma4KeqVTests \\
  -skipMacroValidation
\`\`\`

## Test plan

- [x] \`swift build\` clean.
- [x] Two regression tests pin the k / v shape contract under \`attention_k_eq_v=true\` for both decode and prefill.
- [ ] Reviewers running \`mlx-community/gemma-4-26b-a4b-it-4bit\` or \`mlx-community/gemma-4-31b-it-4bit\` should no longer crash with \`broadcast_shapes\` and should produce greedy output matching the Python \`mlx-lm\` reference.