### PR TITLE
Fix Qwen35 VLM sanitize for bare 'model.*' weight keys (#143)

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1095,6 +1095,11 @@ public class Qwen35: Module, VLMModel {
                         of: "model.language_model", with: "language_model.model")
                 } else if key.contains("model.visual") {
                     key = key.replacingOccurrences(of: "model.visual", with: "vision_tower")
+                } else if key.hasPrefix("model.") {
+                    // Unified Qwen 3.5 checkpoints (e.g. Qwen3.5-0.8B-MLX-4bit) ship
+                    // language model tensors at bare `model.*` paths instead of
+                    // `model.language_model.*`. Mirror the LLM-side fallback.
+                    key = "language_model." + key
                 }
             } else if key.contains("lm_head") {
                 key = key.replacingOccurrences(of: "lm_head", with: "language_model.lm_head")

--- a/Tests/MLXLMTests/Qwen35SanitizeTests.swift
+++ b/Tests/MLXLMTests/Qwen35SanitizeTests.swift
@@ -1,0 +1,105 @@
+// Copyright © 2026 Apple Inc.
+//
+// Verifies the #143 fix: Qwen35 VLM sanitize must remap bare `model.*`
+// weight keys to `language_model.model.*`. Pre-fix the keys fell through
+// unchanged and `language_model` lost its tensors at load time.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import XCTest
+
+final class Qwen35SanitizeTests: XCTestCase {
+
+    private func makeMinimalConfig() throws -> Qwen35Configuration {
+        // Minimum-viable config with small dims so module init stays cheap.
+        // Only the fields without defaults need values; everything else
+        // falls back to the public defaults (which we never exercise in the
+        // sanitize-only test).
+        let json = """
+            {
+                "model_type": "qwen3_5_moe_vl",
+                "text_config": {
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "linear_num_value_heads": 1,
+                    "linear_num_key_heads": 1,
+                    "linear_key_head_dim": 8,
+                    "linear_value_head_dim": 8,
+                    "linear_conv_kernel_dim": 4,
+                    "vocab_size": 32,
+                    "full_attention_interval": 2,
+                    "num_experts": 0,
+                    "num_experts_per_tok": 0
+                },
+                "vision_config": {
+                    "model_type": "qwen3_5_moe_vl",
+                    "depth": 1,
+                    "hidden_size": 8,
+                    "intermediate_size": 16,
+                    "out_hidden_size": 8,
+                    "num_heads": 1,
+                    "patch_size": 16,
+                    "spatial_merge_size": 1,
+                    "temporal_patch_size": 1,
+                    "num_position_embeddings": 8
+                }
+            }
+            """
+        return try JSONDecoder().decode(
+            Qwen35Configuration.self, from: Data(json.utf8))
+    }
+
+    /// Pre-fix, weights with `model.*` paths (no `language_model` prefix and
+    /// no `visual` prefix) fell through `sanitize` unchanged, so the
+    /// `language_model` submodule received no weights and load failed with
+    /// `keyNotFound`.
+    func testBareModelKeysAreRemapped() throws {
+        let config = try makeMinimalConfig()
+        let model = Qwen35(config)
+
+        // 2D dummy avoids tripping vision-side sanitize transposes for any
+        // weights that flow through the Qwen3VL vision model's sanitize at
+        // the end of Qwen35.sanitize — only language-side keys are tested.
+        let dummy = MLXArray.zeros([1, 1])
+        let weights: [String: MLXArray] = [
+            // Path that issue #143 calls out: bare `model.layers.*`.
+            "model.layers.0.mlp.up_proj.weight": dummy,
+            "model.layers.0.self_attn.q_proj.weight": dummy,
+            "model.embed_tokens.weight": dummy,
+            "model.norm.weight": dummy,
+            // Already-namespaced path — verify the existing rename branch
+            // still fires.
+            "model.language_model.layers.0.mlp.up_proj.weight": dummy,
+            // Top-level path the existing logic remaps.
+            "lm_head.weight": dummy,
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        // Bare `model.*` keys are now under `language_model.model.*`.
+        XCTAssertNotNil(
+            sanitized["language_model.model.layers.0.mlp.up_proj.weight"],
+            "bare `model.layers.0.mlp.up_proj.weight` must be remapped")
+        XCTAssertNotNil(
+            sanitized["language_model.model.layers.0.self_attn.q_proj.weight"])
+        XCTAssertNotNil(sanitized["language_model.model.embed_tokens.weight"])
+        XCTAssertNotNil(sanitized["language_model.model.norm.weight"])
+
+        // The `lm_head` rename branch is preserved.
+        XCTAssertNotNil(sanitized["language_model.lm_head.weight"])
+
+        // None of the bare `model.*` keys remain in the sanitized dict.
+        for key in sanitized.keys {
+            XCTAssertFalse(
+                key.hasPrefix("model.layers.")
+                    || key == "model.embed_tokens.weight"
+                    || key == "model.norm.weight",
+                "bare model.* key leaked through sanitize: \(key)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #143. Maintainer green-light from @davidkoski in the issue thread.

The Qwen35 VLM-side \`sanitize\` only remaps \`model.language_model.*\` and \`model.visual.*\` keys. Unified Qwen 3.5 checkpoints (e.g. \`mlx-community/Qwen3.5-0.8B-MLX-4bit\`) ship the language-model tensors at bare \`model.*\` paths, mirroring the LLM-only checkpoints. With no fallback for that shape, the bare keys fall through unchanged and \`language_model\` ends up missing its weights, producing a \`keyNotFound\` failure at load time.

Add the same \`else if key.hasPrefix("model.")\` fallback that the Qwen35Text LLM path already uses, prepending \`language_model.\` so the tensors end up under the right submodule.

## Verification (M4 Max)

\`Tests/MLXLMTests/Qwen35SanitizeTests.swift\` builds a Qwen35 instance from a minimal Qwen3.5-shaped config and calls \`sanitize(weights:)\` with synthetic weights covering the four key shapes encountered in real checkpoints:

| input key | post-fix output key |
|---|---|
| \`model.layers.0.mlp.up_proj.weight\` | \`language_model.model.layers.0.mlp.up_proj.weight\` |
| \`model.layers.0.self_attn.q_proj.weight\` | \`language_model.model.layers.0.self_attn.q_proj.weight\` |
| \`model.embed_tokens.weight\` | \`language_model.model.embed_tokens.weight\` |
| \`model.norm.weight\` | \`language_model.model.norm.weight\` |
| \`model.language_model.layers.0.mlp.up_proj.weight\` (already-namespaced) | \`language_model.model.layers.0.mlp.up_proj.weight\` (existing branch) |
| \`lm_head.weight\` | \`language_model.lm_head.weight\` (existing branch) |

Pre-fix, the four bare \`model.*\` paths fell through unchanged; the test asserts both that they are now remapped and that no bare \`model.layers.*\` / \`model.embed_tokens.weight\` / \`model.norm.weight\` keys survive in the output.

\`\`\`
Test Case 'testBareModelKeysAreRemapped' passed (0.030 seconds)
\`\`\`

Run via:

\`\`\`bash
xcodebuild test -scheme mlx-swift-lm-Package \\
  -destination 'platform=macOS,arch=arm64' \\
  -only-testing:MLXLMTests/Qwen35SanitizeTests \\
  -skipMacroValidation
\`\`\`

## Test plan

- [x] \`swift build\` clean.
- [x] Unit test pins the rename contract for both the new bare-\`model.*\` branch and the pre-existing branches.
- [ ] Reviewers loading \`mlx-community/Qwen3.5-0.8B-MLX-4bit\` via \`VLMModelFactory\` should now succeed instead of throwing on missing \`language_model.model.layers.*\` keys.