### PR TITLE
Propagate errors through tokenizer and generation APIs

### DIFF
--- a/Libraries/BenchmarkHelpers/BenchmarkHelpers.swift
+++ b/Libraries/BenchmarkHelpers/BenchmarkHelpers.swift
@@ -23,8 +23,8 @@ public struct NoOpTokenizerLoader: TokenizerLoader {
 }
 
 private struct NoOpTokenizer: Tokenizer {
-    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
-    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String { "" }
     func convertTokenToId(_ token: String) -> Int? { nil }
     func convertIdToToken(_ id: Int) -> String? { nil }
     var bosToken: String? { nil }
@@ -289,12 +289,12 @@ public func benchmarkTokenization(
         useLatest: useLatest
     )
 
-    _ = tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
+    _ = try tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
 
     var times: [Double] = []
     for i in 1 ... runs {
         let start = CFAbsoluteTimeGetCurrent()
-        let tokenIds = tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
+        let tokenIds = try tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
         let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
         times.append(elapsed)
         print(
@@ -325,16 +325,16 @@ public func benchmarkDecoding(
         configuration: configuration,
         useLatest: useLatest
     )
-    let tokenIds = tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
+    let tokenIds = try tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
 
-    _ = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    _ = try tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
 
     var times: [Double] = []
     for i in 1 ... runs {
         var decoded = ""
         let start = CFAbsoluteTimeGetCurrent()
         for _ in 0 ..< decodesPerRun {
-            decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+            decoded = try tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
         }
         let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000 / Double(decodesPerRun)
         times.append(elapsed)

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -427,10 +427,10 @@ public enum EmbedderTests {
             "In the United States, PepsiCo Inc. is a leading soft drink company.",
         ]
 
-        let resultEmbeddings = await modelContainer.perform { context in
+        let resultEmbeddings = try await modelContainer.perform { context in
             let tokenizer = context.tokenizer
-            let encoded = inputs.map {
-                tokenizer.encode(text: $0, addSpecialTokens: true)
+            let encoded = try inputs.map {
+                try tokenizer.encode(text: $0, addSpecialTokens: true)
             }
             let maxLength = encoded.reduce(into: 1) { acc, elem in
                 acc = max(acc, elem.count)
@@ -490,11 +490,11 @@ public enum EmbedderTests {
             "search_document: Polar Bears",
         ]
 
-        let resultEmbeddings = await container.perform { context in
+        let resultEmbeddings = try await container.perform { context in
             let tokenizer = context.tokenizer
 
-            let inputs = searchInputs.map {
-                tokenizer.encode(text: $0, addSpecialTokens: true)
+            let inputs = try searchInputs.map {
+                try tokenizer.encode(text: $0, addSpecialTokens: true)
             }
             let maxLength = inputs.reduce(into: 16) { acc, elem in
                 acc = max(acc, elem.count)

--- a/Libraries/MLXEmbedders/EmbedderModelContainer.swift
+++ b/Libraries/MLXEmbedders/EmbedderModelContainer.swift
@@ -9,10 +9,10 @@ import MLXLMCommon
 /// the model and/or tokenizer (any values from the ``EmbedderModelContext``):
 ///
 /// ```swift
-/// let resultEmbeddings = await modelContainer.perform { context in
+/// let resultEmbeddings = try await modelContainer.perform { context in
 ///     let tokenizer = context.tokenizer
-///     let encoded = inputs.map {
-///         tokenizer.encode(text: $0, addSpecialTokens: true)
+///     let encoded = try inputs.map {
+///         try tokenizer.encode(text: $0, addSpecialTokens: true)
 ///     }
 ///     ...
 ///     let modelOutput = context.model(

--- a/Libraries/MLXEmbedders/README.md
+++ b/Libraries/MLXEmbedders/README.md
@@ -21,10 +21,10 @@ let searchInputs = [
 ]
 
 // Generate embeddings
-let resultEmbeddings = await modelContainer.perform {
+let resultEmbeddings = try await modelContainer.perform {
     (model: EmbeddingModel, tokenizer: Tokenizer, pooling: Pooling) -> [[Float]] in
-    let inputs = searchInputs.map {
-        tokenizer.encode(text: $0, addSpecialTokens: true)
+    let inputs = try searchInputs.map {
+        try tokenizer.encode(text: $0, addSpecialTokens: true)
     }
     // Pad to longest
     let maxLength = inputs.reduce(into: 16) { acc, elem in

--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -87,12 +87,14 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         self.upstream = upstream
                     }
 
-                    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+                    // The protocol requires `throws`, but swift-transformers'
+                    // `encode` and `decode` never throw.
+                    func encode(text: String, addSpecialTokens: Bool) throws -> [Int] {
                         upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
                     }
 
                     // swift-transformers uses `decode(tokens:)` instead of `decode(tokenIds:)`.
-                    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+                    func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
                         upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
                     }
 

--- a/Libraries/MLXLLM/Documentation.docc/using-model.md
+++ b/Libraries/MLXLLM/Documentation.docc/using-model.md
@@ -62,7 +62,7 @@ load models, if needed.
 - UserInput
 - LMInput
 - generate()
-    - NaiveStreamingDetokenizer
+    - StreamingDetokenizer
     - TokenIterator
 
 ## Evaluating a Model
@@ -95,22 +95,19 @@ let result = try await modelContainer.perform { [input] context in
 ```
 
 Given that `input` we can call `generate()` to produce a stream
-of tokens. In this example we use a `NaiveStreamingDetokenizer`
+of tokens. In this example we use a `StreamingDetokenizer`
 to assist in converting a stream of tokens into text and print it.
 The stream is stopped after we hit a maximum number of tokens:
 
 ```
-    var detokenizer = NaiveStreamingDetokenizer(tokenizer: context.tokenizer)
+    let detokenizer = context.tokenizer.streamingDetokenizer()
 
     return try MLXLMCommon.generate(
         input: input, parameters: generateParameters, context: context
     ) { tokens in
 
-        if let last = tokens.last {
-            detokenizer.append(token: last)
-        }
-
-        if let new = detokenizer.next() {
+        if let last = tokens.last,
+           let new = try? detokenizer.consume(last) {
             print(new, terminator: "")
             fflush(stdout)
         }

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -457,7 +457,7 @@ private struct LLMUserInputProcessor: UserInputProcessor {
                 messages
                 .compactMap { $0["content"] as? String }
                 .joined(separator: "\n\n")
-            let promptTokens = tokenizer.encode(text: prompt)
+            let promptTokens = try tokenizer.encode(text: prompt)
             return LMInput(tokens: MLXArray(promptTokens))
         }
     }

--- a/Libraries/MLXLLM/LoraTrain.swift
+++ b/Libraries/MLXLLM/LoraTrain.swift
@@ -9,22 +9,20 @@ import MLXOptimizers
 /// Equivalent to `lora.py/iterate_batches()`. Used internally by ``LoRATrain``.
 struct LoRABatchIterator: Sequence, IteratorProtocol {
 
-    let dataset: [String]
+    let encodedDataset: [[Int]]
     let batchSize: Int
-    let tokenizer: Tokenizer
 
     let train: Bool
 
     var indices: [Int]
     var index = 0
 
-    public init(dataset: [String], tokenizer: Tokenizer, batchSize: Int, train: Bool) {
-        self.dataset = dataset
+    public init(dataset: [String], tokenizer: Tokenizer, batchSize: Int, train: Bool) throws {
+        self.encodedDataset = try dataset.map { try tokenizer.encode(text: $0) }
         self.batchSize = batchSize
-        self.tokenizer = tokenizer
         self.train = train
 
-        self.indices = Array(0 ..< dataset.count)
+        self.indices = Array(0 ..< encodedDataset.count)
         if train {
             indices.shuffle()
         }
@@ -43,7 +41,7 @@ struct LoRABatchIterator: Sequence, IteratorProtocol {
         let endIndex = Swift.min(index + batchSize, indices.count)
 
         let batch = (index ..< endIndex)
-            .map { tokenizer.encode(text: dataset[indices[$0]]) }
+            .map { encodedDataset[indices[$0]] }
         let lengths = batch.map { $0.count }
         let maxLength = lengths.max() ?? 0
 
@@ -185,11 +183,11 @@ public enum LoRATrain {
     public static func evaluate(
         model: Module, dataset: [String], loss: LoraLossFunction = loss, tokenizer: Tokenizer,
         batchSize: Int, batchCount: Int
-    ) -> Float {
+    ) throws -> Float {
         var allLosses = [Float]()
         var tokenCount = 0
 
-        for (iteration, (inputs, targets, lengths)) in LoRABatchIterator(
+        for (iteration, (inputs, targets, lengths)) in try LoRABatchIterator(
             dataset: dataset, tokenizer: tokenizer, batchSize: batchSize, train: false
         ).enumerated() {
             let (losses, tokens) = loss(model, inputs, targets, lengths)
@@ -272,7 +270,7 @@ public enum LoRATrain {
 
         var start = Date.timeIntervalSinceReferenceDate
 
-        for (iteration, (inputs, targets, lengths)) in LoRABatchIterator(
+        for (iteration, (inputs, targets, lengths)) in try LoRABatchIterator(
             dataset: train, tokenizer: tokenizer, batchSize: parameters.batchSize, train: true
         ).enumerated() {
             // forward and backward pass
@@ -313,7 +311,7 @@ public enum LoRATrain {
             // report validation loss
             if iteration == 0 || (iteration + 1) % parameters.stepsPerEval == 0 {
                 let validationStart = Date.timeIntervalSinceReferenceDate
-                let validationLoss = evaluate(
+                let validationLoss = try evaluate(
                     model: model, dataset: validate, loss: loss, tokenizer: tokenizer,
                     batchSize: parameters.batchSize, batchCount: parameters.validationBatches)
                 let now = Date.timeIntervalSinceReferenceDate

--- a/Libraries/MLXLLM/LoraTrain.swift
+++ b/Libraries/MLXLLM/LoraTrain.swift
@@ -7,28 +7,34 @@ import MLXNN
 import MLXOptimizers
 
 /// Equivalent to `lora.py/iterate_batches()`. Used internally by ``LoRATrain``.
-struct LoRABatchIterator: Sequence, IteratorProtocol {
+///
+/// Tokenization is lazy: each call to `nextBatch()` encodes only the strings
+/// in the batch it returns, so a caller that stops early (e.g. via
+/// `batchCount` in `evaluate`) doesn't pay to encode unused rows.
+struct LoRABatchIterator {
 
-    let encodedDataset: [[Int]]
+    let dataset: [String]
     let batchSize: Int
+    let tokenizer: Tokenizer
 
     let train: Bool
 
     var indices: [Int]
     var index = 0
 
-    public init(dataset: [String], tokenizer: Tokenizer, batchSize: Int, train: Bool) throws {
-        self.encodedDataset = try dataset.map { try tokenizer.encode(text: $0) }
+    public init(dataset: [String], tokenizer: Tokenizer, batchSize: Int, train: Bool) {
+        self.dataset = dataset
         self.batchSize = batchSize
+        self.tokenizer = tokenizer
         self.train = train
 
-        self.indices = Array(0 ..< encodedDataset.count)
+        self.indices = Array(0 ..< dataset.count)
         if train {
             indices.shuffle()
         }
     }
 
-    mutating public func next() -> (MLXArray, MLXArray, MLXArray)? {
+    mutating public func nextBatch() throws -> (MLXArray, MLXArray, MLXArray)? {
         if index >= indices.count {
             if !train {
                 return nil
@@ -40,8 +46,8 @@ struct LoRABatchIterator: Sequence, IteratorProtocol {
 
         let endIndex = Swift.min(index + batchSize, indices.count)
 
-        let batch = (index ..< endIndex)
-            .map { encodedDataset[indices[$0]] }
+        let batch = try (index ..< endIndex)
+            .map { try tokenizer.encode(text: dataset[indices[$0]]) }
         let lengths = batch.map { $0.count }
         let maxLength = lengths.max() ?? 0
 
@@ -187,9 +193,10 @@ public enum LoRATrain {
         var allLosses = [Float]()
         var tokenCount = 0
 
-        for (iteration, (inputs, targets, lengths)) in try LoRABatchIterator(
-            dataset: dataset, tokenizer: tokenizer, batchSize: batchSize, train: false
-        ).enumerated() {
+        var batchIterator = LoRABatchIterator(
+            dataset: dataset, tokenizer: tokenizer, batchSize: batchSize, train: false)
+        var iteration = 0
+        while let (inputs, targets, lengths) = try batchIterator.nextBatch() {
             let (losses, tokens) = loss(model, inputs, targets, lengths)
             allLosses.append((losses * tokens).item(Float.self))
             tokenCount += tokens.item(Int.self)
@@ -197,6 +204,7 @@ public enum LoRATrain {
             if batchCount != 0 && iteration + 1 >= batchCount {
                 break
             }
+            iteration += 1
         }
 
         return (sum(MLXArray(allLosses), stream: .cpu) / tokenCount).item(Float.self)
@@ -270,9 +278,10 @@ public enum LoRATrain {
 
         var start = Date.timeIntervalSinceReferenceDate
 
-        for (iteration, (inputs, targets, lengths)) in try LoRABatchIterator(
-            dataset: train, tokenizer: tokenizer, batchSize: parameters.batchSize, train: true
-        ).enumerated() {
+        var batchIterator = LoRABatchIterator(
+            dataset: train, tokenizer: tokenizer, batchSize: parameters.batchSize, train: true)
+        var iteration = 0
+        while let (inputs, targets, lengths) = try batchIterator.nextBatch() {
             // forward and backward pass
             let (resultArray, grad) = lossValueGrad(model, [inputs, targets, lengths])
             let lvalue = resultArray[0]
@@ -341,6 +350,7 @@ public enum LoRATrain {
             if iteration + 1 >= parameters.iterations {
                 break
             }
+            iteration += 1
         }
     }
 }

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -418,7 +418,7 @@ public final class ChatSession {
                             parameters: generateParameters)
 
                         let (stream, task) = MLXLMCommon.generateTask(
-                            promptTokenCount: input.text.tokens.size,
+                            promptTokenIds: input.text.tokens.asArray(Int.self),
                             modelConfiguration: modelConfiguration,
                             tokenizer: tokenizer,
                             iterator: iterator

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -426,7 +426,7 @@ public final class ChatSession {
 
                         var pendingToolCalls: [ToolCall] = []
 
-                        for await item in stream {
+                        for try await item in stream {
                             // collect tool calls for dispatch; if no
                             // toolDispatch the caller handles them via
                             // the transform (streamDetails path)

--- a/Libraries/MLXLMCommon/Documentation.docc/porting.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/porting.md
@@ -619,7 +619,7 @@ let result = try await modelContainer.perform { [input] context in
     let input = try context.processor.prepare(input: input)
 
     return generate(input: input, parameters: generateParameters, context: context) { tokens in
-        // This could potentially use NaiveStreamingDetokenizer and print
+        // This could potentially use StreamingDetokenizer and print
         // text as it was generated
         if tokens.count >= 20 {
             return .stop

--- a/Libraries/MLXLMCommon/Documentation.docc/upgrade.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/upgrade.md
@@ -281,7 +281,7 @@ let container = try await loadModelContainer(
 let text = tokenizer.decode(tokens: ids)
 
 // After (3.0)
-let text = tokenizer.decode(tokenIds: ids)
+let text = try tokenizer.decode(tokenIds: ids)
 ```
 
 ## Breaking Changes

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1317,7 +1317,7 @@ public func generate(
 /// * Important: if the stream is terminated early (e.g. break from the loop) computation will continue
 /// using the model, parameters, KVCache, etc. for some time (typically a few ms).  This is typically OK for
 /// one-shot calls, but for "chat session" type calls consider using
-/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:)``
+/// ``generateTask(promptTokenIds:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:)``
 /// so that the end of the generation task can be observed.
 ///
 /// - Parameters:
@@ -1363,7 +1363,7 @@ public func generate(
     let iterator = try TokenIterator(
         input: input, model: context.model, cache: cache, parameters: parameters)
     let (stream, _) = generateTask(
-        promptTokenCount: input.text.tokens.size,
+        promptTokenIds: input.text.tokens.asArray(Int.self),
         modelConfiguration: context.configuration,
         tokenizer: context.tokenizer,
         iterator: iterator,
@@ -1443,7 +1443,8 @@ public func generate(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
-            format: context.configuration.toolCallFormat ?? .json
+            format: context.configuration.toolCallFormat ?? .json,
+            promptTokenIds: input.text.tokens.asArray(Int.self)
         )
     )
     return stream
@@ -1459,7 +1460,7 @@ public func generate(
     wiredMemoryTicket: WiredMemoryTicket? = nil
 ) -> AsyncThrowingStream<Generation, Error> {
     let (stream, _) = generateTask(
-        promptTokenCount: input.text.tokens.size,
+        promptTokenIds: input.text.tokens.asArray(Int.self),
         modelConfiguration: context.configuration,
         tokenizer: context.tokenizer,
         iterator: iterator,
@@ -1475,28 +1476,31 @@ public func generate(
 /// the `task` to observe when the use of the parameters is complete.
 ///
 /// - Parameters:
-///   - promptTokenCount: number of tokens in the prompt
+///   - promptTokenIds: prompt token IDs, used for stats and to seed the
+///     streaming detokenizer at the prompt/generated boundary so the first
+///     generated chunk decodes correctly for SentencePiece/metaspace tokenizers.
 ///   - modelConfiguration: model configuration (for EOS/extra EOS tokens and tool-call format)
 ///   - tokenizer: tokenizer (for EOS id, unknown token id, and detokenization)
 ///   - iterator: token iterator
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
 /// - Returns: An `AsyncThrowingStream` that emits `Generation` values and a `Task`
 public func generateTask(
-    promptTokenCount: Int,
+    promptTokenIds: [Int],
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
     iterator: consuming TokenIterator,
     wiredMemoryTicket: WiredMemoryTicket? = nil
 ) -> (AsyncThrowingStream<Generation, Error>, Task<Void, Never>) {
     generateLoopTask(
-        promptTokenCount: promptTokenCount,
+        promptTokenCount: promptTokenIds.count,
         modelConfiguration: modelConfiguration,
         tokenizer: tokenizer,
         iterator: iterator,
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: tokenizer,
-            format: modelConfiguration.toolCallFormat ?? .json
+            format: modelConfiguration.toolCallFormat ?? .json,
+            promptTokenIds: promptTokenIds
         )
     )
 }
@@ -1527,7 +1531,7 @@ public func generateTokens(
     let iterator = try TokenIterator(
         input: input, model: context.model, cache: cache, parameters: parameters)
     let (stream, _) = generateTokenTask(
-        promptTokenCount: input.text.tokens.size,
+        promptTokenIds: input.text.tokens.asArray(Int.self),
         modelConfiguration: context.configuration,
         tokenizer: context.tokenizer,
         iterator: iterator,
@@ -1612,7 +1616,7 @@ public func generateTokensTask(
     let iterator = try TokenIterator(
         input: input, model: context.model, cache: cache, parameters: parameters)
     return generateTokenTask(
-        promptTokenCount: input.text.tokens.size,
+        promptTokenIds: input.text.tokens.asArray(Int.self),
         modelConfiguration: context.configuration,
         tokenizer: context.tokenizer,
         iterator: iterator,
@@ -1628,7 +1632,8 @@ public func generateTokensTask(
 /// without detokenization or tool-call parsing.
 ///
 /// - Parameters:
-///   - promptTokenCount: number of tokens in the prompt
+///   - promptTokenIds: prompt token IDs (used for stats reporting; raw-token generation
+///     does not detokenize, so seeding does not apply here).
 ///   - modelConfiguration: model configuration (for EOS/extra EOS tokens)
 ///   - tokenizer: tokenizer (for EOS id and unknown token id)
 ///   - iterator: token iterator
@@ -1638,7 +1643,7 @@ public func generateTokensTask(
 ///     memory control (macOS 15 / iOS 18 / tvOS 18 or newer).
 /// - Returns: An `AsyncThrowingStream` that emits token IDs and a final `.info`, plus a `Task`.
 public func generateTokenTask(
-    promptTokenCount: Int,
+    promptTokenIds: [Int],
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
     iterator: consuming TokenIterator,
@@ -1646,7 +1651,7 @@ public func generateTokenTask(
     wiredMemoryTicket: WiredMemoryTicket? = nil
 ) -> (AsyncThrowingStream<TokenGeneration, Error>, Task<Void, Never>) {
     generateLoopTask(
-        promptTokenCount: promptTokenCount,
+        promptTokenCount: promptTokenIds.count,
         modelConfiguration: modelConfiguration,
         tokenizer: tokenizer,
         iterator: iterator,
@@ -1959,7 +1964,7 @@ internal protocol TokenLoopHandler: Sendable {
     func infoEvent(_ info: GenerateCompletionInfo) -> Output
 }
 
-private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
+internal struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     typealias Output = Generation
 
     private static let logger = Logger(
@@ -1971,11 +1976,15 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     var detokenizer: StreamingDetokenizer
     let toolCallProcessor: ToolCallProcessor
 
-    init(tokenizer: Tokenizer, format: ToolCallFormat) {
+    init(tokenizer: Tokenizer, format: ToolCallFormat, promptTokenIds: [Int]) {
         self.tokenizer = tokenizer
         self.skipSpecialTokens = false
+        // Seed with the prompt tail — enough to defeat decoder cleanup at
+        // the prompt/generated boundary (vLLM uses `prompt_ids[-7:]`).
         detokenizer = StreamingDetokenizer(
-            tokenizer: tokenizer, skipSpecialTokens: skipSpecialTokens
+            tokenizer: tokenizer,
+            skipSpecialTokens: skipSpecialTokens,
+            initialTokenIds: Array(promptTokenIds.suffix(7))
         )
         toolCallProcessor = ToolCallProcessor(format: format)
     }
@@ -1992,8 +2001,12 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
             Self.logger.warning(
                 "Resetting streaming detokenizer: \(TokenizerError.invalidStreamingPrefix(tokenId: tokenId, expectedPrefix: prefix, actualString: actual).localizedDescription, privacy: .public)"
             )
+            // Recovery is mid-stream, so the prompt boundary is no longer
+            // adjacent to the next chunk: rebuild without the seed (matches
+            // vLLM's recovery path).
             detokenizer = StreamingDetokenizer(
-                tokenizer: tokenizer, skipSpecialTokens: skipSpecialTokens
+                tokenizer: tokenizer,
+                skipSpecialTokens: skipSpecialTokens
             )
             chunk = try detokenizer.consume(token)
         }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3,6 +3,7 @@
 import Foundation
 import MLX
 import MLXNN
+import os
 
 /// A `LogitSampler` is responsible for sampling `logits` produced by
 /// a ``LanguageModel`` to produce a token.
@@ -499,7 +500,7 @@ protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element == Int 
 
 /// Generator of tokens.
 ///
-/// This is typically used via a call to ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncStream<Generation>`.
+/// This is typically used via a call to ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncThrowingStream<Generation, Error>`.
 ///
 /// To use it directly:
 ///
@@ -708,7 +709,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 /// Generator of tokens using speculative decoding.
 ///
 /// This is typically used via a call to ``generate(input:cache:parameters:context:draftModel:draftCache:numDraftTokens:wiredMemoryTicket:)``
-/// returning `AsyncStream<Generation>`.
+/// returning `AsyncThrowingStream<Generation, Error>`.
 ///
 /// To use it directly:
 ///
@@ -1144,7 +1145,7 @@ private func runSynchronousGenerationLoop(
 
 /// Given prompt tokens generate text using the given model and parameters.
 ///
-/// ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncStream<Generation>` is the preferred call.
+/// ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncThrowingStream<Generation, Error>` is the preferred call.
 ///
 /// - Parameters:
 ///   - promptTokens: tokenized prompt
@@ -1156,7 +1157,7 @@ private func runSynchronousGenerationLoop(
 @available(
     *, deprecated,
     message:
-        "Use the AsyncStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
+        "Use the AsyncThrowingStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
 )
 public func generate(
     promptTokens: [Int], parameters: GenerateParameters, model: any LanguageModel,
@@ -1176,14 +1177,14 @@ public func generate(
         configuration: configuration, model: model, processor: StandInUserInputProcessor(),
         tokenizer: tokenizer)
 
-    return generate(
+    return try generate(
         input: input, context: context, iterator: iterator,
         didGenerate: didGenerate)
 }
 
 /// Generate tokens from an ``LMInput`` and a ``ModelContext``.
 ///
-/// Prefer using ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncStream<Generation>` instead.
+/// Prefer using ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncThrowingStream<Generation, Error>` instead.
 ///
 /// - Parameters:
 ///   - input: prepared language model input
@@ -1194,7 +1195,7 @@ public func generate(
 @available(
     *, deprecated,
     message:
-        "Use the AsyncStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
+        "Use the AsyncThrowingStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
 )
 public func generate(
     input: LMInput, parameters: GenerateParameters, context: ModelContext,
@@ -1202,14 +1203,14 @@ public func generate(
 ) throws -> GenerateResult {
     let iterator = try TokenIterator(
         input: input, model: context.model, parameters: parameters)
-    return generate(
+    return try generate(
         input: input, context: context, iterator: iterator,
         didGenerate: didGenerate)
 }
 
 /// Low-level token generation using a ``TokenIterator``.
 ///
-/// ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncStream<Generation>` is the preferred call.
+/// ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncThrowingStream<Generation, Error>` is the preferred call.
 ///
 /// - Parameters:
 ///   - input: prepared language model input
@@ -1220,13 +1221,13 @@ public func generate(
 @available(
     *, deprecated,
     message:
-        "Use the AsyncStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
+        "Use the AsyncThrowingStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
 )
 public func generate(
     input: LMInput, context: ModelContext,
     iterator: TokenIterator,
     didGenerate: ([Int]) -> GenerateDisposition
-) -> GenerateResult {
+) throws -> GenerateResult {
     let result = runSynchronousGenerationLoop(
         modelConfiguration: context.configuration,
         tokenizer: context.tokenizer,
@@ -1237,7 +1238,7 @@ public func generate(
 
     return GenerateResult(
         inputText: input.text, tokenIds: result.generatedTokenIds,
-        output: context.tokenizer.decode(tokenIds: result.generatedTokenIds),
+        output: try context.tokenizer.decode(tokenIds: result.generatedTokenIds),
         promptTime: result.promptTime + result.promptPrefillTime,
         generateTime: result.generateTime
     )
@@ -1245,7 +1246,7 @@ public func generate(
 
 /// Generate tokens from an ``LMInput`` and a ``ModelContext``.
 ///
-/// Prefer using ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncStream<Generation>` instead.
+/// Prefer using ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncThrowingStream<Generation, Error>` instead.
 ///
 /// - Parameters:
 ///   - input: prepared language model input
@@ -1256,7 +1257,7 @@ public func generate(
 @available(
     *, deprecated,
     message:
-        "Use the AsyncStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
+        "Use the AsyncThrowingStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
 )
 public func generate(
     input: LMInput, parameters: GenerateParameters, context: ModelContext,
@@ -1271,7 +1272,7 @@ public func generate(
 
 /// Low-level token generation using a ``TokenIterator``.
 ///
-/// ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncStream<Generation>` is the preferred call.
+/// ``generate(input:cache:parameters:context:wiredMemoryTicket:)`` returning `AsyncThrowingStream<Generation, Error>` is the preferred call.
 ///
 /// - Parameters:
 ///   - input: prepared language model input
@@ -1282,7 +1283,7 @@ public func generate(
 @available(
     *, deprecated,
     message:
-        "Use the AsyncStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
+        "Use the AsyncThrowingStream-based generate(input:cache:parameters:context:) instead for better Swift concurrency support"
 )
 public func generate(
     input: LMInput, context: ModelContext,
@@ -1327,7 +1328,7 @@ public func generate(
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination across
 ///     concurrent tasks. This is opt-in and only applied on GPU devices that support wired
 ///     memory control (macOS 15 / iOS 18 / tvOS 18 or newer).
-/// - Returns: An `AsyncStream` that emits `Generation` values, including generated text chunks (`.chunk`),
+/// - Returns: An `AsyncThrowingStream` that emits `Generation` values, including generated text chunks (`.chunk`),
 ///   tool calls (`.toolCall`), and completion information (`.info`).
 /// - Throws: An error if the `TokenIterator` initialization fails due to invalid input or model configuration.
 ///
@@ -1344,7 +1345,7 @@ public func generate(
 /// let stream = try generate(input: lmInput, parameters: generateParameters, context: context)
 ///
 /// // Process the stream asynchronously to handle text chunks and completion info.
-/// for await generation in stream {
+/// for try await generation in stream {
 ///     switch generation {
 ///     case .chunk(let text):
 ///         print("Generated text: \(text)")
@@ -1358,7 +1359,7 @@ public func generate(
 public func generate(
     input: LMInput, cache: [KVCache]? = nil, parameters: GenerateParameters, context: ModelContext,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) throws -> AsyncStream<Generation> {
+) throws -> AsyncThrowingStream<Generation, Error> {
     let iterator = try TokenIterator(
         input: input, model: context.model, cache: cache, parameters: parameters)
     let (stream, _) = generateTask(
@@ -1392,7 +1393,7 @@ public func generate(
 ///     input: lmInput, parameters: generateParameters,
 ///     context: mainContext, draftModel: draftModel)
 ///
-/// for await generation in stream {
+/// for try await generation in stream {
 ///     switch generation {
 ///     case .chunk(let text):
 ///         print("Generated text: \(text)")
@@ -1413,7 +1414,7 @@ public func generate(
 ///   - draftCache: optional ``KVCache`` for the draft model.
 ///   - numDraftTokens: Number of tokens the draft model proposes per round (default: 2).
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
-/// - Returns: An `AsyncStream` that emits `Generation` values.
+/// - Returns: An `AsyncThrowingStream` that emits `Generation` values.
 /// - Throws: An error if the iterator initialization fails.
 public func generate(
     input: LMInput,
@@ -1424,7 +1425,7 @@ public func generate(
     draftCache: [KVCache]? = nil,
     numDraftTokens: Int = 2,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) throws -> AsyncStream<Generation> {
+) throws -> AsyncThrowingStream<Generation, Error> {
     let iterator = try SpeculativeTokenIterator(
         input: input,
         mainModel: context.model,
@@ -1456,7 +1457,7 @@ public func generate(
     input: LMInput, context: ModelContext,
     iterator: TokenIterator,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) -> AsyncStream<Generation> {
+) -> AsyncThrowingStream<Generation, Error> {
     let (stream, _) = generateTask(
         promptTokenCount: input.text.tokens.size,
         modelConfiguration: context.configuration,
@@ -1467,7 +1468,7 @@ public func generate(
 }
 
 /// Low-level token generation using a ``TokenIterator``, returning an
-/// `AsyncStream<Generation>` and a `Task`.
+/// `AsyncThrowingStream<Generation, Error>` and a `Task`.
 ///
 /// * Important: if the stream is terminated early (e.g. break from the loop) computation will continue
 /// using the model, parameters, KVCache, etc. for some time (typically a few ms).  Callers can await
@@ -1479,14 +1480,14 @@ public func generate(
 ///   - tokenizer: tokenizer (for EOS id, unknown token id, and detokenization)
 ///   - iterator: token iterator
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
-/// - Returns: An `AsyncStream` that emits `Generation` values and a `Task`
+/// - Returns: An `AsyncThrowingStream` that emits `Generation` values and a `Task`
 public func generateTask(
     promptTokenCount: Int,
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
     iterator: consuming TokenIterator,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) -> (AsyncStream<Generation>, Task<Void, Never>) {
+) -> (AsyncThrowingStream<Generation, Error>, Task<Void, Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
         modelConfiguration: modelConfiguration,
@@ -1514,7 +1515,7 @@ public func generateTask(
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination across
 ///     concurrent tasks. This is opt-in and only applied on GPU devices that support wired
 ///     memory control (macOS 15 / iOS 18 / tvOS 18 or newer).
-/// - Returns: An `AsyncStream` that emits `TokenGeneration` values.
+/// - Returns: An `AsyncThrowingStream` that emits `TokenGeneration` values.
 public func generateTokens(
     input: LMInput,
     cache: [KVCache]? = nil,
@@ -1522,7 +1523,7 @@ public func generateTokens(
     context: ModelContext,
     includeStopToken: Bool = false,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) throws -> AsyncStream<TokenGeneration> {
+) throws -> AsyncThrowingStream<TokenGeneration, Error> {
     let iterator = try TokenIterator(
         input: input, model: context.model, cache: cache, parameters: parameters)
     let (stream, _) = generateTokenTask(
@@ -1552,7 +1553,7 @@ public func generateTokens(
 ///   - draftCache: optional ``KVCache`` for the draft model.
 ///   - numDraftTokens: Number of tokens the draft model proposes per round (default: 2).
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
-/// - Returns: An `AsyncStream` that emits `TokenGeneration` values.
+/// - Returns: An `AsyncThrowingStream` that emits `TokenGeneration` values.
 /// - Throws: An error if the iterator initialization fails.
 public func generateTokens(
     input: LMInput,
@@ -1563,7 +1564,7 @@ public func generateTokens(
     draftCache: [KVCache]? = nil,
     numDraftTokens: Int = 2,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) throws -> AsyncStream<TokenGeneration> {
+) throws -> AsyncThrowingStream<TokenGeneration, Error> {
     let iterator = try SpeculativeTokenIterator(
         input: input,
         mainModel: context.model,
@@ -1589,7 +1590,7 @@ public func generateTokens(
 /// Prefer this overload if you want to be able to observe when the underlying generation work is finished
 /// (especially if the consumer terminates the stream early).
 ///
-/// - Returns: An `AsyncStream` that emits `TokenGeneration` values and a `Task`.
+/// - Returns: An `AsyncThrowingStream` that emits `TokenGeneration` values and a `Task`.
 ///
 /// - Parameters:
 ///   - input: The input for the language model.
@@ -1607,7 +1608,7 @@ public func generateTokensTask(
     context: ModelContext,
     includeStopToken: Bool = false,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) throws -> (AsyncStream<TokenGeneration>, Task<Void, Never>) {
+) throws -> (AsyncThrowingStream<TokenGeneration, Error>, Task<Void, Never>) {
     let iterator = try TokenIterator(
         input: input, model: context.model, cache: cache, parameters: parameters)
     return generateTokenTask(
@@ -1621,7 +1622,7 @@ public func generateTokensTask(
 }
 
 /// Low-level raw token generation using a `TokenIterator`, returning an
-/// `AsyncStream<TokenGeneration>` and a `Task`.
+/// `AsyncThrowingStream<TokenGeneration, Error>` and a `Task`.
 ///
 /// This is useful for parsers that need access to the token IDs directly (e.g. Harmony parsing)
 /// without detokenization or tool-call parsing.
@@ -1635,7 +1636,7 @@ public func generateTokensTask(
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination across
 ///     concurrent tasks. This is opt-in and only applied on GPU devices that support wired
 ///     memory control (macOS 15 / iOS 18 / tvOS 18 or newer).
-/// - Returns: An `AsyncStream` that emits token IDs and a final `.info`, plus a `Task`.
+/// - Returns: An `AsyncThrowingStream` that emits token IDs and a final `.info`, plus a `Task`.
 public func generateTokenTask(
     promptTokenCount: Int,
     modelConfiguration: ModelConfiguration,
@@ -1643,7 +1644,7 @@ public func generateTokenTask(
     iterator: consuming TokenIterator,
     includeStopToken: Bool = false,
     wiredMemoryTicket: WiredMemoryTicket? = nil
-) -> (AsyncStream<TokenGeneration>, Task<Void, Never>) {
+) -> (AsyncThrowingStream<TokenGeneration, Error>, Task<Void, Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
         modelConfiguration: modelConfiguration,
@@ -1655,7 +1656,7 @@ public func generateTokenTask(
     )
 }
 
-private func generateLoopTask<Handler: TokenLoopHandler>(
+internal func generateLoopTask<Handler: TokenLoopHandler>(
     promptTokenCount: Int,
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
@@ -1663,9 +1664,9 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
     wiredMemoryTicket: WiredMemoryTicket? = nil,
     includeStopToken: Bool = false,
     handler: consuming Handler
-) -> (AsyncStream<Handler.Output>, Task<Void, Never>) {
+) -> (AsyncThrowingStream<Handler.Output, Error>, Task<Void, Never>) {
 
-    let (stream, continuation) = AsyncStream<Handler.Output>.makeStream()
+    let (stream, continuation) = AsyncThrowingStream<Handler.Output, Error>.makeStream()
 
     let iterator = SendableBox(iterator)
     let handler = SendableBox(handler)
@@ -1681,42 +1682,48 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             var tokenCount = 0
             var stopReason: GenerateStopReason?
 
-            let stopTokenIds = buildStopTokenIds(
-                modelConfiguration: modelConfiguration,
-                tokenizer: tokenizer
-            )
+            do {
+                let stopTokenIds = buildStopTokenIds(
+                    modelConfiguration: modelConfiguration,
+                    tokenizer: tokenizer
+                )
 
-            for token in iterator {
-                // Check for cancellation on every loop iteration.
-                if Task.isCancelled {
-                    stopReason = .cancelled
-                    break
-                }
-
-                if promptTime == 0 {
-                    let now = Date.timeIntervalSinceReferenceDate
-                    promptTime = now - start
-                    start = now
-                }
-
-                // Check for end-of-sequence tokens
-                if token == tokenizer.unknownTokenId || stopTokenIds.contains(token) {
-                    if includeStopToken {
-                        tokenCount += 1
-                        if !handler.onStopToken(token, emit: continuation.yield) {
-                            stopReason = .cancelled
-                            break
-                        }
+                for token in iterator {
+                    // Check for cancellation on every loop iteration.
+                    if Task.isCancelled {
+                        stopReason = .cancelled
+                        break
                     }
-                    stopReason = .stop
-                    break
-                }
 
-                tokenCount += 1
-                if !handler.onToken(token, emit: continuation.yield) {
-                    stopReason = .cancelled
-                    break
+                    if promptTime == 0 {
+                        let now = Date.timeIntervalSinceReferenceDate
+                        promptTime = now - start
+                        start = now
+                    }
+
+                    // Check for end-of-sequence tokens
+                    if token == tokenizer.unknownTokenId || stopTokenIds.contains(token) {
+                        if includeStopToken {
+                            tokenCount += 1
+                            if try !handler.onStopToken(token, emit: continuation.yield) {
+                                stopReason = .cancelled
+                                break
+                            }
+                        }
+                        stopReason = .stop
+                        break
+                    }
+
+                    tokenCount += 1
+                    if try !handler.onToken(token, emit: continuation.yield) {
+                        stopReason = .cancelled
+                        break
+                    }
                 }
+            } catch {
+                Stream().synchronize()
+                continuation.finish(throwing: error)
+                return
             }
 
             if stopReason == nil {
@@ -1928,24 +1935,25 @@ public enum TokenGeneration: Sendable {
 
 // MARK: - TokenLoopHandlers
 
-private protocol TokenLoopHandler: Sendable {
+internal protocol TokenLoopHandler: Sendable {
     associatedtype Output
 
-    /// Return false to stop the loop early.
+    /// Return false to stop the loop after the consumer terminates the stream;
+    /// throw to finish the stream with an error.
     mutating func onToken(
         _ token: Int,
-        emit: (sending Output) -> AsyncStream<Output>.Continuation.YieldResult
-    ) -> Bool
+        emit: (sending Output) -> AsyncThrowingStream<Output, Error>.Continuation.YieldResult
+    ) throws -> Bool
 
     /// Called only when includeStopToken == true and a stop token was hit.
     mutating func onStopToken(
         _ token: Int,
-        emit: (sending Output) -> AsyncStream<Output>.Continuation.YieldResult
-    ) -> Bool
+        emit: (sending Output) -> AsyncThrowingStream<Output, Error>.Continuation.YieldResult
+    ) throws -> Bool
 
     /// Called after the token loop finishes, before the info event.
     mutating func onGenerationEnd(
-        emit: (sending Output) -> AsyncStream<Output>.Continuation.YieldResult
+        emit: (sending Output) -> AsyncThrowingStream<Output, Error>.Continuation.YieldResult
     )
 
     func infoEvent(_ info: GenerateCompletionInfo) -> Output
@@ -1954,20 +1962,43 @@ private protocol TokenLoopHandler: Sendable {
 private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     typealias Output = Generation
 
-    var detokenizer: NaiveStreamingDetokenizer
+    private static let logger = Logger(
+        subsystem: "com.apple.mlx-swift-lm", category: "TextToolTokenLoopHandler"
+    )
+
+    let tokenizer: any Tokenizer
+    let skipSpecialTokens: Bool
+    var detokenizer: StreamingDetokenizer
     let toolCallProcessor: ToolCallProcessor
 
     init(tokenizer: Tokenizer, format: ToolCallFormat) {
-        detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+        self.tokenizer = tokenizer
+        self.skipSpecialTokens = false
+        detokenizer = StreamingDetokenizer(
+            tokenizer: tokenizer, skipSpecialTokens: skipSpecialTokens
+        )
         toolCallProcessor = ToolCallProcessor(format: format)
     }
 
     mutating func onToken(
         _ token: Int,
-        emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
-    ) -> Bool {
-        detokenizer.append(token: token)
-        if let chunk = detokenizer.next() {
+        emit: (sending Generation) ->
+            AsyncThrowingStream<Generation, Error>.Continuation.YieldResult
+    ) throws -> Bool {
+        let chunk: String?
+        do {
+            chunk = try detokenizer.consume(token)
+        } catch TokenizerError.invalidStreamingPrefix(let tokenId, let prefix, let actual) {
+            Self.logger.warning(
+                "Resetting streaming detokenizer: \(TokenizerError.invalidStreamingPrefix(tokenId: tokenId, expectedPrefix: prefix, actualString: actual).localizedDescription, privacy: .public)"
+            )
+            detokenizer = StreamingDetokenizer(
+                tokenizer: tokenizer, skipSpecialTokens: skipSpecialTokens
+            )
+            chunk = try detokenizer.consume(token)
+        }
+
+        if let chunk {
             // Process chunk through the tool call processor.
             if let textToYield = toolCallProcessor.processChunk(chunk) {
                 if case .terminated = emit(.chunk(textToYield)) {
@@ -1988,13 +2019,15 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
 
     mutating func onStopToken(
         _ token: Int,
-        emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
-    ) -> Bool {
+        emit: (sending Generation) ->
+            AsyncThrowingStream<Generation, Error>.Continuation.YieldResult
+    ) throws -> Bool {
         true
     }
 
     mutating func onGenerationEnd(
-        emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
+        emit: (sending Generation) ->
+            AsyncThrowingStream<Generation, Error>.Continuation.YieldResult
     ) {
         toolCallProcessor.processEOS()
 
@@ -2015,8 +2048,9 @@ private struct RawTokenLoopHandler: TokenLoopHandler {
 
     mutating func onToken(
         _ token: Int,
-        emit: (sending TokenGeneration) -> AsyncStream<TokenGeneration>.Continuation.YieldResult
-    ) -> Bool {
+        emit: (sending TokenGeneration) ->
+            AsyncThrowingStream<TokenGeneration, Error>.Continuation.YieldResult
+    ) throws -> Bool {
         if case .terminated = emit(.token(token)) {
             return false
         }
@@ -2025,8 +2059,9 @@ private struct RawTokenLoopHandler: TokenLoopHandler {
 
     mutating func onStopToken(
         _ token: Int,
-        emit: (sending TokenGeneration) -> AsyncStream<TokenGeneration>.Continuation.YieldResult
-    ) -> Bool {
+        emit: (sending TokenGeneration) ->
+            AsyncThrowingStream<TokenGeneration, Error>.Continuation.YieldResult
+    ) throws -> Bool {
         if case .terminated = emit(.token(token)) {
             return false
         }
@@ -2034,7 +2069,8 @@ private struct RawTokenLoopHandler: TokenLoopHandler {
     }
 
     mutating func onGenerationEnd(
-        emit: (sending TokenGeneration) -> AsyncStream<TokenGeneration>.Continuation.YieldResult
+        emit: (sending TokenGeneration) ->
+            AsyncThrowingStream<TokenGeneration, Error>.Continuation.YieldResult
     ) {}
 
     func infoEvent(_ info: GenerateCompletionInfo) -> TokenGeneration {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1940,7 +1940,7 @@ public enum TokenGeneration: Sendable {
 
 // MARK: - TokenLoopHandlers
 
-internal protocol TokenLoopHandler: Sendable {
+internal protocol TokenLoopHandler {
     associatedtype Output
 
     /// Return false to stop the loop after the consumer terminates the stream;
@@ -1964,7 +1964,7 @@ internal protocol TokenLoopHandler: Sendable {
     func infoEvent(_ info: GenerateCompletionInfo) -> Output
 }
 
-internal struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
+internal struct TextToolTokenLoopHandler: TokenLoopHandler {
     typealias Output = Generation
 
     private static let logger = Logger(

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -156,7 +156,7 @@ public final class ModelContainer: Sendable {
         return try await processor.prepare(input: input)
     }
 
-    /// Generate tokens from prepared input, returning an AsyncStream.
+    /// Generate tokens from prepared input, returning an AsyncThrowingStream.
     ///
     /// This method provides a thread-safe way to generate tokens without
     /// needing to use closure-based `perform` calls.
@@ -165,7 +165,7 @@ public final class ModelContainer: Sendable {
     /// ```swift
     /// let input = try await modelContainer.prepare(input: userInput)
     /// let stream = try modelContainer.generate(input: input, parameters: parameters)
-    /// for await generation in stream {
+    /// for try await generation in stream {
     ///     switch generation {
     ///     case .chunk(let text): print(text)
     ///     case .info(let info): print(info.tokensPerSecond)
@@ -178,14 +178,14 @@ public final class ModelContainer: Sendable {
     ///   - input: Prepared language model input (transferred via `sending`)
     ///   - parameters: Generation parameters
     ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination
-    /// - Returns: An AsyncStream of generation events
+    /// - Returns: An AsyncThrowingStream of generation events
     /// - Note: The `sending` parameter indicates the input is transferred (not shared),
     ///   allowing non-Sendable types like `LMInput` to safely cross isolation boundaries.
     public func generate(
         input: consuming sending LMInput,
         parameters: GenerateParameters,
         wiredMemoryTicket: WiredMemoryTicket? = nil
-    ) async throws -> AsyncStream<Generation> {
+    ) async throws -> AsyncThrowingStream<Generation, Error> {
         let input = SendableBox(input)
 
         // Note: this is only visiting the model exclusively
@@ -209,23 +209,25 @@ public final class ModelContainer: Sendable {
     ///
     /// - Parameter tokenIds: Array of token IDs
     /// - Returns: Decoded string
-    public func decode(tokenIds: [Int]) async -> String {
+    /// - Throws: Errors propagated from the tokenizer's decode call.
+    public func decode(tokenIds: [Int]) async throws -> String {
         let tokenizer = await self.tokenizer
-        return tokenizer.decode(tokenIds: tokenIds)
+        return try tokenizer.decode(tokenIds: tokenIds)
     }
 
     @available(*, deprecated, renamed: "decode(tokenIds:)")
-    public func decode(tokens: [Int]) async -> String {
-        await decode(tokenIds: tokens)
+    public func decode(tokens: [Int]) async throws -> String {
+        try await decode(tokenIds: tokens)
     }
 
     /// Encode a string to token IDs.
     ///
     /// - Parameter text: Text to encode
     /// - Returns: Array of token IDs
-    public func encode(_ text: String) async -> [Int] {
+    /// - Throws: Errors propagated from the tokenizer's encode call.
+    public func encode(_ text: String) async throws -> [Int] {
         let tokenizer = await self.tokenizer
-        return tokenizer.encode(text: text)
+        return try tokenizer.encode(text: text)
     }
 
     /// Apply chat template to messages and return token IDs.

--- a/Libraries/MLXLMCommon/README.md
+++ b/Libraries/MLXLMCommon/README.md
@@ -167,7 +167,7 @@ load models, if needed.
 - UserInput
 - LMInput
 - generate()
-    - NaiveStreamingDetokenizer
+    - StreamingDetokenizer
     - TokenIterator
 
 ## Using a Model
@@ -200,22 +200,19 @@ let result = try await modelContainer.perform { [input] context in
 ```
 
 Given that `input` we can call `generate()` to produce a stream
-of tokens. In this example we use a `NaiveStreamingDetokenizer`
+of tokens. In this example we use a `StreamingDetokenizer`
 to assist in converting a stream of tokens into text and print it.
 The stream is stopped after we hit a maximum number of tokens:
 
 ```
-    var detokenizer = NaiveStreamingDetokenizer(tokenizer: context.tokenizer)
+    let detokenizer = context.tokenizer.streamingDetokenizer()
 
     return try MLXLMCommon.generate(
         input: input, parameters: generateParameters, context: context
     ) { tokens in
 
-        if let last = tokens.last {
-            detokenizer.append(token: last)
-        }
-
-        if let new = detokenizer.next() {
+        if let last = tokens.last,
+           let new = try? detokenizer.consume(last) {
             print(new, terminator: "")
             fflush(stdout)
         }

--- a/Libraries/MLXLMCommon/StreamingDetokenizer.swift
+++ b/Libraries/MLXLMCommon/StreamingDetokenizer.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Streams a sequence of token IDs into incrementally emitted text chunks,
+/// implementing the upstream Hugging Face `step_decode_stream` algorithm.
+///
+/// Feed tokens one at a time through ``consume(_:)-(Int)``. Each call returns either
+/// a non-empty text chunk that can be displayed, or `nil` to indicate that the
+/// detokenizer has buffered the token because it does not yet form a complete
+/// scalar. Internal state is bounded: after every successful emission the
+/// stored prefix and id buffer are trimmed so memory does not grow with stream
+/// length.
+///
+/// The decoder must be byte-prefix monotonic: `decode(ids + [newId])` must
+/// start with `decode(ids)`. Tokenizers that apply post-decode cleanup in
+/// `decode` (for example whitespace fixups around contractions and
+/// punctuation) can violate that invariant on otherwise-normal output and
+/// throw ``TokenizerError/invalidStreamingPrefix(tokenId:expectedPrefix:actualString:)``.
+/// Tokenizers that have a raw path should conform to
+/// ``StreamingDecodeTokenizer``; this detokenizer uses it automatically when
+/// available and falls back to `decode` otherwise.
+///
+/// `StreamingDetokenizer` is single-consumer by design and is therefore not
+/// `Sendable`.
+public final class StreamingDetokenizer {
+    private let tokenizer: any Tokenizer
+    private let skipSpecialTokens: Bool
+    internal private(set) var ids: [Int]
+    internal private(set) var prefix: String
+    internal private(set) var prefixIndex: Int
+
+    /// Creates an empty stream over `tokenizer`.
+    public convenience init(tokenizer: any Tokenizer, skipSpecialTokens: Bool = false) {
+        self.init(tokenizer: tokenizer, skipSpecialTokens: skipSpecialTokens, initialTokenIds: [])
+    }
+
+    /// Creates a stream seeded with prior token IDs. The first ``consume(_:)-(Int)``
+    /// uses `initialTokenIds` to establish the prefix and emits only the new
+    /// token's chunk. Use this for resuming after interruption.
+    public init(
+        tokenizer: any Tokenizer,
+        skipSpecialTokens: Bool = false,
+        initialTokenIds: [Int]
+    ) {
+        self.tokenizer = tokenizer
+        self.skipSpecialTokens = skipSpecialTokens
+        ids = initialTokenIds
+        prefix = ""
+        prefixIndex = 0
+    }
+
+    /// Consumes a token and returns any complete chunk it produced.
+    ///
+    /// - Parameter id: The next token ID to feed into the stream.
+    /// - Returns: A non-empty chunk if the buffer can now emit one, or `nil`
+    ///   if the buffer ends mid-scalar and the caller should feed the next
+    ///   token. The returned chunk is guaranteed to be non-empty.
+    /// - Throws: ``TokenizerError/invalidStreamingPrefix(tokenId:expectedPrefix:actualString:)``
+    ///   when the decoder produces output that does not begin with the cached
+    ///   prefix, or any error propagated from the tokenizer's decode call. On
+    ///   any throw, internal state is unchanged from before the call.
+    public func consume(_ id: Int) throws -> String? {
+        var workingIds = ids
+        var workingPrefix = prefix
+        var workingPrefixIndex = prefixIndex
+
+        if workingPrefix.isEmpty && !workingIds.isEmpty {
+            let seeded = try rawDecode(workingIds)
+            if !seeded.hasSuffix("\u{fffd}") {
+                workingPrefix = seeded
+                workingPrefixIndex = workingIds.count
+            }
+        }
+
+        workingIds.append(id)
+        let string = try rawDecode(workingIds)
+
+        if string.utf8.count <= workingPrefix.utf8.count || string.hasSuffix("\u{fffd}") {
+            ids = workingIds
+            prefix = workingPrefix
+            prefixIndex = workingPrefixIndex
+            return nil
+        }
+
+        guard string.utf8.starts(with: workingPrefix.utf8) else {
+            throw TokenizerError.invalidStreamingPrefix(
+                tokenId: id,
+                expectedPrefix: workingPrefix,
+                actualString: string
+            )
+        }
+
+        let newChunk = String(
+            decoding: string.utf8.dropFirst(workingPrefix.utf8.count),
+            as: UTF8.self
+        )
+
+        let trimmed = Array(workingIds[workingPrefixIndex...])
+        let refreshed = try rawDecode(trimmed)
+
+        ids = trimmed
+        prefix = refreshed
+        prefixIndex = trimmed.count
+        return newChunk
+    }
+
+    private func rawDecode(_ tokenIds: [Int]) throws -> String {
+        if let raw = tokenizer as? StreamingDecodeTokenizer {
+            return try raw.rawDecode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+        }
+        // TODO: Consider warning once on fallback — Swift Transformers has
+        // no cleanup-free decode, so streaming silently inherits its cleanup.
+        return try tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    /// Consumes a batch of tokens. Returns the concatenation of every chunk
+    /// produced, or `nil` if no chunk was produced.
+    ///
+    /// Each token is consumed atomically, but the batch as a whole is not:
+    /// if a token mid-batch throws, earlier tokens have already been
+    /// committed to internal state.
+    public func consume(_ ids: [Int]) throws -> String? {
+        var combined = ""
+        for id in ids {
+            if let chunk = try consume(id) {
+                combined.append(chunk)
+            }
+        }
+        return combined.isEmpty ? nil : combined
+    }
+}
+
+extension Tokenizer {
+    /// Returns a fresh ``StreamingDetokenizer`` over this tokenizer.
+    public func streamingDetokenizer(skipSpecialTokens: Bool = false) -> StreamingDetokenizer {
+        StreamingDetokenizer(tokenizer: self, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    /// Returns a ``StreamingDetokenizer`` seeded with `initialTokenIds`.
+    public func streamingDetokenizer(
+        skipSpecialTokens: Bool = false,
+        initialTokenIds: [Int]
+    ) -> StreamingDetokenizer {
+        StreamingDetokenizer(
+            tokenizer: self,
+            skipSpecialTokens: skipSpecialTokens,
+            initialTokenIds: initialTokenIds
+        )
+    }
+}

--- a/Libraries/MLXLMCommon/StreamingDetokenizer.swift
+++ b/Libraries/MLXLMCommon/StreamingDetokenizer.swift
@@ -147,3 +147,24 @@ extension Tokenizer {
         )
     }
 }
+
+@available(
+    *, unavailable,
+    message:
+        "Replaced by StreamingDetokenizer. Use tokenizer.streamingDetokenizer() and try consume(_:) in place of append(token:)/next(). See PR #271."
+)
+public struct NaiveStreamingDetokenizer {
+    public init(tokenizer: any Tokenizer) {}
+
+    @available(
+        *, unavailable,
+        message: "Use try StreamingDetokenizer.consume(_:) instead of append(token:)/next()."
+    )
+    public mutating func append(token: Int) {}
+
+    @available(
+        *, unavailable,
+        message: "Use try StreamingDetokenizer.consume(_:) instead of append(token:)/next()."
+    )
+    public mutating func next() -> String? { nil }
+}

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -4,8 +4,8 @@ import Foundation
 
 /// A protocol for tokenizing text into token IDs and decoding token IDs into text.
 public protocol Tokenizer: Sendable {
-    func encode(text: String, addSpecialTokens: Bool) -> [Int]
-    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String
+    func encode(text: String, addSpecialTokens: Bool) throws -> [Int]
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String
     func convertTokenToId(_ token: String) -> Int?
     func convertIdToToken(_ id: Int) -> String?
 
@@ -21,12 +21,12 @@ public protocol Tokenizer: Sendable {
 }
 
 extension Tokenizer {
-    public func encode(text: String) -> [Int] {
-        encode(text: text, addSpecialTokens: true)
+    public func encode(text: String) throws -> [Int] {
+        try encode(text: text, addSpecialTokens: true)
     }
 
-    public func decode(tokenIds: [Int]) -> String {
-        decode(tokenIds: tokenIds, skipSpecialTokens: false)
+    public func decode(tokenIds: [Int]) throws -> String {
+        try decode(tokenIds: tokenIds, skipSpecialTokens: false)
     }
 
     public var eosTokenId: Int? {
@@ -53,62 +53,32 @@ extension Tokenizer {
     }
 }
 
-public enum TokenizerError: LocalizedError {
+/// A `Tokenizer` that exposes a raw decode path for streaming detokenization.
+///
+/// Conforming tokenizers promise that ``rawDecode(tokenIds:skipSpecialTokens:)``
+/// returns text without any post-decode cleanup — no whitespace fixups, no
+/// retroactive contraction rewrites, nothing that would break the byte-prefix
+/// monotonicity that ``StreamingDetokenizer`` depends on. Cleanup, when the
+/// tokenizer applies it, belongs in `decode(tokenIds:skipSpecialTokens:)`.
+///
+/// ``StreamingDetokenizer`` uses `rawDecode` automatically when the tokenizer
+/// conforms; tokenizers that don't conform fall back to `decode` and rely on
+/// the reset-and-retry recovery in the generation loop when cleanup violates
+/// the prefix invariant.
+public protocol StreamingDecodeTokenizer: Tokenizer {
+    func rawDecode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String
+}
+
+public enum TokenizerError: LocalizedError, Equatable {
     case missingChatTemplate
+    case invalidStreamingPrefix(tokenId: Int, expectedPrefix: String, actualString: String)
 
     public var errorDescription: String? {
         switch self {
         case .missingChatTemplate:
             "This tokenizer does not have a chat template."
+        case .invalidStreamingPrefix(let tokenId, let expectedPrefix, let actualString):
+            "Streaming detokenizer prefix invariant violated for token \(tokenId): expected prefix \(expectedPrefix.debugDescription), got \(actualString.debugDescription)."
         }
-    }
-}
-
-public protocol StreamingDetokenizer: IteratorProtocol<String> {
-    mutating func append(token: Int)
-}
-
-public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
-    let tokenizer: any Tokenizer
-
-    var segmentTokens = [Int]()
-    var segment = ""
-
-    public init(tokenizer: any Tokenizer) {
-        self.tokenizer = tokenizer
-    }
-
-    public mutating func append(token: Int) {
-        segmentTokens.append(token)
-    }
-
-    mutating func startNewSegment() {
-        let lastToken = segmentTokens.last
-        segmentTokens.removeAll()
-        if let lastToken {
-            segmentTokens.append(lastToken)
-            segment = tokenizer.decode(tokenIds: segmentTokens)
-        } else {
-            segment = ""
-        }
-    }
-
-    public mutating func next() -> String? {
-        let newSegment = tokenizer.decode(tokenIds: segmentTokens)
-        let new = newSegment.suffix(newSegment.count - segment.count)
-
-        // if the new segment ends with REPLACEMENT CHARACTER this means
-        // that the token didn't produce a complete unicode character
-        if new.last == "\u{fffd}" {
-            return nil
-        }
-
-        if new.hasSuffix("\n") {
-            startNewSegment()
-        } else {
-            self.segment = newSegment
-        }
-
-        return String(new)
     }
 }

--- a/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
+++ b/Libraries/MLXLMCommon/Utilities/SerialAccessContainer.swift
@@ -78,7 +78,7 @@ package final class SerialAccessContainer<T>: @unchecked Sendable {
 /// public func generateTask(
 ///     input: consuming LMInput, context: consuming ModelContext,
 ///     iterator: consuming TokenIterator
-/// ) -> (AsyncStream<Generation>, Task<Void, Never>) {
+/// ) -> (AsyncThrowingStream<Generation, Error>, Task<Void, Never>) {
 ///     let context = SendableBox(context)
 ///     let iterator = SendableBox(iterator)
 ///

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -35,7 +35,7 @@ public enum WiredMemoryUtils {
         count: Int,
         tokenizer: Tokenizer,
         seedText: String = " hello"
-    ) -> [Int] {
+    ) throws -> [Int] {
         guard count > 0 else { return [] }
 
         let pad = tokenizer.eosTokenId ?? tokenizer.unknownTokenId ?? 0
@@ -43,7 +43,7 @@ public enum WiredMemoryUtils {
 
         var chunk = seedText
         while tokens.count < count {
-            let newTokens = tokenizer.encode(text: chunk)
+            let newTokens = try tokenizer.encode(text: chunk)
             if newTokens.isEmpty {
                 tokens.append(pad)
             } else {
@@ -73,8 +73,8 @@ public enum WiredMemoryUtils {
         count: Int,
         tokenizer: Tokenizer,
         seedText: String = " hello"
-    ) -> LMInput {
-        let tokenIds = makeTokenIds(count: count, tokenizer: tokenizer, seedText: seedText)
+    ) throws -> LMInput {
+        let tokenIds = try makeTokenIds(count: count, tokenizer: tokenizer, seedText: seedText)
         return LMInput(tokens: MLXArray(tokenIds))
     }
 
@@ -143,7 +143,7 @@ public enum WiredMemoryUtils {
     ) async throws -> WiredMemoryMeasurement {
         let weights = context.model.parameters().flattened().reduce(0) { $0 + $1.1.nbytes }
 
-        let input = makeTokenInput(
+        let input = try makeTokenInput(
             count: tokenCount,
             tokenizer: context.tokenizer,
             seedText: seedText

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1003,12 +1003,12 @@ public struct FastVLMProcessor: UserInputProcessor {
         let promptTokens = try tokenizer.applyChatTemplate(
             messages: messages, tools: input.tools,
             additionalContext: input.additionalContext)
-        let decoded = tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
+        let decoded = try tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
 
         // Find <image> and replace with token id -200
         let pieces = decoded.split(separator: imageToken)
         let tokens = Array(
-            pieces.map { tokenizer.encode(text: String($0)) }.joined(separator: [-200]))
+            try pieces.map { try tokenizer.encode(text: String($0)) }.joined(separator: [-200]))
 
         let image = try input.images[0]
             .asCIImage()

--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -799,7 +799,7 @@ public struct GlmOcrProcessor: UserInputProcessor {
         in promptTokens: [Int], frames: [THW]
     ) throws -> [Int] {
         let paddingToken = "<|image|>"
-        let placeholderTokens = tokenizer.encode(
+        let placeholderTokens = try tokenizer.encode(
             text: "<|begin_of_image|>\(paddingToken)<|end_of_image|>")
         let placeholderRanges = promptTokens.ranges(of: placeholderTokens)
         guard placeholderRanges.count == frames.count else {
@@ -808,9 +808,9 @@ public struct GlmOcrProcessor: UserInputProcessor {
             )
         }
         let mergeLength = config.mergeSize * config.mergeSize
-        let replacementSequences = frames.map { frame in
+        let replacementSequences = try frames.map { frame in
             let paddingCount = frame.product / mergeLength
-            return tokenizer.encode(
+            return try tokenizer.encode(
                 text:
                     "<|begin_of_image|>\(Array(repeating: paddingToken, count: paddingCount).joined())<|end_of_image|>"
             )

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -838,7 +838,7 @@ public struct Idefics3Processor: UserInputProcessor {
         let prompt = prompt(from: input)
         if input.images.isEmpty {
             // No image scenario
-            let tokens = tokenizer.encode(text: prompt)
+            let tokens = try tokenizer.encode(text: prompt)
             let tokensArray = MLXArray(tokens).expandedDimensions(axis: 0)
             let mask = ones(like: tokensArray)
             return LMInput(text: .init(tokens: tokensArray, mask: mask), image: nil)
@@ -849,7 +849,7 @@ public struct Idefics3Processor: UserInputProcessor {
             }
 
             // Encode only the text part of the prompt, without <image>
-            var promptTokens = tokenizer.encode(text: prompt)
+            var promptTokens = try tokenizer.encode(text: prompt)
 
             let imageTokenIndex = promptTokens.count / 2
             promptTokens.insert(imageTokenId, at: imageTokenIndex)

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -1026,7 +1026,7 @@ public struct Mistral3VLMProcessor: UserInputProcessor {
         )
 
         // Decode to find and replace image placeholder token
-        let decoded = tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
+        let decoded = try tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
 
         // Process image to get dimensions
         let preprocessResult = try preprocessImage(
@@ -1046,7 +1046,7 @@ public struct Mistral3VLMProcessor: UserInputProcessor {
 
             for (index, piece) in pieces.enumerated() {
                 if !piece.isEmpty {
-                    let pieceTokens = tokenizer.encode(text: piece)
+                    let pieceTokens = try tokenizer.encode(text: piece)
                     expandedTokens.append(contentsOf: pieceTokens)
                 }
                 // Add image tokens between pieces (not after the last one)

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -477,7 +477,7 @@ public struct PaliGemmaProcessor: UserInputProcessor {
             Array(repeating: "<image>", count: count).joined() + (tokenizer.bosToken ?? "") + prompt
             + "\n"
 
-        let promptTokens = tokenizer.encode(text: prompt)
+        let promptTokens = try tokenizer.encode(text: prompt)
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
         let mask = ones(like: promptArray).asType(.int8)
 

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -1039,7 +1039,7 @@ public struct PixtralProcessor: UserInputProcessor {
         let prompt = prompt(from: input)
 
         if input.images.isEmpty {
-            let tokens = tokenizer.encode(text: prompt)
+            let tokens = try tokenizer.encode(text: prompt)
             let tokensArray = MLXArray(tokens).expandedDimensions(axis: 0)
             let mask = ones(like: tokensArray)
             return LMInput(text: .init(tokens: tokensArray, mask: mask), image: nil)
@@ -1103,7 +1103,7 @@ public struct PixtralProcessor: UserInputProcessor {
             let numImageTokens = numPatchesH * numPatchesW
 
             // Build prompt with image tokens
-            var promptTokens = tokenizer.encode(text: prompt)
+            var promptTokens = try tokenizer.encode(text: prompt)
 
             // Insert image tokens
             let imageTokens = Array(repeating: imageTokenId, count: numImageTokens)

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -177,7 +177,7 @@ public struct QwenVL {
         tokenizer: any Tokenizer
     ) throws -> [Int] {
         // Replace single padding token with correct number for each image or video frame
-        let placeholderTokens = tokenizer.encode(
+        let placeholderTokens = try tokenizer.encode(
             text: "<|vision_start|>\(paddingToken)<|vision_end|>")
         let placeholderRanges = promptTokens.ranges(of: placeholderTokens)
         guard placeholderRanges.count == frames.count else {
@@ -185,9 +185,9 @@ public struct QwenVL {
                 "Number of placeholder tokens does not match number of frames")
         }
         let mergeLength = mergeSize * mergeSize
-        let replacementSequences = frames.map { frame in
+        let replacementSequences = try frames.map { frame in
             let paddingCount = frame.product / mergeLength
-            return tokenizer.encode(
+            return try tokenizer.encode(
                 text:
                     "<|vision_start|>\(Array(repeating: paddingToken, count: paddingCount).joined())<|vision_end|>"
             )

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -240,7 +240,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
             let promptTokens = try tokenizer.applyChatTemplate(
                 messages: messages, tools: input.tools,
                 additionalContext: input.additionalContext)
-            let decoded = tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
+            let decoded = try tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
 
             let image = try input.images[0].asCIImage().toSRGB()
             let (tiles, imageRows, imageCols) = tiles(from: image)
@@ -271,7 +271,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
             )
 
             let prompt = decoded.replacingOccurrences(of: imageToken, with: imagePromptString)
-            let finalPromptTokens = tokenizer.encode(text: prompt)
+            let finalPromptTokens = try tokenizer.encode(text: prompt)
 
             let promptArray = MLXArray(finalPromptTokens).expandedDimensions(axis: 0)
             let mask = ones(like: promptArray)
@@ -307,7 +307,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
             // Unfortunately we don't have a "render" option in Tokenizers yet, so decoding
             let promptTokens = try tokenizer.applyChatTemplate(
                 messages: messagesWithSystem(messages))
-            let decoded = tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
+            let decoded = try tokenizer.decode(tokenIds: promptTokens, skipSpecialTokens: false)
 
             let video = input.videos[0]
 
@@ -353,7 +353,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
                 // Fallback if the expected marker is not present
                 prompt = decoded + "\n" + videoPromptString
             }
-            let finalPromptTokens = tokenizer.encode(text: prompt)
+            let finalPromptTokens = try tokenizer.encode(text: prompt)
 
             let promptArray = MLXArray(finalPromptTokens).expandedDimensions(axis: 0)
             let mask = ones(like: promptArray)

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -63,14 +63,14 @@ struct SpeculativeDecodingTests {
         )
 
         var normalTokens: [Int] = []
-        for await generation in try generateTokens(
+        for try await generation in try generateTokens(
             input: modelInput, parameters: parameters, context: mainContext
         ) {
             if let token = generation.token { normalTokens.append(token) }
         }
 
         var speculativeTokens: [Int] = []
-        for await generation in try generateTokens(
+        for try await generation in try generateTokens(
             input: modelInput, parameters: parameters, context: mainContext,
             draftModel: draftContext.model, numDraftTokens: numDraftTokens
         ) {

--- a/Tests/MLXLMTests/StreamingDetokenizerTests.swift
+++ b/Tests/MLXLMTests/StreamingDetokenizerTests.swift
@@ -58,6 +58,25 @@ private struct MockTokenizer: MLXLMCommon.Tokenizer {
     ) throws -> [Int] { [] }
 }
 
+/// Thread-safe recorder for `decode` calls. The detokenizer runs on a Task,
+/// so the test fixture and the assertions live on different threads.
+private final class DecodeCallLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [[Int]] = []
+
+    func record(_ ids: [Int]) {
+        lock.lock()
+        defer { lock.unlock() }
+        _calls.append(ids)
+    }
+
+    var calls: [[Int]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _calls
+    }
+}
+
 @Suite("StreamingDetokenizer")
 struct StreamingDetokenizerSuite {
     /// "Hello" split into single-byte ASCII tokens.
@@ -154,6 +173,108 @@ struct StreamingDetokenizerSuite {
 
         // Trim after each emit keeps the buffer bounded regardless of stream length.
         #expect(stream.ids.count <= 1)
+    }
+
+    @Test
+    func seedingPreservesPromptBoundaryWhitespace() throws {
+        // SentencePiece/metaspace tokenizers strip a leading space at the
+        // start of the decoded sequence. An unseeded streaming detokenizer
+        // therefore loses the space at the prompt/generated boundary on
+        // the first generated chunk; seeding with the prompt IDs makes the
+        // first emit correctly include it. This mirrors what Rust
+        // `DecodeStream` and vLLM do by initializing with prompt token IDs.
+        struct MetaspaceTokenizer: MLXLMCommon.Tokenizer {
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                var out = ""
+                for id in tokenIds {
+                    switch id {
+                    case 1: out += "prompt"
+                    case 2: out += " hello"
+                    default: break
+                    }
+                }
+                if out.hasPrefix(" ") { out.removeFirst() }
+                return out
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let tokenizer = MetaspaceTokenizer()
+
+        let unseeded = tokenizer.streamingDetokenizer()
+        #expect(try unseeded.consume(2) == "hello")
+
+        let seeded = tokenizer.streamingDetokenizer(initialTokenIds: [1])
+        #expect(try seeded.consume(2) == " hello")
+    }
+
+    @Test
+    func seededStreamMatchesFullDecodeMinusPromptPrefix() throws {
+        // Equivalence: streaming with the prompt as seed must produce
+        // exactly the suffix of the full decode beyond the prompt prefix.
+        // Mirrors `test_decode_stream_copy_and_prefix_ids` in
+        // huggingface/tokenizers' Python binding and `test_decode_streaming`
+        // in vLLM.
+        struct MetaspaceTokenizer: MLXLMCommon.Tokenizer {
+            static let pieces: [Int: String] = [
+                1: "Q",
+                2: ":",
+                3: " hello",
+                4: " world",
+                5: "?",
+            ]
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                var out = ""
+                for id in tokenIds {
+                    if let piece = Self.pieces[id] { out += piece }
+                }
+                if out.hasPrefix(" ") { out.removeFirst() }
+                return out
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let tokenizer = MetaspaceTokenizer()
+        let promptIds = [1, 2]
+        let generatedIds = [3, 4, 5]
+
+        let fullDecode = try tokenizer.decode(
+            tokenIds: promptIds + generatedIds, skipSpecialTokens: false
+        )
+        let promptDecode = try tokenizer.decode(
+            tokenIds: promptIds, skipSpecialTokens: false
+        )
+        let expectedSuffix = String(fullDecode.dropFirst(promptDecode.count))
+
+        let stream = tokenizer.streamingDetokenizer(initialTokenIds: promptIds)
+        var streamed = ""
+        for id in generatedIds {
+            if let chunk = try stream.consume(id) {
+                streamed.append(chunk)
+            }
+        }
+
+        #expect(streamed == expectedSuffix)
     }
 
     @Test
@@ -436,6 +557,151 @@ struct StreamingDetokenizerSuite {
         } catch is InjectedFailure {
             // Expected.
         }
+    }
+
+    @Test
+    func handlerSlicesSeedToLastSevenPromptTokens() async throws {
+        // The handler must seed with the last seven prompt tokens (vLLM
+        // precedent for defeating decoder cleanup at the boundary). Here
+        // the prompt is ten tokens; the first seed-decode must hit only
+        // the last seven.
+        struct MockIterator: TokenIteratorProtocol {
+            var remaining: [Int]
+            var maxTokens: Int? { nil }
+            var tokenCount: Int { 0 }
+            var promptPrefillTime: TimeInterval { 0 }
+            mutating func next() -> Int? {
+                guard !remaining.isEmpty else { return nil }
+                return remaining.removeFirst()
+            }
+        }
+
+        struct LinearTokenizer: MLXLMCommon.Tokenizer {
+            let log: DecodeCallLog
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                log.record(tokenIds)
+                return tokenIds.map { String(Character(UnicodeScalar(0x60 + $0)!)) }.joined()
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let log = DecodeCallLog()
+        let tokenizer = LinearTokenizer(log: log)
+        let promptIds = Array(1 ... 10)
+        let handler = TextToolTokenLoopHandler(
+            tokenizer: tokenizer,
+            format: .json,
+            promptTokenIds: promptIds
+        )
+        let modelConfiguration = ModelConfiguration(id: "test")
+        let (stream, task) = generateLoopTask(
+            promptTokenCount: promptIds.count,
+            modelConfiguration: modelConfiguration,
+            tokenizer: tokenizer,
+            iterator: MockIterator(remaining: [20]),
+            handler: handler
+        )
+
+        for try await _ in stream {}
+        await task.value
+
+        let firstSeedDecode = log.calls.first { !$0.isEmpty && $0.count <= 7 }
+        #expect(firstSeedDecode == [4, 5, 6, 7, 8, 9, 10])
+    }
+
+    @Test
+    func handlerDropsSeedOnInvalidPrefixReset() async throws {
+        // After `invalidStreamingPrefix`, the handler rebuilds the
+        // detokenizer without the prompt seed (matches vLLM's recovery
+        // path). Verifies that no decode call after the throw contains
+        // any prompt token ID.
+        struct MockIterator: TokenIteratorProtocol {
+            var remaining: [Int]
+            var maxTokens: Int? { nil }
+            var tokenCount: Int { 0 }
+            var promptPrefillTime: TimeInterval { 0 }
+            mutating func next() -> Int? {
+                guard !remaining.isEmpty else { return nil }
+                return remaining.removeFirst()
+            }
+        }
+
+        // Tokenizer where the seed is "P", appending 100 produces "Pa",
+        // and appending 200 produces a strictly-longer prefix-violating
+        // string ("xyz" does not start with "a"), which raises
+        // `invalidStreamingPrefix`. After the reset, decode([200]) is "xyz".
+        struct ResettingTokenizer: MLXLMCommon.Tokenizer {
+            let log: DecodeCallLog
+            static let promptId = 1
+            static let validId = 100
+            static let invalidId = 200
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                log.record(tokenIds)
+                switch tokenIds {
+                case [Self.promptId]: return "P"
+                case [Self.promptId, Self.validId]: return "Pa"
+                case [Self.validId]: return "a"
+                case [Self.validId, Self.invalidId]: return "xyz"
+                case [Self.invalidId]: return "xyz"
+                default: return ""
+                }
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let log = DecodeCallLog()
+        let tokenizer = ResettingTokenizer(log: log)
+        let handler = TextToolTokenLoopHandler(
+            tokenizer: tokenizer,
+            format: .json,
+            promptTokenIds: [ResettingTokenizer.promptId]
+        )
+        let modelConfiguration = ModelConfiguration(id: "test")
+        let (stream, task) = generateLoopTask(
+            promptTokenCount: 1,
+            modelConfiguration: modelConfiguration,
+            tokenizer: tokenizer,
+            iterator: MockIterator(remaining: [
+                ResettingTokenizer.validId,
+                ResettingTokenizer.invalidId,
+            ]),
+            handler: handler
+        )
+
+        for try await _ in stream {}
+        await task.value
+
+        // The post-reset decode must be `[invalidId]` alone — no prompt seed.
+        // Equivalently: no decode call after the throw should contain `promptId`.
+        let calls = log.calls
+        let throwIndex = calls.firstIndex(of: [
+            ResettingTokenizer.validId,
+            ResettingTokenizer.invalidId,
+        ])
+        #expect(throwIndex != nil)
+        let postResetCalls = throwIndex.map { Array(calls[($0 + 1)...]) } ?? []
+        #expect(!postResetCalls.isEmpty)
+        #expect(postResetCalls.allSatisfy { !$0.contains(ResettingTokenizer.promptId) })
     }
 
     @Test

--- a/Tests/MLXLMTests/StreamingDetokenizerTests.swift
+++ b/Tests/MLXLMTests/StreamingDetokenizerTests.swift
@@ -1,0 +1,469 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+private struct MockVocabulary {
+    let bytesByTokenId: [Int: [UInt8]]
+    let stringByTokenId: [Int: String]
+
+    init(_ entries: [Int: [UInt8]]) {
+        bytesByTokenId = entries
+        stringByTokenId = entries.mapValues { String(decoding: $0, as: UTF8.self) }
+    }
+}
+
+/// Tokenizer whose `decode` concatenates the bytes for the requested ids — byte-prefix
+/// monotonic by construction, so every branch of the streaming algorithm is reachable
+/// without a real model.
+private struct MockTokenizer: MLXLMCommon.Tokenizer {
+    let vocabulary: MockVocabulary
+    let invalidIds: Set<Int>
+
+    init(_ entries: [Int: [UInt8]], invalidIds: Set<Int> = []) {
+        vocabulary = MockVocabulary(entries)
+        self.invalidIds = invalidIds
+    }
+
+    private struct UnknownTokenId: Error { let id: Int }
+    private struct InjectedFailure: Error {}
+
+    func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+        var bytes: [UInt8] = []
+        for id in tokenIds {
+            if invalidIds.contains(id) {
+                throw InjectedFailure()
+            }
+            guard let chunk = vocabulary.bytesByTokenId[id] else {
+                throw UnknownTokenId(id: id)
+            }
+            bytes.append(contentsOf: chunk)
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { vocabulary.stringByTokenId[id] }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+@Suite("StreamingDetokenizer")
+struct StreamingDetokenizerSuite {
+    /// "Hello" split into single-byte ASCII tokens.
+    private static let asciiTokenizer = MockTokenizer([
+        1: Array("H".utf8),
+        2: Array("e".utf8),
+        3: Array("l".utf8),
+        4: Array("o".utf8),
+        5: Array(" ".utf8),
+        6: Array("w".utf8),
+        7: Array("r".utf8),
+        8: Array("d".utf8),
+    ])
+
+    /// 🌍 (U+1F30D, four UTF-8 bytes) split byte-by-byte across tokens 10–13.
+    private static let fragmentedEmojiTokenizer = MockTokenizer([
+        10: [0xF0],
+        11: [0x9F],
+        12: [0x8C],
+        13: [0x8D],
+        20: Array("!".utf8),
+    ])
+
+    @Test
+    func emitsEachAsciiToken() throws {
+        let stream = Self.asciiTokenizer.streamingDetokenizer()
+        let ids = [1, 2, 3, 3, 4]  // "Hello"
+        var out = ""
+        for id in ids {
+            if let chunk = try stream.consume(id) {
+                out.append(chunk)
+            }
+        }
+        #expect(out == "Hello")
+    }
+
+    @Test
+    func multiByteScalarBufferedAcrossTokens() throws {
+        let stream = Self.fragmentedEmojiTokenizer.streamingDetokenizer()
+        var collected: [String?] = []
+        for id in [10, 11, 12, 13] {
+            collected.append(try stream.consume(id))
+        }
+        // The first three consumes return nil because the buffered bytes still
+        // form an incomplete scalar; the fourth completes the scalar and emits.
+        #expect(collected[0] == nil)
+        #expect(collected[1] == nil)
+        #expect(collected[2] == nil)
+        #expect(collected[3] == "🌍")
+    }
+
+    @Test
+    func bufferStaysBoundedAcrossLongStream() throws {
+        // Repeat "Hello world" many times. The buffer should trim after each
+        // emission to a small constant rather than growing with stream length.
+        let helloIds = [1, 2, 3, 3, 4, 5, 6, 4, 7, 3, 8]  // "Hello world"
+        let ids = Array(repeating: helloIds, count: 1000).flatMap { $0 }
+        let stream = Self.asciiTokenizer.streamingDetokenizer()
+
+        var output = ""
+        for id in ids {
+            if let chunk = try stream.consume(id) {
+                output.append(chunk)
+            }
+        }
+        let oneShot = try Self.asciiTokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+        #expect(output == oneShot)
+
+        #expect(stream.ids.count < 5)
+    }
+
+    @Test
+    func consumeBatchReturnsConcatenation() throws {
+        let stream = Self.asciiTokenizer.streamingDetokenizer()
+        let chunk = try stream.consume([1, 2, 3, 3, 4])
+        #expect(chunk == "Hello")
+    }
+
+    @Test
+    func seedingFromInitialIds() throws {
+        let stream = Self.asciiTokenizer.streamingDetokenizer(
+            initialTokenIds: [1, 2]
+        )
+        // First consume seeds the prefix from [1, 2] and emits only the
+        // new token's byte. Subsequent consumes must continue to emit
+        // only their own bytes — a regression here would re-emit the
+        // seeded "He" once the buffer is trimmed.
+        let first = try stream.consume(3)
+        #expect(first == "l")
+        let second = try stream.consume(3)
+        #expect(second == "l")
+        let third = try stream.consume(4)
+        #expect(third == "o")
+
+        // Trim after each emit keeps the buffer bounded regardless of stream length.
+        #expect(stream.ids.count <= 1)
+    }
+
+    @Test
+    func consumeReturnsNilWhenTokenAddsNoBytes() throws {
+        // A skipped-special token adds no bytes to the cumulative decode, so
+        // `consume` withholds rather than throwing — the cached prefix is
+        // still a valid prefix of the unchanged decode.
+        struct SkipSpecial: MLXLMCommon.Tokenizer {
+            static let regularBytes: [Int: [UInt8]] = [
+                0: Array("a".utf8),
+                1: Array("b".utf8),
+            ]
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                var bytes: [UInt8] = []
+                for id in tokenIds {
+                    if id == 99 {
+                        if skipSpecialTokens { continue }
+                        bytes.append(contentsOf: Array("<eos>".utf8))
+                        continue
+                    }
+                    if let chunk = Self.regularBytes[id] {
+                        bytes.append(contentsOf: chunk)
+                    }
+                }
+                return String(decoding: bytes, as: UTF8.self)
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { "<eos>" }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let stream = SkipSpecial().streamingDetokenizer(skipSpecialTokens: true)
+        #expect(try stream.consume(0) == "a")
+        #expect(try stream.consume(99) == nil)
+        #expect(try stream.consume(1) == "b")
+    }
+
+    @Test
+    func consumeRollsBackWhenDecodeThrowsForUnknownToken() throws {
+        // When the tokenizer rejects the just-appended id, `consume`
+        // must not mutate any internal state — the next valid id has
+        // to behave as if the rejected one had never been fed.
+        let tokenizer = MockTokenizer(
+            [
+                1: Array("Hi".utf8),
+                2: Array(" ".utf8),
+                3: Array("there".utf8),
+            ],
+            invalidIds: [99]
+        )
+        let stream = tokenizer.streamingDetokenizer()
+
+        _ = try stream.consume(1)
+
+        let beforeIds = stream.ids
+        let beforePrefix = stream.prefix
+        let beforeIndex = stream.prefixIndex
+
+        // This token causes decode to throw — internal state must not change.
+        do {
+            _ = try stream.consume(99)
+            Issue.record("Expected decode failure")
+        } catch {
+            // Expected.
+        }
+
+        #expect(stream.ids == beforeIds)
+        #expect(stream.prefix == beforePrefix)
+        #expect(stream.prefixIndex == beforeIndex)
+
+        // Subsequent valid consumes still produce the right text — i.e. the
+        // poison id was fully rolled back, not buffered.
+        let chunk2 = try stream.consume(2)
+        let chunk3 = try stream.consume(3)
+        let combined = (chunk2 ?? "") + (chunk3 ?? "")
+        #expect(combined == " there")
+    }
+
+    @Test
+    func consumeRollsBackWhenLaterDecodeThrows() throws {
+        // The algorithm calls `decode` twice per `consume` (working text, then
+        // prefix refresh). This mock fails on the second call to verify the
+        // rollback holds for the post-emit decode, not just the first one.
+        struct PartialFailureTokenizer: MLXLMCommon.Tokenizer {
+            struct Failure: Error {}
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                switch tokenIds {
+                case [1]: return "Hello"
+                case [1, 2]: return "Hello world"
+                case [2]: throw Failure()
+                default: return ""
+                }
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let stream = PartialFailureTokenizer().streamingDetokenizer()
+        let first = try stream.consume(1)
+        #expect(first == "Hello")
+
+        #expect(stream.ids == [1])
+        #expect(stream.prefix == "Hello")
+        #expect(stream.prefixIndex == 1)
+
+        let beforeIds = stream.ids
+        let beforePrefix = stream.prefix
+        let beforeIndex = stream.prefixIndex
+
+        do {
+            _ = try stream.consume(2)
+            Issue.record("Expected decode failure")
+        } catch is PartialFailureTokenizer.Failure {
+            // Expected.
+        }
+
+        #expect(stream.ids == beforeIds)
+        #expect(stream.prefix == beforePrefix)
+        #expect(stream.prefixIndex == beforeIndex)
+    }
+
+    @Test
+    func invalidStreamingPrefixThrows() throws {
+        // Non-monotonic decode: the one-token result is not a prefix of the two-token result.
+        struct NonMonotonic: MLXLMCommon.Tokenizer {
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                if tokenIds == [1] { return "abc" }
+                if tokenIds == [1, 2] { return "xyzlonger" }  // breaks the prefix invariant
+                return ""
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let stream = NonMonotonic().streamingDetokenizer()
+        _ = try stream.consume(1)
+        do {
+            _ = try stream.consume(2)
+            Issue.record("Expected invalidStreamingPrefix throw")
+        } catch let error as TokenizerError {
+            guard
+                case .invalidStreamingPrefix(let tokenId, let expectedPrefix, let actualString) =
+                    error
+            else {
+                Issue.record("Expected .invalidStreamingPrefix, got \(error)")
+                return
+            }
+            #expect(tokenId == 2)
+            #expect(expectedPrefix == "abc")
+            #expect(actualString == "xyzlonger")
+        }
+    }
+
+    @Test
+    func streamingDetokenizerPrefersRawDecode() throws {
+        // A tokenizer where `decode` applies cleanup (uppercases) and
+        // `rawDecode` returns the original bytes. The streaming detokenizer
+        // should pick `rawDecode` and emit lowercase chunks.
+        struct CleanupTokenizer: MLXLMCommon.StreamingDecodeTokenizer {
+            func encode(text: String, addSpecialTokens: Bool) throws -> [Int] { [] }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                try rawDecode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+                    .uppercased()
+            }
+            func rawDecode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
+                let map: [Int: String] = [1: "h", 2: "i"]
+                return tokenIds.compactMap { map[$0] }.joined()
+            }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [] }
+        }
+
+        let tokenizer = CleanupTokenizer()
+        // Sanity-check the cleanup divergence is wired correctly.
+        #expect(try tokenizer.decode(tokenIds: [1, 2], skipSpecialTokens: false) == "HI")
+        #expect(try tokenizer.rawDecode(tokenIds: [1, 2], skipSpecialTokens: false) == "hi")
+
+        let stream = tokenizer.streamingDetokenizer()
+        let first = try stream.consume(1)
+        let second = try stream.consume(2)
+        #expect((first ?? "") + (second ?? "") == "hi")
+    }
+
+    @Test
+    func generationStreamFinishesThrowingOnHandlerError() async throws {
+        // Verify the throwing-stream wiring: when a TokenLoopHandler.onToken
+        // throws, generateLoopTask catches it and finishes the AsyncThrowingStream
+        // with that error rather than truncating silently.
+        struct InjectedFailure: Error, Equatable {}
+
+        struct MockIterator: TokenIteratorProtocol {
+            var remaining: [Int]
+            var maxTokens: Int? { nil }
+            var tokenCount: Int { 0 }
+            var promptPrefillTime: TimeInterval { 0 }
+
+            mutating func next() -> Int? {
+                guard !remaining.isEmpty else { return nil }
+                return remaining.removeFirst()
+            }
+        }
+
+        struct ThrowingHandler: TokenLoopHandler {
+            typealias Output = String
+
+            mutating func onToken(
+                _ token: Int,
+                emit: (sending String) ->
+                    AsyncThrowingStream<String, Error>.Continuation
+                    .YieldResult
+            ) throws -> Bool {
+                throw InjectedFailure()
+            }
+
+            mutating func onStopToken(
+                _ token: Int,
+                emit: (sending String) ->
+                    AsyncThrowingStream<String, Error>.Continuation
+                    .YieldResult
+            ) throws -> Bool { true }
+
+            mutating func onGenerationEnd(
+                emit: (sending String) ->
+                    AsyncThrowingStream<String, Error>.Continuation
+                    .YieldResult
+            ) {}
+
+            func infoEvent(_ info: GenerateCompletionInfo) -> String { "info" }
+        }
+
+        let iterator = MockIterator(remaining: [1, 2, 3])
+        let modelConfiguration = ModelConfiguration(id: "test")
+        let (stream, _) = generateLoopTask(
+            promptTokenCount: 0,
+            modelConfiguration: modelConfiguration,
+            tokenizer: Self.asciiTokenizer,
+            iterator: iterator,
+            handler: ThrowingHandler()
+        )
+
+        do {
+            for try await _ in stream {
+                Issue.record("Stream should have thrown before yielding")
+            }
+            Issue.record("Stream finished without throwing")
+        } catch is InjectedFailure {
+            // Expected.
+        }
+    }
+
+    @Test
+    func consumeReturnsNilWhenTokenAddsInvalidTrailingByte() throws {
+        // Byte-fallback case: a token grows the cumulative decode but the new
+        // bytes only extend it with a Unicode replacement character. The
+        // length guard alone wouldn't withhold (length grew), but the
+        // `\u{fffd}`-suffix check must — the trailing fragment is not yet a
+        // valid scalar. Mirrors Rust's `decode_byte_fallback` doctest.
+        let tokenizer = MockTokenizer([
+            0: Array(" ".utf8),
+            1: [0xC3],  // first byte of "é"
+            2: [0xA9],  // second byte of "é"; alone, an invalid trailing byte
+        ])
+        let stream = tokenizer.streamingDetokenizer()
+
+        #expect(try stream.consume(0) == " ")
+        #expect(try stream.consume(1) == nil)
+        #expect(try stream.consume(2) == "é")
+
+        let prefixBeforeStrayByte = stream.prefix
+        let indexBeforeStrayByte = stream.prefixIndex
+
+        // Feeding 0xA9 again grows the decode but only with `\u{fffd}`.
+        #expect(try stream.consume(2) == nil)
+
+        // No emission, so the cached prefix and index must not advance.
+        #expect(stream.prefix == prefixBeforeStrayByte)
+        #expect(stream.prefixIndex == indexBeforeStrayByte)
+    }
+}

--- a/Tests/MLXLMTests/TestTokenizer.swift
+++ b/Tests/MLXLMTests/TestTokenizer.swift
@@ -34,13 +34,13 @@ struct TestTokenizer: MLXLMCommon.Tokenizer {
         )
     }
 
-    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+    func encode(text: String, addSpecialTokens: Bool) throws -> [Int] {
         (0 ..< length).map { _ in
             Int.random(in: 1 ..< vocabularySize)
         }
     }
 
-    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) throws -> String {
         var tokenIds = tokenIds
         if tokenIds.count > maxLength {
             tokenIds.append(_eosTokenId)
@@ -72,7 +72,7 @@ struct TestTokenizer: MLXLMCommon.Tokenizer {
         tools: [[String: any Sendable]]?,
         additionalContext: [String: any Sendable]?
     ) throws -> [Int] {
-        encode(text: "")
+        try encode(text: "")
     }
 
 }


### PR DESCRIPTION
> Note: 735 of the 1163 new lines in this PR are tests.

The `Tokenizer` protocol's `encode` and `decode` methods are currently non-throwing, which forces conformers to choose between crashing and silently corrupting the output – neither of which is ideal. Swift Transformers' `PreTrainedTokenizer` does both: [`encode` force-unwraps vocab lookups](https://github.com/huggingface/swift-transformers/blob/349a7ce54ccb8ebe4bc10c2022e9806f01adb7c6/Sources/Tokenizers/Tokenizer.swift#L643), so an out-of-vocabulary token kills the process, and [`decode` `compactMap`s them](https://github.com/huggingface/swift-transformers/blob/349a7ce54ccb8ebe4bc10c2022e9806f01adb7c6/Sources/Tokenizers/Tokenizer.swift#L670), so an unknown ID disappears with no signal to the caller. [Swift Tokenizers](https://github.com/DePasqualeOrg/swift-tokenizers), which wraps the Rust `tokenizers` library, already handles this correctly, but errors can't currently propagate across the MLX bridge.

The non-throwing behavior is at odds with how other tokenizer libraries handle these operations. Rust `tokenizers` surfaces failures from [`encode`](https://github.com/huggingface/tokenizers/blob/bcdd25b97fcd78549903082ecf3ddd87d42c456b/tokenizers/src/tokenizer/mod.rs#L837) and [`decode`](https://github.com/huggingface/tokenizers/blob/bcdd25b97fcd78549903082ecf3ddd87d42c456b/tokenizers/src/tokenizer/mod.rs#L901) as `Result`s, and [the Python binding](https://github.com/huggingface/tokenizers/blob/bcdd25b97fcd78549903082ecf3ddd87d42c456b/bindings/python/src/tokenizer.rs#L1473) preserves that shape via PyO3's `PyResult`, so failures cross into Python as exceptions.

This PR makes `encode` and `decode` throwing, bringing their behavior into line with the broader ecosystem.

## Related changes in streaming detokenizer

`NaiveStreamingDetokenizer.next()` currently calls `tokenizer.decode` and conforms to `IteratorProtocol`, whose `next()` cannot throw. Once `decode` can throw, the only ways to keep the iterator shape are `try?` (which re-introduces the silent-drop pattern this PR removes) or `try!` (which crashes). The current detokenizer isn't really an iterator anyway: `next()` returns `nil` to mean "feed me more", not "end of sequence", so a `for-in` loop would exit at the first multi-byte UTF-8 fragment, before the actual end of the stream. Rust's [`DecodeStream`](https://github.com/huggingface/tokenizers/blob/bcdd25b97fcd78549903082ecf3ddd87d42c456b/tokenizers/src/tokenizer/mod.rs#L1027) skips `Iterator` for the same reason.

To rectify this, `NaiveStreamingDetokenizer` is replaced with a `StreamingDetokenizer` class whose `consume(_:)` method is throwing. The replacement uses the algorithm Rust `tokenizers` exposes as [`step_decode_stream`](https://github.com/huggingface/tokenizers/blob/bcdd25b97fcd78549903082ecf3ddd87d42c456b/tokenizers/src/tokenizer/mod.rs#L1094). The replacement differs from the naive version in two important ways:

- The new version's memory stays roughly constant during generation. The naive version cleared its token buffer only when a chunk ended with a newline, so memory grew across long stretches of newline-free output.
- If the decoder produces inconsistent output (a chunk that doesn't follow from text already emitted), the new version detects this and throws. The naive version silently emitted the corrupted result.

The tool-call handler in `Evaluate.swift` recovers from the new error class by rebuilding the detokenizer and retrying once – [the same recovery shape vLLM uses](https://github.com/vllm-project/vllm/blob/66d1cc0c77628e36df8e5e245c116e6aac3045fb/vllm/v1/engine/detokenizer.py#L220) for the same error.

Some tokenizers rewrite their `decode` output (whitespace fixups, contractions), which can retroactively change earlier text and break streaming. Tokenizers that conform to the new `StreamingDecodeTokenizer` protocol expose a cleanup-free `rawDecode`, which is used by `StreamingDetokenizer` when available.

Using this separate protocol would allow for logging a warning (currently not implemented) when the behavior degrades with libraries such as Swift Transformers, which don't offer `rawDecode`. Swift Tokenizers already behaves correctly.

## Seeding the streaming detokenizer at the prompt boundary

SentencePiece-style tokenizers strip a leading space when decoding a sequence that begins with a metaspace marker. A streaming detokenizer with no prior context decodes the first generated token as sequence-start, so the space at the prompt/generated boundary is silently dropped (`"...isParis"` instead of `"...is Paris"`). Python mlx-lm has the same gap; its [`_maybe_trim_space`](https://github.com/ml-explore/mlx-lm/blob/df1d3f3c9a7aae402dcbb8f41d4c36bcc13a50ae/mlx_lm/tokenizer_utils.py#L195) papers over the symptom with a per-model strip-leading-space flag.

`StreamingDetokenizer` now takes an `initialTokenIds` parameter, and the engine seeds it with the last 7 prompt tokens, [matching vLLM](https://github.com/vllm-project/vllm/blob/66d1cc0c77628e36df8e5e245c116e6aac3045fb/vllm/tokenizers/detokenizer_utils.py#L73). On `invalidStreamingPrefix` recovery the seed is dropped, [matching vLLM](https://github.com/vllm-project/vllm/blob/66d1cc0c77628e36df8e5e245c116e6aac3045fb/vllm/v1/engine/detokenizer.py#L240): once text has been emitted, the boundary is no longer adjacent. `generateTask` and `generateTokenTask` now take `promptTokenIds: [Int]` in place of `promptTokenCount: Int`; high-level `generate(input:)` callers see no change.

## Throwing generation stream

`generate(...)` and the related `generateTask`, `generateTokens`, and `generateTokenTask` overloads previously returned `AsyncStream<Generation>` (or `AsyncStream<TokenGeneration>`). With the throwing tokenizer API and a throwing `StreamingDetokenizer`, errors from deeper in the pipeline could not propagate to the consumer through a non-throwing stream. Those return types have been converted to `AsyncThrowingStream<Generation, Error>` (and the token-ID equivalent), so any error thrown during generation finishes the stream with that error, and the consumer can handle it.

vLLM's [`AsyncLLM.generate`](https://github.com/vllm-project/vllm/blob/66d1cc0c77628e36df8e5e245c116e6aac3045fb/vllm/v1/engine/async_llm.py#L524) takes the same approach: errors from the engine are pushed onto the [output queue](https://github.com/vllm-project/vllm/blob/66d1cc0c77628e36df8e5e245c116e6aac3045fb/vllm/v1/engine/output_processor.py#L45) and raised when the consumer reads them.

## Migration

The migration is mechanical: add `try` to `tokenizer.encode`/`decode` call sites, and `for try await` in place of `for await` on generation streams. Users who implement a lower-level token iteration loop replace `NaiveStreamingDetokenizer`, `append(token:)`, and `next()` with `tokenizer.streamingDetokenizer()` and `consume(_:)`. Callers of `generateTask` and `generateTokenTask` rename `promptTokenCount: input.text.tokens.size` to `promptTokenIds: input.text.tokens.asArray(Int.self)`. Callers that want the old swallow-and-continue behavior can wrap in `try?`, but this is an explicit choice now.

These are breaking changes that will require a major version bump, but the migration for users is simple and contained: in most cases they'll just need to add `try`.

## Testing

`StreamingDetokenizerTests` exercises the new algorithm against a mock tokenizer, with cases modeled on equivalents in [`huggingface/tokenizers`](https://github.com/huggingface/tokenizers/blob/bcdd25b97fcd78549903082ecf3ddd87d42c456b/bindings/python/tests/bindings/test_tokenizer.py#L418), [vLLM](https://github.com/vllm-project/vllm/blob/66d1cc0c77628e36df8e5e245c116e6aac3045fb/tests/v1/engine/test_fast_incdec_prefix_err.py), and [`transformers`](https://github.com/huggingface/transformers/blob/main/tests/generation/test_streamers.py).