### PR TITLE
fix ropeOffset use in Gemma3NText

### DIFF
--- a/Libraries/MLXLLM/Models/AfMoE.swift
+++ b/Libraries/MLXLLM/Models/AfMoE.swift
@@ -197,8 +197,9 @@ class AfMoEAttention: Module {
 
         // Apply RoPE only for local (sliding window) attention
         if isLocalAttention, let rope = rope {
-            queries = applyRotaryPosition(rope, to: queries, cache: cache)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            let offset = cache?.ropeOffset
+            queries = applyRotaryPosition(rope, to: queries, offset: offset)
+            keys = applyRotaryPosition(rope, to: keys, offset: offset)
         }
 
         var output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/Apertus.swift
+++ b/Libraries/MLXLLM/Models/Apertus.swift
@@ -223,8 +223,9 @@ private class ApertusAttention: Module {
         values = values.transposed(0, 2, 1, 3)
 
         // 4. RoPE
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         if let cache = cache {
             // Update cache (expects [B, H, L, D])

--- a/Libraries/MLXLLM/Models/BaichuanM1.swift
+++ b/Libraries/MLXLLM/Models/BaichuanM1.swift
@@ -130,8 +130,9 @@ class BaichuanM1Attention: Module {
         keys = customConvolution(keys, convK, state: lastK)
         values = customConvolution(values, convV, state: lastV)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: kvSubCache)
-        keys = applyRotaryPosition(rope, to: keys, cache: kvSubCache)
+        let offset = kvSubCache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         if let cache = cache as? CacheList {
             let kvCache = cache[1]

--- a/Libraries/MLXLLM/Models/BailingMoe.swift
+++ b/Libraries/MLXLLM/Models/BailingMoe.swift
@@ -145,8 +145,9 @@ class BailingMoeAttention: Module {
         keys = keys.transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Bitnet.swift
+++ b/Libraries/MLXLLM/Models/Bitnet.swift
@@ -315,8 +315,9 @@ class BitnetAttention: Module {
         keys = keys.reshaped(B, L, args.resolvedKvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.resolvedKvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         if let cache {
             (keys, values) = cache.update(keys: keys, values: values)

--- a/Libraries/MLXLLM/Models/Cohere.swift
+++ b/Libraries/MLXLLM/Models/Cohere.swift
@@ -50,8 +50,9 @@ class CohereAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -197,8 +197,9 @@ class DeepseekV3Attention: Module {
 
         var (kNope, values) = (splitKv[0], splitKv[1])
 
-        qPe = applyRotaryPosition(rope, to: qPe, cache: cache)
-        kPe = applyRotaryPosition(rope, to: kPe, cache: cache)
+        let offset = cache?.ropeOffset
+        qPe = applyRotaryPosition(rope, to: qPe, offset: offset)
+        kPe = applyRotaryPosition(rope, to: kPe, offset: offset)
         kPe = repeated(kPe, count: numHeads, axis: 1)
 
         var keys: MLXArray

--- a/Libraries/MLXLLM/Models/Ernie4_5.swift
+++ b/Libraries/MLXLLM/Models/Ernie4_5.swift
@@ -104,8 +104,9 @@ class Ernie45Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Exaone4.swift
+++ b/Libraries/MLXLLM/Models/Exaone4.swift
@@ -72,8 +72,9 @@ class Exaone4Attention: Module {
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
         if useRope, let rope {
-            queries = applyRotaryPosition(rope, to: queries, cache: cache)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            let offset = cache?.ropeOffset
+            queries = applyRotaryPosition(rope, to: queries, offset: offset)
+            keys = applyRotaryPosition(rope, to: keys, offset: offset)
         }
 
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -302,8 +302,9 @@ class FalconH1Attention: Module {
         keys = keys.reshaped(B, L, numKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, numKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         if let cache {
             (keys, values) = cache.update(keys: keys, values: values)

--- a/Libraries/MLXLLM/Models/GLM4.swift
+++ b/Libraries/MLXLLM/Models/GLM4.swift
@@ -55,8 +55,9 @@ class GLM4Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/GLM4MOE.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOE.swift
@@ -70,8 +70,9 @@ class GLM4MoEAttention: Module {
         keys = keys.transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/GLM4MOELite.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOELite.swift
@@ -254,8 +254,9 @@ class GLM4MoELiteAttention: Module {
         kPe = kPe.reshaped(B, L, 1, qkRopeHeadDim).transposed(0, 2, 1, 3)
         var kvLatent = kvALayerNorm(compressedKv)
 
-        qPe = applyRotaryPosition(rope, to: qPe, cache: cache)
-        kPe = applyRotaryPosition(rope, to: kPe, cache: cache)
+        let offset = cache?.ropeOffset
+        qPe = applyRotaryPosition(rope, to: qPe, offset: offset)
+        kPe = applyRotaryPosition(rope, to: kPe, offset: offset)
 
         // Expand kvLatent for attention: [B, L, kvLoraRank] -> [B, 1, L, kvLoraRank]
         kvLatent = expandedDimensions(kvLatent, axis: 1)

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -229,8 +229,9 @@ class AttentionBlock: Module {
             if sinksActive {
                 fatalError("Quantized attention does not support non-zero sinks.")
             }
-            q = applyRotaryPosition(rope, to: q, cache: cache)
-            k = applyRotaryPosition(rope, to: k, cache: cache)
+            let offset = cache?.ropeOffset
+            q = applyRotaryPosition(rope, to: q, offset: offset)
+            k = applyRotaryPosition(rope, to: k, offset: offset)
 
             let (qKeys, qValues) = qcache.updateQuantized(keys: k, values: v)
             let vHat = quantizedScaledDotProductAttention(
@@ -247,8 +248,9 @@ class AttentionBlock: Module {
             return oProj(vHat.swappedAxes(1, 2).reshaped(B, L, -1))
         }
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let offset = cache?.ropeOffset
+        q = applyRotaryPosition(rope, to: q, offset: offset)
+        k = applyRotaryPosition(rope, to: k, offset: offset)
 
         if let cache {
             (k, v) = cache.update(keys: k, values: v)

--- a/Libraries/MLXLLM/Models/Gemma.swift
+++ b/Libraries/MLXLLM/Models/Gemma.swift
@@ -68,8 +68,9 @@ class GemmaAttention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Gemma2.swift
+++ b/Libraries/MLXLLM/Models/Gemma2.swift
@@ -54,8 +54,9 @@ class Gemma2Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         if let cache {
             (keys, values) = cache.update(keys: keys, values: values)

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -197,8 +197,9 @@ class Gemma3Attention: Module {
         queries = queryNorm(queries)
         keys = keyNorm(keys)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Gemma3nText.swift
+++ b/Libraries/MLXLLM/Models/Gemma3nText.swift
@@ -14,52 +14,11 @@ import MLXNN
 
 // MARK: - Configuration
 
-/// A type that can be decoded as either a single Int or an array of Ints.
-/// This is needed because some models (like Gemma 3n) specify intermediate_size
-/// as a per-layer array, while others use a single value.
-public struct IntOrArray: Codable {
-    public let values: [Int]
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if let array = try? container.decode([Int].self) {
-            self.values = array
-        } else if let single = try? container.decode(Int.self) {
-            self.values = [single]
-        } else {
-            throw DecodingError.typeMismatch(
-                IntOrArray.self,
-                DecodingError.Context(
-                    codingPath: decoder.codingPath,
-                    debugDescription: "Expected Int or [Int]"
-                )
-            )
-        }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        if values.count == 1 {
-            try container.encode(values[0])
-        } else {
-            try container.encode(values)
-        }
-    }
-
-    /// Get the intermediate size for a specific layer
-    public subscript(layerIdx: Int) -> Int {
-        if values.count == 1 {
-            return values[0]
-        }
-        return values[layerIdx]
-    }
-}
-
 public struct Gemma3nTextConfiguration: Codable {
     let modelType: String
     let hiddenSize: Int
     let numHiddenLayers: Int
-    let intermediateSize: IntOrArray
+    let intermediateSize: IntOrIntArray
     let numAttentionHeads: Int
     let headDim: Int
     let rmsNormEps: Float
@@ -132,7 +91,7 @@ public struct Gemma3nTextConfiguration: Codable {
         modelType = try container.decode(String.self, forKey: .modelType)
         hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
         numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
-        intermediateSize = try container.decode(IntOrArray.self, forKey: .intermediateSize)
+        intermediateSize = try container.decode(IntOrIntArray.self, forKey: .intermediateSize)
         numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
         headDim = try container.decode(Int.self, forKey: .headDim)
         rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
@@ -158,6 +117,39 @@ public struct Gemma3nTextConfiguration: Codable {
         ropeScaling = try container.decodeIfPresent([String: String].self, forKey: .ropeScaling)
         slidingWindowPattern = try container.decodeIfPresent(
             Int.self, forKey: .slidingWindowPattern)
+    }
+
+    package init() {
+        // smallish defaults for testing
+        activationSparsityPattern = [0.95, 0.95, 0, 0]
+        altupActiveIdx = 0
+        altupCoefClip = 120
+        altupCorrectScale = true
+        altupNumInputs = 4
+        finalLogitSoftcapping = 30
+        headDim = 64
+        hiddenSize = 512
+        hiddenSizePerLayerInput = 256
+        intermediateSize = .init([8192, 8192, 8192, 8192])
+        laurelRank = 64
+        layerTypes = [
+            "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+        ]
+        maxPositionEmbeddings = 32768
+        modelType = "gemma3n"
+        numAttentionHeads = 8
+        numHiddenLayers = 4
+        numKeyValueHeads = 2
+        numKvSharedLayers = 0
+        queryPreAttnScalar = nil
+        rmsNormEps = 1e-6
+        ropeLocalBaseFreq = 10000
+        ropeScaling = nil
+        ropeTheta = 1_000_000
+        slidingWindow = 512
+        slidingWindowPattern = nil
+        vocabSize = 262400
+        vocabSizePerLayerInput = 262144
     }
 }
 
@@ -263,6 +255,7 @@ class Gemma3nAttention: Module {
         queries = queries.reshaped(B, L, -1, headDim)
         queries = qNorm(queries)
 
+        let offset = cache?.ropeOffset
         var keys: MLXArray
         var values: MLXArray
 
@@ -275,7 +268,7 @@ class Gemma3nAttention: Module {
                 keys = kProj(x).reshaped(B, L, -1, headDim)
                 keys = kNorm(keys)
                 keys = keys.transposed(0, 2, 1, 3)
-                keys = applyRotaryPosition(rope, to: keys, cache: cache)
+                keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
                 values = vProj(x).reshaped(B, L, -1, headDim)
                 values = vNorm(values)
@@ -289,7 +282,7 @@ class Gemma3nAttention: Module {
             keys = kProj(x).reshaped(B, L, -1, headDim)
             keys = kNorm(keys)
             keys = keys.transposed(0, 2, 1, 3)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
             values = vProj(x).reshaped(B, L, -1, headDim)
             values = vNorm(values)
@@ -301,7 +294,7 @@ class Gemma3nAttention: Module {
         }
 
         queries = queries.transposed(0, 2, 1, 3)
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
 
         var adjustedMask = mask
         if case .array(let maskArray) = mask {

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -175,33 +175,6 @@ private class ScaledLinear: Module {
     }
 }
 
-private enum Gemma4PositionOffset {
-    case scalar(Int)
-    case batch(MLXArray)
-}
-
-private func gemma4CapturePositionOffset(from cache: KVCache?) -> Gemma4PositionOffset {
-    if let batchCache = cache as? BatchPositionedKVCache {
-        // Snapshot the per-sequence offsets before cache.update(...) advances them.
-        .batch(batchCache.batchOffset + 0)
-    } else {
-        .scalar(cache?.offset ?? 0)
-    }
-}
-
-private func gemma4ApplyRotaryPosition<R: RoPELayer>(
-    _ rope: R,
-    to x: MLXArray,
-    offset: Gemma4PositionOffset
-) -> MLXArray {
-    switch offset {
-    case .scalar(let value):
-        rope(x, offset: value)
-    case .batch(let values):
-        rope(x, offset: values)
-    }
-}
-
 // MARK: - Attention
 
 private class Gemma4Attention: Module {
@@ -283,8 +256,8 @@ private class Gemma4Attention: Module {
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
         sharedKV: (MLXArray, MLXArray)? = nil,
-        positionOffset: Gemma4PositionOffset? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), Gemma4PositionOffset) {
+        positionOffset: RoPEOffset? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray), RoPEOffset?) {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x).reshaped(B, L, nHeads, effectiveHeadDim)
@@ -292,7 +265,7 @@ private class Gemma4Attention: Module {
 
         let keys: MLXArray
         let values: MLXArray
-        let activePositionOffset = positionOffset ?? gemma4CapturePositionOffset(from: cache)
+        let activePositionOffset = positionOffset ?? cache?.ropeOffset
 
         if let (sharedK, sharedV) = sharedKV {
             // KV-shared layers use pre-computed KV from an earlier layer
@@ -302,7 +275,7 @@ private class Gemma4Attention: Module {
             var k = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             k = kNorm(k)
             k = k.transposed(0, 2, 1, 3)
-            k = gemma4ApplyRotaryPosition(rope, to: k, offset: activePositionOffset)
+            k = applyRotaryPosition(rope, to: k, offset: activePositionOffset)
 
             var v: MLXArray
             if let vProj {
@@ -324,7 +297,7 @@ private class Gemma4Attention: Module {
         }
 
         queries = queries.transposed(0, 2, 1, 3)
-        queries = gemma4ApplyRotaryPosition(rope, to: queries, offset: activePositionOffset)
+        queries = applyRotaryPosition(rope, to: queries, offset: activePositionOffset)
 
         // Adjust mask if cache size differs from mask size
         var adjustedMask = mask
@@ -435,8 +408,8 @@ private class Gemma4DecoderLayer: Module {
         cache: KVCache? = nil,
         perLayerInput: MLXArray? = nil,
         sharedKV: (MLXArray, MLXArray)? = nil,
-        positionOffset: Gemma4PositionOffset? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), Gemma4PositionOffset) {
+        positionOffset: RoPEOffset? = nil
+    ) -> (MLXArray, (MLXArray, MLXArray), RoPEOffset?) {
         let residual = x
 
         let h = inputLayernorm(x)
@@ -605,7 +578,7 @@ private class Gemma4TextModelInner: Module {
         }
 
         // Forward through layers, tracking intermediate KV pairs for sharing
-        var intermediates = [(kv: (MLXArray, MLXArray)?, positionOffset: Gemma4PositionOffset?)](
+        var intermediates = [(kv: (MLXArray, MLXArray)?, positionOffset: RoPEOffset?)](
             repeating: (nil, nil), count: config.numHiddenLayers)
 
         for (idx, layer) in layers.enumerated() {

--- a/Libraries/MLXLLM/Models/Granite.swift
+++ b/Libraries/MLXLLM/Models/Granite.swift
@@ -59,8 +59,9 @@ class GraniteAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -245,8 +245,9 @@ class GraniteMoeHybridAttention: Module {
         values = values.reshaped(B, L, args.kvHeads, headDim).transposed(0, 2, 1, 3)
 
         if let rope {
-            queries = applyRotaryPosition(rope, to: queries, cache: cache)
-            keys = applyRotaryPosition(rope, to: keys, cache: cache)
+            let offset = cache?.ropeOffset
+            queries = applyRotaryPosition(rope, to: queries, offset: offset)
+            keys = applyRotaryPosition(rope, to: keys, offset: offset)
         }
 
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/Internlm2.swift
+++ b/Libraries/MLXLLM/Models/Internlm2.swift
@@ -119,8 +119,9 @@ class Internlm2Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -157,8 +157,9 @@ class LFM2Attention: Module {
         keys = kLayerNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -154,8 +154,9 @@ class LFM2MoEAttention: Module {
         keys = kLayerNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Lille130m.swift
+++ b/Libraries/MLXLLM/Models/Lille130m.swift
@@ -66,8 +66,9 @@ final class Lille130mAttention: Module {
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
         // Apply RoPE with cache-aware offset if available
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -55,8 +55,9 @@ class LlamaAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/MiMo.swift
+++ b/Libraries/MLXLLM/Models/MiMo.swift
@@ -59,8 +59,9 @@ class MiMoAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -169,8 +169,9 @@ class MiMoV2FlashAttention: Module {
         var k = keys.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
         let v = values.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let offset = cache?.ropeOffset
+        q = applyRotaryPosition(rope, to: q, offset: offset)
+        k = applyRotaryPosition(rope, to: k, offset: offset)
 
         let output = attentionWithCacheUpdateAndSinks(
             queries: q,

--- a/Libraries/MLXLLM/Models/MiniCPM.swift
+++ b/Libraries/MLXLLM/Models/MiniCPM.swift
@@ -54,8 +54,9 @@ final class MiniCPMAttention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/MiniMax.swift
+++ b/Libraries/MLXLLM/Models/MiniMax.swift
@@ -77,8 +77,9 @@ class MiniMaxAttention: Module {
         var k = keys.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
         let v = values.reshaped(B, L, numKeyValueHeads, -1).transposed(0, 2, 1, 3)
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let offset = cache?.ropeOffset
+        q = applyRotaryPosition(rope, to: q, offset: offset)
+        k = applyRotaryPosition(rope, to: k, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: q,

--- a/Libraries/MLXLLM/Models/Mistral3Text.swift
+++ b/Libraries/MLXLLM/Models/Mistral3Text.swift
@@ -87,8 +87,9 @@ class Mistral3Attention: Module {
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
         // Apply RoPE
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         // Apply attention scaling
         queries = queries * attnScale

--- a/Libraries/MLXLLM/Models/NanoChat.swift
+++ b/Libraries/MLXLLM/Models/NanoChat.swift
@@ -112,8 +112,9 @@ final class NanoChatAttention: Module {
         keys = keys.reshaped(batchSize, sequenceLength, numKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(batchSize, sequenceLength, numKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         queries = functionalRMSNorm(queries, eps: config.rmsNormEps)
         keys = functionalRMSNorm(keys, eps: config.rmsNormEps)

--- a/Libraries/MLXLLM/Models/Olmo2.swift
+++ b/Libraries/MLXLLM/Models/Olmo2.swift
@@ -68,8 +68,9 @@ class Olmo2Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Olmo3.swift
+++ b/Libraries/MLXLLM/Models/Olmo3.swift
@@ -78,8 +78,9 @@ class Olmo3Attention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/OlmoE.swift
+++ b/Libraries/MLXLLM/Models/OlmoE.swift
@@ -67,8 +67,9 @@ class OlmoEAttention: Module {
         keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/OpenELM.swift
+++ b/Libraries/MLXLLM/Models/OpenELM.swift
@@ -78,8 +78,9 @@ class MultiHeadCausalAttention: Module {
             keys = kNorm(keys)
         }
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Phi.swift
+++ b/Libraries/MLXLLM/Models/Phi.swift
@@ -57,8 +57,9 @@ class PhiAttention: Module {
         values = values.reshaped(B, L, args.kvHeads, headDim).transposed(0, 2, 1, 3)
 
         // Add RoPE to the queries and keys and combine them with the cache
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         // Finally perform the attention computation
         let scale = sqrt(1 / Float(queries.dim(-1)))

--- a/Libraries/MLXLLM/Models/Phi3.swift
+++ b/Libraries/MLXLLM/Models/Phi3.swift
@@ -82,8 +82,9 @@ class Phi3Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/PhiMoE.swift
+++ b/Libraries/MLXLLM/Models/PhiMoE.swift
@@ -91,8 +91,9 @@ class PhiMoEAttention: Module {
         var k = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         let v = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        q = applyRotaryPosition(rope, to: q, cache: cache)
-        k = applyRotaryPosition(rope, to: k, cache: cache)
+        let offset = cache?.ropeOffset
+        q = applyRotaryPosition(rope, to: q, offset: offset)
+        k = applyRotaryPosition(rope, to: k, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: q,

--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -70,8 +70,9 @@ class Qwen2Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -77,8 +77,9 @@ class Qwen3Attention: Module {
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
         // Apply RoPE positioning
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         // Use the automatic attention router that handles both quantized and regular caches
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -359,8 +359,9 @@ final class Qwen35Attention: Module {
         keys = kNorm(keys.reshaped(B, L, kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -76,8 +76,9 @@ class Qwen3MoEAttention: Module {
         keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -99,8 +99,9 @@ public final class Qwen3NextAttention: Module {
         keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/SmolLM3.swift
+++ b/Libraries/MLXLLM/Models/SmolLM3.swift
@@ -71,8 +71,9 @@ class SmolLM3Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLLM/Models/Starcoder2.swift
+++ b/Libraries/MLXLLM/Models/Starcoder2.swift
@@ -55,8 +55,9 @@ class Starcoder2Attention: Module {
         keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
         values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
 
-        queries = applyRotaryPosition(rope, to: queries, cache: cache)
-        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,

--- a/Libraries/MLXLMCommon/JSONDecodingTypes.swift
+++ b/Libraries/MLXLMCommon/JSONDecodingTypes.swift
@@ -42,6 +42,14 @@ public struct IntOrIntArray: Codable, Sendable, Equatable {
             try container.encode(values)
         }
     }
+
+    /// Get the intermediate size for a specific layer
+    public subscript(layerIdx: Int) -> Int {
+        if values.count == 1 {
+            return values[0]
+        }
+        return values[layerIdx]
+    }
 }
 
 // MARK: - StringOrNumber

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -4,6 +4,14 @@ import Foundation
 import MLX
 import MLXNN
 
+/// Offset to use with ``applyRotaryPosition(_:to:offset:)``.
+///
+/// See ``KVCache/ropeOffset``.
+public enum RoPEOffset {
+    case scalar(Int)
+    case batch(MLXArray)
+}
+
 /// Implementation of KV cache functionality for MLX Swift
 ///
 ///
@@ -38,6 +46,9 @@ import MLXNN
 public protocol KVCache: Evaluatable {
     /// get the current offset
     var offset: Int { get }
+
+    /// Offset to use with ``applyRotaryPosition(_:to:offset:)``.
+    var ropeOffset: RoPEOffset { get }
 
     /// get the maximum size (if any)
     var maxSize: Int? { get }
@@ -74,6 +85,12 @@ public protocol KVCache: Evaluatable {
 
     /// Create an independent deep copy of this cache.
     func copy() -> any KVCache
+}
+
+extension KVCache {
+    public var ropeOffset: RoPEOffset {
+        .scalar(offset)
+    }
 }
 
 /// Protocol for caches that support efficient quantized operations

--- a/Libraries/MLXLMCommon/RoPEApplication.swift
+++ b/Libraries/MLXLMCommon/RoPEApplication.swift
@@ -15,16 +15,15 @@ public protocol BatchPositionedKVCache: KVCache {
     var batchOffset: MLXArray { get }
 }
 
+extension BatchPositionedKVCache {
+    public var ropeOffset: RoPEOffset {
+        .batch(batchOffset[.ellipsis])
+    }
+}
+
 // MARK: - applyRotaryPosition Helper
 
 /// Apply rotary position embeddings, using the cache offset when available.
-///
-/// This function enables models to use a single call site instead of
-/// repeating conditional offset handling:
-/// ```swift
-/// queries = applyRotaryPosition(rope, to: queries, cache: cache)
-/// keys = applyRotaryPosition(rope, to: keys, cache: cache)
-/// ```
 ///
 /// - Parameters:
 ///   - rope: A RoPE layer conforming to both `OffsetLayer` and `ArrayOffsetLayer`.
@@ -32,12 +31,38 @@ public protocol BatchPositionedKVCache: KVCache {
 ///   - cache: The KV cache (determines scalar or per-sequence offset), or `nil`
 ///     for offset 0.
 /// - Returns: The input with rotary positional encoding applied.
+@available(*, deprecated, message: "use applyRotaryPosition(_:to:offset:) instead")
 public func applyRotaryPosition<R: RoPELayer>(_ rope: R, to x: MLXArray, cache: KVCache?)
     -> MLXArray
 {
-    if let batchCache = cache as? BatchPositionedKVCache {
-        return rope(x, offset: batchCache.batchOffset)
-    } else {
-        return rope(x, offset: cache?.offset ?? 0)
+    applyRotaryPosition(rope, to: x, offset: cache?.ropeOffset)
+}
+
+/// Apply rotary position embeddings, using the cache offset when available.
+///
+/// This function enables models to use a single call site instead of
+/// repeating conditional offset handling:
+///
+/// ```swift
+/// let offset = cache?.ropeOffset
+/// queries = applyRotaryPosition(rope, to: queries, offset: offset)
+/// keys = applyRotaryPosition(rope, to: keys, offset: offset)
+/// ```
+///
+/// - Parameters:
+///   - rope: A RoPE layer conforming to both `OffsetLayer` and `ArrayOffsetLayer`.
+///   - x: The input tensor to apply RoPE to.
+///   - offset: the offset into the rotary positional encoding.  0 if nil.
+/// - Returns: The input with rotary positional encoding applied.
+public func applyRotaryPosition<R: RoPELayer>(_ rope: R, to x: MLXArray, offset: RoPEOffset?)
+    -> MLXArray
+{
+    switch offset {
+    case nil:
+        rope(x, offset: 0)
+    case .scalar(let v):
+        rope(x, offset: v)
+    case .batch(let v):
+        rope(x, offset: v)
     }
 }

--- a/Tests/MLXLMTests/RoPEApplicationTests.swift
+++ b/Tests/MLXLMTests/RoPEApplicationTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import MLX
+import MLXNN
+import Testing
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct RoPEApplicationTests {
+
+    /// Gemma3nAttention applies rope, updates the cache and applies rope again.
+    /// Ensure that it is correctly implemented.  We can observe prefill vs single token
+    /// generaton and they should produce the same answers if implemented correctly.
+    @Test func gemma3nAttentionTest() {
+        let config = Gemma3nTextConfiguration()
+        let attention = Gemma3nAttention(config, layerIdx: 3)
+
+        #expect(!attention.isKvSharedLayer)
+
+        let B = 1
+        let L = 4
+        let D = config.hiddenSize
+
+        MLXRandom.seed(42)
+        let x = MLXRandom.normal([B, L, D])
+        eval(x)
+
+        // Batch: process all L tokens at once with a causal mask
+        let cacheBatch = KVCacheSimple()
+        let causalMask = createAttentionMask(h: x, cache: cacheBatch)
+        let outputBatch = attention(x, mask: causalMask, cache: cacheBatch)
+        eval(outputBatch)
+
+        // Sequential: process one token at a time (mask=.none since L=1 with cache)
+        let cacheSeq = KVCacheSimple()
+        var seqOutputs: [MLXArray] = []
+        for i in 0 ..< L {
+            let token = x[0..., i ..< (i + 1), 0...]
+            let mask = createAttentionMask(h: token, cache: cacheSeq)
+            let out = attention(token, mask: mask, cache: cacheSeq)
+            seqOutputs.append(out)
+        }
+        let outputSeq = concatenated(seqOutputs, axis: 1)
+        eval(outputSeq)
+
+        // With correct RoPE these would match.  The buggy code would use
+        // different offsets for keys/queries.
+        let match = allClose(outputBatch, outputSeq, atol: 1e-4)
+        eval(match)
+        print(outputBatch)
+        print(outputSeq)
+        print(abs(outputSeq - outputBatch))
+        #expect(match.item(Bool.self))
+    }
+}


### PR DESCRIPTION
## Proposed changes

See #234 -- match python pattern and pass offset into applyRotaryPosition.  This is critical for Gemma3NText which has a pattern of apply/update/apply where the second apply uses a _different_ offset.

FYI @ronaldmannak 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
