### PR TITLE
JSONToolCallParser: accept stringified `arguments` field (#169, Granite 4)

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -2,6 +2,48 @@
 
 import Foundation
 
+/// Wire-side decoder that accepts both shapes the upstream models emit:
+///   * arguments as a nested object: `{"name":"f","arguments":{"k":"v"}}`
+///   * arguments as a JSON-encoded string (Granite 4 etc.):
+///     `{"name":"f","arguments":"{\"k\":\"v\"}"}`
+private struct WireFunction: Decodable {
+    let name: String
+    let arguments: [String: JSONValue]
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case arguments
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try c.decode(String.self, forKey: .name)
+
+        if c.contains(.arguments) {
+            if let nested = try? c.decode([String: JSONValue].self, forKey: .arguments) {
+                self.arguments = nested
+            } else if let stringified = try? c.decode(String.self, forKey: .arguments) {
+                guard let data = stringified.data(using: .utf8),
+                    let nested = try? JSONDecoder().decode(
+                        [String: JSONValue].self, from: data)
+                else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .arguments, in: c,
+                        debugDescription:
+                            "arguments is a String but does not contain a JSON object")
+                }
+                self.arguments = nested
+            } else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .arguments, in: c,
+                    debugDescription: "arguments must be an object or a JSON-encoded string")
+            }
+        } else {
+            self.arguments = [:]
+        }
+    }
+}
+
 /// Parser for JSON format: <tag>{"name": "...", "arguments": {...}}</tag>
 /// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/default.py
 public struct JSONToolCallParser: ToolCallParser, Sendable {
@@ -30,9 +72,10 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
         let jsonStr = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard let data = jsonStr.data(using: .utf8),
-            let function = try? JSONDecoder().decode(ToolCall.Function.self, from: data)
+            let wire = try? JSONDecoder().decode(WireFunction.self, from: data)
         else { return nil }
 
-        return ToolCall(function: function)
+        return ToolCall(
+            function: ToolCall.Function(name: wire.name, arguments: wire.arguments))
     }
 }

