### PR TITLE
Add Gemma 4 MTP assistant model and native MTP speculative decoding

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -33,6 +33,8 @@ public enum LLMTypeRegistry {
         "gemma3n": create(Gemma3nTextConfiguration.self, Gemma3nTextModel.init),
         "gemma4": create(Gemma4Configuration.self, Gemma4Model.init),
         "gemma4_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
+        "gemma4_assistant": create(
+            Gemma4AssistantConfiguration.self, Gemma4AssistantModel.init),
         "qwen2": create(Qwen2Configuration.self, Qwen2Model.init),
         "qwen3": create(Qwen3Configuration.self, Qwen3Model.init),
         "qwen3_moe": create(Qwen3MoEConfiguration.self, Qwen3MoEModel.init),

--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -98,6 +98,18 @@ public class Gemma4Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 }
 
+// MARK: - MTP Backbone Support
+
+extension Gemma4Model: MTPBackboneModel {
+    public func forwardMTP(_ inputs: MLXArray, cache: [KVCache]?) -> MTPBackboneOutput {
+        languageModel.forwardMTP(inputs, cache: cache)
+    }
+
+    public var sharedEmbeddings: Embedding { languageModel.sharedEmbeddings }
+    public var embeddingScale: Float { languageModel.embeddingScale }
+    public var backboneLayerTypes: [String] { languageModel.backboneLayerTypes }
+}
+
 // MARK: - LoRA
 
 extension Gemma4Model: LoRAModel {

--- a/Libraries/MLXLLM/Models/Gemma4Assistant.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Assistant.swift
@@ -350,6 +350,7 @@ private class Gemma4AssistantDecoderLayer: Module {
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: RMSNorm
     @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: RMSNorm
     @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: RMSNorm
+    @ModuleInfo(key: "layer_scalar") var layerScalar: MLXArray
 
     init(_ config: Gemma4AssistantTextConfiguration, layerIdx: Int) {
         self.layerType = config.layerTypes[layerIdx]
@@ -363,6 +364,7 @@ private class Gemma4AssistantDecoderLayer: Module {
             dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._postFeedforwardLayernorm.wrappedValue = RMSNorm(
             dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._layerScalar.wrappedValue = MLXArray.ones([1], dtype: .float16)
         super.init()
     }
 
@@ -382,6 +384,8 @@ private class Gemma4AssistantDecoderLayer: Module {
         out = mlp(out)
         out = postFeedforwardLayernorm(out)
         out = residual2 + out
+
+        out = out * layerScalar
 
         return out
     }

--- a/Libraries/MLXLLM/Models/Gemma4Assistant.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Assistant.swift
@@ -1,0 +1,546 @@
+// Copyright © 2025 Apple Inc.
+//
+// Port of https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma4_assistant/modeling_gemma4_assistant.py
+//
+// Gemma 4 MTP assistant model — a small 4-layer transformer (~78M params)
+// used as a native drafter for Multi-Token Prediction speculative decoding.
+//
+// Architecture:
+// 1. pre_projection: Linear(2 * backbone_hidden, drafter_hidden) — down-projects
+//    [backbone_last_hidden, token_embedding] into drafter space
+// 2. model: 4-layer Gemma4-style transformer with shared KV from backbone
+// 3. post_projection: Linear(drafter_hidden, backbone_hidden) — up-projects back
+// 4. lm_head or centroid masked_embedding: produces logits over vocabulary
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct Gemma4AssistantConfiguration: Codable, Sendable {
+    var modelType: String = "gemma4_assistant"
+    var backboneHiddenSize: Int = 2560
+    var numCentroids: Int = 2048
+    var centroidIntermediateTopK: Int = 32
+    var useOrderedEmbeddings: Bool = true
+    var tieWordEmbeddings: Bool = true
+    var textConfig: Gemma4AssistantTextConfiguration
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case backboneHiddenSize = "backbone_hidden_size"
+        case numCentroids = "num_centroids"
+        case centroidIntermediateTopK = "centroid_intermediate_top_k"
+        case useOrderedEmbeddings = "use_ordered_embeddings"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case textConfig = "text_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType =
+            try container.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_assistant"
+        self.backboneHiddenSize =
+            try container.decodeIfPresent(Int.self, forKey: .backboneHiddenSize) ?? 2560
+        self.numCentroids =
+            try container.decodeIfPresent(Int.self, forKey: .numCentroids) ?? 2048
+        self.centroidIntermediateTopK =
+            try container.decodeIfPresent(Int.self, forKey: .centroidIntermediateTopK) ?? 32
+        self.useOrderedEmbeddings =
+            try container.decodeIfPresent(Bool.self, forKey: .useOrderedEmbeddings) ?? true
+        self.tieWordEmbeddings =
+            try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+        self.textConfig = try container.decode(
+            Gemma4AssistantTextConfiguration.self, forKey: .textConfig)
+    }
+}
+
+public struct Gemma4AssistantTextConfiguration: Codable, Sendable {
+    var modelType: String = "gemma4_text"
+    var hiddenSize: Int = 256
+    var numHiddenLayers: Int = 4
+    var intermediateSize: Int = 2048
+    var numAttentionHeads: Int = 4
+    var headDim: Int = 256
+    var globalHeadDim: Int = 512
+    var rmsNormEps: Float = 1e-6
+    var vocabSize: Int = 262144
+    var numKeyValueHeads: Int = 2
+    var numGlobalKeyValueHeads: Int?
+    var numKvSharedLayers: Int = 4
+    var slidingWindow: Int = 512
+    var maxPositionEmbeddings: Int = 131072
+    var attentionKeqV: Bool = false
+    var layerTypes: [String] = [
+        "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+    ]
+    var tieWordEmbeddings: Bool = true
+    var hiddenActivation: String = "gelu_pytorch_tanh"
+    var ropeParameters: [String: [String: StringOrNumber]]?
+
+    var slidingRopeTheta: Float = 10000.0
+    var fullRopeTheta: Float = 1_000_000.0
+    var fullPartialRotaryFactor: Float = 0.25
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case numAttentionHeads = "num_attention_heads"
+        case headDim = "head_dim"
+        case globalHeadDim = "global_head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case vocabSize = "vocab_size"
+        case numKeyValueHeads = "num_key_value_heads"
+        case numGlobalKeyValueHeads = "num_global_key_value_heads"
+        case numKvSharedLayers = "num_kv_shared_layers"
+        case slidingWindow = "sliding_window"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case attentionKeqV = "attention_k_eq_v"
+        case layerTypes = "layer_types"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case hiddenActivation = "hidden_activation"
+        case ropeParameters = "rope_parameters"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType =
+            try container.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_text"
+        self.hiddenSize = try container.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 256
+        self.numHiddenLayers =
+            try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 4
+        self.intermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 2048
+        self.numAttentionHeads =
+            try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 4
+        self.headDim = try container.decodeIfPresent(Int.self, forKey: .headDim) ?? 256
+        self.globalHeadDim =
+            try container.decodeIfPresent(Int.self, forKey: .globalHeadDim) ?? 512
+        self.rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        self.vocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 262144
+        self.numKeyValueHeads =
+            try container.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 2
+        self.numGlobalKeyValueHeads =
+            try container.decodeIfPresent(Int.self, forKey: .numGlobalKeyValueHeads)
+        self.numKvSharedLayers =
+            try container.decodeIfPresent(Int.self, forKey: .numKvSharedLayers) ?? 4
+        self.slidingWindow =
+            try container.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 512
+        self.maxPositionEmbeddings =
+            try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 131072
+        self.attentionKeqV =
+            try container.decodeIfPresent(Bool.self, forKey: .attentionKeqV) ?? false
+        self.layerTypes =
+            try container.decodeIfPresent([String].self, forKey: .layerTypes)
+            ?? ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"]
+        self.tieWordEmbeddings =
+            try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+        self.hiddenActivation =
+            try container.decodeIfPresent(String.self, forKey: .hiddenActivation)
+            ?? "gelu_pytorch_tanh"
+        self.ropeParameters =
+            try container.decodeIfPresent(
+                [String: [String: StringOrNumber]].self, forKey: .ropeParameters)
+
+        if let ropeParams = ropeParameters {
+            if let sliding = ropeParams["sliding_attention"] {
+                self.slidingRopeTheta = sliding["rope_theta"]?.asFloat() ?? 10000.0
+            }
+            if let full = ropeParams["full_attention"] {
+                self.fullRopeTheta = full["rope_theta"]?.asFloat() ?? 1_000_000.0
+                self.fullPartialRotaryFactor =
+                    full["partial_rotary_factor"]?.asFloat() ?? 0.25
+            }
+        }
+    }
+}
+
+// MARK: - Centroid Masked Embedder
+
+/// Centroid-based masked embedder for efficient vocabulary logit computation.
+///
+/// Instead of computing logits over the full 262K vocabulary, this groups tokens
+/// into centroids and only computes logits for tokens in the top-K predicted centroids.
+private class CentroidMaskedEmbedder: Module {
+    let numCentroids: Int
+    let centroidIntermediateTopK: Int
+    let hiddenSize: Int
+    let vocabSize: Int
+    let vocabSizePerCentroid: Int
+
+    @ModuleInfo var centroids: Linear
+    @ModuleInfo(key: "token_ordering") var tokenOrdering: MLXArray
+
+    init(_ config: Gemma4AssistantConfiguration) {
+        let textConfig = config.textConfig
+        self.numCentroids = config.numCentroids
+        self.centroidIntermediateTopK = config.centroidIntermediateTopK
+        self.hiddenSize = textConfig.hiddenSize
+        self.vocabSize = textConfig.vocabSize
+        self.vocabSizePerCentroid = vocabSize / numCentroids
+
+        self._centroids.wrappedValue = Linear(hiddenSize, numCentroids, bias: false)
+        self._tokenOrdering.wrappedValue = MLXArray.zeros([vocabSize], dtype: .int64)
+
+        super.init()
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray, lmHeadWeight: MLXArray) -> MLXArray {
+        let batch = hiddenStates.dim(0)
+        let seqLen = hiddenStates.dim(1)
+
+        let centroidLogits = centroids(hiddenStates)
+
+        let sorted = argSort(centroidLogits, axis: -1)
+        let n = centroidLogits.dim(-1)
+        let topKIndices = sorted[.ellipsis, (n - centroidIntermediateTopK)...]
+
+        let ordering = tokenOrdering.asType(.int32)
+        let canonicalPositions = ordering.reshaped(numCentroids, vocabSizePerCentroid)
+        let selectedCanonical = canonicalPositions[topKIndices]
+
+        let selectedFlat = selectedCanonical.reshaped(-1)
+        let selectedEmbeddings = lmHeadWeight[selectedFlat].reshaped(
+            batch, seqLen,
+            centroidIntermediateTopK * vocabSizePerCentroid,
+            hiddenSize
+        )
+
+        let query = hiddenStates.expandedDimensions(axis: -2)
+        let selectedLogits = matmul(query, selectedEmbeddings.transposed(0, 1, 3, 2))
+            .squeezed(axis: -2)
+
+        let maskValue = selectedLogits.min().item(Float.self) - 1.0
+        var output = MLXArray.full([batch, seqLen, vocabSize], values: MLXArray(maskValue))
+
+        let scatterIdx = selectedCanonical.reshaped(batch, seqLen, -1)
+
+        let numUpdates = scatterIdx.dim(2)
+        let numRows = batch * seqLen
+        var flatBase = output.reshaped(-1)
+        let flatIndices = scatterIdx.reshaped(numRows, numUpdates).asType(.int32)
+        let rowOffsets = (MLXArray(0 ..< Int32(numRows)) * Int32(vocabSize))
+            .expandedDimensions(axis: 1)
+        let absIndices = (flatIndices + rowOffsets).reshaped(-1)
+        let flatUpdates = selectedLogits.reshaped(-1)
+        flatBase = MLXArray.full([numRows * vocabSize], values: output.min())
+        flatBase = flatBase.at[absIndices].add(flatUpdates - output.min())
+        output = flatBase.reshaped(batch, seqLen, vocabSize)
+
+        return output
+    }
+}
+
+// MARK: - Attention
+
+private class Gemma4AssistantAttention: Module {
+    let layerType: String
+    let isSliding: Bool
+    let effectiveHeadDim: Int
+    let nHeads: Int
+    let nKvHeads: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+
+    init(_ config: Gemma4AssistantTextConfiguration, layerIdx: Int) {
+        self.layerType = config.layerTypes[layerIdx]
+        self.isSliding = layerType == "sliding_attention"
+        self.effectiveHeadDim = isSliding ? config.headDim : config.globalHeadDim
+        self.nHeads = config.numAttentionHeads
+        self.nKvHeads = config.numKeyValueHeads
+        self.scale = 1.0
+
+        let dim = config.hiddenSize
+        self._qProj.wrappedValue = Linear(dim, nHeads * effectiveHeadDim, bias: false)
+        self._kProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+        self._vProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+        self._oProj.wrappedValue = Linear(nHeads * effectiveHeadDim, dim, bias: false)
+        self._qNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
+        self._kNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
+
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
+        sharedKV: (MLXArray, MLXArray)? = nil
+    ) -> MLXArray {
+        let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
+
+        var queries = qProj(x).reshaped(B, L, nHeads, effectiveHeadDim)
+        queries = qNorm(queries)
+        queries = queries.transposed(0, 2, 1, 3)
+
+        let keys: MLXArray
+        let values: MLXArray
+
+        if let (sharedK, sharedV) = sharedKV {
+            keys = sharedK
+            values = sharedV
+        } else {
+            var k = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
+            k = kNorm(k)
+            keys = k.transposed(0, 2, 1, 3)
+            values = vProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim).transposed(0, 2, 1, 3)
+        }
+
+        var adjustedMask = mask
+        if case .array(let maskArray) = mask {
+            let keysSeqLen = keys.dim(2)
+            if maskArray.dim(-1) != keysSeqLen {
+                adjustedMask = .array(maskArray[.ellipsis, 0 ..< keysSeqLen])
+            }
+        }
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: adjustedMask ?? .none
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return oProj(output)
+    }
+}
+
+// MARK: - MLP
+
+private class Gemma4AssistantMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(_ config: Gemma4AssistantTextConfiguration) {
+        self._gateProj.wrappedValue = Linear(
+            config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(
+            config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(
+            config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(geluApproximate(gateProj(x)) * upProj(x))
+    }
+}
+
+// MARK: - Decoder Layer
+
+private class Gemma4AssistantDecoderLayer: Module {
+    let layerType: String
+
+    @ModuleInfo(key: "self_attn") var selfAttn: Gemma4AssistantAttention
+    @ModuleInfo var mlp: Gemma4AssistantMLP
+    @ModuleInfo(key: "input_layernorm") var inputLayernorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: RMSNorm
+
+    init(_ config: Gemma4AssistantTextConfiguration, layerIdx: Int) {
+        self.layerType = config.layerTypes[layerIdx]
+        self._selfAttn.wrappedValue = Gemma4AssistantAttention(config, layerIdx: layerIdx)
+        self._mlp.wrappedValue = Gemma4AssistantMLP(config)
+        self._inputLayernorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayernorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._preFeedforwardLayernorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._postFeedforwardLayernorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
+        sharedKV: (MLXArray, MLXArray)? = nil
+    ) -> MLXArray {
+        let residual = x
+        let h = inputLayernorm(x)
+        let attnOut = selfAttn(h, mask: mask, sharedKV: sharedKV)
+        let postAttn = postAttentionLayernorm(attnOut)
+        var out = residual + postAttn
+
+        let residual2 = out
+        out = preFeedforwardLayernorm(out)
+        out = mlp(out)
+        out = postFeedforwardLayernorm(out)
+        out = residual2 + out
+
+        return out
+    }
+}
+
+// MARK: - Text Model Inner
+
+private class Gemma4AssistantTextModelInner: Module {
+    let config: Gemma4AssistantTextConfiguration
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "layers") var layers: [Gemma4AssistantDecoderLayer]
+    @ModuleInfo var norm: RMSNorm
+
+    init(_ config: Gemma4AssistantTextConfiguration) {
+        self.config = config
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
+        self._layers.wrappedValue = (0 ..< config.numHiddenLayers).map {
+            Gemma4AssistantDecoderLayer(config, layerIdx: $0)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ inputsEmbeds: MLXArray,
+        sharedKVStates: [String: (MLXArray, MLXArray)]? = nil
+    ) -> MLXArray {
+        var h = inputsEmbeds
+
+        for layer in layers {
+            let sharedKV = sharedKVStates?[layer.layerType]
+            h = layer(h, mask: nil, sharedKV: sharedKV)
+        }
+
+        return norm(h)
+    }
+}
+
+// MARK: - Gemma4 Assistant Model
+
+/// Output of the Gemma 4 MTP assistant model forward pass.
+public struct Gemma4AssistantOutput {
+    /// Up-projected hidden state back in backbone dimension space.
+    public let projectedState: MLXArray
+    /// Logits over the vocabulary.
+    public let logits: MLXArray
+}
+
+/// Gemma 4 MTP assistant model for speculative decoding.
+///
+/// This model is NOT a standalone language model — it operates as a drafter
+/// alongside a Gemma 4 backbone model, sharing KV cache and embeddings.
+///
+/// The forward pass:
+/// 1. Takes concatenated `[backbone_last_hidden, token_embedding]` as input
+/// 2. Down-projects via `pre_projection` from `2 * backbone_hidden_size` to drafter `hidden_size`
+/// 3. Runs through 4 transformer layers (with shared KV from backbone)
+/// 4. Up-projects via `post_projection` back to `backbone_hidden_size`
+/// 5. Produces logits via `lm_head` (or centroid `masked_embedding` for E2B/E4B)
+public class Gemma4AssistantModel: Module, LLMModel, KVCacheDimensionProvider {
+    public var vocabularySize: Int { config.textConfig.vocabSize }
+    public var kvHeads: [Int] {
+        (0 ..< config.textConfig.numHiddenLayers).map { _ in config.textConfig.numKeyValueHeads }
+    }
+
+    let config: Gemma4AssistantConfiguration
+
+    @ModuleInfo(key: "model") fileprivate var textModel: Gemma4AssistantTextModelInner
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+    @ModuleInfo(key: "pre_projection") var preProjection: Linear
+    @ModuleInfo(key: "post_projection") var postProjection: Linear
+    @ModuleInfo(key: "masked_embedding") fileprivate var maskedEmbedding: CentroidMaskedEmbedder?
+
+    public init(_ config: Gemma4AssistantConfiguration) {
+        self.config = config
+        let hiddenSize = config.textConfig.hiddenSize
+
+        self._textModel.wrappedValue = Gemma4AssistantTextModelInner(config.textConfig)
+        self._lmHead.wrappedValue = Linear(
+            hiddenSize, config.textConfig.vocabSize, bias: false)
+        self._preProjection.wrappedValue = Linear(
+            2 * config.backboneHiddenSize, hiddenSize, bias: false)
+        self._postProjection.wrappedValue = Linear(
+            hiddenSize, config.backboneHiddenSize, bias: false)
+
+        if config.useOrderedEmbeddings {
+            self._maskedEmbedding.wrappedValue = CentroidMaskedEmbedder(config)
+        }
+    }
+
+    /// Forward pass for MTP drafting.
+    ///
+    /// - Parameters:
+    ///   - inputsEmbeds: Concatenated `[backbone_hidden, token_embedding]` of shape
+    ///     `[B, L, 2 * backbone_hidden_size]`
+    ///   - sharedKVStates: Per-layer-type shared KV from backbone's last layers
+    /// - Returns: Projected state (in backbone dim space) and logits
+    public func assistantForward(
+        inputsEmbeds: MLXArray,
+        sharedKVStates: [String: (MLXArray, MLXArray)]? = nil
+    ) -> Gemma4AssistantOutput {
+        let projected = preProjection(inputsEmbeds)
+        let lastHidden = textModel(projected, sharedKVStates: sharedKVStates)
+        let projectedState = postProjection(lastHidden)
+
+        let logits: MLXArray
+        if let maskedEmbedding {
+            logits = maskedEmbedding(lastHidden, lmHeadWeight: lmHead.weight)
+        } else {
+            logits = lmHead(lastHidden)
+        }
+
+        return Gemma4AssistantOutput(projectedState: projectedState, logits: logits)
+    }
+
+    /// LanguageModel conformance — limited standalone usage.
+    ///
+    /// In practice this model is used via ``forward(inputsEmbeds:sharedKVStates:)``
+    /// during MTP speculative decoding. This conformance exists primarily for
+    /// weight loading through the model factory.
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let embeddings = textModel.embedTokens(inputs)
+        let zeros = MLXArray.zeros(like: embeddings)
+        let dummyInput = concatenated([zeros, embeddings], axis: -1)
+        let output = assistantForward(inputsEmbeds: dummyInput)
+        return output.logits
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var sanitized = [String: MLXArray]()
+        for (key, value) in weights {
+            if key.contains("self_attn.rotary_emb") {
+                continue
+            }
+            sanitized[key] = value
+        }
+        return sanitized
+    }
+}
+
+// MARK: - MTP Draft Model
+
+extension Gemma4AssistantModel: MTPDraftModel {
+    public func forward(
+        inputsEmbeds: MLXArray,
+        sharedKVStates: [String: (MLXArray, MLXArray)]?
+    ) -> MTPDraftOutput {
+        let result = assistantForward(
+            inputsEmbeds: inputsEmbeds, sharedKVStates: sharedKVStates)
+        return MTPDraftOutput(projectedState: result.projectedState, logits: result.logits)
+    }
+}
+
+// MARK: - LoRA
+
+extension Gemma4AssistantModel: LoRAModel {
+    public var loraLayers: [Module] {
+        textModel.layers.map { $0.selfAttn }
+    }
+}

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -695,6 +695,35 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 }
 
+// MARK: - MTP Backbone Support
+
+extension Gemma4TextModel: MTPBackboneModel {
+    /// Forward pass returning both logits and the pre-logit hidden states.
+    ///
+    /// The hidden states are needed by the MTP drafter model which concatenates
+    /// them with token embeddings as input.
+    public func forwardMTP(_ inputs: MLXArray, cache: [KVCache]?) -> MTPBackboneOutput {
+        let hiddenStates = model(inputs, cache: cache)
+        var logits: MLXArray
+        if let lmHead {
+            logits = lmHead(hiddenStates)
+        } else {
+            logits = model.embedTokens.asLinear(hiddenStates)
+        }
+        logits = tanh(logits / config.finalLogitSoftcapping) * config.finalLogitSoftcapping
+        return MTPBackboneOutput(logits: logits, hiddenStates: hiddenStates)
+    }
+
+    public var sharedEmbeddings: Embedding { model.embedTokens }
+
+    public var embeddingScale: Float { model.embedScale }
+
+    public var backboneLayerTypes: [String] {
+        let firstKvShared = config.numHiddenLayers - config.numKvSharedLayers
+        return Array(config.layerTypes.prefix(firstKvShared))
+    }
+}
+
 // MARK: - LoRA
 
 extension Gemma4TextModel: LoRAModel {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1655,7 +1655,7 @@ public func generateTokenTask(
     )
 }
 
-private func generateLoopTask<Handler: TokenLoopHandler>(
+func generateLoopTask<Handler: TokenLoopHandler>(
     promptTokenCount: Int,
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
@@ -1928,7 +1928,7 @@ public enum TokenGeneration: Sendable {
 
 // MARK: - TokenLoopHandlers
 
-private protocol TokenLoopHandler: Sendable {
+protocol TokenLoopHandler: Sendable {
     associatedtype Output
 
     /// Return false to stop the loop early.
@@ -1951,7 +1951,7 @@ private protocol TokenLoopHandler: Sendable {
     func infoEvent(_ info: GenerateCompletionInfo) -> Output
 }
 
-private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
+struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     typealias Output = Generation
 
     var detokenizer: NaiveStreamingDetokenizer
@@ -2010,7 +2010,7 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     }
 }
 
-private struct RawTokenLoopHandler: TokenLoopHandler {
+struct RawTokenLoopHandler: TokenLoopHandler {
     typealias Output = TokenGeneration
 
     mutating func onToken(

--- a/Libraries/MLXLMCommon/MTPGeneration.swift
+++ b/Libraries/MLXLMCommon/MTPGeneration.swift
@@ -1,0 +1,572 @@
+// Copyright © 2025 Apple Inc.
+//
+// Multi-Token Prediction (MTP) speculative decoding support.
+//
+// MTP differs from classic two-model speculative decoding (SpeculativeTokenIterator)
+// in that the drafter is a small model embedded within the backbone checkpoint that
+// shares KV cache and embeddings with the backbone. This eliminates the overhead of
+// maintaining a separate draft model's cache.
+//
+// The generation cycle:
+// 1. Backbone forward → logits + last hidden state
+// 2. MTP drafter uses hidden state to propose K tokens (tiny, fast)
+// 3. Backbone verifies all K tokens in one forward pass
+// 4. Leviathan-Chen rejection sampling accepts/rejects each draft
+// 5. Accepted tokens + bonus token emitted; cache trimmed on rejection
+
+import Foundation
+import MLX
+import MLXNN
+
+// MARK: - MTP Model Protocols
+
+/// Output from a backbone model that supports MTP speculative decoding.
+///
+/// Includes both the standard logits and the pre-logit hidden states needed
+/// by the MTP drafter model.
+public struct MTPBackboneOutput {
+    public let logits: MLXArray
+    public let hiddenStates: MLXArray
+    public let state: LMOutput.State?
+
+    public init(logits: MLXArray, hiddenStates: MLXArray, state: LMOutput.State? = nil) {
+        self.logits = logits
+        self.hiddenStates = hiddenStates
+        self.state = state
+    }
+}
+
+/// Protocol for backbone language models that support MTP speculative decoding.
+///
+/// Backbone models conforming to this protocol expose their pre-logit hidden states,
+/// which the MTP drafter consumes to generate draft tokens. The token embeddings are
+/// also exposed so the drafter can concatenate them with hidden states.
+public protocol MTPBackboneModel: LanguageModel {
+    /// Forward pass returning both logits and last-layer hidden states.
+    func forwardMTP(_ inputs: MLXArray, cache: [KVCache]?) -> MTPBackboneOutput
+
+    /// The token embedding layer, shared with the drafter.
+    var sharedEmbeddings: Embedding { get }
+
+    /// Embedding scale factor (typically sqrt(hidden_size)).
+    var embeddingScale: Float { get }
+
+    /// Layer types for the backbone (e.g. "sliding_attention", "full_attention").
+    /// Used to extract the correct shared KV states for the drafter.
+    var backboneLayerTypes: [String] { get }
+}
+
+/// Output from an MTP draft model forward pass.
+public struct MTPDraftOutput {
+    /// Up-projected hidden state back in backbone dimension space.
+    public let projectedState: MLXArray
+    /// Logits over the vocabulary.
+    public let logits: MLXArray
+
+    public init(projectedState: MLXArray, logits: MLXArray) {
+        self.projectedState = projectedState
+        self.logits = logits
+    }
+}
+
+/// Protocol for MTP draft models (e.g. Gemma4AssistantModel).
+///
+/// Unlike a standard ``LanguageModel``, an MTP draft model:
+/// - Takes pre-projected embeddings as input (not raw tokens)
+/// - Uses shared KV from the backbone (no separate cache)
+/// - Returns a projected state for chained drafting
+public protocol MTPDraftModel: Module {
+    /// Forward pass for one draft step.
+    ///
+    /// - Parameters:
+    ///   - inputsEmbeds: Concatenated `[backbone_hidden, token_embedding]`
+    ///     of shape `[B, 1, 2 * backbone_hidden_size]`
+    ///   - sharedKVStates: KV states from backbone cache, keyed by layer type
+    /// - Returns: Projected state and logits
+    func forward(
+        inputsEmbeds: MLXArray,
+        sharedKVStates: [String: (MLXArray, MLXArray)]?
+    ) -> MTPDraftOutput
+}
+
+// MARK: - MTP Verification
+
+/// Result of verifying a batch of draft tokens against backbone logits.
+public struct MTPVerificationResult {
+    public let acceptedTokens: [Int]
+    public let nextToken: Int
+    public let acceptanceProbabilities: [Float]
+
+    public var acceptanceRate: Float {
+        guard !acceptanceProbabilities.isEmpty else { return 0 }
+        return Float(acceptedTokens.count) / Float(acceptanceProbabilities.count)
+    }
+
+    public var allTokens: [Int] { acceptedTokens + [nextToken] }
+}
+
+/// Verifies draft tokens against target model logits using Leviathan-Chen
+/// rejection sampling with residual correction.
+///
+/// Critical: probability ratios are computed in fp32 to avoid BF16 underflow.
+///
+/// Reference: "Fast Inference from Transformers via Speculative Decoding"
+/// (Leviathan et al., 2023)
+public struct MTPVerifier {
+    private let epsilon: Float = 1e-10
+
+    public init() {}
+
+    /// Verify draft tokens against target logits.
+    ///
+    /// - Parameters:
+    ///   - draftTokens: Token IDs proposed by the drafter
+    ///   - draftLogits: Logits from drafter for each position
+    ///   - targetLogits: Logits from backbone verification pass `[K+1, vocab]`
+    ///   - temperature: Sampling temperature (0 = greedy argmax matching)
+    public func verify(
+        draftTokens: [Int],
+        draftLogits: [MLXArray],
+        targetLogits: MLXArray,
+        temperature: Float
+    ) -> MTPVerificationResult {
+        let n = draftTokens.count
+
+        if temperature == 0 {
+            return verifyGreedy(draftTokens: draftTokens, targetLogits: targetLogits)
+        }
+
+        var acceptedTokens: [Int] = []
+        var nextToken: Int?
+        var probabilities: [Float] = []
+
+        for i in 0 ..< n {
+            var draftProbs = softmax(draftLogits[i].asType(.float32) / temperature)
+            var targetProbs = softmax(targetLogits[i].asType(.float32) / temperature)
+            draftProbs = draftProbs.squeezed()
+            targetProbs = targetProbs.squeezed()
+
+            let draftToken = draftTokens[i]
+            let pTarget = targetProbs[draftToken].item(Float.self)
+            let pDraft = max(draftProbs[draftToken].item(Float.self), epsilon)
+
+            let acceptProb = min(1.0, pTarget / pDraft)
+            probabilities.append(acceptProb)
+
+            let u = Float.random(in: 0 ..< 1)
+            if u < acceptProb {
+                acceptedTokens.append(draftToken)
+            } else {
+                let residual = maximum(targetProbs - draftProbs, MLXArray(0.0))
+                let residualSum = residual.sum().item(Float.self)
+                if residualSum > epsilon {
+                    nextToken = categorical(residual / residualSum).item(Int.self)
+                } else {
+                    nextToken = categorical(targetProbs).item(Int.self)
+                }
+                break
+            }
+        }
+
+        if nextToken == nil {
+            let bonusLogits = targetLogits[n].asType(.float32)
+            nextToken = categorical(softmax(bonusLogits / temperature)).item(Int.self)
+        }
+
+        return MTPVerificationResult(
+            acceptedTokens: acceptedTokens,
+            nextToken: nextToken!,
+            acceptanceProbabilities: probabilities
+        )
+    }
+
+    private func verifyGreedy(
+        draftTokens: [Int],
+        targetLogits: MLXArray
+    ) -> MTPVerificationResult {
+        var acceptedTokens: [Int] = []
+        var nextToken: Int?
+
+        for i in 0 ..< draftTokens.count {
+            let targetToken = argMax(targetLogits[i].squeezed(), axis: -1).item(Int.self)
+            if targetToken == draftTokens[i] {
+                acceptedTokens.append(draftTokens[i])
+            } else {
+                nextToken = targetToken
+                break
+            }
+        }
+
+        if nextToken == nil {
+            nextToken = argMax(
+                targetLogits[draftTokens.count].squeezed(), axis: -1
+            ).item(Int.self)
+        }
+
+        return MTPVerificationResult(
+            acceptedTokens: acceptedTokens,
+            nextToken: nextToken!,
+            acceptanceProbabilities: acceptedTokens.map { _ in Float(1.0) }
+        )
+    }
+}
+
+// MARK: - MTP Speculative Token Iterator
+
+/// Generator of tokens using MTP (Multi-Token Prediction) speculative decoding.
+///
+/// Unlike ``SpeculativeTokenIterator`` which uses a separate draft model with its own
+/// KV cache, this iterator uses the backbone's built-in MTP assistant heads that share
+/// the backbone's KV cache and embeddings.
+///
+/// To use it directly:
+///
+/// ```swift
+/// let iterator = try MTPSpeculativeTokenIterator(
+///     input: input, backbone: backboneModel, drafter: assistantModel,
+///     parameters: generateParameters, numDraftTokens: 3)
+///
+/// for token in iterator {
+///     // process token
+/// }
+/// ```
+///
+/// Port of MTP speculative generation from Gemma 4 assistant models.
+public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
+
+    var y: LMInput.Text
+
+    let backbone: any MTPBackboneModel
+    let drafter: any MTPDraftModel
+
+    var backboneState: LMOutput.State?
+    var cache: [KVCache]
+
+    var processor: LogitProcessor?
+    let sampler: LogitSampler
+    let verifier: MTPVerifier
+
+    var tokenCount = 0
+    let maxTokens: Int?
+    let numDraftTokens: Int
+
+    private var pendingTokens = [Int]()
+    private var pendingIndex = 0
+
+    private var lastHiddenState: MLXArray?
+
+    var promptPrefillTime: TimeInterval = 0.0
+
+    /// Initialize an `MTPSpeculativeTokenIterator`.
+    ///
+    /// - Parameters:
+    ///   - input: language model input
+    ///   - backbone: the backbone ``MTPBackboneModel`` (verifier)
+    ///   - drafter: the MTP ``MTPDraftModel`` (assistant)
+    ///   - cache: optional ``KVCache`` for the backbone
+    ///   - parameters: the generation parameters
+    ///   - numDraftTokens: number of tokens the drafter proposes per round
+    public init(
+        input: LMInput,
+        backbone: any MTPBackboneModel,
+        drafter: any MTPDraftModel,
+        cache: [KVCache]? = nil,
+        parameters: GenerateParameters,
+        numDraftTokens: Int = 3
+    ) throws {
+        self.y = input.text
+        self.backbone = backbone
+        self.drafter = drafter
+
+        self.cache = cache ?? backbone.newCache(parameters: parameters)
+        guard canTrimPromptCache(self.cache) else {
+            throw KVCacheError(message: "MTP speculative decoding requires trimmable KV caches.")
+        }
+
+        self.sampler = parameters.sampler()
+        self.processor = parameters.processor()
+        self.maxTokens = parameters.maxTokens
+        self.numDraftTokens = numDraftTokens
+        self.verifier = MTPVerifier()
+
+        self.promptPrefillTime = try mtpMeasure {
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
+        }
+    }
+
+    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+        processor?.prompt(input.text.tokens)
+
+        switch try backbone.prepare(input, cache: cache, windowSize: windowSize) {
+        case .tokens(let tokens):
+            y = tokens
+
+            // Forward the remaining tokens through MTP-capable path to get hidden states
+            let mtpOutput = backbone.forwardMTP(y[text: .newAxis].tokens, cache: cache)
+            lastHiddenState = mtpOutput.hiddenStates
+
+            var logits = mtpOutput.logits[0..., -1, 0...]
+            logits = processor?.process(logits: logits) ?? logits
+            let token = sampler.sample(logits: logits)
+            processor?.didSample(token: token)
+            y = .init(tokens: token)
+            backboneState = mtpOutput.state
+            asyncEval(y.tokens)
+
+        case .logits(let result):
+            var logits = result.logits[0..., -1, 0...]
+            logits = processor?.process(logits: logits) ?? logits
+            let token = sampler.sample(logits: logits)
+            processor?.didSample(token: token)
+            y = .init(tokens: token)
+            backboneState = result.state
+            asyncEval(y.tokens)
+        }
+    }
+
+    /// Extract shared KV states from the backbone cache for the drafter.
+    func extractSharedKV() -> [String: (MLXArray, MLXArray)] {
+        let layerTypes = backbone.backboneLayerTypes
+        var lastByType = [String: Int]()
+        for (i, lt) in layerTypes.enumerated() {
+            if i < cache.count {
+                lastByType[lt] = i
+            }
+        }
+
+        var result = [String: (MLXArray, MLXArray)]()
+        for (lt, cacheIdx) in lastByType {
+            let state = cache[cacheIdx].innerState()
+            if state.count >= 2 {
+                result[lt] = (state[0], state[1])
+            }
+        }
+        return result
+    }
+
+    /// Run one round of MTP speculative decoding.
+    mutating func speculateRound() {
+        let remaining = maxTokens.map { $0 - tokenCount } ?? numDraftTokens
+        let numDraft = Swift.min(remaining, numDraftTokens)
+        guard numDraft > 0 else { return }
+
+        // Draft phase: use MTP assistant to propose tokens
+        let sharedKV = extractSharedKV()
+        let currentToken = y.tokens.item(Int.self)
+
+        var draftTokens = [Int]()
+        var draftLogits = [MLXArray]()
+        var currentHidden = lastHiddenState ?? MLXArray.zeros([1, 1, backbone.sharedEmbeddings.weight.dim(1)])
+        var draftToken = currentToken
+
+        for _ in 0 ..< numDraft {
+            let tokenEmbedding = backbone.sharedEmbeddings(
+                MLXArray([Int32(draftToken)])
+            ).expandedDimensions(axis: 0) * backbone.embeddingScale
+
+            let inputEmbeds = concatenated([currentHidden, tokenEmbedding], axis: -1)
+            let output = drafter.forward(inputsEmbeds: inputEmbeds, sharedKVStates: sharedKV)
+            let logits = output.logits.squeezed(axis: 0).squeezed(axis: 0)
+
+            let token: Int
+            if sampler is ArgMaxSampler {
+                token = argMax(logits, axis: -1).item(Int.self)
+            } else {
+                let logits32 = logits.asType(.float32)
+                token = categorical(softmax(logits32)).item(Int.self)
+            }
+
+            draftTokens.append(token)
+            draftLogits.append(logits)
+            currentHidden = output.projectedState
+            draftToken = token
+        }
+
+        // Verify phase: backbone processes all draft tokens in one pass
+        let verifyTokens = [y.tokens] + draftTokens.map { MLXArray([$0]) }
+        let verifyInput = concatenated(verifyTokens)
+        let verifyMTP = backbone.forwardMTP(
+            verifyInput.expandedDimensions(axis: 0), cache: cache)
+
+        let verifyStart = verifyInput.dim(0) - (numDraft + 1)
+        let verifyLogits = verifyMTP.logits[0..., verifyStart..., 0...]
+            .squeezed(axis: 0)
+
+        // Accept/reject with Leviathan-Chen
+        let temperature: Float = (sampler is ArgMaxSampler) ? 0 : 0.6
+        let result = verifier.verify(
+            draftTokens: draftTokens,
+            draftLogits: draftLogits,
+            targetLogits: verifyLogits,
+            temperature: temperature
+        )
+
+        // Emit accepted tokens
+        for token in result.acceptedTokens {
+            processor?.didSample(token: MLXArray([token]))
+            pendingTokens.append(token)
+        }
+
+        let finalToken = MLXArray([result.nextToken])
+        processor?.didSample(token: finalToken)
+        pendingTokens.append(result.nextToken)
+
+        // Trim cache: rewind positions beyond accepted prefix
+        let accepted = result.acceptedTokens.count
+        let trimAmount = numDraft - accepted
+        if trimAmount > 0 {
+            trimPromptCache(cache, numTokens: trimAmount)
+        }
+
+        // Update state for next round
+        let hiddenIdx = verifyStart + accepted
+        lastHiddenState = verifyMTP.hiddenStates[0..., hiddenIdx ... hiddenIdx, 0...]
+        backboneState = verifyMTP.state
+        y = .init(tokens: finalToken)
+    }
+
+    mutating public func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            return nil
+        }
+
+        if pendingIndex < pendingTokens.count {
+            let token = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            tokenCount += 1
+            return token
+        }
+
+        pendingTokens.removeAll(keepingCapacity: true)
+        pendingIndex = 0
+        speculateRound()
+
+        if pendingTokens.isEmpty {
+            return nil
+        }
+
+        let token = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        return token
+    }
+}
+
+// MARK: - Generate Functions
+
+/// Generates text asynchronously using MTP speculative decoding.
+///
+/// This function uses the backbone model's built-in MTP assistant heads as a drafter,
+/// potentially achieving 2-3x speedup over standard autoregressive generation without
+/// any quality degradation.
+///
+/// Both models share the same tokenizer and KV cache. The drafter's parameters are
+/// typically < 1% of the backbone's, adding negligible memory overhead.
+///
+/// - Parameters:
+///   - input: The input for the language model.
+///   - cache: optional ``KVCache`` for the backbone.
+///   - parameters: The configuration options for token generation.
+///   - context: The model context for the backbone model.
+///   - mtpDrafter: The MTP draft model (e.g. `Gemma4AssistantModel`).
+///   - numDraftTokens: Number of tokens the drafter proposes per round (default: 3).
+///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
+/// - Returns: An `AsyncStream` that emits `Generation` values.
+/// - Throws: An error if the backbone does not conform to ``MTPBackboneModel``.
+public func generate(
+    input: LMInput,
+    cache: [KVCache]? = nil,
+    parameters: GenerateParameters,
+    context: ModelContext,
+    mtpDrafter: any MTPDraftModel,
+    numDraftTokens: Int = 3,
+    wiredMemoryTicket: WiredMemoryTicket? = nil
+) throws -> AsyncStream<Generation> {
+    guard let backbone = context.model as? any MTPBackboneModel else {
+        throw MTPGenerationError.backboneNotMTPCapable
+    }
+
+    let iterator = try MTPSpeculativeTokenIterator(
+        input: input,
+        backbone: backbone,
+        drafter: mtpDrafter,
+        cache: cache,
+        parameters: parameters,
+        numDraftTokens: numDraftTokens
+    )
+    let (stream, _) = generateLoopTask(
+        promptTokenCount: input.text.tokens.size,
+        modelConfiguration: context.configuration,
+        tokenizer: context.tokenizer,
+        iterator: iterator,
+        wiredMemoryTicket: wiredMemoryTicket,
+        handler: TextToolTokenLoopHandler(
+            tokenizer: context.tokenizer,
+            format: context.configuration.toolCallFormat ?? .json
+        )
+    )
+    return stream
+}
+
+/// Generates raw token IDs asynchronously using MTP speculative decoding.
+///
+/// Same as the `Generation` variant but yields raw token IDs instead of decoded text.
+///
+/// - Parameters:
+///   - input: The input for the language model.
+///   - cache: optional ``KVCache`` for the backbone.
+///   - parameters: The configuration options for token generation.
+///   - context: The model context for the backbone model.
+///   - mtpDrafter: The MTP draft model.
+///   - numDraftTokens: Number of tokens the drafter proposes per round (default: 3).
+///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
+/// - Returns: An `AsyncStream` that emits `TokenGeneration` values.
+public func generateTokens(
+    input: LMInput,
+    cache: [KVCache]? = nil,
+    parameters: GenerateParameters,
+    context: ModelContext,
+    mtpDrafter: any MTPDraftModel,
+    numDraftTokens: Int = 3,
+    wiredMemoryTicket: WiredMemoryTicket? = nil
+) throws -> AsyncStream<TokenGeneration> {
+    guard let backbone = context.model as? any MTPBackboneModel else {
+        throw MTPGenerationError.backboneNotMTPCapable
+    }
+
+    let iterator = try MTPSpeculativeTokenIterator(
+        input: input,
+        backbone: backbone,
+        drafter: mtpDrafter,
+        cache: cache,
+        parameters: parameters,
+        numDraftTokens: numDraftTokens
+    )
+    let (stream, _) = generateLoopTask(
+        promptTokenCount: input.text.tokens.size,
+        modelConfiguration: context.configuration,
+        tokenizer: context.tokenizer,
+        iterator: iterator,
+        wiredMemoryTicket: wiredMemoryTicket,
+        handler: RawTokenLoopHandler()
+    )
+    return stream
+}
+
+/// Errors specific to MTP generation.
+public enum MTPGenerationError: LocalizedError {
+    case backboneNotMTPCapable
+
+    public var errorDescription: String? {
+        switch self {
+        case .backboneNotMTPCapable:
+            "Backbone model does not conform to MTPBackboneModel. Only Gemma 4 models with MTP assistant heads are supported."
+        }
+    }
+}
+
+private func mtpMeasure(_ closure: () throws -> Void) rethrows -> TimeInterval {
+    let start = Date.timeIntervalSinceReferenceDate
+    try closure()
+    return Date.timeIntervalSinceReferenceDate - start
+}

--- a/Libraries/MLXLMCommon/MTPGeneration.swift
+++ b/Libraries/MLXLMCommon/MTPGeneration.swift
@@ -160,17 +160,18 @@ public struct MTPVerifier {
                 let residual = maximum(targetProbs - draftProbs, MLXArray(0.0))
                 let residualSum = residual.sum().item(Float.self)
                 if residualSum > epsilon {
-                    nextToken = categorical(residual / residualSum).item(Int.self)
+                    let normalized = residual / residualSum
+                    nextToken = categorical(log(normalized + epsilon)).item(Int.self)
                 } else {
-                    nextToken = categorical(targetProbs).item(Int.self)
+                    nextToken = categorical(log(targetProbs + epsilon)).item(Int.self)
                 }
                 break
             }
         }
 
         if nextToken == nil {
-            let bonusLogits = targetLogits[n].asType(.float32)
-            nextToken = categorical(softmax(bonusLogits / temperature)).item(Int.self)
+            let bonusLogits = targetLogits[n].asType(.float32).squeezed()
+            nextToken = categorical(bonusLogits / temperature).item(Int.self)
         }
 
         return MTPVerificationResult(
@@ -303,7 +304,9 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
             // Forward the remaining tokens through MTP-capable path to get hidden states
             let mtpOutput = backbone.forwardMTP(y[text: .newAxis].tokens, cache: cache)
-            lastHiddenState = mtpOutput.hiddenStates
+            // Keep only the last position — the drafter needs [1, 1, hidden_size]
+            let lastPos = mtpOutput.hiddenStates.dim(1) - 1
+            lastHiddenState = mtpOutput.hiddenStates[0..., lastPos..<(lastPos + 1), 0...]
 
             var logits = mtpOutput.logits[0..., -1, 0...]
             logits = processor?.process(logits: logits) ?? logits


### PR DESCRIPTION
## Summary

Adds native Multi-Token Prediction (MTP) speculative decoding support for Gemma 4 models. The MTP drafter uses the model's own assistant heads (~78M params for E4B) that share KV cache and embeddings with the backbone, enabling 2-3x inference speedup with zero quality degradation.

**Key changes:**

- **`Gemma4Assistant.swift`** — Full `Gemma4AssistantForCausalLM` model definition: 4-layer transformer drafter with sliding+full attention, pre/post projection, and centroid-masked embedder for efficient vocabulary narrowing (262K vocab to ~4K candidates during drafting)
- **`MTPGeneration.swift`** — MTP infrastructure: `MTPBackboneModel` / `MTPDraftModel` protocols, `MTPSpeculativeTokenIterator` (follows `SpeculativeTokenIterator` pattern), `MTPVerifier` with Leviathan-Chen rejection sampling (fp32 ratios to avoid BF16 underflow), and `generate()` overloads
- **`LLMModelFactory.swift`** — Registers `"gemma4_assistant"` model type in the type registry
- **`Gemma4Text.swift`** — Adds `MTPBackboneModel` conformance to `Gemma4TextModel`, exposing pre-logit hidden states via `forwardMTP()`
- **`Gemma4.swift`** — Forwards `MTPBackboneModel` through the `Gemma4Model` wrapper
- **`Evaluate.swift`** — Widens access on `generateLoopTask` and `TokenLoopHandler` from `private` to `internal` so `MTPGeneration.swift` can reuse the shared generation infrastructure

## Supported Model Pairs

| Backbone | MTP Assistant | Params | Target |
|----------|--------------|--------|--------|
| gemma-4-e2b-it (4-bit) | gemma-4-E2B-it-assistant-bf16 | 78M | 8GB constrained |
| gemma-4-e4b-it (4-bit) | gemma-4-E4B-it-assistant-bf16 | 78.8M | 16GB+ standard |
| gemma-4-26B-A4B-it (4-bit) | gemma-4-26B-A4B-it-assistant-bf16 | 0.4B | 32GB+ |
| gemma-4-31B-it (4-bit) | gemma-4-31B-it-assistant-bf16 | 0.5B | 64GB+ |

## Architecture

The MTP speculative decoding loop follows the same Leviathan-Chen algorithm as the existing `SpeculativeTokenIterator`, but adapted for the shared-backbone MTP pattern:

1. **Draft**: MTP assistant runs K tiny forward passes using backbone last-layer activations
2. **Verify**: Backbone runs ONE forward pass over all K draft tokens
3. **Accept/Reject**: Per-position probability-ratio acceptance (fp32 for correctness)
4. **Residual correction**: On rejection, sample from `max(0, p_target - p_draft)`
5. **Cache management**: Only backbone cache needs trimming on rejection (drafter has no separate cache)

## Design Decisions

- **Protocols over concrete types**: `MTPBackboneModel` and `MTPDraftModel` are model-agnostic protocols. While only Gemma 4 implements them today, this enables future MTP-capable models to plug in
- **Centroid embedder**: Reduces the expensive lm_head matmul from 262K to ~4K output dimensions during drafting by predicting top-32 of 2048 centroids
- **fp32 verification**: Critical for correctness — BF16 underflows at small probability values, corrupting acceptance decisions (per MTPLX findings)
- **Internal access widening**: `generateLoopTask` and friends changed from `private` to `internal` to enable code reuse — no public API surface change

## Test Plan

- [ ] Verify `swift build` passes for all targets (confirmed locally)
- [ ] Test Gemma4AssistantModel weight loading from HuggingFace checkpoint
- [ ] Test MTP generation produces correct output vs standard autoregressive baseline
- [ ] Benchmark tokens/s improvement with MTP vs standard generation
- [ ] Verify acceptance rate > 70% on typical summarization prompts

## References

- [Gemma 4 MTP blog post](https://blog.google/innovation-and-ai/technology/developers-tools/multi-token-prediction-gemma-4/)
- [HuggingFace transformers Gemma4Assistant](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma4_assistant/modeling_gemma4_assistant.py)
- [MTPLX (Python MLX MTP)](https://github.com/youssofal/MTPLX) — achieved 2.24x speedup
- [Leviathan et al. 2023 — Speculative Decoding](https://arxiv.org/abs/2211.17192)

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
