### PR TITLE
TokenRing: flatten 2D prompts before measuring length (#220)

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -334,19 +334,24 @@ struct TokenRing {
 
     /// Bulk-load from a prompt. Keeps the last `capacity` tokens.
     mutating func loadPrompt(_ prompt: MLXArray) {
-        let n = prompt.dim(0)
-        let promptTokens = prompt.asType(.int32)
+        // Flatten first so 2D `(B, L)` prompts are treated as length `L` rather
+        // than `B`. Without this, 2D prompts (which is the standard shape from
+        // `*Processor.prepare`) underflow capacity, leaving `buffer` shaped
+        // `(L,)` instead of `(capacity,)` and breaking `append()`'s
+        // mask broadcast.
+        let promptTokens = prompt.asType(.int32).reshaped(-1)
+        let n = promptTokens.dim(0)
         if n <= capacity {
             if n < capacity {
                 let padding = MLXArray.zeros([capacity - n], type: Int32.self)
-                buffer = concatenated([promptTokens.reshaped(-1), padding])
+                buffer = concatenated([promptTokens, padding])
             } else {
-                buffer = promptTokens.reshaped(-1)
+                buffer = promptTokens
             }
             count = n
             writeIndex = n % capacity
         } else {
-            buffer = promptTokens[(-capacity)...].reshaped(-1)
+            buffer = promptTokens[(-capacity)...]
             count = capacity
             writeIndex = 0
         }

--- a/Tests/MLXLMTests/TokenRingTests.swift
+++ b/Tests/MLXLMTests/TokenRingTests.swift
@@ -1,0 +1,67 @@
+// Copyright © 2026 Apple Inc.
+//
+// Verifies the #220 fix: `TokenRing.loadPrompt` must measure prompt length
+// after flattening. Prompts coming from `*Processor.prepare` are typically
+// shaped `(1, L)`; pre-fix the ring used `dim(0) == 1` as the length and
+// `append` then crashed on a broadcast mismatch.
+
+import MLX
+import MLXLMCommon
+import XCTest
+
+final class TokenRingTests: XCTestCase {
+
+    /// 2D `(1, L)` prompt longer than the context window must (a) load
+    /// without crashing and (b) leave the next `didSample()` working.
+    func test2DPromptLongerThanContextDoesNotCrash() {
+        var ctx = RepetitionContext(repetitionPenalty: 1.1, repetitionContextSize: 64)
+        // (1, 1009) — the exact shape range #220 reports.
+        let promptTokens = (0 ..< 1009).map { Int32($0 % 1000) }
+        let prompt = MLXArray(promptTokens, [1, 1009])
+
+        // Pre-fix: this call set the ring's internal `count = 1` while
+        // resizing buffer to length 1009 — internally inconsistent state
+        // that would manifest later.
+        ctx.prompt(prompt)
+
+        // Pre-fix: the next `didSample` triggers `MLX.where(positions, token,
+        // buffer)` where positions is shaped (64,) and buffer is shaped
+        // (1009,) → broadcast crash.
+        let nextToken = MLXArray(Int32(42))
+        ctx.didSample(token: nextToken)
+
+        // Process must produce a logits array of the same shape as input.
+        let logits = MLXArray.zeros([1, 32_000], type: Float.self)
+        let processed = ctx.process(logits: logits)
+        XCTAssertEqual(processed.shape, logits.shape)
+    }
+
+    /// 1D prompt path (the only shape that worked pre-fix) still works —
+    /// regression guard.
+    func test1DPromptStillWorks() {
+        var ctx = RepetitionContext(repetitionPenalty: 1.1, repetitionContextSize: 64)
+        let promptTokens = (0 ..< 200).map { Int32($0) }
+        let prompt = MLXArray(promptTokens)
+
+        ctx.prompt(prompt)
+        ctx.didSample(token: MLXArray(Int32(7)))
+
+        let logits = MLXArray.zeros([1, 32_000], type: Float.self)
+        let processed = ctx.process(logits: logits)
+        XCTAssertEqual(processed.shape, logits.shape)
+    }
+
+    /// 2D prompt SHORTER than the context window must also load cleanly.
+    func test2DPromptShorterThanContextDoesNotCrash() {
+        var ctx = RepetitionContext(repetitionPenalty: 1.1, repetitionContextSize: 64)
+        let promptTokens = (0 ..< 32).map { Int32($0) }
+        let prompt = MLXArray(promptTokens, [1, 32])
+
+        ctx.prompt(prompt)
+        ctx.didSample(token: MLXArray(Int32(7)))
+
+        let logits = MLXArray.zeros([1, 32_000], type: Float.self)
+        let processed = ctx.process(logits: logits)
+        XCTAssertEqual(processed.shape, logits.shape)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #220.

\`TokenRing.loadPrompt\` measured prompt length with \`prompt.dim(0)\`, which returns the batch dimension for a 2D \`(1, L)\` tensor — the standard shape that comes out of every \`*Processor.prepare\` implementation. As a result the ring buffer was sized to length \`L\` (via \`reshaped(-1)\`) while \`count\` was set to \`1\`, producing internally inconsistent state that crashed the next \`append()\`:

\`\`\`
Fatal error: [broadcast_shapes] Shapes (64) and (1009) cannot be broadcast.
\`\`\`

The fix flattens before measuring length so 2D and 1D prompts are treated identically.

## Verification (M4 Max)

\`Tests/MLXLMTests/TokenRingTests.swift\` exercises the path through the public \`RepetitionContext\` (which wraps \`TokenRing\`):

| test | input | pre-fix | post-fix |
|---|---|---|---|
| \`test2DPromptLongerThanContextDoesNotCrash\` | \`(1, 1009)\`, ctx=64 | \`broadcast_shapes\` fatal | passes |
| \`test2DPromptShorterThanContextDoesNotCrash\` | \`(1, 32)\`, ctx=64 | inconsistent state | passes |
| \`test1DPromptStillWorks\` | \`(200,)\`, ctx=64 | already worked | regression guard |

\`\`\`
Test Case 'test1DPromptStillWorks' passed (0.021 seconds)
Test Case 'test2DPromptLongerThanContextDoesNotCrash' passed (0.001 seconds)
Test Case 'test2DPromptShorterThanContextDoesNotCrash' passed (0.001 seconds)
\`\`\`

Run via:

\`\`\`bash
xcodebuild test -scheme mlx-swift-lm-Package \\
  -destination 'platform=macOS,arch=arm64' \\
  -only-testing:MLXLMTests/TokenRingTests \\
  -skipMacroValidation
\`\`\`

## Test plan

- [x] \`swift build\` clean.
- [x] Three regression tests pin the 2D-prompt contract on \`RepetitionContext\` (which is the path #220 reports).
- [ ] Reviewers running a 1000+ token prompt with \`repetitionPenalty: 1.1\`, \`repetitionContextSize: 64\` should no longer crash.