--- a/Tests/MLXLMTests/JSONToolCallParserTests.swift
+++ b/Tests/MLXLMTests/JSONToolCallParserTests.swift
@@ -1,0 +1,76 @@
+// Copyright © 2026 Apple Inc.
+//
+// Verifies the #169 fix: JSONToolCallParser must accept the
+// `{"arguments":"{\"k\":\"v\"}"}` shape that Granite 4 (and others) emit,
+// in addition to the standard nested-object form.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+struct JSONToolCallParserTests {
+
+    private let parser = JSONToolCallParser(
+        startTag: "<tool_call>",
+        endTag: "</tool_call>")
+
+    private func stringValue(_ v: JSONValue?) -> String? {
+        if case let .string(s) = v { return s }
+        return nil
+    }
+
+    @Test("Parses nested object arguments (standard shape)")
+    func nestedObjectArguments() throws {
+        let raw = """
+            <tool_call>{"name": "get_weather", "arguments": {"city": "Tokyo", "unit": "c"}}</tool_call>
+            """
+        let call = try #require(parser.parse(content: raw, tools: nil))
+        #expect(call.function.name == "get_weather")
+        #expect(stringValue(call.function.arguments["city"]) == "Tokyo")
+        #expect(stringValue(call.function.arguments["unit"]) == "c")
+    }
+
+    @Test("Parses JSON-encoded string arguments (Granite 4 shape, #169)")
+    func stringifiedArguments() throws {
+        // The arguments field is a JSON-encoded string of the inner object.
+        // Pre-fix this returned nil (parse failed) and the tool call was
+        // silently dropped.
+        let raw = """
+            <tool_call>{"name": "get_weather", "arguments": "{\\"city\\": \\"Tokyo\\", \\"unit\\": \\"c\\"}"}</tool_call>
+            """
+        let call = try #require(parser.parse(content: raw, tools: nil))
+        #expect(call.function.name == "get_weather")
+        #expect(stringValue(call.function.arguments["city"]) == "Tokyo")
+        #expect(stringValue(call.function.arguments["unit"]) == "c")
+    }
+
+    @Test("Empty object arguments are preserved")
+    func emptyArguments() throws {
+        let raw = """
+            <tool_call>{"name": "ping", "arguments": {}}</tool_call>
+            """
+        let call = try #require(parser.parse(content: raw, tools: nil))
+        #expect(call.function.name == "ping")
+        #expect(call.function.arguments.isEmpty)
+    }
+
+    @Test("Empty stringified arguments are also preserved")
+    func emptyStringifiedArguments() throws {
+        let raw = """
+            <tool_call>{"name": "ping", "arguments": "{}"}</tool_call>
+            """
+        let call = try #require(parser.parse(content: raw, tools: nil))
+        #expect(call.function.name == "ping")
+        #expect(call.function.arguments.isEmpty)
+    }
+
+    @Test("Malformed stringified arguments returns nil instead of crashing")
+    func malformedStringifiedArguments() {
+        let raw = """
+            <tool_call>{"name": "ping", "arguments": "not-json"}</tool_call>
+            """
+        // The parser should fail gracefully on a malformed stringified blob;
+        // the wire function decode throws and parse returns nil.
+        #expect(parser.parse(content: raw, tools: nil) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #169.

The IBM Granite 4 family (and others) emit tool calls with the \`arguments\` field as a JSON-encoded *string* rather than a nested object:

\`\`\`
{"name": "func", "arguments": "{\\"key\\": \\"value\\"}"}
\`\`\`

\`JSONDecoder().decode(ToolCall.Function.self, ...)\` requires \`arguments\` to be a nested \`{...}\`, so the parse silently returned \`nil\` and tool calls never reached the user.

This PR adds a private \`WireFunction\` decoder that accepts either shape:

- nested JSON object → use directly
- JSON-encoded string → re-decode the string contents as \`[String: JSONValue]\`

Models that already emit nested objects (Llama 3, Qwen, etc.) keep the original behavior. Empty \`{}\` arguments are preserved. Mirrors the flexibility of the Python \`mlx-lm\` default tool parser. Credit to @neon52 for the analysis and proposed fix in #169.

## Verification (M4 Max)

\`Tests/MLXLMTests/JSONToolCallParserTests.swift\` covers the five interesting shapes:

| test | input arguments shape | expected |
|---|---|---|
| \`nestedObjectArguments\` | nested \`{...}\` (standard) | parses (regression guard) |
| \`stringifiedArguments\` | JSON-encoded string (#169 / Granite 4) | parses (the fix) |
| \`emptyArguments\` | \`{}\` | preserves empty dict |
| \`emptyStringifiedArguments\` | \`"{}"\` | preserves empty dict |
| \`malformedStringifiedArguments\` | \`"not-json"\` | fails gracefully (returns \`nil\`, no crash) |

\`\`\`
✔ Test "Parses nested object arguments (standard shape)" passed (0.016s)
✔ Test "Parses JSON-encoded string arguments (Granite 4 shape, #169)" passed (0.016s)
✔ Test "Empty object arguments are preserved" passed (0.001s)
✔ Test "Empty stringified arguments are also preserved" passed (0.001s)
✔ Test "Malformed stringified arguments returns nil instead of crashing" passed (0.016s)
\`\`\`

Run via:

\`\`\`bash
xcodebuild test -scheme mlx-swift-lm-Package \\
  -destination 'platform=macOS,arch=arm64' \\
  -only-testing:MLXLMTests/JSONToolCallParserTests \\
  -skipMacroValidation
\`\`\`

## Test plan

- [x] \`swift build --target MLXLMCommon\` passes (no warnings).
- [x] Five regression tests pin both shapes plus the malformed input failure mode.
- [ ] Reviewers running \`mlx-community/granite-4.0-h-micro-4bit\` with tools enabled should see tool calls parsed instead of silently dropped.