### PR TITLE
Add continuous batching and Gemma 4 text support

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -36,6 +36,12 @@ public struct Gemma4TextConfiguration: Codable, Sendable {
     var layerTypes: [String] = []
     var tieWordEmbeddings: Bool = true
 
+    // MoE (only set on the 26B-A4B variant; 2B/4B/31B are dense)
+    var enableMoeBlock: Bool = false
+    var numExperts: Int?
+    var topKExperts: Int?
+    var moeIntermediateSize: Int?
+
     // RoPE parameters (nested dict with full_attention/sliding_attention sub-configs)
     var ropeParameters: [String: [String: StringOrNumber]]?
 
@@ -69,6 +75,10 @@ public struct Gemma4TextConfiguration: Codable, Sendable {
         case layerTypes = "layer_types"
         case tieWordEmbeddings = "tie_word_embeddings"
         case ropeParameters = "rope_parameters"
+        case enableMoeBlock = "enable_moe_block"
+        case numExperts = "num_experts"
+        case topKExperts = "top_k_experts"
+        case moeIntermediateSize = "moe_intermediate_size"
     }
 
     public init(from decoder: Decoder) throws {
@@ -130,6 +140,14 @@ public struct Gemma4TextConfiguration: Codable, Sendable {
         self.ropeParameters =
             try container.decodeIfPresent(
                 [String: [String: StringOrNumber]].self, forKey: .ropeParameters)
+
+        // MoE (Gemma 4 26B-A4B)
+        self.enableMoeBlock =
+            try container.decodeIfPresent(Bool.self, forKey: .enableMoeBlock) ?? false
+        self.numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts)
+        self.topKExperts = try container.decodeIfPresent(Int.self, forKey: .topKExperts)
+        self.moeIntermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .moeIntermediateSize)
 
         // Extract RoPE parameters from nested config
         if let ropeParams = ropeParameters {
@@ -299,16 +317,20 @@ private class Gemma4Attention: Module {
             keys = sharedK
             values = sharedV
         } else {
-            var k = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
-            k = kNorm(k)
+            let kRaw = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
+            var k = kNorm(kRaw)
             k = k.transposed(0, 2, 1, 3)
             k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
 
+            // K-eq-V (`attention_k_eq_v: true` on Gemma 4 26B/31B):
+            // values reuses the raw key projection (pre-norm), then goes
+            // through its own `vNorm` and transpose to land in the same
+            // `[B, n_kv_heads, L, D]` layout as keys.
             var v: MLXArray
             if let vProj {
                 v = vProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             } else {
-                v = k
+                v = kRaw
             }
             v = vNorm(v)
             v = v.transposed(0, 2, 1, 3)
@@ -346,6 +368,79 @@ private class Gemma4Attention: Module {
         .reshaped(B, L, -1)
 
         return (oProj(output), (keys, values), activePositionOffset)
+    }
+}
+
+// MARK: - MoE (26B-A4B)
+
+/// Expert router. Norms `x` with a learnable scale, projects to expert
+/// scores, and returns top-K (indices, weights) where weights are
+/// softmax-normalized and scaled by a per-expert scalar.
+private class Gemma4Router: Module {
+    @ModuleInfo(key: "proj") var proj: Linear
+    @ModuleInfo(key: "scale") var scale: MLXArray
+    @ModuleInfo(key: "per_expert_scale") var perExpertScale: MLXArray
+
+    let topK: Int
+    let eps: Float
+    let rootSize: Float
+
+    init(_ config: Gemma4TextConfiguration) {
+        precondition(
+            config.numExperts != nil && config.topKExperts != nil,
+            "Gemma4Router requires num_experts and top_k_experts in the config"
+        )
+        let numExperts = config.numExperts ?? 0
+        self.topK = config.topKExperts ?? 0
+        self.eps = config.rmsNormEps
+        self.rootSize = pow(Float(config.hiddenSize), -0.5)
+
+        self._proj.wrappedValue = Linear(config.hiddenSize, numExperts, bias: false)
+        self._scale.wrappedValue = MLXArray.ones([config.hiddenSize])
+        self._perExpertScale.wrappedValue = MLXArray.ones([numExperts])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (topKIndices: MLXArray, topKWeights: MLXArray) {
+        let normed = MLXFast.rmsNorm(x, weight: scale * rootSize, eps: eps)
+        let expertScores = proj(normed)
+
+        let kth = expertScores.dim(-1) - topK
+        var topKIndices = MLX.argPartition(expertScores, kth: kth, axis: -1)
+        topKIndices = topKIndices[.ellipsis, kth...]
+
+        var topKWeights = MLX.takeAlong(expertScores, topKIndices, axis: -1)
+        topKWeights = MLX.softmax(topKWeights, axis: -1, precise: true)
+        topKWeights = topKWeights * perExpertScale[topKIndices]
+
+        return (topKIndices, topKWeights)
+    }
+}
+
+/// Sparse MoE feed-forward block. Wraps `SwitchGLU` with GeGLU activation.
+private class Gemma4Experts: Module {
+    @ModuleInfo(key: "switch_glu") var switchGLU: SwitchGLU
+
+    init(_ config: Gemma4TextConfiguration) {
+        let numExperts = config.numExperts ?? 1
+        let moeIntermediate = config.moeIntermediateSize ?? config.intermediateSize
+
+        self._switchGLU.wrappedValue = SwitchGLU(
+            inputDims: config.hiddenSize,
+            hiddenDims: moeIntermediate,
+            numExperts: numExperts,
+            activation: { geluApproximate($0) },
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, topKIndices: MLXArray, topKWeights: MLXArray
+    ) -> MLXArray {
+        let w = MLX.expandedDimensions(topKWeights, axis: -1)
+        let y = switchGLU(x, topKIndices)
+        return (w * y).sum(axis: -2)
     }
 }
 
@@ -389,6 +484,13 @@ private class Gemma4DecoderLayer: Module {
     @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: RMSNorm
     @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: RMSNorm
 
+    // MoE-only modules (26B-A4B); nil on dense variants.
+    @ModuleInfo(key: "router") var router: Gemma4Router?
+    @ModuleInfo(key: "experts") var experts: Gemma4Experts?
+    @ModuleInfo(key: "post_feedforward_layernorm_1") var postFeedforwardLayernorm1: RMSNorm?
+    @ModuleInfo(key: "pre_feedforward_layernorm_2") var preFeedforwardLayernorm2: RMSNorm?
+    @ModuleInfo(key: "post_feedforward_layernorm_2") var postFeedforwardLayernorm2: RMSNorm?
+
     // Per-layer input (PLE) gating
     @ModuleInfo(key: "per_layer_input_gate") var perLayerInputGate: Linear?
     @ModuleInfo(key: "per_layer_projection") var perLayerProjection: Linear?
@@ -397,11 +499,14 @@ private class Gemma4DecoderLayer: Module {
     // Per-layer scalar
     @ModuleInfo(key: "layer_scalar") var layerScalar: MLXArray
 
+    let isMoE: Bool
+
     init(_ config: Gemma4TextConfiguration, layerIdx: Int) {
         self.config = config
         self.layerIdx = layerIdx
         self.layerType = config.layerTypes[layerIdx]
         self.hiddenSizePerLayerInput = config.hiddenSizePerLayerInput
+        self.isMoE = config.enableMoeBlock
 
         self._selfAttn.wrappedValue = Gemma4Attention(config, layerIdx: layerIdx)
         self._mlp.wrappedValue = Gemma4MLP(config, layerIdx: layerIdx)
@@ -414,6 +519,17 @@ private class Gemma4DecoderLayer: Module {
             dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._postFeedforwardLayernorm.wrappedValue = RMSNorm(
             dimensions: config.hiddenSize, eps: config.rmsNormEps)
+
+        if config.enableMoeBlock {
+            self._router.wrappedValue = Gemma4Router(config)
+            self._experts.wrappedValue = Gemma4Experts(config)
+            self._postFeedforwardLayernorm1.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.rmsNormEps)
+            self._preFeedforwardLayernorm2.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.rmsNormEps)
+            self._postFeedforwardLayernorm2.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        }
 
         if hiddenSizePerLayerInput > 0 {
             self._perLayerInputGate.wrappedValue = Linear(
@@ -446,8 +562,30 @@ private class Gemma4DecoderLayer: Module {
         var out = residual + postAttn
 
         let residual2 = out
-        out = preFeedforwardLayernorm(out)
-        out = mlp(out)
+
+        if isMoE,
+            let router,
+            let experts,
+            let postFeedforwardLayernorm1,
+            let preFeedforwardLayernorm2,
+            let postFeedforwardLayernorm2
+        {
+            // Dense + sparse branches in parallel, summed into one residual.
+            var h1 = preFeedforwardLayernorm(out)
+            h1 = mlp(h1)
+            h1 = postFeedforwardLayernorm1(h1)
+
+            let (topKIndices, topKWeights) = router(out)
+            var h2 = preFeedforwardLayernorm2(out)
+            h2 = experts(h2, topKIndices: topKIndices, topKWeights: topKWeights)
+            h2 = postFeedforwardLayernorm2(h2)
+
+            out = h1 + h2
+        } else {
+            out = preFeedforwardLayernorm(out)
+            out = mlp(out)
+        }
+
         out = postFeedforwardLayernorm(out)
         out = residual2 + out
 
@@ -666,7 +804,7 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         var sanitized = [String: MLXArray]()
         for (k, v) in weights {
-            // Skip vision/audio/rotary weights
+            // Skip vision/audio/rotary/quantization-range weights.
             if k.contains("self_attn.rotary_emb")
                 || k.contains("input_max")
                 || k.contains("input_min")
@@ -675,6 +813,25 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
             {
                 continue
             }
+
+            // 26B-A4B checkpoints ship the experts as a fused
+            // `gate_up_proj` (concatenated along axis -2) plus a separate
+            // `down_proj`. SwitchGLU expects three separate
+            // `switch_glu.{gate,up,down}_proj.weight` tensors.
+            if k.hasSuffix(".experts.gate_up_proj") {
+                let base = String(k.dropLast(".gate_up_proj".count))
+                let parts = MLX.split(v, parts: 2, axis: -2)
+                sanitized["\(base).switch_glu.gate_proj.weight"] = parts[0]
+                sanitized["\(base).switch_glu.up_proj.weight"] = parts[1]
+                continue
+            }
+
+            if k.hasSuffix(".experts.down_proj") {
+                let base = String(k.dropLast(".down_proj".count))
+                sanitized["\(base).switch_glu.down_proj.weight"] = v
+                continue
+            }
+
             sanitized[k] = v
         }
         return sanitized

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -231,16 +231,17 @@ private class Gemma4Attention: Module {
     let nHeads: Int
     let nKvHeads: Int
     let useKeqV: Bool
+    let usesSharedKV: Bool
     let scale: Float
 
     @ModuleInfo(key: "q_proj") var qProj: Linear
-    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear?
     @ModuleInfo(key: "v_proj") var vProj: Linear?
     @ModuleInfo(key: "o_proj") var oProj: Linear
 
     @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
-    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
-    @ModuleInfo(key: "v_norm") var vNorm: RMSNormNoScale
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm?
+    @ModuleInfo(key: "v_norm") var vNorm: RMSNormNoScale?
 
     @ModuleInfo var rope: RoPELayer
 
@@ -249,6 +250,8 @@ private class Gemma4Attention: Module {
         self.layerIdx = layerIdx
         self.layerType = config.layerTypes[layerIdx]
         self.isSliding = layerType == "sliding_attention"
+        let firstKvSharedLayerIdx = config.numHiddenLayers - config.numKvSharedLayers
+        self.usesSharedKV = layerIdx >= firstKvSharedLayerIdx && firstKvSharedLayerIdx > 0
 
         // Full attention uses globalHeadDim, sliding uses headDim
         self.effectiveHeadDim =
@@ -268,15 +271,17 @@ private class Gemma4Attention: Module {
         self.scale = 1.0
 
         self._qProj.wrappedValue = Linear(dim, nHeads * effectiveHeadDim, bias: false)
-        self._kProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
-        if !useKeqV {
-            self._vProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+        if !usesSharedKV {
+            self._kProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+            if !useKeqV {
+                self._vProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+            }
+            self._kNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
+            self._vNorm.wrappedValue = RMSNormNoScale(eps: config.rmsNormEps)
         }
         self._oProj.wrappedValue = Linear(nHeads * effectiveHeadDim, dim, bias: false)
 
         self._qNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
-        self._kNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
-        self._vNorm.wrappedValue = RMSNormNoScale(eps: config.rmsNormEps)
 
         // RoPE: sliding uses default, full uses proportional with partial rotation
         if isSliding {
@@ -317,6 +322,10 @@ private class Gemma4Attention: Module {
             keys = sharedK
             values = sharedV
         } else {
+            guard let kProj, let kNorm, let vNorm else {
+                preconditionFailure("Gemma4 shared-KV layers require sharedKV input")
+            }
+
             let kRaw = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             var k = kNorm(kRaw)
             k = k.transposed(0, 2, 1, 3)

--- a/Libraries/MLXLMCommon/BatchGenerator.swift
+++ b/Libraries/MLXLMCommon/BatchGenerator.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Eigen Labs.
-//
 // Port of mlx_lm.generate.BatchGenerator.
 // https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
 
@@ -84,13 +82,14 @@ public final class BatchGenerator: @unchecked Sendable {
             let uid = uidCounter
             uidCounter += 1
             assignedUids.append(uid)
-            unprocessed.append(QueuedRequest(
-                uid: uid,
-                tokens: prompts[i],
-                maxTokens: maxTokens?[i] ?? defaultMaxTokens,
-                sampler: samplers?[i],
-                stateMachine: stateMachines?[i] ?? defaultStateMachine
-            ))
+            unprocessed.append(
+                QueuedRequest(
+                    uid: uid,
+                    tokens: prompts[i],
+                    maxTokens: maxTokens?[i] ?? defaultMaxTokens,
+                    sampler: samplers?[i],
+                    stateMachine: stateMachines?[i] ?? defaultStateMachine
+                ))
         }
         return assignedUids
     }
@@ -191,8 +190,13 @@ public final class BatchGenerator: @unchecked Sendable {
             if layer is MambaCache {
                 return MambaCache(leftPadding: zeroLeftPadding)
             }
-            if layer is ArraysCache {
-                return ArraysCache(size: layer.state.count, leftPadding: zeroLeftPadding)
+            if let arrays = layer as? ArraysCache {
+                return ArraysCache(size: arrays.slotCount, leftPadding: zeroLeftPadding)
+            }
+            if let rotating = layer as? RotatingKVCache, let maxSize = rotating.maxSize {
+                let keep = Int(rotating.metaState.first ?? "0") ?? 0
+                precondition(keep == 0, "RotatingKVCache with keep tokens is not supported")
+                return BatchRotatingKVCache(maxSize: maxSize, leftPadding: zeroLeftPadding)
             }
             return BatchKVCache(leftPadding: zeroLeftPadding)
         }

--- a/Libraries/MLXLMCommon/BatchGenerator.swift
+++ b/Libraries/MLXLMCommon/BatchGenerator.swift
@@ -1,0 +1,208 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Port of mlx_lm.generate.BatchGenerator.
+// https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
+
+import Foundation
+import MLX
+
+/// Continuous-batching engine.
+///
+///   1. `insert(prompts:)` queues new requests and returns their UIDs.
+///   2. `next()` runs one engine step: drains the queue into prefill,
+///      runs one decode step, and emits per-row responses. Finished rows
+///      are filtered out and their slots become available for new
+///      admissions on the next call.
+///   3. `close()` releases resources.
+public final class BatchGenerator: @unchecked Sendable {
+
+    public let model: any LanguageModel
+    public let prefillStepSize: Int
+    public let prefillBatchSize: Int
+    public let completionBatchSize: Int
+    public let defaultMaxTokens: Int
+
+    public let defaultEosTokens: [[Int]]
+    public let defaultSampler: RowSampler
+    public let defaultStateMachine: SequenceStateMachine
+
+    private var uidCounter: Int = 0
+    private var unprocessed: [QueuedRequest] = []
+    private var promptBatch: PromptProcessingBatch
+    private var generationBatch: GenerationBatch?
+
+    public private(set) var promptTokensProcessed: Int = 0
+    public private(set) var generatedTokens: Int = 0
+
+    public init(
+        model: any LanguageModel,
+        eosTokens: [[Int]] = [],
+        defaultMaxTokens: Int = 128,
+        prefillStepSize: Int = 2048,
+        prefillBatchSize: Int = 8,
+        completionBatchSize: Int = 32
+    ) {
+        self.model = model
+        self.prefillStepSize = prefillStepSize
+        self.prefillBatchSize = prefillBatchSize
+        self.completionBatchSize = max(completionBatchSize, prefillBatchSize)
+        self.defaultMaxTokens = defaultMaxTokens
+        self.defaultEosTokens = eosTokens
+        self.defaultSampler = greedySampler
+
+        if eosTokens.isEmpty {
+            self.defaultStateMachine = SequenceStateMachine()
+        } else {
+            self.defaultStateMachine = SequenceStateMachine(
+                states: ["normal": eosTokens.map { (sequence: $0, next: nil) }],
+                initial: "normal"
+            )
+        }
+        self.promptBatch = PromptProcessingBatch.empty(
+            model: model,
+            prefillStepSize: prefillStepSize
+        )
+    }
+
+    /// Append a batch of prompts. Returns the assigned UIDs in input order.
+    @discardableResult
+    public func insert(
+        prompts: [[Int]],
+        maxTokens: [Int]? = nil,
+        samplers: [RowSampler?]? = nil,
+        stateMachines: [SequenceStateMachine]? = nil
+    ) -> [Int] {
+        precondition(
+            maxTokens == nil || maxTokens?.count == prompts.count,
+            "maxTokens.count must equal prompts.count"
+        )
+
+        var assignedUids: [Int] = []
+        assignedUids.reserveCapacity(prompts.count)
+
+        for i in 0 ..< prompts.count {
+            let uid = uidCounter
+            uidCounter += 1
+            assignedUids.append(uid)
+            unprocessed.append(QueuedRequest(
+                uid: uid,
+                tokens: prompts[i],
+                maxTokens: maxTokens?[i] ?? defaultMaxTokens,
+                sampler: samplers?[i],
+                stateMachine: stateMachines?[i] ?? defaultStateMachine
+            ))
+        }
+        return assignedUids
+    }
+
+    /// Run one engine step. Returns per-uid responses for the active rows;
+    /// rows that finished on this step have a non-nil `finishReason`.
+    ///
+    /// Looped to drain the queue:
+    /// `while gen.hasWork { for r in gen.next() { ... } }`
+    public func next() -> [GenerationBatchResponse] {
+        admitFromQueue()
+
+        if let gen = generationBatch, !gen.isEmpty {
+            let responses = gen.next()
+            generatedTokens += responses.count
+            if gen.isEmpty {
+                generationBatch = nil
+            }
+            return responses
+        }
+
+        if unprocessed.isEmpty {
+            return []
+        }
+
+        admitFromQueue(forceTransition: true)
+        return next()
+    }
+
+    public var hasWork: Bool {
+        !unprocessed.isEmpty
+            || (generationBatch?.isEmpty == false)
+            || !promptBatch.isEmpty
+    }
+
+    public var queuedCount: Int { unprocessed.count }
+    public var activeCount: Int { generationBatch?.batchSize ?? 0 }
+
+    public func close() {
+        unprocessed.removeAll()
+        generationBatch = nil
+        promptBatch = PromptProcessingBatch.empty(
+            model: model,
+            prefillStepSize: prefillStepSize
+        )
+    }
+
+    /// Admit up to `min(prefillBatchSize, free completion slots)` queued
+    /// requests, prefill them as a sub-batch, and merge them into the
+    /// running `GenerationBatch`.
+    private func admitFromQueue(forceTransition: Bool = false) {
+        let activeRunning = generationBatch?.batchSize ?? 0
+        var capacity = max(0, completionBatchSize - activeRunning)
+
+        if generationBatch == nil {
+            capacity = max(capacity, 1)
+        }
+        if capacity == 0 || unprocessed.isEmpty { return }
+
+        let admitCount = min(capacity, prefillBatchSize, unprocessed.count)
+        let batchSlice = Array(unprocessed.prefix(admitCount))
+        unprocessed.removeFirst(admitCount)
+
+        let promptCache = makeBatchedCache(batchSize: batchSlice.count)
+        let prompt = PromptProcessingBatch(
+            model: model,
+            uids: batchSlice.map { $0.uid },
+            promptCache: promptCache,
+            tokens: Array(repeating: [], count: batchSlice.count),
+            maxTokens: batchSlice.map { $0.maxTokens },
+            prefillStepSize: prefillStepSize,
+            samplers: batchSlice.map { $0.sampler },
+            fallbackSampler: defaultSampler,
+            stateMachines: batchSlice.map { $0.stateMachine }
+        )
+
+        let admittedGen = prompt.generate(
+            lastTokensOf: batchSlice.map { $0.tokens }
+        )
+        promptTokensProcessed += batchSlice.reduce(into: 0) { $0 += $1.tokens.count }
+
+        if let existing = generationBatch {
+            existing.extend(admittedGen)
+        } else if !admittedGen.isEmpty || forceTransition {
+            generationBatch = admittedGen
+        }
+    }
+
+    /// Allocate one batched cache per layer. The model's
+    /// `newCache(parameters:)` describes the per-layer cache topology
+    /// (`KVCacheSimple` / `RotatingKVCache` for full attention, `MambaCache`
+    /// or other `ArraysCache` subclasses for SSM-style layers); we build a
+    /// batched analog of each.
+    private func makeBatchedCache(batchSize B: Int) -> [any BatchedCache] {
+        let probe = model.newCache(parameters: nil)
+        let zeroLeftPadding = Array(repeating: 0, count: B)
+        return probe.map { layer -> any BatchedCache in
+            if layer is MambaCache {
+                return MambaCache(leftPadding: zeroLeftPadding)
+            }
+            if layer is ArraysCache {
+                return ArraysCache(size: layer.state.count, leftPadding: zeroLeftPadding)
+            }
+            return BatchKVCache(leftPadding: zeroLeftPadding)
+        }
+    }
+
+    private struct QueuedRequest: Sendable {
+        let uid: Int
+        let tokens: [Int]
+        let maxTokens: Int
+        let sampler: RowSampler?
+        let stateMachine: SequenceStateMachine
+    }
+}

--- a/Libraries/MLXLMCommon/BatchKVCache.swift
+++ b/Libraries/MLXLMCommon/BatchKVCache.swift
@@ -1,0 +1,480 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Port of mlx_lm.models.cache.BatchKVCache.
+// https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py
+
+import Foundation
+import MLX
+
+/// A `KVCache` that supports continuous-batching primitives (in-place row
+/// filtering and concatenation). Both `BatchKVCache` (for full-attention
+/// layers) and `ArraysCache` (for SSM-style layers like Qwen 3.5's
+/// GatedDeltaNet) conform.
+public protocol BatchedCache: KVCache {
+    /// In-place keep only the rows at the given batch indices.
+    func filterBatched(batchIndices: MLXArray)
+
+    /// In-place append `other`'s rows. The runtime types must match.
+    func extendBatched(_ other: any BatchedCache)
+}
+
+/// Continuous-batching KV cache.
+///
+/// Storage is right-justified along axis=2: for each row `b`, real keys
+/// live at `[..., leftPadding[b]..._idx, :]` and the leading `leftPadding[b]`
+/// slots are zero. Per-row position offsets are exposed via `batchOffset`
+/// for RoPE dispatch through `BatchPositionedKVCache`.
+///
+/// Not thread-safe; the `BatchGenerator` mutates this from a single task.
+public final class BatchKVCache: BaseKVCache, BatchPositionedKVCache, BatchedCache {
+
+    public func filterBatched(batchIndices: MLXArray) {
+        filter(batchIndices: batchIndices)
+    }
+
+    public func extendBatched(_ other: any BatchedCache) {
+        guard let other = other as? BatchKVCache else {
+            preconditionFailure("BatchKVCache.extendBatched requires another BatchKVCache")
+        }
+        extend(other)
+    }
+
+    /// Allocation chunk size along the time axis.
+    public static let allocationStep = 256
+
+    /// `[B, kvHeads, T, headDim]`, nil until the first `update`.
+    public private(set) var keys: MLXArray?
+
+    /// `[B, kvHeads, T, headValueDim]`, nil until the first `update`.
+    public private(set) var values: MLXArray?
+
+    /// Per-row position counter `[B]`. Starts at `-leftPadding[b]`; advances
+    /// by `keys.dim(2)` per `update`. Read by RoPE via `BatchPositionedKVCache`.
+    public private(set) var batchOffset: MLXArray
+
+    /// Per-row left padding `[B]`. Slots `[..., 0..<leftPadding[b], :]` are
+    /// zero and the mask blocks them.
+    public private(set) var leftPadding: MLXArray
+
+    /// Rightmost-valid slot. Shared scalar across rows because they're kept
+    /// right-aligned. Slots past `_idx` are pre-allocated capacity.
+    private var _idx: Int = 0
+
+    /// Right-padding applied at `finalize()`. Set when chunked prefill needs
+    /// to roll rows shorter than the prefill window into right-aligned
+    /// position.
+    private var _rightPadding: MLXArray?
+
+    /// Scalar offset for the legacy `KVCache` API. Returns `_idx` (the
+    /// rightmost trailing edge); only `makeMask` consumes it on this path,
+    /// since `applyRotaryPosition` dispatches to `batchOffset` instead.
+    public override var offset: Int {
+        get { _idx }
+        set { _idx = newValue }
+    }
+
+    public override var maxSize: Int? { nil }
+    public override var isTrimmable: Bool { true }
+
+    // MARK: - Init
+
+    /// Construct an empty cache for a batch of `leftPadding.count` rows.
+    ///
+    /// The cache expects inputs to be left-padded. For these prompts:
+    /// ```
+    /// [1, 3, 5]
+    /// [7]
+    /// [2, 6, 8, 9]
+    /// ```
+    /// the effective batched input is right-aligned to:
+    /// ```
+    /// [0, 1, 3, 5]
+    /// [0, 0, 0, 7]
+    /// [2, 6, 8, 9]
+    /// ```
+    /// and `leftPadding = [1, 3, 0]`.
+    public init(leftPadding: [Int]) {
+        self.leftPadding = MLXArray(leftPadding.map { Int32($0) })
+        self.batchOffset = MLXArray(leftPadding.map { Int32(-$0) })
+        super.init()
+    }
+
+    private init(
+        keys: MLXArray?,
+        values: MLXArray?,
+        offset: MLXArray,
+        leftPadding: MLXArray,
+        idx: Int
+    ) {
+        self.keys = keys
+        self.values = values
+        self.batchOffset = offset
+        self.leftPadding = leftPadding
+        super.init()
+        self._idx = idx
+    }
+
+    /// Append `[B, kvHeads, T, D]` keys/values and return the full populated
+    /// keys/values (`[B, kvHeads, _idx, D]`). Storage grows in
+    /// `allocationStep` chunks when capacity is exceeded.
+    public override func update(
+        keys: MLXArray, values: MLXArray
+    ) -> (MLXArray, MLXArray) {
+        let prev = _idx
+        let stepCount = keys.dim(2)
+        let needGrow: Bool = {
+            guard let storedKeys = self.keys else { return true }
+            return (prev + stepCount) > storedKeys.dim(2)
+        }()
+
+        if needGrow {
+            let B = keys.dim(0)
+            let nKVHeads = keys.dim(1)
+            let kHeadDim = keys.dim(3)
+            let vHeadDim = values.dim(3)
+            let nSteps = (Self.allocationStep + stepCount - 1) / Self.allocationStep
+            let kShape = [B, nKVHeads, nSteps * Self.allocationStep, kHeadDim]
+            let vShape = [B, nKVHeads, nSteps * Self.allocationStep, vHeadDim]
+            let newK = MLXArray.zeros(kShape, dtype: keys.dtype)
+            let newV = MLXArray.zeros(vShape, dtype: values.dtype)
+
+            if var currentK = self.keys, var currentV = self.values {
+                if prev % Self.allocationStep != 0 {
+                    currentK = currentK[.ellipsis, ..<prev, 0...]
+                    currentV = currentV[.ellipsis, ..<prev, 0...]
+                }
+                self.keys = concatenated([currentK, newK], axis: 2)
+                self.values = concatenated([currentV, newV], axis: 2)
+            } else {
+                self.keys = newK
+                self.values = newV
+            }
+        }
+
+        batchOffset = batchOffset + Int32(stepCount)
+        _idx += stepCount
+        self.keys?[.ellipsis, prev ..< _idx, 0...] = keys
+        self.values?[.ellipsis, prev ..< _idx, 0...] = values
+
+        return (
+            self.keys![.ellipsis, ..<_idx, 0...],
+            self.values![.ellipsis, ..<_idx, 0...]
+        )
+    }
+
+    // MARK: - prefill helpers
+
+    /// Prepare for chunked prefill. `leftPadding` may only be added to an
+    /// empty cache. `rightPadding` is recorded and applied by `finalize()`
+    /// after the prompt forward pass completes.
+    public func prepare(
+        leftPadding additionalLeftPadding: [Int]? = nil,
+        lengths _: [Int]? = nil,
+        rightPadding: [Int]? = nil
+    ) {
+        if let additionalLeftPadding {
+            precondition(
+                keys == nil,
+                "prepare() with leftPadding can only be called on an empty BatchKVCache"
+            )
+            let additional = MLXArray(additionalLeftPadding.map { Int32($0) })
+            leftPadding = leftPadding + additional
+            batchOffset = batchOffset - additional
+        }
+
+        if let rightPadding, rightPadding.contains(where: { $0 > 0 }) {
+            _rightPadding = MLXArray(rightPadding.map { Int32($0) })
+        }
+    }
+
+    /// Roll each row right by its pending right-padding so all rows are
+    /// right-justified along the time axis.
+    public func finalize() {
+        guard let pending = _rightPadding else { return }
+        guard let storedK = keys, let storedV = values else {
+            _rightPadding = nil
+            return
+        }
+
+        let shifts = pending[0..., .newAxis]
+        keys = dynamicRoll(storedK, shifts: shifts, axis: 2)
+        values = dynamicRoll(storedV, shifts: shifts, axis: 2)
+        batchOffset = batchOffset - pending
+        leftPadding = leftPadding + pending
+        _rightPadding = nil
+    }
+
+    /// In-place: keep only rows at `batchIndices` and shave any common
+    /// left-padding from the front of the storage.
+    public func filter(batchIndices: MLXArray) {
+        if keys != nil {
+            keys = take(keys!, batchIndices, axis: 0)
+            values = take(values!, batchIndices, axis: 0)
+        }
+        batchOffset = take(batchOffset, batchIndices, axis: 0)
+        leftPadding = take(leftPadding, batchIndices, axis: 0)
+
+        let minLeftPad = leftPadding.min().item(Int32.self)
+        if minLeftPad > 0 {
+            let minPadInt = Int(minLeftPad)
+            if let storedK = keys, let storedV = values {
+                keys = storedK[.ellipsis, minPadInt..., 0...]
+                values = storedV[.ellipsis, minPadInt..., 0...]
+            }
+            _idx -= minPadInt
+            leftPadding = leftPadding - Int32(minPadInt)
+        }
+    }
+
+    // MARK: - extend (in-place admission)
+
+    /// In-place concatenation of another batched cache's rows onto this one.
+    /// Both caches are padded to be right-justified and same time-axis size,
+    /// then concatenated along the batch axis.
+    public func extend(_ other: BatchKVCache) {
+        // Both empty: just concat the metadata.
+        if keys == nil && other.keys == nil {
+            leftPadding = concatenated([leftPadding, other.leftPadding], axis: 0)
+            batchOffset = concatenated([batchOffset, other.batchOffset], axis: 0)
+            return
+        }
+
+        let maxIdx = max(_idx, other._idx)
+        var L1 = 0
+        var L2 = 0
+        var H = 0
+        var Dk = 0
+        var Dv = 0
+
+        if let storedK = keys {
+            L1 = storedK.dim(2)
+            H = storedK.dim(1)
+            Dk = storedK.dim(3)
+            Dv = values!.dim(3)
+        }
+        if let storedK = other.keys {
+            L2 = storedK.dim(2)
+            H = storedK.dim(1)
+            Dk = storedK.dim(3)
+            Dv = other.values!.dim(3)
+        }
+        let maxSize = max(L1, L2)
+
+        // Pad each cache so its keys/values share the same shape and are
+        // right-justified with the rightmost index `maxIdx`.
+        func pad(
+            _ cacheKeys: MLXArray?,
+            _ cacheValues: MLXArray?,
+            cacheIdx: Int,
+            cacheOffset: MLXArray,
+            cacheLeftPadding: MLXArray
+        ) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+            var k: MLXArray
+            var v: MLXArray
+            if let cacheKeys, let cacheValues {
+                k = cacheKeys
+                v = cacheValues
+            } else {
+                let Bc = cacheOffset.dim(0)
+                k = MLXArray.zeros([Bc, H, 0, Dk], dtype: keys?.dtype ?? .float32)
+                v = MLXArray.zeros([Bc, H, 0, Dv], dtype: values?.dtype ?? .float32)
+            }
+
+            let leftPad = maxIdx - cacheIdx
+            var rightPad = maxSize - k.dim(2) - leftPad
+            if rightPad < 0 {
+                k = k[.ellipsis, ..<(k.dim(2) + rightPad), 0...]
+                v = v[.ellipsis, ..<(v.dim(2) + rightPad), 0...]
+                rightPad = 0
+            }
+            if leftPad != 0 || rightPad != 0 {
+                let widths: [IntOrPair] = [
+                    .init(0), .init(0), .init((leftPad, rightPad)), .init(0),
+                ]
+                k = padded(k, widths: widths)
+                v = padded(v, widths: widths)
+            }
+            return (k, v, cacheOffset, cacheLeftPadding + Int32(leftPad))
+        }
+
+        let (k1, v1, o1, lp1) = pad(
+            keys, values, cacheIdx: _idx,
+            cacheOffset: batchOffset, cacheLeftPadding: leftPadding
+        )
+        let (k2, v2, o2, lp2) = pad(
+            other.keys, other.values, cacheIdx: other._idx,
+            cacheOffset: other.batchOffset, cacheLeftPadding: other.leftPadding
+        )
+
+        keys = concatenated([k1, k2], axis: 0)
+        values = concatenated([v1, v2], axis: 0)
+        batchOffset = concatenated([o1, o2], axis: 0)
+        leftPadding = concatenated([lp1, lp2], axis: 0)
+        _idx = maxIdx
+    }
+
+    /// Slice row `idx` out as a standalone single-row `KVCacheSimple`. The
+    /// slice is materialized so it owns its storage and survives subsequent
+    /// `filter` / `extend` mutations on this batched cache.
+    public func extract(_ idx: Int) -> KVCacheSimple {
+        let cache = KVCacheSimple()
+        guard let storedK = keys, let storedV = values else {
+            return cache
+        }
+        let leftPad = Int(leftPadding[idx].item(Int32.self))
+        let kSlice = storedK[idx ..< (idx + 1), 0..., leftPad ..< _idx, 0...]
+        let vSlice = storedV[idx ..< (idx + 1), 0..., leftPad ..< _idx, 0...]
+        eval(kSlice, vSlice)
+        cache.state = [kSlice, vSlice]
+        return cache
+    }
+
+    /// Build a `BatchKVCache` from a list of single-row caches by padding
+    /// each to the longest length and right-justifying.
+    public static func merge(_ caches: [KVCacheSimple]) -> BatchKVCache {
+        let lengths = caches.map { $0.offset }
+        let maxLength = lengths.max() ?? 0
+
+        if maxLength == 0 {
+            return BatchKVCache(leftPadding: Array(repeating: 0, count: caches.count))
+        }
+
+        let leftPaddings = lengths.map { maxLength - $0 }
+        let B = caches.count
+
+        guard let template = caches.first(where: { $0.state.count >= 2 }) else {
+            return BatchKVCache(leftPadding: leftPaddings)
+        }
+        let templateK = template.state[0]
+        let templateV = template.state[1]
+        let H = templateK.dim(1)
+        let Dk = templateK.dim(3)
+        let Dv = templateV.dim(3)
+        let dtype = templateK.dtype
+
+        var keys = MLXArray.zeros([B, H, maxLength, Dk], dtype: dtype)
+        var values = MLXArray.zeros([B, H, maxLength, Dv], dtype: dtype)
+
+        for (i, (pad, cache)) in zip(leftPaddings, caches).enumerated() {
+            guard cache.state.count >= 2 else { continue }
+            let k = cache.state[0]
+            let v = cache.state[1]
+            let len = cache.offset
+            keys[i ..< (i + 1), 0..., pad ..< (pad + len), 0...] = k[.ellipsis, ..<len, 0...]
+            values[i ..< (i + 1), 0..., pad ..< (pad + len), 0...] = v[.ellipsis, ..<len, 0...]
+        }
+
+        let result = BatchKVCache(leftPadding: leftPaddings)
+        result.keys = keys
+        result.values = values
+        result.batchOffset = result.batchOffset + Int32(maxLength)
+        result._idx = maxLength
+        return result
+    }
+
+    /// Causal mask that also blocks each row's own left-padded slots.
+    /// Always materialized to an array because per-row left-padding can't
+    /// be expressed via the symbolic `.causal` mode.
+    public override func makeMask(
+        n: Int, windowSize: Int?, returnArray _: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        let mask = createCausalMask(
+            n: n,
+            offset: _idx,
+            windowSize: windowSize,
+            leftPadding: leftPadding
+        )
+        return .array(mask)
+    }
+
+    @discardableResult
+    public override func trim(_ n: Int) -> Int {
+        let trimmed = min(_idx, n)
+        _idx -= trimmed
+        batchOffset = batchOffset - Int32(trimmed)
+        return trimmed
+    }
+
+    public func size() -> Int { _idx }
+    public func isEmpty() -> Bool { keys == nil }
+
+    public override var state: [MLXArray] {
+        get {
+            guard let storedK = keys, let storedV = values else {
+                return [batchOffset, leftPadding]
+            }
+            let kClipped: MLXArray
+            let vClipped: MLXArray
+            if _idx < storedK.dim(2) {
+                kClipped = storedK[.ellipsis, ..<_idx, 0...]
+                vClipped = storedV[.ellipsis, ..<_idx, 0...]
+            } else {
+                kClipped = storedK
+                vClipped = storedV
+            }
+            return [kClipped, vClipped, batchOffset, leftPadding]
+        }
+        set {
+            if newValue.count >= 4 {
+                keys = newValue[0]
+                values = newValue[1]
+                batchOffset = newValue[2]
+                leftPadding = newValue[3]
+                _idx = newValue[0].dim(2)
+            } else if newValue.count == 2 {
+                batchOffset = newValue[0]
+                leftPadding = newValue[1]
+                keys = nil
+                values = nil
+                _idx = 0
+            } else {
+                fatalError("BatchKVCache.state setter expects 2 or 4 arrays")
+            }
+        }
+    }
+
+    public override func copy() -> any KVCache {
+        BatchKVCache(
+            keys: keys.map { $0[.ellipsis] },
+            values: values.map { $0[.ellipsis] },
+            offset: batchOffset[0...],
+            leftPadding: leftPadding[0...],
+            idx: _idx
+        )
+    }
+}
+
+// MARK: - ArraysCache conformance
+
+extension ArraysCache: BatchedCache {
+    public func filterBatched(batchIndices: MLXArray) {
+        filter(batchIndices: batchIndices)
+    }
+
+    public func extendBatched(_ other: any BatchedCache) {
+        guard let other = other as? ArraysCache else {
+            preconditionFailure("ArraysCache.extendBatched requires another ArraysCache")
+        }
+        extend(other: other)
+    }
+}
+
+/// Per-row roll of `x` along `axis`. `shifts` broadcasts on the leading
+/// axes (typically rank `axis+1` -- the per-row shift count).
+@inline(__always)
+public func dynamicRoll(
+    _ x: MLXArray, shifts: MLXArray, axis: Int
+) -> MLXArray {
+    let n = x.dim(axis)
+    var arangeShape = Array(repeating: 1, count: x.ndim)
+    arangeShape[axis] = n
+    var shiftShape = Array(repeating: 1, count: x.ndim)
+    for i in 0 ..< min(shifts.ndim, axis) {
+        shiftShape[i] = shifts.dim(i)
+    }
+
+    let arange = MLXArray(Int32(0) ..< Int32(n)).reshaped(arangeShape)
+    let reshapedShifts = shifts.reshaped(shiftShape)
+    let idx = (arange - reshapedShifts) % Int32(n)
+    return takeAlong(x, idx, axis: axis)
+}

--- a/Libraries/MLXLMCommon/BatchKVCache.swift
+++ b/Libraries/MLXLMCommon/BatchKVCache.swift
@@ -433,6 +433,10 @@ public final class BatchKVCache: BaseKVCache, BatchPositionedKVCache, BatchedCac
         }
     }
 
+    public override func innerState() -> [MLXArray] {
+        state
+    }
+
     public override func copy() -> any KVCache {
         BatchKVCache(
             keys: keys.map { $0[.ellipsis] },

--- a/Libraries/MLXLMCommon/BatchKVCache.swift
+++ b/Libraries/MLXLMCommon/BatchKVCache.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Eigen Labs.
-//
 // Port of mlx_lm.models.cache.BatchKVCache.
 // https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/cache.py
 
@@ -16,6 +14,18 @@ public protocol BatchedCache: KVCache {
 
     /// In-place append `other`'s rows. The runtime types must match.
     func extendBatched(_ other: any BatchedCache)
+
+    /// Prepare cache metadata before ragged prompt prefill.
+    func prepareBatched(leftPadding: [Int]?, lengths: [Int]?, rightPadding: [Int]?)
+
+    /// Finalize cache metadata after ragged prompt prefill.
+    func finalizeBatched()
+
+    /// Extract one row as its corresponding single-request cache.
+    func extractBatched(_ idx: Int) -> any KVCache
+
+    /// Advance chunk-local metadata after a chunked prefill step.
+    func advanceBatched(_ n: Int)
 }
 
 /// Continuous-batching KV cache.
@@ -38,6 +48,20 @@ public final class BatchKVCache: BaseKVCache, BatchPositionedKVCache, BatchedCac
         }
         extend(other)
     }
+
+    public func prepareBatched(leftPadding: [Int]?, lengths: [Int]?, rightPadding: [Int]?) {
+        prepare(leftPadding: leftPadding, lengths: lengths, rightPadding: rightPadding)
+    }
+
+    public func finalizeBatched() {
+        finalize()
+    }
+
+    public func extractBatched(_ idx: Int) -> any KVCache {
+        extract(idx)
+    }
+
+    public func advanceBatched(_: Int) {}
 
     /// Allocation chunk size along the time axis.
     public static let allocationStep = 256
@@ -352,8 +376,8 @@ public final class BatchKVCache: BaseKVCache, BatchPositionedKVCache, BatchedCac
         let Dv = templateV.dim(3)
         let dtype = templateK.dtype
 
-        var keys = MLXArray.zeros([B, H, maxLength, Dk], dtype: dtype)
-        var values = MLXArray.zeros([B, H, maxLength, Dv], dtype: dtype)
+        let keys = MLXArray.zeros([B, H, maxLength, Dk], dtype: dtype)
+        let values = MLXArray.zeros([B, H, maxLength, Dv], dtype: dtype)
 
         for (i, (pad, cache)) in zip(leftPaddings, caches).enumerated() {
             guard cache.state.count >= 2 else { continue }
@@ -448,6 +472,336 @@ public final class BatchKVCache: BaseKVCache, BatchPositionedKVCache, BatchedCac
     }
 }
 
+/// Sliding-window batched KV cache.
+///
+/// This cache preserves the per-row position and left-padding semantics of
+/// `BatchKVCache`, while trimming stored keys/values to `maxSize` for sliding
+/// attention layers.
+public final class BatchRotatingKVCache: BaseKVCache, BatchPositionedKVCache, BatchedCache {
+    public static let allocationStep = 256
+
+    public private(set) var keys: MLXArray?
+    public private(set) var values: MLXArray?
+    public private(set) var batchOffset: MLXArray
+    public private(set) var leftPadding: MLXArray
+
+    private let maxCacheSize: Int
+    private var _idx: Int = 0
+    private var _rightPadding: MLXArray?
+
+    public init(maxSize: Int, leftPadding: [Int]) {
+        self.maxCacheSize = maxSize
+        self.leftPadding = MLXArray(leftPadding.map { Int32($0) })
+        self.batchOffset = MLXArray(leftPadding.map { Int32(-$0) })
+        super.init()
+    }
+
+    private init(
+        maxSize: Int,
+        keys: MLXArray?,
+        values: MLXArray?,
+        offset: MLXArray,
+        leftPadding: MLXArray,
+        idx: Int
+    ) {
+        self.maxCacheSize = maxSize
+        self.keys = keys
+        self.values = values
+        self.batchOffset = offset
+        self.leftPadding = leftPadding
+        self._idx = idx
+        super.init()
+    }
+
+    public override var maxSize: Int? { maxCacheSize }
+    public override var isTrimmable: Bool { _idx < maxCacheSize }
+
+    public override var offset: Int {
+        get { _idx }
+        set { _idx = newValue }
+    }
+
+    public func filterBatched(batchIndices: MLXArray) {
+        filter(batchIndices: batchIndices)
+    }
+
+    public func extendBatched(_ other: any BatchedCache) {
+        guard let other = other as? BatchRotatingKVCache else {
+            preconditionFailure(
+                "BatchRotatingKVCache.extendBatched requires another BatchRotatingKVCache")
+        }
+        extend(other)
+    }
+
+    public func prepareBatched(leftPadding: [Int]?, lengths: [Int]?, rightPadding: [Int]?) {
+        prepare(leftPadding: leftPadding, lengths: lengths, rightPadding: rightPadding)
+    }
+
+    public func finalizeBatched() {
+        finalize()
+    }
+
+    public func extractBatched(_ idx: Int) -> any KVCache {
+        extract(idx)
+    }
+
+    public func advanceBatched(_: Int) {}
+
+    public override func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        let stepCount = keys.dim(2)
+
+        if self.keys == nil {
+            self.keys = keys
+            self.values = values
+            _idx = stepCount
+        } else {
+            if stepCount > 1 {
+                // Multi-token prefill must keep enough temporary context for
+                // every query in this call. Match RotatingKVCache's concat
+                // path: trim old context before appending, but do not trim the
+                // newly returned prefill block.
+                let trimSize = _idx - maxCacheSize + 1
+                if trimSize > 0 {
+                    self.keys = self.keys![.ellipsis, trimSize..., 0...]
+                    self.values = self.values![.ellipsis, trimSize..., 0...]
+                    leftPadding = leftPadding - Int32(trimSize)
+                    _idx -= trimSize
+                }
+            }
+
+            self.keys = concatenated([self.keys!, keys], axis: 2)
+            self.values = concatenated([self.values!, values], axis: 2)
+            _idx += stepCount
+        }
+
+        batchOffset = batchOffset + Int32(stepCount)
+
+        if stepCount == 1, _idx > maxCacheSize {
+            let trimSize = _idx - maxCacheSize
+            self.keys = self.keys![.ellipsis, trimSize..., 0...]
+            self.values = self.values![.ellipsis, trimSize..., 0...]
+            leftPadding = leftPadding - Int32(trimSize)
+            _idx = maxCacheSize
+        }
+
+        return (self.keys!, self.values!)
+    }
+
+    public func prepare(
+        leftPadding additionalLeftPadding: [Int]? = nil,
+        lengths _: [Int]? = nil,
+        rightPadding: [Int]? = nil
+    ) {
+        if let additionalLeftPadding {
+            precondition(
+                keys == nil,
+                "prepare() with leftPadding can only be called on an empty BatchRotatingKVCache"
+            )
+            let additional = MLXArray(additionalLeftPadding.map { Int32($0) })
+            leftPadding = leftPadding + additional
+            batchOffset = batchOffset - additional
+        }
+
+        if let rightPadding, rightPadding.contains(where: { $0 > 0 }) {
+            _rightPadding = MLXArray(rightPadding.map { Int32($0) })
+        }
+    }
+
+    public func finalize() {
+        guard let pending = _rightPadding else { return }
+        guard let storedK = keys, let storedV = values else {
+            _rightPadding = nil
+            return
+        }
+
+        let shifts = pending[0..., .newAxis]
+        keys = dynamicRoll(storedK, shifts: shifts, axis: 2)
+        values = dynamicRoll(storedV, shifts: shifts, axis: 2)
+        batchOffset = batchOffset - pending
+        leftPadding = leftPadding + pending
+        _rightPadding = nil
+    }
+
+    public func filter(batchIndices: MLXArray) {
+        if keys != nil {
+            keys = take(keys!, batchIndices, axis: 0)
+            values = take(values!, batchIndices, axis: 0)
+        }
+        batchOffset = take(batchOffset, batchIndices, axis: 0)
+        leftPadding = take(leftPadding, batchIndices, axis: 0)
+    }
+
+    public func extend(_ other: BatchRotatingKVCache) {
+        precondition(
+            maxCacheSize == other.maxCacheSize,
+            "BatchRotatingKVCache can only extend caches with the same maximum size"
+        )
+
+        if keys == nil && other.keys == nil {
+            leftPadding = concatenated([leftPadding, other.leftPadding], axis: 0)
+            batchOffset = concatenated([batchOffset, other.batchOffset], axis: 0)
+            return
+        }
+
+        let maxIdx = max(_idx, other._idx)
+        var L1 = 0
+        var L2 = 0
+        var H = 0
+        var Dk = 0
+        var Dv = 0
+
+        if let storedK = keys {
+            L1 = storedK.dim(2)
+            H = storedK.dim(1)
+            Dk = storedK.dim(3)
+            Dv = values!.dim(3)
+        }
+        if let storedK = other.keys {
+            L2 = storedK.dim(2)
+            H = storedK.dim(1)
+            Dk = storedK.dim(3)
+            Dv = other.values!.dim(3)
+        }
+        let maxSize = max(L1, L2)
+
+        func pad(
+            _ cacheKeys: MLXArray?,
+            _ cacheValues: MLXArray?,
+            cacheIdx: Int,
+            cacheOffset: MLXArray,
+            cacheLeftPadding: MLXArray
+        ) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+            var k: MLXArray
+            var v: MLXArray
+            if let cacheKeys, let cacheValues {
+                k = cacheKeys
+                v = cacheValues
+            } else {
+                let Bc = cacheOffset.dim(0)
+                k = MLXArray.zeros([Bc, H, 0, Dk], dtype: keys?.dtype ?? .float32)
+                v = MLXArray.zeros([Bc, H, 0, Dv], dtype: values?.dtype ?? .float32)
+            }
+
+            let leftPad = maxIdx - cacheIdx
+            var rightPad = maxSize - k.dim(2) - leftPad
+            if rightPad < 0 {
+                k = k[.ellipsis, ..<(k.dim(2) + rightPad), 0...]
+                v = v[.ellipsis, ..<(v.dim(2) + rightPad), 0...]
+                rightPad = 0
+            }
+            if leftPad != 0 || rightPad != 0 {
+                let widths: [IntOrPair] = [
+                    .init(0), .init(0), .init((leftPad, rightPad)), .init(0),
+                ]
+                k = padded(k, widths: widths)
+                v = padded(v, widths: widths)
+            }
+            return (k, v, cacheOffset, cacheLeftPadding + Int32(leftPad))
+        }
+
+        let (k1, v1, o1, lp1) = pad(
+            keys, values, cacheIdx: _idx,
+            cacheOffset: batchOffset, cacheLeftPadding: leftPadding
+        )
+        let (k2, v2, o2, lp2) = pad(
+            other.keys, other.values, cacheIdx: other._idx,
+            cacheOffset: other.batchOffset, cacheLeftPadding: other.leftPadding
+        )
+
+        keys = concatenated([k1, k2], axis: 0)
+        values = concatenated([v1, v2], axis: 0)
+        batchOffset = concatenated([o1, o2], axis: 0)
+        leftPadding = concatenated([lp1, lp2], axis: 0)
+        _idx = maxIdx
+    }
+
+    public func extract(_ idx: Int) -> RotatingKVCache {
+        let cache = RotatingKVCache(maxSize: maxCacheSize, keep: 0)
+        guard let storedK = keys, let storedV = values else {
+            return cache
+        }
+
+        let leftPad = max(0, Int(leftPadding[idx].item(Int32.self)))
+        let kSlice = storedK[idx ..< (idx + 1), 0..., leftPad ..< _idx, 0...]
+        let vSlice = storedV[idx ..< (idx + 1), 0..., leftPad ..< _idx, 0...]
+        eval(kSlice, vSlice)
+        cache.state = [kSlice, vSlice]
+
+        let absoluteOffset = Int(batchOffset[idx].item(Int32.self))
+        cache.metaState = [
+            "0", "\(maxCacheSize)", "\(Self.allocationStep)", "\(absoluteOffset)",
+            "\(kSlice.dim(2))",
+        ]
+        return cache
+    }
+
+    public override func makeMask(
+        n: Int, windowSize: Int?, returnArray _: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        let actualWindowSize = windowSize ?? maxCacheSize
+        let maskOffset = min(maxCacheSize - 1, _idx)
+        let mask = createCausalMask(
+            n: n,
+            offset: maskOffset,
+            windowSize: actualWindowSize,
+            leftPadding: leftPadding
+        )
+        return .array(mask)
+    }
+
+    @discardableResult
+    public override func trim(_ n: Int) -> Int {
+        let trimmed = min(_idx, n)
+        _idx -= trimmed
+        batchOffset = batchOffset - Int32(trimmed)
+        return trimmed
+    }
+
+    public func size() -> Int { _idx }
+    public func isEmpty() -> Bool { keys == nil }
+
+    public override var state: [MLXArray] {
+        get {
+            guard let storedK = keys, let storedV = values else {
+                return [batchOffset, leftPadding]
+            }
+            return [storedK, storedV, batchOffset, leftPadding]
+        }
+        set {
+            if newValue.count >= 4 {
+                keys = newValue[0]
+                values = newValue[1]
+                batchOffset = newValue[2]
+                leftPadding = newValue[3]
+                _idx = newValue[0].dim(2)
+            } else if newValue.count == 2 {
+                batchOffset = newValue[0]
+                leftPadding = newValue[1]
+                keys = nil
+                values = nil
+                _idx = 0
+            } else {
+                fatalError("BatchRotatingKVCache.state setter expects 2 or 4 arrays")
+            }
+        }
+    }
+
+    public override func innerState() -> [MLXArray] {
+        state
+    }
+
+    public override func copy() -> any KVCache {
+        BatchRotatingKVCache(
+            maxSize: maxCacheSize,
+            keys: keys.map { $0[.ellipsis] },
+            values: values.map { $0[.ellipsis] },
+            offset: batchOffset[0...],
+            leftPadding: leftPadding[0...],
+            idx: _idx
+        )
+    }
+}
+
 // MARK: - ArraysCache conformance
 
 extension ArraysCache: BatchedCache {
@@ -460,6 +814,22 @@ extension ArraysCache: BatchedCache {
             preconditionFailure("ArraysCache.extendBatched requires another ArraysCache")
         }
         extend(other: other)
+    }
+
+    public func prepareBatched(leftPadding _: [Int]?, lengths: [Int]?, rightPadding _: [Int]?) {
+        prepare(lengths: lengths)
+    }
+
+    public func finalizeBatched() {
+        finalize()
+    }
+
+    public func extractBatched(_ idx: Int) -> any KVCache {
+        extract(idx)
+    }
+
+    public func advanceBatched(_ n: Int) {
+        advance(n)
     }
 }
 

--- a/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
@@ -4,6 +4,7 @@ Common language model code.
 
 ## Articles
 
+- <doc:continuous-batching>
 - <doc:upgrade>
 - <doc:wired-memory>
 

--- a/Libraries/MLXLMCommon/Documentation.docc/continuous-batching.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/continuous-batching.md
@@ -1,0 +1,52 @@
+# Continuous Batching
+
+`BatchGenerator` provides a low-level continuous-batching engine for token
+generation. It batches prompt prefill work, keeps decode rows in a shared
+batched cache, and admits new prompts as existing rows finish.
+
+Use it when you need explicit control over request admission and per-row
+streaming responses:
+
+```swift
+let generator = BatchGenerator(
+    model: model,
+    eosTokens: [[eosToken]],
+    defaultMaxTokens: 128,
+    prefillBatchSize: 8,
+    completionBatchSize: 32
+)
+
+let ids = generator.insert(prompts: [[1, 2, 3], [4, 5]])
+
+while generator.hasWork {
+    for response in generator.next() {
+        print(response.uid, response.token, response.finishReason as Any)
+    }
+}
+```
+
+The engine is intentionally stateful and should be driven from one execution
+context at a time. Each call to `next()` may prefill queued prompts, run one
+decode step for active rows, and return one response per active row. A response
+with a non-`nil` `finishReason` is the final response for that UID.
+
+## Custom Sampling
+
+Pass per-row `RowSampler` values to `insert(prompts:maxTokens:samplers:)` to
+mix greedy and probabilistic decoding inside the same generation batch. Use
+`makeRowSampler(temperature:topP:topK:seed:)` for OpenAI-style temperature,
+top-p, top-k, and seeded categorical sampling.
+
+## Stop Sequences
+
+`SequenceStateMachine` detects single- or multi-token stop sequences per row.
+The `BatchGenerator` initializer accepts default EOS token sequences, and
+`insert(prompts:maxTokens:samplers:stateMachines:)` can override stop logic per
+request.
+
+## Cache Model
+
+Continuous batching uses `BatchKVCache` for attention layers and `ArraysCache`
+or `MambaCache` for array-backed state-space layers. `BatchKVCache` keeps rows
+right-aligned so requests with different prompt lengths can share one cache and
+attention mask while still preserving per-row positions for RoPE.

--- a/Libraries/MLXLMCommon/GenerationBatch.swift
+++ b/Libraries/MLXLMCommon/GenerationBatch.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Eigen Labs.
-//
 // Port of mlx_lm.generate.GenerationBatch.
 // https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
 
@@ -38,7 +36,7 @@ public struct GenerationBatchResponse: @unchecked Sendable {
 
     /// Single-row prompt cache for prefix caching across requests.
     /// Set only on the final response.
-    public let promptCache: [KVCacheSimple]?
+    public let promptCache: [any KVCache]?
 }
 
 /// Decode-phase batch over a shared `[any BatchedCache]` (one per layer).
@@ -131,29 +129,29 @@ public final class GenerationBatch: @unchecked Sendable {
             }
 
             if finishReason != nil {
-                let extracted: [KVCacheSimple] = promptCache.compactMap {
-                    ($0 as? BatchKVCache)?.extract(i)
-                }
-                responses.append(GenerationBatchResponse(
-                    uid: uids[i],
-                    token: stepTokens[i],
-                    finishReason: finishReason,
-                    matchedSequence: matchedSequence,
-                    currentState: currentState,
-                    allTokens: tokens[i],
-                    promptCache: extracted
-                ))
+                let extracted: [any KVCache] = promptCache.map { $0.extractBatched(i) }
+                responses.append(
+                    GenerationBatchResponse(
+                        uid: uids[i],
+                        token: stepTokens[i],
+                        finishReason: finishReason,
+                        matchedSequence: matchedSequence,
+                        currentState: currentState,
+                        allTokens: tokens[i],
+                        promptCache: extracted
+                    ))
             } else {
                 keep.append(i)
-                responses.append(GenerationBatchResponse(
-                    uid: uids[i],
-                    token: stepTokens[i],
-                    finishReason: nil,
-                    matchedSequence: matchedSequence,
-                    currentState: currentState,
-                    allTokens: nil,
-                    promptCache: nil
-                ))
+                responses.append(
+                    GenerationBatchResponse(
+                        uid: uids[i],
+                        token: stepTokens[i],
+                        finishReason: nil,
+                        matchedSequence: matchedSequence,
+                        currentState: currentState,
+                        allTokens: nil,
+                        promptCache: nil
+                    ))
             }
         }
 

--- a/Libraries/MLXLMCommon/GenerationBatch.swift
+++ b/Libraries/MLXLMCommon/GenerationBatch.swift
@@ -1,0 +1,238 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Port of mlx_lm.generate.GenerationBatch.
+// https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Picks one token per row from a `[B, vocab]` logits tensor.
+public typealias RowSampler = @Sendable (MLXArray) -> MLXArray
+
+/// Deterministic greedy sampler.
+@Sendable public func greedySampler(_ logprobs: MLXArray) -> MLXArray {
+    argMax(logprobs, axis: -1)
+}
+
+/// Per-row response from a single decode step.
+///
+/// Marked `@unchecked Sendable` because `promptCache` carries non-Sendable
+/// `KVCacheSimple` references for cross-request prefix caching; cross-actor
+/// transfer is the caller's responsibility.
+public struct GenerationBatchResponse: @unchecked Sendable {
+    public let uid: Int
+    public let token: Int
+
+    /// `"length"`, `"stop"`, or nil if the row is still generating.
+    public let finishReason: String?
+
+    /// The matched stop sequence if a multi-token stop completed on this token.
+    public let matchedSequence: [Int]?
+
+    /// State machine state name after this token's transition (nil = terminated).
+    public let currentState: String?
+
+    /// All produced tokens for this row. Set only on the final response.
+    public let allTokens: [Int]?
+
+    /// Single-row prompt cache for prefix caching across requests.
+    /// Set only on the final response.
+    public let promptCache: [KVCacheSimple]?
+}
+
+/// Decode-phase batch over a shared `[any BatchedCache]` (one per layer).
+/// Each layer's cache is the appropriate batched type for that layer:
+/// `BatchKVCache` for full attention, `ArraysCache`/`MambaCache` for SSM.
+/// Construct after prefill has populated the caches; call `next()` to
+/// drive generation one step at a time.
+public final class GenerationBatch: @unchecked Sendable {
+
+    public let model: any LanguageModel
+    public private(set) var uids: [Int]
+    public private(set) var promptCache: [any BatchedCache]
+    public private(set) var tokens: [[Int]]
+    public private(set) var maxTokens: [Int]
+
+    public private(set) var samplers: [RowSampler?]
+    public let fallbackSampler: RowSampler
+    public private(set) var stateMachines: [SequenceStateMachine]
+
+    /// Tokens sampled at the previous step (or seed tokens at construction). `[B]`.
+    private var nextTokens: MLXArray
+    private var numTokens: [Int]
+    private var matcherStates: [SequenceStateMachineState]
+
+    public init(
+        model: any LanguageModel,
+        uids: [Int],
+        seedTokens: MLXArray,
+        promptCache: [any BatchedCache],
+        tokens: [[Int]],
+        maxTokens: [Int],
+        samplers: [RowSampler?]? = nil,
+        fallbackSampler: @escaping RowSampler = greedySampler,
+        stateMachines: [SequenceStateMachine]? = nil
+    ) {
+        precondition(uids.count == tokens.count, "uids/tokens count mismatch")
+        precondition(uids.count == maxTokens.count, "uids/max_tokens count mismatch")
+        self.model = model
+        self.uids = uids
+        self.promptCache = promptCache
+        self.tokens = tokens
+        self.maxTokens = maxTokens
+        self.samplers = samplers ?? Array(repeating: nil, count: uids.count)
+        self.fallbackSampler = fallbackSampler
+        let machines = stateMachines ?? Array(repeating: SequenceStateMachine(), count: uids.count)
+        self.stateMachines = machines
+        self.matcherStates = machines.map { $0.makeState() }
+        self.numTokens = Array(repeating: 0, count: uids.count)
+        self.nextTokens = seedTokens
+    }
+
+    /// Run one decode step. Finished rows (length / stop) are filtered out
+    /// of the active set after this call; their final responses appear with
+    /// non-nil `finishReason`.
+    public func next() -> [GenerationBatchResponse] {
+        if uids.isEmpty { return [] }
+
+        let stepTokens = step()
+
+        var keep: [Int] = []
+        var responses: [GenerationBatchResponse] = []
+        responses.reserveCapacity(uids.count)
+
+        for i in 0 ..< uids.count {
+            numTokens[i] += 1
+
+            var finishReason: String? = nil
+            if numTokens[i] >= maxTokens[i] {
+                finishReason = "length"
+            }
+
+            let machine = stateMachines[i]
+            let (nextState, matchedSequence, currentState) =
+                machine.match(matcherStates[i], stepTokens[i])
+            matcherStates[i] = nextState
+            if matchedSequence != nil, currentState == nil {
+                finishReason = "stop"
+            }
+
+            if finishReason != nil {
+                let extracted: [KVCacheSimple] = promptCache.compactMap {
+                    ($0 as? BatchKVCache)?.extract(i)
+                }
+                responses.append(GenerationBatchResponse(
+                    uid: uids[i],
+                    token: stepTokens[i],
+                    finishReason: finishReason,
+                    matchedSequence: matchedSequence,
+                    currentState: currentState,
+                    allTokens: tokens[i],
+                    promptCache: extracted
+                ))
+            } else {
+                keep.append(i)
+                responses.append(GenerationBatchResponse(
+                    uid: uids[i],
+                    token: stepTokens[i],
+                    finishReason: nil,
+                    matchedSequence: matchedSequence,
+                    currentState: currentState,
+                    allTokens: nil,
+                    promptCache: nil
+                ))
+            }
+        }
+
+        if keep.count < uids.count {
+            filter(keep: keep)
+        }
+
+        return responses
+    }
+
+    /// In-place keep only the rows at the given indices.
+    public func filter(keep: [Int]) {
+        let keepArr = MLXArray(keep.map { Int32($0) })
+
+        if keep.isEmpty {
+            promptCache.removeAll()
+        } else {
+            for cache in promptCache {
+                cache.filterBatched(batchIndices: keepArr)
+            }
+        }
+
+        uids = keep.map { uids[$0] }
+        tokens = keep.map { tokens[$0] }
+        samplers = keep.map { samplers[$0] }
+        maxTokens = keep.map { maxTokens[$0] }
+        stateMachines = keep.map { stateMachines[$0] }
+        matcherStates = keep.map { matcherStates[$0] }
+        numTokens = keep.map { numTokens[$0] }
+        if !keep.isEmpty {
+            nextTokens = take(nextTokens, keepArr, axis: 0)
+        }
+    }
+
+    /// In-place: append `other`'s rows to this batch. Per-layer caches are
+    /// concatenated via `BatchedCache.extendBatched`.
+    public func extend(_ other: GenerationBatch) {
+        precondition(
+            promptCache.count == other.promptCache.count,
+            "Cannot extend with a batch that has a different layer count"
+        )
+        for (a, b) in zip(promptCache, other.promptCache) {
+            a.extendBatched(b)
+        }
+        uids.append(contentsOf: other.uids)
+        tokens.append(contentsOf: other.tokens)
+        samplers.append(contentsOf: other.samplers)
+        maxTokens.append(contentsOf: other.maxTokens)
+        stateMachines.append(contentsOf: other.stateMachines)
+        matcherStates.append(contentsOf: other.matcherStates)
+        numTokens.append(contentsOf: other.numTokens)
+        nextTokens = concatenated([nextTokens, other.nextTokens], axis: 0)
+    }
+
+    public var isEmpty: Bool { uids.isEmpty }
+    public var batchSize: Int { uids.count }
+
+    /// One forward pass + per-row sample. Synchronous; the async eval
+    /// double-buffering optimization from upstream Python is not implemented.
+    private func step() -> [Int] {
+        let inputs = nextTokens[0..., .newAxis]
+
+        let logits = model.callAsFunction(inputs, cache: promptCache.map { $0 as any KVCache })
+
+        // [B, 1, vocab] -> [B, vocab]
+        let stepLogits = logits[.ellipsis, -1, 0...]
+        let logprobs = stepLogits - logSumExp(stepLogits, axis: -1, keepDims: true)
+
+        let sampledTokens: MLXArray
+        if samplers.contains(where: { $0 != nil }) {
+            var samples: [MLXArray] = []
+            samples.reserveCapacity(uids.count)
+            for i in 0 ..< uids.count {
+                let rowLogprobs = logprobs[i ..< (i + 1), 0...]
+                let sampler = samplers[i] ?? fallbackSampler
+                samples.append(sampler(rowLogprobs))
+            }
+            sampledTokens = concatenated(samples, axis: 0)
+        } else {
+            sampledTokens = fallbackSampler(logprobs)
+        }
+
+        eval(sampledTokens, inputs)
+        let stepTokens = inputs.asArray(Int32.self).map { Int($0) }
+        let outTokens = sampledTokens.asArray(Int32.self).map { Int($0) }
+
+        for (i, t) in stepTokens.enumerated() {
+            tokens[i].append(t)
+        }
+
+        nextTokens = sampledTokens
+        return outTokens
+    }
+}

--- a/Libraries/MLXLMCommon/GenerationBatch.swift
+++ b/Libraries/MLXLMCommon/GenerationBatch.swift
@@ -58,7 +58,10 @@ public final class GenerationBatch: @unchecked Sendable {
     public let fallbackSampler: RowSampler
     public private(set) var stateMachines: [SequenceStateMachine]
 
-    /// Tokens sampled at the previous step (or seed tokens at construction). `[B]`.
+    /// Tokens queued for the next model call. At construction this is the
+    /// final prompt token for each row. After priming, and after every
+    /// decode step, it holds the sampled token that should be returned on
+    /// the next `next()` call. `[B]`.
     private var nextTokens: MLXArray
     private var numTokens: [Int]
     private var matcherStates: [SequenceStateMachineState]
@@ -88,6 +91,15 @@ public final class GenerationBatch: @unchecked Sendable {
         self.matcherStates = machines.map { $0.makeState() }
         self.numTokens = Array(repeating: 0, count: uids.count)
         self.nextTokens = seedTokens
+
+        // Match upstream mlx_lm.GenerationBatch: immediately run one
+        // decode step in the constructor so the first call to `next()`
+        // returns an already-computed token while scheduling the following
+        // token. This double-buffer keeps the GPU queue ahead of the CPU
+        // token extraction path.
+        if !uids.isEmpty {
+            _ = step()
+        }
     }
 
     /// Run one decode step. Finished rows (length / stop) are filtered out
@@ -199,19 +211,26 @@ public final class GenerationBatch: @unchecked Sendable {
     public var isEmpty: Bool { uids.isEmpty }
     public var batchSize: Int { uids.count }
 
-    /// One forward pass + per-row sample. Synchronous; the async eval
-    /// double-buffering optimization from upstream Python is not implemented.
+    /// One forward pass + per-row sample, double-buffered like upstream
+    /// `mlx_lm.generate.GenerationBatch._step`.
+    ///
+    /// `nextTokens` is treated as the *current* token batch to return from
+    /// this call. We immediately feed it back through the model, sample the
+    /// following token batch, and `asyncEval` that future batch before
+    /// synchronously materializing the current tokens for CPU-side stop
+    /// detection / response dispatch.
     private func step() -> [Int] {
-        let inputs = nextTokens[0..., .newAxis]
+        let currentTokens = nextTokens
+        let inputs = currentTokens[0..., .newAxis]
 
         let logits = model.callAsFunction(inputs, cache: promptCache.map { $0 as any KVCache })
 
         // [B, 1, vocab] -> [B, vocab]
         let stepLogits = logits[.ellipsis, -1, 0...]
-        let logprobs = stepLogits - logSumExp(stepLogits, axis: -1, keepDims: true)
 
         let sampledTokens: MLXArray
         if samplers.contains(where: { $0 != nil }) {
+            let logprobs = stepLogits - logSumExp(stepLogits, axis: -1, keepDims: true)
             var samples: [MLXArray] = []
             samples.reserveCapacity(uids.count)
             for i in 0 ..< uids.count {
@@ -221,18 +240,26 @@ public final class GenerationBatch: @unchecked Sendable {
             }
             sampledTokens = concatenated(samples, axis: 0)
         } else {
-            sampledTokens = fallbackSampler(logprobs)
+            // Greedy fast path. Avoid the full-vocabulary logSumExp when
+            // all rows are greedy: argMax(logits) == argMax(logprobs),
+            // and Swift does not currently expose logprobs downstream.
+            // This removes one expensive reduction kernel per decode step.
+            sampledTokens = argMax(stepLogits, axis: -1)
         }
 
-        eval(sampledTokens, inputs)
-        let stepTokens = inputs.asArray(Int32.self).map { Int($0) }
-        let outTokens = sampledTokens.asArray(Int32.self).map { Int($0) }
+        // Start computing the next token before forcing the current token
+        // values back to the CPU. This overlaps GPU work with the CPU
+        // extraction / response-building path.
+        nextTokens = sampledTokens
+        asyncEval(sampledTokens)
+
+        eval(currentTokens)
+        let stepTokens = currentTokens.asArray(UInt32.self).map { Int($0) }
 
         for (i, t) in stepTokens.enumerated() {
             tokens[i].append(t)
         }
 
-        nextTokens = sampledTokens
-        return outTokens
+        return stepTokens
     }
 }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -35,7 +35,7 @@ import MLXNN
 /// Interface for Key/Value cache for LLMs.
 ///
 /// See ``LanguageModel/newCache(parameters:)``
-public protocol KVCache: Evaluatable {
+public protocol KVCache: Evaluatable, Updatable {
     /// get the current offset
     var offset: Int { get }
 

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -178,7 +178,8 @@ public func createCausalMask(
     n: Int,
     offset: Int,
     windowSize: Int? = nil,
-    lengths: MLXArray? = nil
+    lengths: MLXArray? = nil,
+    leftPadding: MLXArray? = nil
 ) -> MLXArray {
     var rinds = MLXArray(Int32(0) ..< Int32(offset + n))
     var linds = offset != 0 ? MLXArray(Int32(offset) ..< Int32(offset + n)) : rinds
@@ -191,8 +192,19 @@ public func createCausalMask(
     }
 
     if var lengths {
+        // Right-padding semantics (legacy `lengths`): row b can attend to
+        // positions [0, lengths[b]); positions >= lengths[b] are masked.
         lengths = lengths[0..., .newAxis, .newAxis, .newAxis]
         mask = mask & (rinds .< lengths)
+    }
+
+    if var leftPadding {
+        // Left-padding semantics (BatchKVCache): row b cannot attend to
+        // positions [0, leftPadding[b]); the leading slots are zero
+        // padding, not real KV. Mirrors mlx_lm.create_causal_mask's
+        // left_padding parameter.
+        leftPadding = leftPadding[0..., .newAxis, .newAxis, .newAxis]
+        mask = mask & (leftPadding .<= rinds)
     }
 
     return mask

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1097,6 +1097,7 @@ public class ChunkedKVCache: KVCacheSimple {
 public class ArraysCache: BaseKVCache {
     private var cache: [MLXArray?]
     internal var leftPadding: MLXArray?
+    internal var lengths: MLXArray?
 
     public init(size: Int, leftPadding: [Int]? = nil) {
         self.cache = Array(repeating: nil, count: size)
@@ -1138,24 +1139,67 @@ public class ArraysCache: BaseKVCache {
         cache = cache.map { c in
             c?[batchIndices]
         }
-        leftPadding = nil
+        leftPadding = leftPadding.map { take($0, batchIndices, axis: 0) }
+        lengths = lengths.map { take($0, batchIndices, axis: 0) }
     }
 
     /// In-place extend this cache with the other cache
     public func extend(other: ArraysCache) {
-        cache = zip(cache, other.cache).map { (c, o) in
-            if let c = c, let o = o {
-                return MLX.concatenated([c, o])
+        let lhsBatch = batchSize
+        let rhsBatch = other.batchSize
+
+        func concatenateOptional(_ lhs: MLXArray?, _ rhs: MLXArray?) -> MLXArray? {
+            var shape: [Int]?
+            var dtype: DType?
+            if let lhs {
+                shape = lhs.shape
+                dtype = lhs.dtype
             }
-            return c ?? o
+            if let rhs {
+                shape = rhs.shape
+                dtype = rhs.dtype
+            }
+            guard let shape, let dtype else { return nil }
+
+            let itemShape = Array(shape.dropFirst())
+            let lhsValue = lhs ?? MLXArray.zeros([lhsBatch] + itemShape, dtype: dtype)
+            let rhsValue = rhs ?? MLXArray.zeros([rhsBatch] + itemShape, dtype: dtype)
+            return MLX.concatenated([lhsValue, rhsValue])
         }
+
+        cache = zip(cache, other.cache).map { (c, o) in
+            concatenateOptional(c, o)
+        }
+        leftPadding = concatenateOptional(leftPadding, other.leftPadding)
+        lengths = concatenateOptional(lengths, other.lengths)
+    }
+
+    open func extract(_ idx: Int) -> ArraysCache {
+        let extracted = ArraysCache(size: cache.count)
+        extracted.cache = cache.map { $0?[idx ..< (idx + 1)] }
+        return extracted
+    }
+
+    public func prepare(lengths: [Int]? = nil) {
+        self.lengths = lengths.map { MLXArray($0.map { Int32($0) }) }
+    }
+
+    public func finalize() {
+        lengths = nil
         leftPadding = nil
+    }
+
+    public func advance(_ n: Int) {
+        lengths = lengths.map { $0 - Int32(n) }
+        leftPadding = leftPadding.map { $0 - Int32(n) }
     }
 
     /// Create attention mask based on left padding
     public func makeMask(N: Int) -> MLXArray? {
-        if cache[0] == nil, let leftPadding = leftPadding {
+        if let leftPadding {
             return MLXArray(0 ..< N) .>= leftPadding[0..., .newAxis]
+        } else if let lengths {
+            return MLXArray(0 ..< N) .< lengths[0..., .newAxis]
         } else {
             return nil
         }
@@ -1219,6 +1263,21 @@ public class ArraysCache: BaseKVCache {
         guard let lp = leftPadding else { return nil }
         return lp.asArray(Int.self)
     }
+
+    private var batchSize: Int {
+        for item in cache {
+            if let item {
+                return item.dim(0)
+            }
+        }
+        if let leftPadding {
+            return leftPadding.dim(0)
+        }
+        if let lengths {
+            return lengths.dim(0)
+        }
+        return 0
+    }
 }
 
 /// Simple cache for Mamba-style state space models
@@ -1236,6 +1295,12 @@ public class MambaCache: ArraysCache {
         new.offset = self.offset
         new.leftPadding = self.leftPadding
         return new
+    }
+
+    public override func extract(_ idx: Int) -> ArraysCache {
+        let extracted = MambaCache()
+        extracted.state = state.map { $0[idx ..< (idx + 1)] }
+        return extracted
     }
 }
 

--- a/Libraries/MLXLMCommon/PromptProcessingBatch.swift
+++ b/Libraries/MLXLMCommon/PromptProcessingBatch.swift
@@ -99,7 +99,7 @@ public final class PromptProcessingBatch: @unchecked Sendable {
             for t in promptTokens {
                 padded.append(t + Array(repeating: 0, count: maxLength - t.count))
             }
-            let flat: [Int32] = padded.flatMap { $0.map { Int32($0) } }
+            let flat: [UInt32] = padded.flatMap { $0.map { UInt32($0) } }
             inputs = MLXArray(flat).reshaped([promptTokens.count, maxLength])
 
             for cache in promptCache {
@@ -108,7 +108,7 @@ public final class PromptProcessingBatch: @unchecked Sendable {
                 }
             }
         } else {
-            let flat: [Int32] = promptTokens.flatMap { $0.map { Int32($0) } }
+            let flat: [UInt32] = promptTokens.flatMap { $0.map { UInt32($0) } }
             inputs = MLXArray(flat).reshaped([promptTokens.count, maxLength])
         }
 
@@ -156,7 +156,7 @@ public final class PromptProcessingBatch: @unchecked Sendable {
             prompt(prefixes)
         }
 
-        let lastTokens = inputTokens.map { Int32($0.last ?? 0) }
+        let lastTokens = inputTokens.map { UInt32($0.last ?? 0) }
         let seed = MLXArray(lastTokens)
 
         let gen = GenerationBatch(

--- a/Libraries/MLXLMCommon/PromptProcessingBatch.swift
+++ b/Libraries/MLXLMCommon/PromptProcessingBatch.swift
@@ -1,0 +1,216 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Port of mlx_lm.generate.PromptProcessingBatch.
+// https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
+
+import Foundation
+import MLX
+
+/// Prefill-phase batch over a shared `[any BatchedCache]`.
+///
+/// Right-pads ragged prompts to a uniform `[B, max_length]` tensor, runs
+/// chunked prefill through the model, then rolls each row into right-aligned
+/// position via per-cache finalization. Transition into a `GenerationBatch`
+/// via `generate(lastTokensOf:)`.
+public final class PromptProcessingBatch: @unchecked Sendable {
+
+    public let model: any LanguageModel
+    public private(set) var uids: [Int]
+    public private(set) var promptCache: [any BatchedCache]
+    public private(set) var tokens: [[Int]]
+    public private(set) var maxTokens: [Int]
+
+    public let prefillStepSize: Int
+
+    public private(set) var samplers: [RowSampler?]
+    public let fallbackSampler: RowSampler
+    public private(set) var stateMachines: [SequenceStateMachine]
+
+    public init(
+        model: any LanguageModel,
+        uids: [Int],
+        promptCache: [any BatchedCache],
+        tokens: [[Int]],
+        maxTokens: [Int],
+        prefillStepSize: Int = 2048,
+        samplers: [RowSampler?]? = nil,
+        fallbackSampler: @escaping RowSampler = greedySampler,
+        stateMachines: [SequenceStateMachine]? = nil
+    ) {
+        self.model = model
+        self.uids = uids
+        self.promptCache = promptCache
+        self.tokens = tokens
+        self.maxTokens = maxTokens
+        self.prefillStepSize = prefillStepSize
+        self.samplers = samplers ?? Array(repeating: nil, count: uids.count)
+        self.fallbackSampler = fallbackSampler
+        self.stateMachines = stateMachines ?? Array(
+            repeating: SequenceStateMachine(),
+            count: uids.count
+        )
+    }
+
+    public static func empty(
+        model: any LanguageModel,
+        prefillStepSize: Int = 2048,
+        fallbackSampler: @escaping RowSampler = greedySampler
+    ) -> PromptProcessingBatch {
+        PromptProcessingBatch(
+            model: model,
+            uids: [],
+            promptCache: [],
+            tokens: [],
+            maxTokens: [],
+            prefillStepSize: prefillStepSize,
+            samplers: [],
+            fallbackSampler: fallbackSampler,
+            stateMachines: []
+        )
+    }
+
+    public var batchSize: Int { uids.count }
+    public var isEmpty: Bool { uids.isEmpty }
+
+    /// Run the model over `promptTokens` to populate the cache. Ragged
+    /// rows are right-padded to `max(lengths)`; the BatchKVCache records
+    /// the right-padding for `finalize()` to roll out afterwards.
+    public func prompt(_ promptTokens: [[Int]]) {
+        precondition(
+            promptTokens.count == uids.count,
+            "PromptProcessingBatch.prompt: token list length \(promptTokens.count) "
+                + "does not match batch size \(uids.count)"
+        )
+        if promptTokens.isEmpty { return }
+
+        for (i, t) in promptTokens.enumerated() {
+            tokens[i].append(contentsOf: t)
+        }
+
+        let lengths = promptTokens.map { $0.count }
+        let maxLength = lengths.max() ?? 0
+        let padding = lengths.map { maxLength - $0 }
+        let maxPadding = padding.max() ?? 0
+
+        var inputs: MLXArray
+        if maxPadding > 0 {
+            var padded: [[Int]] = []
+            padded.reserveCapacity(promptTokens.count)
+            for t in promptTokens {
+                padded.append(t + Array(repeating: 0, count: maxLength - t.count))
+            }
+            let flat: [Int32] = padded.flatMap { $0.map { Int32($0) } }
+            inputs = MLXArray(flat).reshaped([promptTokens.count, maxLength])
+
+            for cache in promptCache {
+                if let kv = cache as? BatchKVCache {
+                    kv.prepare(rightPadding: padding)
+                }
+            }
+        } else {
+            let flat: [Int32] = promptTokens.flatMap { $0.map { Int32($0) } }
+            inputs = MLXArray(flat).reshaped([promptTokens.count, maxLength])
+        }
+
+        var remaining = inputs
+        while remaining.dim(1) > 0 {
+            let n = min(prefillStepSize, remaining.dim(1))
+            let chunk = remaining[0..., ..<n]
+            _ = model.callAsFunction(
+                chunk,
+                cache: promptCache.map { $0 as any KVCache }
+            )
+            for cache in promptCache {
+                eval(cache.innerState())
+            }
+            if n == remaining.dim(1) {
+                break
+            }
+            remaining = remaining[0..., n...]
+        }
+
+        if maxPadding > 0 {
+            for cache in promptCache {
+                if let kv = cache as? BatchKVCache {
+                    kv.finalize()
+                    eval(kv.innerState())
+                }
+            }
+        }
+    }
+
+    /// Move from prefill into decode. The last token of each row's prompt
+    /// becomes the seed input for the GenerationBatch; any prefix of length
+    /// > 1 is run through `prompt(...)` first.
+    ///
+    /// Ownership of the cache and per-row state transfers to the returned
+    /// `GenerationBatch`.
+    public func generate(lastTokensOf inputTokens: [[Int]]) -> GenerationBatch {
+        precondition(
+            inputTokens.count == uids.count,
+            "PromptProcessingBatch.generate: token list length \(inputTokens.count) "
+                + "does not match batch size \(uids.count)"
+        )
+        if inputTokens.contains(where: { $0.count > 1 }) {
+            let prefixes = inputTokens.map { Array($0.dropLast()) }
+            prompt(prefixes)
+        }
+
+        let lastTokens = inputTokens.map { Int32($0.last ?? 0) }
+        let seed = MLXArray(lastTokens)
+
+        let gen = GenerationBatch(
+            model: model,
+            uids: uids,
+            seedTokens: seed,
+            promptCache: promptCache,
+            tokens: tokens,
+            maxTokens: maxTokens,
+            samplers: samplers,
+            fallbackSampler: fallbackSampler,
+            stateMachines: stateMachines
+        )
+
+        uids = []
+        promptCache = []
+        tokens = []
+        samplers = []
+        maxTokens = []
+        stateMachines = []
+
+        return gen
+    }
+
+    public func filter(keep: [Int]) {
+        let keepArr = keep.isEmpty ? nil : MLXArray(keep.map { Int32($0) })
+
+        if let keepArr {
+            for cache in promptCache {
+                cache.filterBatched(batchIndices: keepArr)
+            }
+        } else {
+            promptCache.removeAll()
+        }
+
+        uids = keep.map { uids[$0] }
+        tokens = keep.map { tokens[$0] }
+        samplers = keep.map { samplers[$0] }
+        maxTokens = keep.map { maxTokens[$0] }
+        stateMachines = keep.map { stateMachines[$0] }
+    }
+
+    /// Append `other`'s rows. Currently restricted to merging two batches
+    /// before either has run prefill (i.e. both caches empty); merging
+    /// non-empty prefill caches is not yet implemented.
+    public func extend(_ other: PromptProcessingBatch) {
+        precondition(
+            promptCache.isEmpty && other.promptCache.isEmpty,
+            "PromptProcessingBatch.extend currently only supports merging two empty caches"
+        )
+        uids.append(contentsOf: other.uids)
+        tokens.append(contentsOf: other.tokens)
+        samplers.append(contentsOf: other.samplers)
+        maxTokens.append(contentsOf: other.maxTokens)
+        stateMachines.append(contentsOf: other.stateMachines)
+    }
+}

--- a/Libraries/MLXLMCommon/PromptProcessingBatch.swift
+++ b/Libraries/MLXLMCommon/PromptProcessingBatch.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Eigen Labs.
-//
 // Port of mlx_lm.generate.PromptProcessingBatch.
 // https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
 
@@ -45,10 +43,12 @@ public final class PromptProcessingBatch: @unchecked Sendable {
         self.prefillStepSize = prefillStepSize
         self.samplers = samplers ?? Array(repeating: nil, count: uids.count)
         self.fallbackSampler = fallbackSampler
-        self.stateMachines = stateMachines ?? Array(
-            repeating: SequenceStateMachine(),
-            count: uids.count
-        )
+        self.stateMachines =
+            stateMachines
+            ?? Array(
+                repeating: SequenceStateMachine(),
+                count: uids.count
+            )
     }
 
     public static func empty(
@@ -103,9 +103,7 @@ public final class PromptProcessingBatch: @unchecked Sendable {
             inputs = MLXArray(flat).reshaped([promptTokens.count, maxLength])
 
             for cache in promptCache {
-                if let kv = cache as? BatchKVCache {
-                    kv.prepare(rightPadding: padding)
-                }
+                cache.prepareBatched(leftPadding: nil, lengths: lengths, rightPadding: padding)
             }
         } else {
             let flat: [UInt32] = promptTokens.flatMap { $0.map { UInt32($0) } }
@@ -123,6 +121,9 @@ public final class PromptProcessingBatch: @unchecked Sendable {
             for cache in promptCache {
                 eval(cache.innerState())
             }
+            for cache in promptCache {
+                cache.advanceBatched(n)
+            }
             if n == remaining.dim(1) {
                 break
             }
@@ -131,10 +132,8 @@ public final class PromptProcessingBatch: @unchecked Sendable {
 
         if maxPadding > 0 {
             for cache in promptCache {
-                if let kv = cache as? BatchKVCache {
-                    kv.finalize()
-                    eval(kv.innerState())
-                }
+                cache.finalizeBatched()
+                eval(cache.innerState())
             }
         }
     }

--- a/Libraries/MLXLMCommon/RowSamplers.swift
+++ b/Libraries/MLXLMCommon/RowSamplers.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Eigen Labs.
-//
 // Per-row samplers for `BatchGenerator`. Mirrors `mlx_lm.sample_utils`:
 // temperature scaling, top-K truncation, top-P (nucleus) truncation, and
 // optional seeded categorical sampling. Each constructed sampler is

--- a/Libraries/MLXLMCommon/RowSamplers.swift
+++ b/Libraries/MLXLMCommon/RowSamplers.swift
@@ -1,0 +1,121 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Per-row samplers for `BatchGenerator`. Mirrors `mlx_lm.sample_utils`:
+// temperature scaling, top-K truncation, top-P (nucleus) truncation, and
+// optional seeded categorical sampling. Each constructed sampler is
+// `@Sendable` so it can be stored alongside an admitted batch row.
+
+import Foundation
+import MLX
+import MLXRandom
+
+/// Build a `RowSampler` from OpenAI-style request parameters.
+///
+/// Behavior, mirroring upstream `mlx_lm.sample_utils.make_sampler`:
+///   - `temperature <= 0`: return `greedySampler` (no RNG, deterministic).
+///   - `temperature > 0`: scale logits by `1/temperature`, optionally
+///     mask to top-K and/or top-P, then sample categorically.
+///
+/// `seed` makes the resulting stream deterministic. Each call to the
+/// returned sampler advances the per-sampler PRNG key, so successive
+/// decode steps produce different draws even with the same input
+/// distribution. Two requests sharing the same seed but called in
+/// different orders/contexts will produce **different** sequences --
+/// this matches `mlx_lm` behavior and OpenAI's documented "best-effort"
+/// determinism.
+///
+/// - Parameters:
+///   - temperature: 0 = greedy, otherwise the logits divisor.
+///   - topP: nucleus probability mass (1.0 = disabled).
+///   - topK: number of top tokens to keep (0 = disabled).
+///   - seed: optional RNG seed; nil uses MLX's global PRNG.
+public func makeRowSampler(
+    temperature: Float = 0.0,
+    topP: Float = 1.0,
+    topK: Int = 0,
+    seed: UInt64? = nil
+) -> RowSampler {
+    if temperature <= 0 {
+        return greedySampler
+    }
+
+    let keyHolder = SamplerKeyHolder(seed: seed)
+    let temp = temperature
+    let p = topP
+    let k = topK
+
+    return { @Sendable logprobs in
+        var lp = logprobs * (1.0 / temp)
+        if k > 0 { lp = applyTopK(lp, k: k) }
+        if p > 0, p < 1 { lp = applyTopP(lp, p: p) }
+        let key = keyHolder.next()
+        return MLXRandom.categorical(lp, axis: -1, key: key)
+    }
+}
+
+// MARK: - Top-K
+
+/// Mask all but the top-K logits along the last axis to `-inf`. If
+/// `k >= vocab` the input is returned unchanged.
+@usableFromInline
+func applyTopK(_ logprobs: MLXArray, k: Int) -> MLXArray {
+    let vocab = logprobs.shape.last ?? 0
+    if k <= 0 || k >= vocab { return logprobs }
+
+    let sortedIdx = argSort(-logprobs, axis: -1)
+    let topIdx = sortedIdx[.ellipsis, 0 ..< k]
+    let topVals = takeAlong(logprobs, topIdx, axis: -1)
+    let threshold = topVals.min(axes: [-1], keepDims: true)
+    let negInf = MLXArray(-Float.infinity)
+    return which(logprobs .>= threshold, logprobs, negInf)
+}
+
+// MARK: - Top-P (nucleus)
+
+/// Keep the smallest set of tokens whose cumulative softmax mass is at
+/// least `p`. Tokens outside that nucleus are masked to `-inf`. The
+/// "first token over threshold" stays in (mlx_lm semantics) so a
+/// degenerate distribution still yields one valid pick.
+@usableFromInline
+func applyTopP(_ logprobs: MLXArray, p: Float) -> MLXArray {
+    let sortedIdxAsc = argSort(logprobs, axis: -1)
+    let sortedLogits = takeAlong(logprobs, sortedIdxAsc, axis: -1)
+    let sortedProbs = softmax(sortedLogits, axis: -1)
+    let cumProbs = sortedProbs.cumsum(axis: -1)
+
+    // Keep tokens whose suffix-mass (tail starting here) >= 1 - p.
+    // i.e. mask sorted positions where cumProbs <= 1 - p, but keep the
+    // boundary token (first one above threshold).
+    let keepThreshold = MLXArray(1.0 - p)
+    let keepMask = cumProbs .> keepThreshold
+    let negInf = MLXArray(-Float.infinity)
+    let maskedSorted = which(keepMask, sortedLogits, negInf)
+
+    // Scatter back to original token order.
+    let inverseIdx = argSort(sortedIdxAsc, axis: -1)
+    return takeAlong(maskedSorted, inverseIdx, axis: -1)
+}
+
+// MARK: - Per-sampler PRNG state
+
+/// Holds a per-sampler PRNG key and advances it on every draw.
+///
+/// `RowSampler` is `@Sendable`, but each row's sampler is invoked from a
+/// single context (`GenerationBatch.step` runs serially on the
+/// `ModelContainer` actor), so a class-backed mutable holder is sound;
+/// we mark it `@unchecked Sendable` because MLX `MLXArray` keys are not
+/// Sendable but our access pattern is single-threaded per row.
+final class SamplerKeyHolder: @unchecked Sendable {
+    private var key: MLXArray?
+
+    init(seed: UInt64?) {
+        self.key = seed.map { MLXRandom.key($0) }
+    }
+
+    func next() -> MLXArray? {
+        guard let current = key else { return nil }
+        let (subkey, nextKey) = MLXRandom.split(key: current)
+        key = nextKey
+        return subkey
+    }
+}

--- a/Libraries/MLXLMCommon/SequenceStateMachine.swift
+++ b/Libraries/MLXLMCommon/SequenceStateMachine.swift
@@ -1,0 +1,166 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Port of mlx_lm.generate.SequenceStateMachine.
+// https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
+
+import Foundation
+
+/// A trie node for matching a multi-token stop sequence.
+public struct StateMachineTrieNode: Sendable {
+    public var children: [Int: StateMachineTrieNode] = [:]
+
+    /// Set on terminal nodes. Reaching this node completes the sequence
+    /// and transitions to `transition.next`, or terminates if that's nil.
+    public var transition: Transition?
+
+    public struct Transition: Sendable {
+        public let matchedSequence: [Int]
+        public let next: String?
+    }
+
+    public init() {}
+}
+
+/// Snapshot of a single row's match progress.
+public struct SequenceStateMachineState: Sendable {
+    public let currentState: String?
+    public let trieNode: StateMachineTrieNode?
+    public let allStates: [String: StateMachineTrieNode]
+    public let pendingMatch: [Int]
+
+    public init(
+        currentState: String?,
+        trieNode: StateMachineTrieNode?,
+        allStates: [String: StateMachineTrieNode],
+        pendingMatch: [Int] = []
+    ) {
+        self.currentState = currentState
+        self.trieNode = trieNode
+        self.allStates = allStates
+        self.pendingMatch = pendingMatch
+    }
+}
+
+/// Per-row stop-sequence detector. Each named state holds a list of
+/// `(sequence, nextState)` transitions; matching `sequence` from `state`
+/// transitions to `nextState`, or terminates the row if `nextState` is nil.
+///
+/// A typical configuration is `["normal": [(eosTokens, nil)]]` -- one
+/// terminal match on the model's EOS tokens.
+public struct SequenceStateMachine: Sendable {
+
+    public let states: [String: StateMachineTrieNode]
+    public let initial: String
+
+    public init(
+        states: [String: [(sequence: [Int], next: String?)]],
+        initial: String = "normal"
+    ) {
+        var compiled: [String: StateMachineTrieNode] = [:]
+        for (name, transitions) in states {
+            var root = StateMachineTrieNode()
+            for (sequence, next) in transitions {
+                let transition = StateMachineTrieNode.Transition(
+                    matchedSequence: sequence,
+                    next: next
+                )
+                Self.insert(
+                    into: &root,
+                    sequence: sequence,
+                    index: 0,
+                    transition: transition
+                )
+            }
+            compiled[name] = root
+        }
+        self.states = compiled
+        self.initial = initial
+    }
+
+    private static func insert(
+        into node: inout StateMachineTrieNode,
+        sequence: [Int],
+        index: Int,
+        transition: StateMachineTrieNode.Transition
+    ) {
+        if index == sequence.count {
+            node.transition = transition
+            return
+        }
+        let token = sequence[index]
+        var child = node.children[token] ?? StateMachineTrieNode()
+        insert(into: &child, sequence: sequence, index: index + 1, transition: transition)
+        node.children[token] = child
+    }
+
+    /// An empty machine that never matches. Rows finish only on `max_tokens`.
+    public init() {
+        self.states = [:]
+        self.initial = "normal"
+    }
+
+    public func makeState() -> SequenceStateMachineState {
+        SequenceStateMachineState(
+            currentState: states.isEmpty ? nil : initial,
+            trieNode: states[initial],
+            allStates: states,
+            pendingMatch: []
+        )
+    }
+
+    /// Advance the state by one token. Returns the new state, the matched
+    /// sequence if a terminal node was reached on this token, and the state
+    /// name after the transition (nil indicates the row terminated).
+    public func match(
+        _ state: SequenceStateMachineState, _ token: Int
+    ) -> (
+        next: SequenceStateMachineState,
+        matchedSequence: [Int]?,
+        currentState: String?
+    ) {
+        guard let node = state.trieNode else {
+            return (state, nil, state.currentState)
+        }
+
+        if let child = node.children[token] {
+            let nextPending = state.pendingMatch + [token]
+            if let transition = child.transition {
+                let nextState = transition.next
+                let nextNode = nextState.flatMap { state.allStates[$0] }
+                return (
+                    SequenceStateMachineState(
+                        currentState: nextState,
+                        trieNode: nextNode,
+                        allStates: state.allStates,
+                        pendingMatch: []
+                    ),
+                    transition.matchedSequence,
+                    nextState
+                )
+            }
+            return (
+                SequenceStateMachineState(
+                    currentState: state.currentState,
+                    trieNode: child,
+                    allStates: state.allStates,
+                    pendingMatch: nextPending
+                ),
+                nil,
+                state.currentState
+            )
+        }
+
+        // Mismatch: reset to the root of the current state's trie.
+        let resetNode = state.allStates[state.currentState ?? ""]
+        return (
+            SequenceStateMachineState(
+                currentState: state.currentState,
+                trieNode: resetNode,
+                allStates: state.allStates,
+                pendingMatch: []
+            ),
+            nil,
+            state.currentState
+        )
+    }
+}

--- a/Libraries/MLXLMCommon/SequenceStateMachine.swift
+++ b/Libraries/MLXLMCommon/SequenceStateMachine.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Eigen Labs.
-//
 // Port of mlx_lm.generate.SequenceStateMachine.
 // https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py
 
@@ -118,49 +116,67 @@ public struct SequenceStateMachine: Sendable {
         matchedSequence: [Int]?,
         currentState: String?
     ) {
-        guard let node = state.trieNode else {
+        guard state.trieNode != nil, let currentState = state.currentState,
+            let root = state.allStates[currentState]
+        else {
             return (state, nil, state.currentState)
         }
 
-        if let child = node.children[token] {
-            let nextPending = state.pendingMatch + [token]
-            if let transition = child.transition {
-                let nextState = transition.next
-                let nextNode = nextState.flatMap { state.allStates[$0] }
+        var candidate = state.pendingMatch + [token]
+        while !candidate.isEmpty {
+            if let child = Self.findPrefix(candidate, in: root) {
+                if let transition = child.transition {
+                    let nextState = transition.next
+                    let nextNode = nextState.flatMap { state.allStates[$0] }
+                    return (
+                        SequenceStateMachineState(
+                            currentState: nextState,
+                            trieNode: nextNode,
+                            allStates: state.allStates,
+                            pendingMatch: []
+                        ),
+                        transition.matchedSequence,
+                        nextState
+                    )
+                }
                 return (
                     SequenceStateMachineState(
-                        currentState: nextState,
-                        trieNode: nextNode,
+                        currentState: currentState,
+                        trieNode: child,
                         allStates: state.allStates,
-                        pendingMatch: []
+                        pendingMatch: candidate
                     ),
-                    transition.matchedSequence,
-                    nextState
+                    nil,
+                    currentState
                 )
             }
-            return (
-                SequenceStateMachineState(
-                    currentState: state.currentState,
-                    trieNode: child,
-                    allStates: state.allStates,
-                    pendingMatch: nextPending
-                ),
-                nil,
-                state.currentState
-            )
+
+            candidate.removeFirst()
         }
 
-        // Mismatch: reset to the root of the current state's trie.
-        let resetNode = state.allStates[state.currentState ?? ""]
         return (
             SequenceStateMachineState(
-                currentState: state.currentState,
-                trieNode: resetNode,
+                currentState: currentState,
+                trieNode: root,
                 allStates: state.allStates,
                 pendingMatch: []
             ),
             nil,
-            state.currentState
+            currentState
         )
+    }
+
+    private static func findPrefix(
+        _ tokens: [Int],
+        in root: StateMachineTrieNode
+    ) -> StateMachineTrieNode? {
+        var node = root
+        for token in tokens {
+            guard let child = node.children[token] else {
+                return nil
+            }
+            node = child
+        }
+        return node
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -72,6 +72,7 @@ let package = Package(
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
             ],
             path: "Libraries/MLXLMCommon",
             exclude: [

--- a/Tests/MLXLMTests/ContinuousBatchingTests.swift
+++ b/Tests/MLXLMTests/ContinuousBatchingTests.swift
@@ -1,0 +1,245 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+final class ContinuousBatchingTests: XCTestCase {
+
+    func testBatchKVCacheMergeExtendFilterAndExtract() {
+        let first = makeCache(keys: [1, 2], values: [11, 12])
+        let second = makeCache(keys: [3, 4, 5], values: [13, 14, 15])
+
+        let merged = BatchKVCache.merge([first])
+        merged.extend(BatchKVCache.merge([second]))
+
+        XCTAssertEqual(merged.size(), 3)
+        XCTAssertEqual(merged.leftPadding.asArray(Int32.self), [1, 0])
+        assertCache(merged.extract(0), keys: [1, 2], values: [11, 12])
+        assertCache(merged.extract(1), keys: [3, 4, 5], values: [13, 14, 15])
+
+        merged.filter(batchIndices: MLXArray([Int32(0)]))
+
+        XCTAssertEqual(merged.size(), 2)
+        XCTAssertEqual(merged.leftPadding.asArray(Int32.self), [0])
+        assertCache(merged.extract(0), keys: [1, 2], values: [11, 12])
+    }
+
+    func testBatchRotatingKVCacheKeepsSlidingWindowRows() {
+        let cache = BatchRotatingKVCache(maxSize: 3, leftPadding: [0, 1])
+        let (prefillKeys, _) = cache.update(
+            keys: MLXArray([1, 2, 3, 4, 5, 6, 7, 8] as [Float]).reshaped([2, 1, 4, 1]),
+            values: MLXArray([11, 12, 13, 14, 15, 16, 17, 18] as [Float]).reshaped([2, 1, 4, 1])
+        )
+
+        XCTAssertEqual(prefillKeys.dim(2), 4)
+        XCTAssertEqual(cache.size(), 4)
+
+        _ = cache.update(
+            keys: MLXArray([9, 10] as [Float]).reshaped([2, 1, 1, 1]),
+            values: MLXArray([19, 20] as [Float]).reshaped([2, 1, 1, 1])
+        )
+
+        XCTAssertEqual(cache.size(), 3)
+        XCTAssertEqual(cache.state[0].asArray(Float.self), [3, 4, 9, 7, 8, 10])
+
+        let extracted = cache.extract(0)
+        XCTAssertEqual(extracted.state[0].asArray(Float.self), [3, 4, 9])
+    }
+
+    func testArraysCachePreservesBatchMetadataThroughFilterAndExtend() {
+        let first = ArraysCache(size: 1, leftPadding: [0, 2])
+        first[0] = MLXArray([1, 2] as [Float]).reshaped([2, 1])
+        let second = ArraysCache(size: 1, leftPadding: [1])
+        second[0] = MLXArray([3] as [Float]).reshaped([1, 1])
+
+        first.extend(other: second)
+        XCTAssertEqual(
+            first.makeMask(N: 3)?.asArray(Bool.self),
+            [
+                true, true, true,
+                false, false, true,
+                false, true, true,
+            ])
+
+        first.filter(batchIndices: MLXArray([Int32(1), Int32(2)]))
+        XCTAssertEqual(
+            first.makeMask(N: 3)?.asArray(Bool.self),
+            [
+                false, false, true,
+                false, true, true,
+            ])
+    }
+
+    func testArraysCacheAdvancesLengthsForChunkedPrefill() {
+        let cache = ArraysCache(size: 1)
+        cache.prepare(lengths: [3, 5])
+
+        XCTAssertEqual(
+            cache.makeMask(N: 2)?.asArray(Bool.self),
+            [
+                true, true,
+                true, true,
+            ])
+
+        cache.advance(2)
+
+        XCTAssertEqual(
+            cache.makeMask(N: 3)?.asArray(Bool.self),
+            [
+                true, false, false,
+                true, true, true,
+            ])
+    }
+
+    func testSequenceStateMachineMatchesMultiTokenStopsAndTransitions() {
+        let machine = SequenceStateMachine(
+            states: [
+                "normal": [(sequence: [4, 5], next: "afterMarker")],
+                "afterMarker": [(sequence: [6], next: nil)],
+            ]
+        )
+
+        var state = machine.makeState()
+
+        var result = machine.match(state, 4)
+        XCTAssertNil(result.matchedSequence)
+        XCTAssertEqual(result.currentState, "normal")
+        state = result.next
+
+        result = machine.match(state, 5)
+        XCTAssertEqual(result.matchedSequence, [4, 5])
+        XCTAssertEqual(result.currentState, "afterMarker")
+        state = result.next
+
+        result = machine.match(state, 6)
+        XCTAssertEqual(result.matchedSequence, [6])
+        XCTAssertNil(result.currentState)
+    }
+
+    func testSequenceStateMachineMatchesOverlappingStopSequence() {
+        let machine = SequenceStateMachine(states: ["normal": [(sequence: [1, 2], next: nil)]])
+        var state = machine.makeState()
+
+        var result = machine.match(state, 1)
+        XCTAssertNil(result.matchedSequence)
+        state = result.next
+
+        result = machine.match(state, 1)
+        XCTAssertNil(result.matchedSequence)
+        state = result.next
+
+        result = machine.match(state, 2)
+        XCTAssertEqual(result.matchedSequence, [1, 2])
+        XCTAssertNil(result.currentState)
+    }
+
+    func testRowSamplerTopKOneAlwaysSelectsBestToken() {
+        let sampler = makeRowSampler(temperature: 1, topP: 1, topK: 1, seed: 7)
+        let logprobs = MLXArray([0.1 as Float, 3.0 as Float, 2.0 as Float])[
+            .newAxis, .ellipsis
+        ]
+
+        for _ in 0 ..< 5 {
+            XCTAssertEqual(sampler(logprobs).item(Int.self), 1)
+        }
+    }
+
+    func testBatchGeneratorAdmitsQueuedRowsAndReportsFinishReasons() {
+        let generator = BatchGenerator(
+            model: IncrementingLanguageModel(),
+            eosTokens: [[5]],
+            defaultMaxTokens: 4,
+            prefillBatchSize: 1,
+            completionBatchSize: 2
+        )
+
+        let uids = generator.insert(prompts: [[1, 2], [8]], maxTokens: [4, 2])
+        XCTAssertEqual(uids, [0, 1])
+
+        var tokensByUID: [Int: [Int]] = [:]
+        var finishReasonByUID: [Int: String] = [:]
+        var steps = 0
+
+        while generator.hasWork {
+            steps += 1
+            XCTAssertLessThan(steps, 10)
+
+            for response in generator.next() {
+                tokensByUID[response.uid, default: []].append(response.token)
+                if let finishReason = response.finishReason {
+                    finishReasonByUID[response.uid] = finishReason
+                }
+            }
+        }
+
+        XCTAssertEqual(tokensByUID[0], [3, 4, 5])
+        XCTAssertEqual(tokensByUID[1], [9, 10])
+        XCTAssertEqual(finishReasonByUID[0], "stop")
+        XCTAssertEqual(finishReasonByUID[1], "length")
+        XCTAssertEqual(generator.promptTokensProcessed, 3)
+        XCTAssertFalse(generator.hasWork)
+    }
+}
+
+private func makeCache(keys: [Float], values: [Float]) -> KVCacheSimple {
+    let cache = KVCacheSimple()
+    _ = cache.update(
+        keys: MLXArray(keys).reshaped([1, 1, keys.count, 1]),
+        values: MLXArray(values).reshaped([1, 1, values.count, 1])
+    )
+    return cache
+}
+
+private func assertCache(
+    _ cache: KVCacheSimple,
+    keys expectedKeys: [Float],
+    values expectedValues: [Float],
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let state = cache.state
+    XCTAssertEqual(state.count, 2, file: file, line: line)
+    XCTAssertEqual(state[0].asArray(Float.self), expectedKeys, file: file, line: line)
+    XCTAssertEqual(state[1].asArray(Float.self), expectedValues, file: file, line: line)
+}
+
+private final class IncrementingLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let vocabularySize = 16
+    var kvHeads: [Int] { [1] }
+
+    func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
+        let batchSize = inputs.dim(0)
+        let sequenceLength = inputs.dim(1)
+
+        if let cache {
+            let keys = MLXArray.ones([batchSize, 1, sequenceLength, 1], dtype: .float32)
+            let values = keys * 2
+            for layerCache in cache {
+                _ = layerCache.update(keys: keys, values: values)
+            }
+        }
+
+        let inputTokens = inputs.asArray(UInt32.self).map { Int($0) }
+        var logits = Array(
+            repeating: Float(-1_000),
+            count: batchSize * sequenceLength * vocabularySize
+        )
+
+        for batchIndex in 0 ..< batchSize {
+            for tokenIndex in 0 ..< sequenceLength {
+                let inputIndex = batchIndex * sequenceLength + tokenIndex
+                let nextToken = (inputTokens[inputIndex] + 1) % vocabularySize
+                let logitIndex =
+                    (batchIndex * sequenceLength + tokenIndex) * vocabularySize + nextToken
+                logits[logitIndex] = 0
+            }
+        }
+
+        return MLXArray(logits).reshaped([batchSize, sequenceLength, vocabularySize])
+    }
+}


### PR DESCRIPTION
## Summary
- Add a continuous-batching generation path with batched KV caches, per-row samplers, and stop-sequence handling.
- Add Gemma 4 text model support, including shared-KV handling and MoE projection sanitization.
- Document continuous batching and add upstream-local tests for batching caches, row samplers, stop matching, and request admission.

## Test plan
- [x] `uvx pre-commit run --all-files`
- [x] `xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS'`
- [x] `scripts/verify-docs.sh`


Made with [Cursor](https://cursor.com)