### PR TITLE
Fix Gemma 4 vision pooler kernel derivation

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -82,6 +82,24 @@ private func gemma4OneHot(_ indices: MLXArray, numClasses: Int) -> MLXArray {
     expandedDimensions(indices, axis: -1) .== MLXArray(0 ..< numClasses)
 }
 
+/// Average-pool kernel for Gemma 4's vision pooler.
+///
+/// The padded patch tensor has length
+/// `paddedPatchCount = outputLength × pool²` where `pool` is the
+/// model's `pooling_kernel_size`. Recovering `pool` from these
+/// two values yields `floor(sqrt(paddedPatchCount / outputLength))`.
+///
+/// Matches HuggingFace's reference image processor (see
+/// `image_processing_gemma4.py`: `max_patches = max_soft_tokens *
+/// pooling_kernel_size**2`).
+internal func gemma4VisionPoolingKernel(
+    paddedPatchCount: Int, outputLength: Int
+) -> Int {
+    let safeLength = max(outputLength, 1)
+    let ratio = max(1, paddedPatchCount / safeLength)
+    return Int(sqrt(Double(ratio)))
+}
+
 private func gemma4RotateHalf(_ x: MLXArray) -> MLXArray {
     let half = x.shape[x.shape.count - 1] / 2
     let x1 = x[.ellipsis, ..<half]
@@ -1485,7 +1503,8 @@ private final class Gemma4VisionPooler: Module {
 
         let actualPositions = patchPositions[0, ..<validCount]
         let maxX = Int(actualPositions[0..., 0].max().item(Int32.self)) + 1
-        let kernel = Int(sqrt(Double(max(1, validCount / max(length, 1)))))
+        let kernel = gemma4VisionPoolingKernel(
+            paddedPatchCount: pooledHiddenStates.dim(1), outputLength: length)
         let divisor = max(kernel * kernel, 1)
         let pooledLength = max(length, 1)
 

--- a/Tests/MLXLMTests/Gemma4PoolingTests.swift
+++ b/Tests/MLXLMTests/Gemma4PoolingTests.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXVLM
+
+/// Unit tests for `gemma4VisionPoolingKernel`. Pins the recovered
+/// kernel to Gemma 4's `pooling_kernel_size` (3) for every
+/// supported soft-token budget.
+struct Gemma4VisionPoolingTests {
+
+    /// `pooling_kernel_size` for Gemma 4 (per HF + the model
+    /// config's `pooling_kernel_size` field).
+    private static let expectedPoolingKernel = 3
+
+    @Test(
+        "Kernel matches pooling_kernel_size (3) for every supported budget",
+        arguments: [70, 140, 280, 560, 1120])
+    func testKernelMatchesPoolingKernelSize(budget: Int) {
+        // Per HF: max_patches = max_soft_tokens * pool², so the
+        // padded patch tensor fed into the pooler has length
+        // budget * pool². The kernel recovered from those values
+        // must equal pool.
+        let pool = Self.expectedPoolingKernel
+        let paddedPatchCount = budget * pool * pool
+
+        let kernel = gemma4VisionPoolingKernel(
+            paddedPatchCount: paddedPatchCount, outputLength: budget)
+
+        #expect(
+            kernel == pool,
+            """
+            Expected pooling kernel \(pool) for budget \(budget) \
+            (padded patch count \(paddedPatchCount)), got \(kernel). \
+            Kernel must match Gemma 4's `pooling_kernel_size` config field for \
+            every supported soft-token budget.
+            """)
+    }
+
+    @Test("Kernel is robust to degenerate inputs")
+    func testKernelHandlesDegenerateInputs() {
+        // A zero `outputLength` must not divide by zero — the
+        // function falls back to treating it as 1, matching the
+        // upstream pattern. The exact returned value at degenerate
+        // inputs is unspecified; the assertion is "does not crash".
+        _ = gemma4VisionPoolingKernel(paddedPatchCount: 0, outputLength: 0)
+        _ = gemma4VisionPoolingKernel(paddedPatchCount: 100, outputLength: 0)
+
+        // A zero `paddedPatchCount` with a real `outputLength`
+        // yields kernel = 1 (no patches to pool yields the minimum
+        // kernel).
+        #expect(gemma4VisionPoolingKernel(paddedPatchCount: 0, outputLength: 280) == 1)
+    }
+
+    /// Documents the prior bug. The original formula divided the
+    /// real (un-padded) patch count by `outputLength` and floored
+    /// the square root. For a 768×768 image — the aligned default
+    /// for Gemma 4 (divisible by `patch_size × pooling_kernel_size
+    /// = 48`) — this returns 2 even though `pooling_kernel_size`
+    /// is 3.
+    @Test("Pre-fix formula returns kernel=2 at the aligned default size")
+    func testPreFixFormulaReproducesBug() {
+        // 768×768 image at patch_size=16 → 48×48 = 2304 real patches.
+        let realPatchCount = 48 * 48
+        let outputLength = 280
+
+        // The old formula, preserved here for documentation.
+        let safeLength = max(outputLength, 1)
+        let ratio = max(1, realPatchCount / safeLength)
+        let oldKernel = Int(sqrt(Double(ratio)))
+
+        #expect(
+            oldKernel == 2,
+            "Sanity check on the pre-fix formula: should reproduce the bug.")
+        #expect(
+            oldKernel != Self.expectedPoolingKernel,
+            """
+            The pre-fix kernel (\(oldKernel)) does not match Gemma 4's \
+            documented `pooling_kernel_size` of \(Self.expectedPoolingKernel). \
+            This is the bug `gemma4VisionPoolingKernel` was introduced to fix.
+            """)
+    }
+}


### PR DESCRIPTION
Gemma4VisionPooler.callAsFunction derived the kernel from the real (un-padded) patch count rather than the padded sequence length. At the default 280 soft-token budget, this can recover kernel=2 for typical image sizes, while HuggingFace's reference implementation and the model's pooling_kernel_size config both expect 3. Real-patch positions whose flat-kernel bucket index exceeds pooledLength then map to all-zero one-hot rows by gemma4OneHot and contribute nothing to the einsum output.

Extract the formula into gemma4VisionPoolingKernel(paddedPatchCount: outputLength:) and derive the kernel from pooledHiddenStates.dim(1) (= outputLength * pool^2) so it returns pool=3 for every supported budget.

Add Gemma4VisionPoolingTests asserting kernel=3 for all five documented budgets {70, 140, 280, 560, 1120}, with a regression test documenting the prior formula's behavior.

## Proposed changes

Fixes #289. Aligns the Gemma 4 vision pooler's kernel derivation with HuggingFace's reference image processor so the recovered kernel matches the model's `pooling_kernel_size = 3` at every supported soft-token budget.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
