### PR TITLE
Fix/isolated mlx test streams (fixes unit tests on main)

### DIFF
--- a/Tests/MLXLMTests/RoPEApplicationTests.swift
+++ b/Tests/MLXLMTests/RoPEApplicationTests.swift
@@ -51,9 +51,6 @@ struct RoPEApplicationTests {
             // different offsets for keys/queries.
             let match = allClose(outputBatch, outputSeq, atol: 1e-4)
             eval(match)
-            print(outputBatch)
-            print(outputSeq)
-            print(abs(outputSeq - outputBatch))
             #expect(match.item(Bool.self))
         }
     }

--- a/Tests/MLXLMTests/RoPEApplicationTests.swift
+++ b/Tests/MLXLMTests/RoPEApplicationTests.swift
@@ -6,51 +6,55 @@ import Testing
 @testable import MLXLLM
 @testable import MLXLMCommon
 
-@Suite(.serialized)
+@Suite
 struct RoPEApplicationTests {
 
     /// Gemma3nAttention applies rope, updates the cache and applies rope again.
     /// Ensure that it is correctly implemented.  We can observe prefill vs single token
     /// generaton and they should produce the same answers if implemented correctly.
     @Test func gemma3nAttentionTest() {
-        let config = Gemma3nTextConfiguration()
-        let attention = Gemma3nAttention(config, layerIdx: 3)
+        Stream.withNewDefaultStream {
+            defer { StreamOrDevice.default.stream.synchronize() }
 
-        #expect(!attention.isKvSharedLayer)
+            let config = Gemma3nTextConfiguration()
+            let attention = Gemma3nAttention(config, layerIdx: 3)
 
-        let B = 1
-        let L = 4
-        let D = config.hiddenSize
+            #expect(!attention.isKvSharedLayer)
 
-        MLXRandom.seed(42)
-        let x = MLXRandom.normal([B, L, D])
-        eval(x)
+            let B = 1
+            let L = 4
+            let D = config.hiddenSize
 
-        // Batch: process all L tokens at once with a causal mask
-        let cacheBatch = KVCacheSimple()
-        let causalMask = createAttentionMask(h: x, cache: cacheBatch)
-        let outputBatch = attention(x, mask: causalMask, cache: cacheBatch)
-        eval(outputBatch)
+            MLXRandom.seed(42)
+            let x = MLXRandom.normal([B, L, D])
+            eval(x)
 
-        // Sequential: process one token at a time (mask=.none since L=1 with cache)
-        let cacheSeq = KVCacheSimple()
-        var seqOutputs: [MLXArray] = []
-        for i in 0 ..< L {
-            let token = x[0..., i ..< (i + 1), 0...]
-            let mask = createAttentionMask(h: token, cache: cacheSeq)
-            let out = attention(token, mask: mask, cache: cacheSeq)
-            seqOutputs.append(out)
+            // Batch: process all L tokens at once with a causal mask
+            let cacheBatch = KVCacheSimple()
+            let causalMask = createAttentionMask(h: x, cache: cacheBatch)
+            let outputBatch = attention(x, mask: causalMask, cache: cacheBatch)
+            eval(outputBatch)
+
+            // Sequential: process one token at a time (mask=.none since L=1 with cache)
+            let cacheSeq = KVCacheSimple()
+            var seqOutputs: [MLXArray] = []
+            for i in 0 ..< L {
+                let token = x[0..., i ..< (i + 1), 0...]
+                let mask = createAttentionMask(h: token, cache: cacheSeq)
+                let out = attention(token, mask: mask, cache: cacheSeq)
+                seqOutputs.append(out)
+            }
+            let outputSeq = concatenated(seqOutputs, axis: 1)
+            eval(outputSeq)
+
+            // With correct RoPE these would match.  The buggy code would use
+            // different offsets for keys/queries.
+            let match = allClose(outputBatch, outputSeq, atol: 1e-4)
+            eval(match)
+            print(outputBatch)
+            print(outputSeq)
+            print(abs(outputSeq - outputBatch))
+            #expect(match.item(Bool.self))
         }
-        let outputSeq = concatenated(seqOutputs, axis: 1)
-        eval(outputSeq)
-
-        // With correct RoPE these would match.  The buggy code would use
-        // different offsets for keys/queries.
-        let match = allClose(outputBatch, outputSeq, atol: 1e-4)
-        eval(match)
-        print(outputBatch)
-        print(outputSeq)
-        print(abs(outputSeq - outputBatch))
-        #expect(match.item(Bool.self))
     }
 }


### PR DESCRIPTION
## Proposed changes

Swift Testing can run suites concurrently. The previous .serialized trait only serialized tests within RoPEApplicationTests, so it did not prevent gemma3nAttentionTest from running alongside KV cache and speculative decoding tests.

Those tests all enqueue and evaluate MLX work through StreamOrDevice.default. Without a task-local override, that resolves to the shared default GPU stream, so separate tests can interact through the same underlying command-buffer lifecycle and trip Metal's 'Completed handler provided after commit call' assertion.

Run the RoPE test under Stream.withNewDefaultStream and synchronize that scoped stream before returning. This isolates the MLX stream state for the test while preserving Swift Testing parallelism instead of serializing unrelated tests.
Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
