### PR TITLE
fix build

### DIFF
--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -341,6 +341,7 @@ private struct ParoQuantInputProcessor: UserInputProcessor {
 /// - Parameters:
 ///   - directory: Local path to the model checkpoint directory.
 ///   - typeRegistry: Registry used to create the underlying model architecture.
+///   - tokenizerLoader: Loader for tokenizer.
 ///   - toolCallFormat: Optional tool-call format for the model configuration.
 /// - Returns: A ``ModelContainer`` ready for inference.
 public func loadParoQuantModel<T: LanguageModel>(

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -343,9 +343,9 @@ private struct ParoQuantInputProcessor: UserInputProcessor {
 ///   - typeRegistry: Registry used to create the underlying model architecture.
 ///   - toolCallFormat: Optional tool-call format for the model configuration.
 /// - Returns: A ``ModelContainer`` ready for inference.
-public func loadParoQuantModel(
+public func loadParoQuantModel<T: LanguageModel>(
     from directory: URL,
-    typeRegistry: ModelTypeRegistry,
+    typeRegistry: ModelTypeRegistry<T>,
     tokenizerLoader: any TokenizerLoader,
     toolCallFormat: ToolCallFormat? = nil
 ) async throws -> ModelContainer {

--- a/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/RotateQuantizedLinear.swift
@@ -6,7 +6,7 @@ import MLXNN
 
 /// Pairwise Givens rotation kernel for Metal (Apple Silicon).
 /// Template parameters are substituted at compile time.
-nonisolated private func metalSource(
+private func metalSource(
     rowsPerTile: Int, maxGroupSize: Int = 128, maxKrot: Int = 16
 ) -> String {
     """
@@ -137,7 +137,7 @@ nonisolated private func packPairs(_ pairs: MLXArray, groupSize: Int) -> MLXArra
 ///
 /// Rotation is applied to activations at runtime via a Metal kernel, preserving
 /// the quantization-friendly properties of the original weights.
-nonisolated open class RotateQuantizedLinear: QuantizedLinear {
+open class RotateQuantizedLinear: QuantizedLinear {
 
     // Rotation parameters — discovered by Module reflection for update(parameters:).
     // `channelScales` uses @ParameterInfo so it can keep the snake_case checkpoint


### PR DESCRIPTION
## Proposed changes

Fix build problem from #164 -- that was based on an older mlx-swift-lm.  CI passed and there were no conflicts, but main no longer built.  `ModelTypeRegistry` is now `ModelTypeRegistry<T>` for use in loading embedding models.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
