### PR TITLE
Remove TokenLoopHandler Sendable requirement

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1934,7 +1934,7 @@ public enum TokenGeneration: Sendable {
 
 // MARK: - TokenLoopHandlers
 
-private protocol TokenLoopHandler: Sendable {
+private protocol TokenLoopHandler {
     associatedtype Output
 
     /// Return false to stop the loop early.
@@ -1957,7 +1957,7 @@ private protocol TokenLoopHandler: Sendable {
     func infoEvent(_ info: GenerateCompletionInfo) -> Output
 }
 
-private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
+private struct TextToolTokenLoopHandler: TokenLoopHandler {
     typealias Output = Generation
 
     var detokenizer: NaiveStreamingDetokenizer


### PR DESCRIPTION
## Proposed changes

Fixes #272.

- Remove the protocol-level `Sendable` requirement from the private `TokenLoopHandler` protocol.
- Remove the corresponding `@unchecked Sendable` marker from `TextToolTokenLoopHandler`.

`TokenLoopHandler` instances are created and passed into the generation loop as `consuming` values, matching the issue's requested cleanup. No runtime behavior is changed.

## Test plan

- [x] `xcodebuild build -scheme mlx-swift-lm-Package -destination 'platform=macOS,arch=arm64' -skipMacroValidation`
- [x] `xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS,arch=arm64' -skipMacroValidation`
- [x] `pre-commit run --all-files` (`swift-format` hook passed)
- [x] `swift-format lint --recursive Libraries Tools Applications IntegrationTesting`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

No new test was added because this is a private protocol constraint cleanup with no runtime behavior change; the existing package build and test suite pass. No documentation update is needed.
