### PR TITLE
Fix(Docs) non-compiling README quick-start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,26 +57,45 @@ Then chose an [integration package for downloaders and tokenizers](https://swift
 
 ## Quick Start
 
-After installing the package you can use LLMs to generate content with only a few lines
-of code.  (Note: the exact line to load the model depends on the [integration package](https://swiftpackageindex.com/ml-explore/mlx-swift-lm/main/documentation/mlxlmcommon/using#Integration-Packages)).
+See also [MLXLMCommon](Libraries/MLXLMCommon). The simplest way to get started is using the `MLXHuggingFace` macros, which provide a default Hugging Face downloader and tokenizer integration.
 
-> [!NOTE]
-> If the documentation link shows a 404, view the
-> [source](https://github.com/ml-explore/mlx-swift-lm/blob/main/Libraries/MLXLMCommon/Documentation.docc/using.md).
+## Package.swift
 
+```swift
+dependencies: [
+    .package(url: "https://github.com/ml-explore/mlx-swift-lm", .upToNextMajor(from: "3.31.3")),
+    .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
+    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+],
+targets: [
+    .target(
+        name: "YourTargetName",
+        dependencies: [
+            .product(name: "MLXLLM", package: "mlx-swift-lm"),
+            .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
+            .product(name: "HuggingFace", package: "swift-huggingface"),
+            .product(name: "Tokenizers", package: "swift-transformers"),
+        ]),
+]
+```
+
+## Usage
 
 ```swift
 import MLXLLM
 import MLXLMCommon
+import MLXHuggingFace
+import HuggingFace
+import Tokenizers
 
-let modelConfiguration = LLMRegistry.gemma3_1B_qat_4bit
-
-// customize this line per the integration package
-let model = try await loadModelContainer(
-    configuration: modelConfiguration
+let model = try await #huggingFaceLoadModelContainer(
+    configuration: LLMRegistry.gemma3_1B_qat_4bit
 )
 
 let session = ChatSession(model)
 print(try await session.respond(to: "What are two things to see in San Francisco?"))
 print(try await session.respond(to: "How about a great place to eat?"))
 ```
+
+For alternative integration approaches (custom downloaders, alternative tokenizer packages, local-only weights), see the [using documentation](Libraries/MLXLMCommon/Documentation.docc/using.md).


### PR DESCRIPTION
## Proposed changes

The current README quick-start example doesn't compile on 3.x:

```swift
let model = try await loadModelContainer(configuration: modelConfiguration)
```

This signature was removed in the 3.x decoupling. All `loadModelContainer` overloads now require `from:` (Downloader) and `using:` (TokenizerLoader) parameters. New users hit `Missing arguments for parameters 'from', 'using' in call` immediately.

The comment "customize this line per the integration package" doesn't explain what's needed or link to the integration docs.

## Fix

Replace the example with the `#huggingFaceLoadModelContainer` macro path — the simplest working setup and the closest equivalent to the 2.x experience. Includes:

- Required imports (`MLXHuggingFace`, `HuggingFace`, `Tokenizers`)
- Required `Package.swift` dependencies (`swift-huggingface`, `swift-transformers`)
- Link to `using.md` for alternative integration paths

Related: #201
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [] (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
