### PR TITLE
fix: avoid shared CIContext in media processing

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -1,7 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 import AVFoundation
-import CoreImage.CIFilterBuiltins
+@preconcurrency import CoreImage.CIFilterBuiltins
 import MLX
 import MLXLMCommon
 
@@ -12,6 +12,8 @@ public struct ProcessedFrames {
     public let timestamps: [CMTime]
     public let totalDuration: CMTime
 }
+
+private let context = CIContext()
 
 /// Collection of methods for processing media (images, video, etc.).
 ///
@@ -167,12 +169,11 @@ public enum MediaProcessing {
         let bytesPerRow = w * bytesPerPixel
 
         var data = Data(count: w * h * bytesPerPixel)
-        let renderContext = CIContext()
         data.withUnsafeMutableBytes { ptr in
-            renderContext.render(
+            context.render(
                 image, toBitmap: ptr.baseAddress!, rowBytes: bytesPerRow, bounds: image.extent,
                 format: format, colorSpace: colorSpace)
-            renderContext.clearCaches()
+            context.clearCaches()
         }
 
         var array = MLXArray(data, [h, w, 4], type: Float32.self)

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -13,8 +13,6 @@ public struct ProcessedFrames {
     public let totalDuration: CMTime
 }
 
-private let context = CIContext()
-
 /// Collection of methods for processing media (images, video, etc.).
 ///
 /// A typical image preparation pipeline might look like this:
@@ -169,11 +167,12 @@ public enum MediaProcessing {
         let bytesPerRow = w * bytesPerPixel
 
         var data = Data(count: w * h * bytesPerPixel)
+        let renderContext = CIContext()
         data.withUnsafeMutableBytes { ptr in
-            context.render(
+            renderContext.render(
                 image, toBitmap: ptr.baseAddress!, rowBytes: bytesPerRow, bounds: image.extent,
                 format: format, colorSpace: colorSpace)
-            context.clearCaches()
+            renderContext.clearCaches()
         }
 
         var array = MLXArray(data, [h, w, 4], type: Float32.self)


### PR DESCRIPTION
## Summary

- Removes the shared file-level `CIContext` from `MediaProcessing`.
- Creates a local `CIContext` inside `asMLXArray(...)` before rendering.
- Avoids Swift 6.1 strict concurrency failures caused by a non-Sendable global `CIContext` while preserving existing rendering behavior.

## Test Plan

- Verified downstream SwiftPM build from `Meapri/mlx-vlm` against this fork branch.
- The previous strict-concurrency error was:
  - `let context is not concurrency-safe because non-Sendable type CIContext may have shared mutable state`.