### PR TITLE
Fix UserInput init not setting self.images / self.videos (#182)

### DIFF
--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -202,6 +202,9 @@ public struct UserInput {
         self.prompt = .chat([
             .user(prompt, images: images, videos: videos)
         ])
+        // note: prompt.didSet is not triggered in init
+        self.images = images
+        self.videos = videos
         self.tools = tools
         self.additionalContext = additionalContext
     }
@@ -317,12 +320,18 @@ public struct UserInput {
         tools: [ToolSpec]? = nil, additionalContext: [String: any Sendable]? = nil
     ) {
         self.prompt = prompt
+        // note: prompt.didSet is not triggered in init
         switch prompt {
         case .text, .messages:
             self.images = images
             self.videos = videos
-        case .chat:
-            break
+        case .chat(let messages):
+            self.images = messages.reduce(into: []) { result, message in
+                result.append(contentsOf: message.images)
+            }
+            self.videos = messages.reduce(into: []) { result, message in
+                result.append(contentsOf: message.videos)
+            }
         }
         self.processing = processing
         self.tools = tools

--- a/Tests/MLXLMTests/UserInputTests.swift
+++ b/Tests/MLXLMTests/UserInputTests.swift
@@ -294,4 +294,52 @@ public class UserInputTests: XCTestCase {
         assertEqual(expected, messages)
     }
 
+    // MARK: - Init self.images / self.videos sync (#182)
+
+    public func testInitFromPromptStringPopulatesImages() throws {
+        // Reproducer for #182: a `.chat` prompt is built from the parameters
+        // but `prompt.didSet` does not fire during init, so `self.images`
+        // used to stay empty.
+        let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+        let placeholder = CIImage(
+            color: CIColor(red: 0.5, green: 0.5, blue: 0.5, colorSpace: cs)!
+        ).cropped(to: CGRect(x: 0, y: 0, width: 4, height: 4))
+
+        let input = UserInput(
+            prompt: "What is in this image?",
+            images: [.ciImage(placeholder)])
+        XCTAssertEqual(
+            input.images.count, 1,
+            "UserInput(prompt:images:) must surface the images parameter on self.images")
+        XCTAssertEqual(input.videos.count, 0)
+    }
+
+    public func testInitFromPromptEnumPopulatesImagesForChat() throws {
+        // The `init(prompt: Prompt, images:, videos:, ...)` overload also had
+        // `case .chat: break` and dropped the images parameter on the floor.
+        // After the fix it derives images from the chat messages instead.
+        let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+        let placeholder = CIImage(
+            color: CIColor(red: 0.5, green: 0.5, blue: 0.5, colorSpace: cs)!
+        ).cropped(to: CGRect(x: 0, y: 0, width: 4, height: 4))
+
+        let chat: [Chat.Message] = [
+            .user("describe", images: [.ciImage(placeholder)])
+        ]
+        let input = UserInput(prompt: .chat(chat))
+        XCTAssertEqual(
+            input.images.count, 1,
+            "UserInput(prompt:.chat) must derive self.images from the chat messages")
+    }
+
+    public func testInitFromPromptStringPopulatesVideos() throws {
+        // Same bug, video edition.
+        let videoURL = URL(fileURLWithPath: "/tmp/nonexistent.mp4")
+        let input = UserInput(
+            prompt: "describe this video",
+            videos: [.url(videoURL)])
+        XCTAssertEqual(input.videos.count, 1)
+        XCTAssertEqual(input.images.count, 0)
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #182.

\`UserInput.prompt\`'s \`didSet\` rebuilds \`self.images\` / \`self.videos\` from chat messages, but property observers do not fire during initialization. Two of the inits left those properties empty as a result:

- \`init(prompt: String, images:, videos:, tools:, additionalContext:)\` built a \`.chat([.user(...)])\` prompt from its parameters but never copied the arguments into \`self.images\` / \`self.videos\`.
- \`init(prompt: Prompt, images:, videos:, ...)\` had \`case .chat: break\`, dropping the parameters entirely.

Both inits now mirror what \`init(chat:processing:tools:additionalContext:)\` already does — extract images and videos from the chat messages (or use the explicit parameters for non-chat prompts).

## Verification (M4 Max)

\`Tests/MLXLMTests/UserInputTests.swift\` gains three regression tests:

| test | exercises | pre-fix | post-fix |
|---|---|---|---|
| \`testInitFromPromptStringPopulatesImages\` | \`init(prompt: String, images: [.ciImage])\` | \`images.count == 0\` ❌ | \`images.count == 1\` ✅ |
| \`testInitFromPromptEnumPopulatesImagesForChat\` | \`init(prompt: .chat([.user(images:)]))\` | \`images.count == 0\` ❌ | \`images.count == 1\` ✅ |
| \`testInitFromPromptStringPopulatesVideos\` | \`init(prompt: String, videos: [.url])\` | \`videos.count == 0\` ❌ | \`videos.count == 1\` ✅ |

\`\`\`
Test Case 'testInitFromPromptEnumPopulatesImagesForChat' passed (0.002 seconds)
Test Case 'testInitFromPromptStringPopulatesImages' passed (0.001 seconds)
Test Case 'testInitFromPromptStringPopulatesVideos' passed (0.001 seconds)
\`\`\`

Run via:

\`\`\`bash
xcodebuild test -scheme mlx-swift-lm-Package \\
  -destination 'platform=macOS,arch=arm64' \\
  -only-testing:MLXLMTests/UserInputTests \\
  -skipMacroValidation
\`\`\`

## Test plan

- [x] \`swift build\` clean.
- [x] Three regression tests in \`UserInputTests\` pin the property-sync contract for both inits.