### PR TITLE
fix Idefics3 vision encoder dtype -- SigLIP runs in float32 instead of bf16

### DIFF
--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -591,7 +591,11 @@ private enum Vision {
             MLXArray,
             [MLXArray]?
         ) {
-            let e = embeddings(x)
+            // Cast to the patch-embedding weight dtype (bf16) before the encoder,
+            // matching mlx-vlm's `VisionModel.__call__`. `VisionEmbeddings` sums a
+            // float32 conv output with the bf16 position embedding, promoting to
+            // float32 — without this the encoder would run in float32, not bf16.
+            let e = embeddings(x).asType(embeddings.patchEmbedding.weight.dtype)
             let (encoded, hiddenStates) = encoder(
                 e,
                 outputHiddenStates: outputHiddenStates


### PR DESCRIPTION
## Proposed changes

\`Idefics3.Vision.VisionModel.callAsFunction\` feeds the output of \`VisionEmbeddings\`
straight into the 12-layer SigLIP encoder with no dtype cast. \`VisionEmbeddings\` sums
a float32 conv output with the bfloat16 position embedding, which promotes the result
to float32 — so the encoder runs in float32 rather than the model's bfloat16.

Python \`mlx-vlm\`'s \`VisionModel.__call__\` casts back explicitly:

    x = self.embeddings(x).astype(self.embeddings.patch_embedding.weight.dtype)

This adds the equivalent cast in Swift:

    let e = embeddings(x).asType(embeddings.patchEmbedding.weight.dtype)

## Verification

Found while bringing an on-device Granite Docling (Idefics3) pipeline to parity with
the Python \`mlx-vlm\` reference. Running the encoder in float32 instead of bfloat16
produced a divergence at the encoder input that amplified through the connector into
the merged embedding and poisoned the language-model KV cache; on a dense document
page it flipped a close decode argmax and degenerated into a token-repetition loop.
Adding the cast eliminates the divergence and restores parity with \`mlx-vlm\`. The
cast is a no-op when the dtypes already agree, and benefits all Idefics3 / SmolVLM2
users.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run \`pre-commit run --all-files\` to format my code
- [ ] I have added tests -- the unit test suite does not exercise VLM forward passes against live models; no unit test covers this path
- [ ] I have updated the documentation -- no public API change