### PR TITLE
fix Idefics3 prepare() to honor windowSize -- prompt prefill is never chunked

### DIFF
--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -730,10 +730,33 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
     {
         let inputIds = input.text.tokens
         let pixelValues = input.image?.pixels
-        let embeddings = getInputEmbeddings(
+        var embeddings = getInputEmbeddings(
             inputIds: inputIds,
             pixelValues: pixelValues
         )
+
+        // Prefill the merged image+text embeddings in windowSize-sized chunks,
+        // matching mlx-vlm (and `LLMModel.prepare`'s token chunking): evaluate
+        // the KV cache between chunks, leaving the last embedding for the logits.
+        let prefillStepSize = windowSize ?? 512
+        let totalTokens = embeddings.dim(1)
+
+        var processed = 0
+        while embeddings.dim(1) > 1 {
+            let nToProcess = min(prefillStepSize, embeddings.dim(1) - 1)
+            let chunk = embeddings[0..., ..<nToProcess]
+            _ = languageModel(nil, cache: cache, inputs_embeds: chunk)
+            eval(cache)
+            embeddings = embeddings[0..., nToProcess...]
+            processed += nToProcess
+        }
+
+        // The prefix is now in the KV cache; the final embedding yields the
+        // first-token logits.
+        precondition(
+            processed == totalTokens - 1,
+            "Idefics3 chunked prefill: expected one residual embedding, processed "
+                + "\(processed) of \(totalTokens)")
         let result = languageModel(nil, cache: cache, inputs_embeds: embeddings)
         return .logits(result)
     }


### PR DESCRIPTION
## Proposed changes

\`Idefics3.prepare(_:cache:windowSize:)\` accepts a \`windowSize\` argument but never
uses it: the entire merged image+text embedding -- which can be 10k+ positions for
multi-tile Idefics3 / SmolVLM2 inputs -- is run through the language model in a
single forward pass.

\`LLMModel.prepare\` already chunks token prompts into \`windowSize\`-sized slices. This
applies the same chunking to Idefics3's merged-embedding prefill: the embeddings are
fed in \`windowSize\`-sized slices with the KV cache evaluated between chunks, and the
final embedding is run for the first-token logits. This matches \`mlx-vlm\`'s
\`generate_step\` chunked prefill.

Unlike \`LLMModel.prepare\` -- which works on tokens and returns \`.tokens\` -- Idefics3's
merged image+text embeddings have no token IDs, so this keeps the existing \`.logits\`
return: it chunks down to the final embedding and returns its logits.

## Verification

Verified as part of the same Granite Docling parity effort. Chunked vs single-pass
prefill is logit-neutral under causal masking -- generated output is unchanged -- but
it honors the \`windowSize\` contract and bounds peak prefill memory on large
multi-tile inputs, consistent with \`LLMModel.prepare\` and every other model's
prefill path.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run \`pre-commit run --all-files\` to format my code
- [ ] I have added tests -- the unit test suite does not exercise VLM forward passes against live models; no unit test covers this path
- [ ] I have updated the documentation -- no public API change