### PR TITLE
models should not mutate state during eval

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -27,9 +27,11 @@ extension LLMModel {
         // Prepare the prompt in chunks if larger than the prefill size.
         // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
         // chunk N.
+        var state: LMOutput.State?
         while y.tokens.size > prefillStepSize {
             let input = y[.newAxis, ..<prefillStepSize]
-            _ = self(input, cache: cache.isEmpty ? nil : cache, state: nil)
+            let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
+            state = output.state
             asyncEval(cache)
             y = y[prefillStepSize...]
         }

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -161,6 +161,7 @@ class AttentionBlock: Module {
     let numKeyValueHeads: Int
     let numKeyValueGroups: Int
     let smScale: Float
+    var sinksActive: Bool
 
     @ParameterInfo(key: "sinks") var sinks: MLXArray
     @ModuleInfo(key: "q_proj") var qProj: Linear
@@ -169,7 +170,6 @@ class AttentionBlock: Module {
     @ModuleInfo(key: "o_proj") var oProj: Linear
 
     let rope: YarnRoPE
-    private var cachedSinksActive: Bool?
 
     public init(_ config: GPTOSSConfiguration) {
         self.headDim = config.headDim
@@ -178,6 +178,8 @@ class AttentionBlock: Module {
         self.numKeyValueGroups = config.attentionHeads / config.kvHeads
 
         _sinks.wrappedValue = zeros([config.attentionHeads])
+        self.sinksActive = false
+
         _qProj.wrappedValue = Linear(
             config.hiddenSize, config.attentionHeads * config.headDim, bias: true)
         _kProj.wrappedValue = Linear(config.hiddenSize, config.kvHeads * config.headDim, bias: true)
@@ -205,6 +207,20 @@ class AttentionBlock: Module {
         }
     }
 
+    open override func update(
+        parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
+        modulePath: [String] = []
+    ) throws -> Self {
+        try super.update(
+            parameters: parameters, verify: verify, path: path, modulePath: modulePath)
+
+        if parameters["sinks"] != nil {
+            self.sinksActive = (sinks * sinks).max().item(Float.self) > 0
+        }
+
+        return self
+    }
+
     public func callAsFunction(
         _ x: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode,
@@ -216,13 +232,6 @@ class AttentionBlock: Module {
         var q = qProj(x).reshaped(B, L, -1, D).swappedAxes(1, 2)
         var k = kProj(x).reshaped(B, L, -1, D).swappedAxes(1, 2)
         var v = vProj(x).reshaped(B, L, -1, D).swappedAxes(1, 2)
-        let sinksActive =
-            cachedSinksActive
-            ?? {
-                let active = (sinks * sinks).max().item(Float.self) > 0
-                cachedSinksActive = active
-                return active
-            }()
 
         // Quantized cache path
         if let qcache = cache as? QuantizedKVCacheProtocol {

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -161,7 +161,6 @@ class AttentionBlock: Module {
     let numKeyValueHeads: Int
     let numKeyValueGroups: Int
     let smScale: Float
-    var sinksActive: Bool
 
     @ParameterInfo(key: "sinks") var sinks: MLXArray
     @ModuleInfo(key: "q_proj") var qProj: Linear
@@ -178,7 +177,6 @@ class AttentionBlock: Module {
         self.numKeyValueGroups = config.attentionHeads / config.kvHeads
 
         _sinks.wrappedValue = zeros([config.attentionHeads])
-        self.sinksActive = false
 
         _qProj.wrappedValue = Linear(
             config.hiddenSize, config.attentionHeads * config.headDim, bias: true)
@@ -207,20 +205,6 @@ class AttentionBlock: Module {
         }
     }
 
-    open override func update(
-        parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
-        modulePath: [String] = []
-    ) throws -> Self {
-        try super.update(
-            parameters: parameters, verify: verify, path: path, modulePath: modulePath)
-
-        if parameters["sinks"] != nil {
-            self.sinksActive = (sinks * sinks).max().item(Float.self) > 0
-        }
-
-        return self
-    }
-
     public func callAsFunction(
         _ x: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode,
@@ -235,9 +219,6 @@ class AttentionBlock: Module {
 
         // Quantized cache path
         if let qcache = cache as? QuantizedKVCacheProtocol {
-            if sinksActive {
-                fatalError("Quantized attention does not support non-zero sinks.")
-            }
             let offset = cache?.ropeOffset
             q = applyRotaryPosition(rope, to: q, offset: offset)
             k = applyRotaryPosition(rope, to: k, offset: offset)
@@ -269,7 +250,7 @@ class AttentionBlock: Module {
             queries: q, keys: k, values: v,
             scale: smScale,
             mask: mask,
-            sinks: sinksActive ? sinks : nil)
+            sinks: sinks)
 
         return oProj(vHat.swappedAxes(1, 2).reshaped(B, L, -1))
     }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -848,8 +848,11 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         // Draft generation: autoregressive loop with draft model
         var draftProcessor = processor  // Copy to discard later
         var draftTokens = [MLXArray]()
+        var draftState: LMOutput.State?
         for _ in 0 ..< numDraft {
-            let draftResult = draftModel(draftY[text: .newAxis], cache: draftCache, state: nil)
+            let draftResult = draftModel(
+                draftY[text: .newAxis], cache: draftCache, state: draftState)
+            draftState = draftResult.state
             var draftLogits = draftResult.logits[0..., -1, 0...]
             draftLogits = draftProcessor?.process(logits: draftLogits) ?? draftLogits
             let draftToken = sampler.sample(logits: draftLogits)

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -144,11 +144,30 @@ public struct LMOutput {
     /// optional ``State`` to carry forward into the next step
     public let state: State?
 
-    public struct State {
-        public let crossAttentionStates: MLXArray?
+    /// typed key for use in ``State``
+    public struct Key<T>: Identifiable, Sendable {
+        public let id: String
 
-        public init(crossAttentionStates: MLXArray? = nil) {
-            self.crossAttentionStates = crossAttentionStates
+        public init(_ id: String) {
+            self.id = id
+        }
+    }
+
+    /// Dictionary of typed ``Key`` to carry state between steps.
+    public struct State {
+        private var contents: [String: Any]
+
+        public init() {
+            self.contents = [:]
+        }
+
+        public subscript<T>(_ key: Key<T>) -> T? {
+            get {
+                contents[key.id] as? T
+            }
+            set {
+                contents[key.id] = newValue
+            }
         }
     }
 

--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -13,6 +13,11 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+private let precomputedPositionIdsKey = LMOutput.Key<MLXArray>(
+    "glmocr.precomputedPositionIds")
+private let ropeDeltasKey = LMOutput.Key<MLXArray>(
+    "glmocr.ropeDeltas")
+
 // MARK: - Language
 
 private enum Language {
@@ -327,8 +332,6 @@ private enum Language {
         @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
         var kvHeads: [Int]
-        var _positionIds: MLXArray?
-        var _ropeDeltas: MLXArray?
 
         public init(_ args: GlmOcrConfiguration.TextConfiguration) {
             self.model = GlmOcrTextModel(args)
@@ -342,8 +345,10 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
+            _ inputs: MLXArray?, cache: [KVCache]? = nil, state: LMOutput.State? = nil,
+            inputEmbedding: MLXArray? = nil
         ) -> LMOutput {
+            let state = state ?? .init()
             var positionIds: MLXArray? = nil
 
             let cacheOffset: Int
@@ -353,7 +358,7 @@ private enum Language {
                 cacheOffset = 0
             }
 
-            if let storedPositionIds = _positionIds {
+            if let storedPositionIds = state[precomputedPositionIdsKey] {
                 let seqLen: Int
                 if let inputEmbedding {
                     seqLen = inputEmbedding.dim(inputEmbedding.ndim - 2)
@@ -371,7 +376,7 @@ private enum Language {
                             0..., 0..., cacheOffset ..< (cacheOffset + seqLen)]
                 } else {
                     // Autoregressive: compute sequential positions using rope_deltas
-                    let delta = _ropeDeltas ?? MLXArray(Int32(0))
+                    let delta = state[ropeDeltasKey] ?? MLXArray(Int32(0))
                     let batchSize = inputEmbedding?.dim(0) ?? inputs?.dim(0) ?? 1
                     var posArrays = [MLXArray]()
                     for _ in 0 ..< 3 {
@@ -392,7 +397,7 @@ private enum Language {
             } else {
                 out = model.embedTokens.asLinear(out)
             }
-            return LMOutput(logits: out)
+            return LMOutput(logits: out, state: state)
         }
     }
 }
@@ -986,12 +991,10 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)
-        -> MLXArray
+        -> (MLXArray, MLXArray?, MLXArray?)
     {
         guard let pixelValues, let frames else {
-            languageModel._positionIds = nil
-            languageModel._ropeDeltas = nil
-            return languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis])
+            return (languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis]), nil, nil)
         }
 
         let inputEmbeds = languageModel.model.embedTokens(inputIds)
@@ -1007,13 +1010,10 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
             imageTokenId: config.baseConfiguration.imageTokenId,
             videoTokenId: config.baseConfiguration.videoTokenId)
 
-        // Pre-compute M-RoPE position IDs
         let (positionIds, ropeDeltas) = getRopeIndex(
             inputIds: inputIds, imageGridThw: frames)
-        languageModel._positionIds = positionIds
-        languageModel._ropeDeltas = ropeDeltas
 
-        return merged
+        return (merged, positionIds, ropeDeltas)
     }
 
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
@@ -1029,17 +1029,24 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: imageFrames)
         }
 
-        let inputEmbeddings = self.inputEmbeddings(
+        let (inputEmbeddings, positionIds, ropeDeltas) = self.inputEmbeddings(
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)
 
-        let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings)
+        var state = LMOutput.State()
+        state[precomputedPositionIdsKey] = positionIds
+        state[ropeDeltasKey] = ropeDeltas
+
+        let result = languageModel(
+            nil, cache: cache, state: state, inputEmbedding: inputEmbeddings)
 
         return .logits(result)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
-        languageModel(inputs, cache: cache).logits
+    public func callAsFunction(
+        _ input: LMInput.Text, cache: [any KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        languageModel(input.tokens, cache: cache, state: state)
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -16,6 +16,11 @@ private enum Qwen35VLError: Error {
     case featureTokenMismatch(expected: Int, actual: Int)
 }
 
+private let precomputedPositionIdsKey = LMOutput.Key<MLXArray>(
+    "qwen35.precomputedPositionIds")
+private let ropeDeltasKey = LMOutput.Key<MLXArray>(
+    "qwen35.ropeDeltas")
+
 // MARK: - Gated Delta Helpers
 
 private func computeGatedDeltaG(_ aLog: MLXArray, _ a: MLXArray, _ dtBias: MLXArray)
@@ -884,9 +889,6 @@ enum Qwen35Language {
         let modelType: String
         let kvHeads: [Int]
 
-        fileprivate var precomputedPositionIds: MLXArray? = nil
-        fileprivate var ropeDeltas: MLXArray? = nil
-
         init(_ config: Qwen35Configuration) {
             self.config = config
             self.textConfig = config.textConfiguration
@@ -906,29 +908,29 @@ enum Qwen35Language {
             super.init()
         }
 
-        func resetPositionState() {
-            precomputedPositionIds = nil
-            ropeDeltas = nil
-        }
-
         func callAsFunction(
             _ inputs: MLXArray,
             inputsEmbeds: MLXArray? = nil,
             cache: [KVCache?]? = nil,
+            state: LMOutput.State?,
             mask: MLXArray? = nil,
             positionIds providedPositionIds: MLXArray? = nil,
             pixelValues: MLXArray? = nil,
             imageGridTHW: [THW]? = nil,
             videoGridTHW: [THW]? = nil
         ) -> LMOutput {
+            var state = state ?? .init()
+
             // Ensure inputs is 2D [batch, seq]. Text-only callers (e.g.
             // WiredMemoryUtils, TokenIterator) may pass 1D token arrays.
             let inputs = inputs.ndim == 1 ? inputs.expandedDimensions(axis: 0) : inputs
 
             if pixelValues != nil {
-                precomputedPositionIds = nil
-                ropeDeltas = nil
+                state[precomputedPositionIdsKey] = nil
+                state[ropeDeltasKey] = nil
             }
+            let precomputedPositionIds = state[precomputedPositionIdsKey]
+            let ropeDeltas = state[ropeDeltasKey]
 
             var cacheOffset = 0
             if let cache, let faCache = cache[model.faIdx] {
@@ -962,8 +964,8 @@ enum Qwen35Language {
                             visionStartTokenId: config.visionStartTokenId,
                             attentionMask: ropeMask)
                         positionIds = computed
-                        precomputedPositionIds = computed
-                        ropeDeltas = deltas
+                        state[precomputedPositionIdsKey] = computed
+                        state[ropeDeltasKey] = deltas
                     }
                 } else {
                     let batchSize = inputs.dim(0)
@@ -1004,7 +1006,7 @@ enum Qwen35Language {
                 out = model.embedTokens.asLinear(out)
             }
 
-            return LMOutput(logits: out)
+            return LMOutput(logits: out, state: state)
         }
 
         func makeCache(maxKVSize: Int?) -> [KVCache] {
@@ -1149,8 +1151,6 @@ public class Qwen35: Module, VLMModel {
                 videoTokenIndex: config.videoTokenIndex
             )
             inputEmbeddings = mergedEmbeds
-        } else {
-            languageModel.resetPositionState()
         }
 
         let typedCache = castCache(cache)
@@ -1158,6 +1158,7 @@ public class Qwen35: Module, VLMModel {
             inputIds,
             inputsEmbeds: inputEmbeddings,
             cache: typedCache,
+            state: nil,
             mask: input.text.mask,
             positionIds: nil,
             pixelValues: pixelValues,
@@ -1168,19 +1169,22 @@ public class Qwen35: Module, VLMModel {
         return .logits(output)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
+    public func callAsFunction(
+        _ input: LMInput.Text, cache: [any KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
         let typedCache = castCacheOptional(cache)
         let result = languageModel(
-            inputs,
+            input.tokens,
             inputsEmbeds: nil,
             cache: typedCache,
+            state: state,
             mask: nil,
             positionIds: nil,
             pixelValues: nil,
             imageGridTHW: nil,
             videoGridTHW: nil
         )
-        return result.logits
+        return result
     }
 
     public func sanitize(weights: [String: MLXArray], metadata: [String: String]) -> [String:

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -12,6 +12,8 @@ private enum Qwen3VLError: Error {
     case featureTokenMismatch(expected: Int, actual: Int)
 }
 
+private let ropeDeltasKey = LMOutput.Key<MLXArray>("qwen35vl.ropeDeltas")
+
 // MARK: - Processor
 
 public struct Qwen3VLProcessor: UserInputProcessor {
@@ -1215,8 +1217,6 @@ enum Qwen3VLLanguage {
         let textConfig: Qwen3VLConfiguration.TextConfiguration
         var kvHeads: [Int]
 
-        private var ropeDeltas: MLXArray? = nil
-
         init(_ config: Qwen3VLConfiguration) {
             self.config = config
             self.textConfig = config.textConfiguration
@@ -1236,6 +1236,7 @@ enum Qwen3VLLanguage {
         func callAsFunction(
             _ inputIds: MLXArray?,
             cache: [KVCache]?,
+            state: LMOutput.State?,
             inputEmbeddings: MLXArray?,
             mask: MLXArray?,
             positionIds providedPositionIds: MLXArray?,
@@ -1245,14 +1246,16 @@ enum Qwen3VLLanguage {
             imageGridTHW: [THW]?,
             videoGridTHW: [THW]?
         ) -> LMOutput {
+            var state = state ?? .init()
+
             if pixelValues != nil {
-                ropeDeltas = nil
+                state[ropeDeltasKey] = nil
             }
 
             var positionIds = providedPositionIds
 
             if positionIds == nil && (mask == nil || mask?.ndim == 2) {
-                if (cache?.first?.offset ?? 0) == 0 || ropeDeltas == nil || cache == nil {
+                if (cache?.first?.offset ?? 0) == 0 || state[ropeDeltasKey] == nil || cache == nil {
                     if let inputIds {
                         let (computed, deltas) = Qwen3VLLanguage.getRopeIndex(
                             inputIds: inputIds,
@@ -1265,8 +1268,8 @@ enum Qwen3VLLanguage {
                             attentionMask: mask)
 
                         positionIds = computed
-                        ropeDeltas = deltas
-                    } else if let cache, ropeDeltas == nil {
+                        state[ropeDeltasKey] = deltas
+                    } else if let cache, state[ropeDeltasKey] == nil {
                         let batch = inputEmbeddings!.dim(0)
                         let seqLength = inputEmbeddings!.dim(1)
                         let currentOffset = cache.first?.offset ?? 0
@@ -1279,7 +1282,7 @@ enum Qwen3VLLanguage {
                         positionIds = base[.newAxis, 0..., 0...]
                         positionIds = tiled(positionIds!, repetitions: [3, batch, seqLength])
                     }
-                } else if let cache, let ropeDeltas {
+                } else if let cache, let ropeDeltas = state[ropeDeltasKey] {
                     let batch = (inputIds ?? inputEmbeddings!).dim(0)
                     let seqLength = (inputIds ?? inputEmbeddings!).dim(1)
 
@@ -1317,7 +1320,7 @@ enum Qwen3VLLanguage {
                 output = model.embedTokens.asLinear(output)
             }
 
-            return LMOutput(logits: output)
+            return LMOutput(logits: output, state: state)
         }
 
     }
@@ -1673,6 +1676,7 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
         let languageOutput = languageModel(
             inputIds,
             cache: typedCache,
+            state: nil,
             inputEmbeddings: inputEmbeddings,
             mask: nil,
             positionIds: nil,
@@ -1685,12 +1689,15 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
         return .logits(languageOutput)
     }
 
-    public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
+    public func callAsFunction(
+        _ input: LMInput.Text, cache: [any KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
         let typedCache = castCacheOptional(cache)
 
         let result = languageModel(
-            inputs,
+            input.tokens,
             cache: typedCache,
+            state: state,
             inputEmbeddings: nil,
             mask: nil,
             positionIds: nil,
@@ -1699,7 +1706,7 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: nil,
             imageGridTHW: nil,
             videoGridTHW: nil
-        ).logits
+        )
         return result
     }
 


### PR DESCRIPTION
## Proposed changes

- fixes #157
- the LMOutputState (currently unused) is updated to hold key/value pairs
- that allows models to produce cached values for later use

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
