### PR TITLE
Complete VLM processor TODOs

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -378,8 +378,20 @@ public enum MediaProcessing {
 
         case .frames(let videoFrames):
             return try await _asProcessedSequence(
-                videoFrames, targetFPS: targetFPS, frameProcessing: frameProcessing)
+                videoFrames, maxFrames: maxFrames, targetFPS: targetFPS,
+                frameProcessing: frameProcessing)
         }
+    }
+
+    static func sampledFrameCount(
+        fps: Double, duration: CMTime, maxFrames: Int, availableFrames: Int? = nil
+    ) -> Int {
+        let estimatedFrames = Int(round(fps * duration.seconds))
+        var desiredFrames = min(estimatedFrames, maxFrames)
+        if let availableFrames {
+            desiredFrames = min(desiredFrames, availableFrames)
+        }
+        return max(desiredFrames, 1)
     }
 
     @available(
@@ -421,10 +433,8 @@ public enum MediaProcessing {
                 userInfo: [NSLocalizedDescriptionKey: "Failed to load the asset's duration"])
         }
         let fps = targetFPS(duration)
-        // Note: the round was not present in `asCIImageSequence`, so we may now be passing 1 more frame to Qwen depending on video duration.
-        let estimatedFrames = Int(round(fps * duration.seconds))
-        let desiredFrames = min(estimatedFrames, maxFrames)
-        let finalFrameCount = max(desiredFrames, 1)
+        let finalFrameCount = sampledFrameCount(
+            fps: fps, duration: duration, maxFrames: maxFrames)
 
         let sampledTimeValues = MLXArray.linspace(
             0, duration.value, count: Int(finalFrameCount)
@@ -461,6 +471,7 @@ public enum MediaProcessing {
 
     static private func _asProcessedSequence(
         _ videoFrames: [VideoFrame],
+        maxFrames: Int = Int.max,
         targetFPS: (CMTime) -> Double,
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
@@ -474,10 +485,9 @@ public enum MediaProcessing {
         let duration = timeRangeOfVideoFrames.duration
 
         let fps = targetFPS(duration)
-        // Note: the round was not present in `asCIImageSequence`, so we may now be passing 1 more frame to Qwen depending on video duration.
-        let estimatedFrames = Int(round(fps * duration.seconds))
-        let desiredFrames = min(estimatedFrames, videoFrames.count)
-        let finalFrameCount = max(desiredFrames, 1)
+        let finalFrameCount = sampledFrameCount(
+            fps: fps, duration: duration, maxFrames: maxFrames,
+            availableFrames: videoFrames.count)
 
         let sampledTimeValues = MLXArray.linspace(
             0, duration.value, count: Int(finalFrameCount)

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -386,6 +386,10 @@ public enum MediaProcessing {
     static func sampledFrameCount(
         fps: Double, duration: CMTime, maxFrames: Int, availableFrames: Int? = nil
     ) -> Int {
+        if availableFrames == 0 {
+            return 0
+        }
+
         let estimatedFrames = Int(round(fps * duration.seconds))
         var desiredFrames = min(estimatedFrames, maxFrames)
         if let availableFrames {
@@ -476,7 +480,9 @@ public enum MediaProcessing {
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
 
-        precondition(videoFrames.isEmpty == false)
+        guard videoFrames.isEmpty == false else {
+            throw VLMError.processing("Video frame input must contain at least one frame.")
+        }
 
         let startTime = videoFrames.first?.timeStamp ?? .zero
         let endTime = videoFrames.last?.timeStamp ?? .zero

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -580,7 +580,9 @@ public enum MediaProcessing {
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
 
-        precondition(!videoFrames.isEmpty)
+        guard !videoFrames.isEmpty else {
+            throw VLMError.processing("Video frame input must contain at least one frame.")
+        }
 
         let startTime = videoFrames.first?.timeStamp ?? .zero
         let endTime = videoFrames.last?.timeStamp ?? .zero

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -68,6 +68,7 @@ public struct FastVLMConfiguration: Codable, Sendable {
         public let multimodalProjectorType: String
         public let multimodalProjectorHiddenSize: Int
         public let tokenizerModelMaxLangth: Int
+        public var tokenizerModelMaxLength: Int { tokenizerModelMaxLangth }
         public let tokenizerPaddingSide: String
 
         enum CodingKeys: String, CodingKey {
@@ -1079,7 +1080,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     private func getInputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, mask: MLXArray?)
-        -> MLXArray
+        throws -> MLXArray
     {
         guard let pixelValues = pixelValues else {
             return languageModel.model.embedTokens(inputIds)
@@ -1091,7 +1092,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             imageFeatures.dim(3)
         )
         let mmInputs = multimodalProjector(imageFeatures.reshaped(B, H * W, C))
-        let finalEmbeddings = prepareInputsForMultimodal(
+        let finalEmbeddings = try prepareInputsForMultimodal(
             imageFeatures: mmInputs, inputIds: inputIds, mask: mask)
         return finalEmbeddings
     }
@@ -1099,7 +1100,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     // This method assumes bs == 1, and one single image
     private func prepareInputsForMultimodal(
         imageFeatures: MLXArray, inputIds ids: MLXArray, mask: MLXArray?
-    ) -> MLXArray {
+    ) throws -> MLXArray {
         let inputIds: MLXArray
         if let mask = mask {
             // Remove padding
@@ -1111,26 +1112,81 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         let inputIdsArray = inputIds.asArray(Int.self)
-        let imageTokenIndex =
-            inputIdsArray.firstIndex(of: config.baseConfiguration.imageTokenIndex) ?? 0
-        // Embed tokens before and after and then split to insert the image
-        let tokens = inputIdsArray.split(separator: config.baseConfiguration.imageTokenIndex)
-            .joined()
-        let tokenEmbeddings = languageModel.model.embedTokens(MLXArray(tokens))
-        let splitTokenEmbeddings = tokenEmbeddings.split(indices: [imageTokenIndex])
+        let imageBlock = imageFeatures[0]
+        let imageLength = imageBlock.dim(0)
+        let (beforeTokens, afterTokens) = try Self.splitTextTokensForMultimodal(
+            inputIds: inputIdsArray,
+            imageTokenId: config.baseConfiguration.imageTokenIndex,
+            imageLength: imageLength,
+            maxLength: config.baseConfiguration.tokenizerModelMaxLength,
+            paddingSide: config.baseConfiguration.tokenizerPaddingSide)
 
-        // Concatenate - once again this is easy because we assume bs==1 and a single image
-        let embeddings = concatenated(
-            [splitTokenEmbeddings[0], imageFeatures[0], splitTokenEmbeddings[1]], axis: 0)
-
-        // TODO: trim if we went over model_max_length
+        var embeddingParts = [MLXArray]()
+        if !beforeTokens.isEmpty {
+            embeddingParts.append(languageModel.model.embedTokens(MLXArray(beforeTokens)))
+        }
+        embeddingParts.append(imageBlock)
+        if !afterTokens.isEmpty {
+            embeddingParts.append(languageModel.model.embedTokens(MLXArray(afterTokens)))
+        }
+        let embeddings = concatenated(embeddingParts, axis: 0)
         return embeddings.expandedDimensions(axis: 0)
+    }
+
+    static func splitTextTokensForMultimodal(
+        inputIds: [Int], imageTokenId: Int, imageLength: Int, maxLength: Int, paddingSide: String
+    ) throws -> (beforeTokens: [Int], afterTokens: [Int]) {
+        guard let imageTokenIndex = inputIds.firstIndex(of: imageTokenId) else {
+            throw VLMError.processing("FastVLM prompt is missing image token \(imageTokenId).")
+        }
+
+        var beforeTokens = Array(inputIds[..<imageTokenIndex])
+        var afterTokens =
+            imageTokenIndex + 1 < inputIds.count
+            ? Array(inputIds[(imageTokenIndex + 1)...])
+            : []
+
+        guard maxLength > 0 else {
+            return (beforeTokens, afterTokens)
+        }
+        guard imageLength <= maxLength else {
+            throw VLMError.processing(
+                "FastVLM image features (\(imageLength)) exceed tokenizer_model_max_length (\(maxLength))."
+            )
+        }
+
+        var overflow = beforeTokens.count + afterTokens.count + imageLength - maxLength
+        guard overflow > 0 else {
+            return (beforeTokens, afterTokens)
+        }
+
+        func trimStart(_ tokens: inout [Int], by count: inout Int) {
+            let removed = min(tokens.count, count)
+            tokens.removeFirst(removed)
+            count -= removed
+        }
+
+        func trimEnd(_ tokens: inout [Int], by count: inout Int) {
+            let removed = min(tokens.count, count)
+            tokens.removeLast(removed)
+            count -= removed
+        }
+
+        if paddingSide.lowercased() == "left" {
+            trimStart(&beforeTokens, by: &overflow)
+            trimStart(&afterTokens, by: &overflow)
+        } else {
+            trimEnd(&afterTokens, by: &overflow)
+            trimEnd(&beforeTokens, by: &overflow)
+        }
+
+        return (beforeTokens, afterTokens)
     }
 
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        let embeddings = getInputEmbeddings(
+        let embeddings = try getInputEmbeddings(
             inputIds: input.text.tokens,
             pixelValues: input.image?.pixels,
             mask: input.text.mask

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -68,6 +68,7 @@ public struct FastVLMConfiguration: Codable, Sendable {
         public let multimodalProjectorType: String
         public let multimodalProjectorHiddenSize: Int
         public let tokenizerModelMaxLangth: Int
+        public var tokenizerModelMaxLength: Int { tokenizerModelMaxLangth }
         public let tokenizerPaddingSide: String
 
         enum CodingKeys: String, CodingKey {
@@ -1079,7 +1080,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     private func getInputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, mask: MLXArray?)
-        -> MLXArray
+        throws -> MLXArray
     {
         guard let pixelValues = pixelValues else {
             return languageModel.model.embedTokens(inputIds)
@@ -1091,7 +1092,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             imageFeatures.dim(3)
         )
         let mmInputs = multimodalProjector(imageFeatures.reshaped(B, H * W, C))
-        let finalEmbeddings = prepareInputsForMultimodal(
+        let finalEmbeddings = try prepareInputsForMultimodal(
             imageFeatures: mmInputs, inputIds: inputIds, mask: mask)
         return finalEmbeddings
     }
@@ -1099,7 +1100,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     // This method assumes bs == 1, and one single image
     private func prepareInputsForMultimodal(
         imageFeatures: MLXArray, inputIds ids: MLXArray, mask: MLXArray?
-    ) -> MLXArray {
+    ) throws -> MLXArray {
         let inputIds: MLXArray
         if let mask = mask {
             // Remove padding
@@ -1111,20 +1112,75 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         let inputIdsArray = inputIds.asArray(Int.self)
-        let imageTokenIndex =
-            inputIdsArray.firstIndex(of: config.baseConfiguration.imageTokenIndex) ?? 0
-        // Embed tokens before and after and then split to insert the image
-        let tokens = inputIdsArray.split(separator: config.baseConfiguration.imageTokenIndex)
-            .joined()
-        let tokenEmbeddings = languageModel.model.embedTokens(MLXArray(tokens))
-        let splitTokenEmbeddings = tokenEmbeddings.split(indices: [imageTokenIndex])
+        let imageBlock = imageFeatures[0]
+        let imageLength = imageBlock.dim(0)
+        let (beforeTokens, afterTokens) = try Self.splitTextTokensForMultimodal(
+            inputIds: inputIdsArray,
+            imageTokenId: config.baseConfiguration.imageTokenIndex,
+            imageLength: imageLength,
+            maxLength: config.baseConfiguration.tokenizerModelMaxLength,
+            paddingSide: config.baseConfiguration.tokenizerPaddingSide)
 
-        // Concatenate - once again this is easy because we assume bs==1 and a single image
-        let embeddings = concatenated(
-            [splitTokenEmbeddings[0], imageFeatures[0], splitTokenEmbeddings[1]], axis: 0)
-
-        // TODO: trim if we went over model_max_length
+        var embeddingParts = [MLXArray]()
+        if !beforeTokens.isEmpty {
+            embeddingParts.append(languageModel.model.embedTokens(MLXArray(beforeTokens)))
+        }
+        embeddingParts.append(imageBlock)
+        if !afterTokens.isEmpty {
+            embeddingParts.append(languageModel.model.embedTokens(MLXArray(afterTokens)))
+        }
+        let embeddings = concatenated(embeddingParts, axis: 0)
         return embeddings.expandedDimensions(axis: 0)
+    }
+
+    static func splitTextTokensForMultimodal(
+        inputIds: [Int], imageTokenId: Int, imageLength: Int, maxLength: Int, paddingSide: String
+    ) throws -> (beforeTokens: [Int], afterTokens: [Int]) {
+        guard let imageTokenIndex = inputIds.firstIndex(of: imageTokenId) else {
+            throw VLMError.processing("FastVLM prompt is missing image token \(imageTokenId).")
+        }
+
+        var beforeTokens = Array(inputIds[..<imageTokenIndex])
+        var afterTokens =
+            imageTokenIndex + 1 < inputIds.count
+            ? Array(inputIds[(imageTokenIndex + 1)...])
+            : []
+
+        guard maxLength > 0 else {
+            return (beforeTokens, afterTokens)
+        }
+        guard imageLength <= maxLength else {
+            throw VLMError.processing(
+                "FastVLM image features (\(imageLength)) exceed tokenizer_model_max_length (\(maxLength))."
+            )
+        }
+
+        var overflow = beforeTokens.count + afterTokens.count + imageLength - maxLength
+        guard overflow > 0 else {
+            return (beforeTokens, afterTokens)
+        }
+
+        func trimStart(_ tokens: inout [Int], by count: inout Int) {
+            let removed = min(tokens.count, count)
+            tokens.removeFirst(removed)
+            count -= removed
+        }
+
+        func trimEnd(_ tokens: inout [Int], by count: inout Int) {
+            let removed = min(tokens.count, count)
+            tokens.removeLast(removed)
+            count -= removed
+        }
+
+        if paddingSide.lowercased() == "left" {
+            trimStart(&beforeTokens, by: &overflow)
+            trimStart(&afterTokens, by: &overflow)
+        } else {
+            trimEnd(&afterTokens, by: &overflow)
+            trimEnd(&beforeTokens, by: &overflow)
+        }
+
+        return (beforeTokens, afterTokens)
     }
 
     public func prepare(
@@ -1132,7 +1188,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     ) throws
         -> PrepareResult
     {
-        let embeddings = getInputEmbeddings(
+        let embeddings = try getInputEmbeddings(
             inputIds: input.text.tokens,
             pixelValues: input.image?.pixels,
             mask: input.text.mask

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -151,7 +151,11 @@ public struct SmolVLMProcessor: UserInputProcessor {
     let imageToken = "<image>"
     let fakeImageToken = "<fake_token_around_image>"
     let globalImageToken = "<global-img>"
-    var imageTokenId: Int { tokenizer.convertTokenToId(imageToken) ?? fallbackImageTokenId }
+    var imageTokenId: Int {
+        Self.resolvedImageTokenId(
+            tokenizer: tokenizer, imageToken: imageToken, fallbackImageTokenId: fallbackImageTokenId
+        )
+    }
 
     var maxProcessingImageSize: CGFloat { CGFloat(config.size.longestEdge) }  // 2048
     var fixedImageSize: CGFloat { CGFloat(config.maxImageSize.longestEdge) }  // 384 for big models, 512 for small models (200-500M)
@@ -168,6 +172,17 @@ public struct SmolVLMProcessor: UserInputProcessor {
     ) {
         self.config = config
         self.tokenizer = tokenizer
+    }
+
+    static func resolvedImageTokenId(
+        tokenizer: any Tokenizer, imageToken: String, fallbackImageTokenId: Int
+    ) -> Int {
+        guard let tokenId = tokenizer.convertTokenToId(imageToken),
+            tokenId != tokenizer.unknownTokenId
+        else {
+            return fallbackImageTokenId
+        }
+        return tokenId
     }
 
     func getVideoPromptString(

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -44,7 +44,6 @@ public struct SmolVLMProcessorConfiguration: Codable, Sendable {
     public let maxImageSize: Size
     public let videoSampling: VideoSampling
     private let _imageSequenceLength: Int?
-    // TODO: this does not come in preprocessor_config.json, verify where transformers gets it from
     public var imageSequenceLength: Int { _imageSequenceLength ?? 64 }
 
     init(
@@ -73,6 +72,74 @@ public struct SmolVLMProcessorConfiguration: Codable, Sendable {
         case maxImageSize = "max_image_size"
         case videoSampling = "video_sampling"
         case _imageSequenceLength = "image_seq_len"
+        case imageSequenceLengthAlias = "image_sequence_length"
+        case sequenceLengthAlias = "image_sequence_len"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.imageMean = try container.decode([CGFloat].self, forKey: .imageMean)
+        self.imageStd = try container.decode([CGFloat].self, forKey: .imageStd)
+        self.size = try container.decode(Size.self, forKey: .size)
+        self.maxImageSize = try container.decode(Size.self, forKey: .maxImageSize)
+        self.videoSampling = try container.decode(VideoSampling.self, forKey: .videoSampling)
+        self._imageSequenceLength =
+            try container.decodeIfPresent(Int.self, forKey: ._imageSequenceLength)
+            ?? container.decodeIfPresent(Int.self, forKey: .imageSequenceLengthAlias)
+            ?? container.decodeIfPresent(Int.self, forKey: .sequenceLengthAlias)
+        if let _imageSequenceLength, _imageSequenceLength <= 0 {
+            throw DecodingError.dataCorruptedError(
+                forKey: ._imageSequenceLength,
+                in: container,
+                debugDescription: "image sequence length must be positive"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(imageMean, forKey: .imageMean)
+        try container.encode(imageStd, forKey: .imageStd)
+        try container.encode(size, forKey: .size)
+        try container.encode(maxImageSize, forKey: .maxImageSize)
+        try container.encode(videoSampling, forKey: .videoSampling)
+        try container.encodeIfPresent(_imageSequenceLength, forKey: ._imageSequenceLength)
+    }
+}
+
+public struct SmolVLM2MessageGenerator: MessageGenerator {
+    public init() {}
+
+    private func content(text: String, imageCount: Int, videoCount: Int) -> [MLXLMCommon.Message] {
+        (0 ..< imageCount).map { _ in ["type": "image"] }
+            + (0 ..< videoCount).map { _ in ["type": "video"] }
+            + [["type": "text", "text": text]]
+    }
+
+    public func generate(from input: UserInput) -> [MLXLMCommon.Message] {
+        switch input.prompt {
+        case .text(let text):
+            [
+                [
+                    "role": "user",
+                    "content": content(
+                        text: text, imageCount: input.images.count, videoCount: input.videos.count),
+                ]
+            ]
+        case .messages(let messages):
+            messages
+        case .chat(let messages):
+            generate(messages: messages)
+        }
+    }
+
+    public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        [
+            "role": message.role.rawValue,
+            "content": content(
+                text: message.content, imageCount: message.images.count,
+                videoCount: message.videos.count),
+        ]
     }
 }
 
@@ -80,18 +147,16 @@ public struct SmolVLMProcessor: UserInputProcessor {
     private let config: SmolVLMProcessorConfiguration
     private let tokenizer: any Tokenizer
 
-    // FIXME: hardcoded values for now
-
-    // Hardcode this since we can't pass it in or rely on it from the preprocessor config.
-    let imageTokenId = 49190
+    private let fallbackImageTokenId = 49190
     let imageToken = "<image>"
     let fakeImageToken = "<fake_token_around_image>"
     let globalImageToken = "<global-img>"
+    var imageTokenId: Int { tokenizer.convertTokenToId(imageToken) ?? fallbackImageTokenId }
 
     var maxProcessingImageSize: CGFloat { CGFloat(config.size.longestEdge) }  // 2048
     var fixedImageSize: CGFloat { CGFloat(config.maxImageSize.longestEdge) }  // 384 for big models, 512 for small models (200-500M)
     var imageSequenceLength: Int { config.imageSequenceLength }
-    var maxVideoFrames: Int { 20 /*config.videoSampling.maxFrames*/ }
+    var maxVideoFrames: Int { max(config.videoSampling.maxFrames, 1) }
     var targetVideoFPS: Double { Double(config.videoSampling.fps) }
 
     let defaultVideoSystemMessage =
@@ -177,8 +242,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
             for: size, longestEdge: CGFloat(longestEdge), multiple: multiple.flatMap(CGFloat.init))
     }
 
-    /// Tile image if it's larger than the maxProcessingImageSize, so the model gets to see more of it
-    /// TODO: disable in video mode
+    /// Tile image if it's larger than the maxProcessingImageSize, so the model gets to see more of it.
+    /// Video frames are processed through the fixed-size global-frame path instead.
     func tiles(from originalImage: CIImage) -> (tiles: [CIImage], rows: Int, cols: Int) {
         // The original code resizes to maxProcessingImageSize, then resizes again ensuring multiples of fixedImageSize
         // We do both resizes in one go.
@@ -227,7 +292,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
     }
 
     public func prepare(input: UserInput) async throws -> LMInput {
-        let messages = Qwen2VLMessageGenerator().generate(from: input)  // TODO: Create SmolVLM2MessageGenerator
+        let messages = SmolVLM2MessageGenerator().generate(from: input)
 
         if input.images.isEmpty && input.videos.isEmpty {
             // No image scenario
@@ -324,7 +389,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
                 targetFPS: { duration in
                     // 1 fps for duration >= 10s, apply a multiplier if smaller
                     max((10 - 0.9 * duration.seconds) * targetVideoFPS, 1)
-                }
+                },
+                maxFrames: maxVideoFrames
             ) { frame in
 
                 let processedFrame = frame.frame

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -44,7 +44,6 @@ public struct SmolVLMProcessorConfiguration: Codable, Sendable {
     public let maxImageSize: Size
     public let videoSampling: VideoSampling
     private let _imageSequenceLength: Int?
-    // TODO: this does not come in preprocessor_config.json, verify where transformers gets it from
     public var imageSequenceLength: Int { _imageSequenceLength ?? 64 }
 
     init(
@@ -73,6 +72,74 @@ public struct SmolVLMProcessorConfiguration: Codable, Sendable {
         case maxImageSize = "max_image_size"
         case videoSampling = "video_sampling"
         case _imageSequenceLength = "image_seq_len"
+        case imageSequenceLengthAlias = "image_sequence_length"
+        case sequenceLengthAlias = "image_sequence_len"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.imageMean = try container.decode([CGFloat].self, forKey: .imageMean)
+        self.imageStd = try container.decode([CGFloat].self, forKey: .imageStd)
+        self.size = try container.decode(Size.self, forKey: .size)
+        self.maxImageSize = try container.decode(Size.self, forKey: .maxImageSize)
+        self.videoSampling = try container.decode(VideoSampling.self, forKey: .videoSampling)
+        self._imageSequenceLength =
+            try container.decodeIfPresent(Int.self, forKey: ._imageSequenceLength)
+            ?? container.decodeIfPresent(Int.self, forKey: .imageSequenceLengthAlias)
+            ?? container.decodeIfPresent(Int.self, forKey: .sequenceLengthAlias)
+        if let _imageSequenceLength, _imageSequenceLength <= 0 {
+            throw DecodingError.dataCorruptedError(
+                forKey: ._imageSequenceLength,
+                in: container,
+                debugDescription: "image sequence length must be positive"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(imageMean, forKey: .imageMean)
+        try container.encode(imageStd, forKey: .imageStd)
+        try container.encode(size, forKey: .size)
+        try container.encode(maxImageSize, forKey: .maxImageSize)
+        try container.encode(videoSampling, forKey: .videoSampling)
+        try container.encodeIfPresent(_imageSequenceLength, forKey: ._imageSequenceLength)
+    }
+}
+
+public struct SmolVLM2MessageGenerator: MessageGenerator {
+    public init() {}
+
+    private func content(text: String, imageCount: Int, videoCount: Int) -> [MLXLMCommon.Message] {
+        (0 ..< imageCount).map { _ in ["type": "image"] }
+            + (0 ..< videoCount).map { _ in ["type": "video"] }
+            + [["type": "text", "text": text]]
+    }
+
+    public func generate(from input: UserInput) -> [MLXLMCommon.Message] {
+        switch input.prompt {
+        case .text(let text):
+            [
+                [
+                    "role": "user",
+                    "content": content(
+                        text: text, imageCount: input.images.count, videoCount: input.videos.count),
+                ]
+            ]
+        case .messages(let messages):
+            messages
+        case .chat(let messages):
+            generate(messages: messages)
+        }
+    }
+
+    public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        [
+            "role": message.role.rawValue,
+            "content": content(
+                text: message.content, imageCount: message.images.count,
+                videoCount: message.videos.count),
+        ]
     }
 }
 
@@ -80,18 +147,16 @@ public struct SmolVLMProcessor: UserInputProcessor {
     private let config: SmolVLMProcessorConfiguration
     private let tokenizer: any Tokenizer
 
-    // FIXME: hardcoded values for now
-
-    // Hardcode this since we can't pass it in or rely on it from the preprocessor config.
-    let imageTokenId = 49190
+    private let fallbackImageTokenId = 49190
     let imageToken = "<image>"
     let fakeImageToken = "<fake_token_around_image>"
     let globalImageToken = "<global-img>"
+    var imageTokenId: Int { tokenizer.convertTokenToId(imageToken) ?? fallbackImageTokenId }
 
     var maxProcessingImageSize: CGFloat { CGFloat(config.size.longestEdge) }  // 2048
     var fixedImageSize: CGFloat { CGFloat(config.maxImageSize.longestEdge) }  // 384 for big models, 512 for small models (200-500M)
     var imageSequenceLength: Int { config.imageSequenceLength }
-    var maxVideoFrames: Int { 20 /*config.videoSampling.maxFrames*/ }
+    var maxVideoFrames: Int { max(config.videoSampling.maxFrames, 1) }
     var targetVideoFPS: Double { Double(config.videoSampling.fps) }
 
     let defaultVideoSystemMessage =
@@ -177,8 +242,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
             for: size, longestEdge: CGFloat(longestEdge), multiple: multiple.flatMap(CGFloat.init))
     }
 
-    /// Tile image if it's larger than the maxProcessingImageSize, so the model gets to see more of it
-    /// TODO: disable in video mode
+    /// Tile image if it's larger than the maxProcessingImageSize, so the model gets to see more of it.
+    /// Video frames are processed through the fixed-size global-frame path instead.
     func tiles(from originalImage: CIImage) -> (tiles: [CIImage], rows: Int, cols: Int) {
         // The original code resizes to maxProcessingImageSize, then resizes again ensuring multiples of fixedImageSize
         // We do both resizes in one go.
@@ -227,7 +292,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
     }
 
     public func prepare(input: UserInput) async throws -> LMInput {
-        let messages = Qwen2VLMessageGenerator().generate(from: input)  // TODO: Create SmolVLM2MessageGenerator
+        let messages = SmolVLM2MessageGenerator().generate(from: input)
 
         if input.images.isEmpty && input.videos.isEmpty {
             // No image scenario
@@ -325,7 +390,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
                 targetFPS: { duration in
                     // 1 fps for duration >= 10s, apply a multiplier if smaller
                     max((10 - 0.9 * duration.seconds) * targetVideoFPS, 1)
-                }
+                },
+                maxFrames: maxVideoFrames
             ) { frame in
 
                 let processedFrame = try frame.image

--- a/Tests/MLXLMTests/VLMProcessorTests.swift
+++ b/Tests/MLXLMTests/VLMProcessorTests.swift
@@ -1,0 +1,238 @@
+import CoreImage
+import CoreMedia
+import Foundation
+import MLXLMCommon
+import XCTest
+
+@testable import MLXVLM
+
+private struct FixedTokenizer: Tokenizer {
+    var encodedTokens: [Int] = [11, 12, 13]
+    var decodedText: String = "User: describe"
+    var tokenIds: [String: Int] = [:]
+    var bosToken: String?
+    var eosToken: String?
+    var unknownToken: String?
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        encodedTokens + text.unicodeScalars.map { Int($0.value % 97) + 1 }
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        decodedText
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        tokenIds[token]
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        tokenIds.first { $0.value == id }?.key
+    }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        encodedTokens
+    }
+}
+
+private func smolProcessorConfig(
+    imageSequenceLength: Int? = 4,
+    maxFrames: Int = 3,
+    fps: Int = 10,
+    imageEdge: Int = 8
+) -> SmolVLMProcessorConfiguration {
+    SmolVLMProcessorConfiguration(
+        imageMean: [0, 0, 0],
+        imageStd: [1, 1, 1],
+        size: .init(longestEdge: imageEdge),
+        maxImageSize: .init(longestEdge: imageEdge),
+        videoSampling: .init(fps: fps, maxFrames: maxFrames),
+        imageSequenceLength: imageSequenceLength)
+}
+
+private func smolProcessorConfigJSON(sequenceKey: String, sequenceLength: Int) -> Data {
+    Data(
+        """
+        {
+          "image_mean": [0.5, 0.5, 0.5],
+          "image_std": [0.25, 0.25, 0.25],
+          "size": { "longest_edge": 16 },
+          "max_image_size": { "longest_edge": 8 },
+          "video_sampling": { "fps": 2, "max_frames": 5 },
+          "\(sequenceKey)": \(sequenceLength)
+        }
+        """.utf8)
+}
+
+private func testImage(edge: CGFloat = 8) -> CIImage {
+    CIImage(color: CIColor(red: 0.5, green: 0.25, blue: 0.75))
+        .cropped(to: CGRect(x: 0, y: 0, width: edge, height: edge))
+}
+
+private func testVideoFrames(count: Int, edge: CGFloat = 8) -> [VideoFrame] {
+    (0 ..< count).map { index in
+        VideoFrame(
+            frame: testImage(edge: edge),
+            timeStamp: CMTime(value: CMTimeValue(index), timescale: 1))
+    }
+}
+
+final class VLMProcessorTests: XCTestCase {
+    func testFastVLMBaseConfigurationExposesCorrectlySpelledModelMaxLength() throws {
+        let data = Data(
+            """
+            {
+              "model_type": "fastvlm",
+              "image_token_index": -200,
+              "eos_token_id": 151645,
+              "mm_projector_type": "mlp2x_gelu",
+              "mm_hidden_size": 1024,
+              "tokenizer_model_max_length": 4096,
+              "tokenizer_padding_side": "right"
+            }
+            """.utf8)
+
+        let config = try JSONDecoder().decode(
+            FastVLMConfiguration.BaseConfiguration.self, from: data)
+
+        XCTAssertEqual(config.tokenizerModelMaxLength, 4096)
+        XCTAssertEqual(config.imageTokenIndex, -200)
+    }
+
+    func testFastVLMTextTokenSplittingTrimsRightPaddingSide() throws {
+        let split = try FastVLM.splitTextTokensForMultimodal(
+            inputIds: [1, 2, -200, 3, 4, 5],
+            imageTokenId: -200,
+            imageLength: 3,
+            maxLength: 6,
+            paddingSide: "right")
+
+        XCTAssertEqual(split.beforeTokens, [1, 2])
+        XCTAssertEqual(split.afterTokens, [3])
+    }
+
+    func testFastVLMTextTokenSplittingTrimsLeftPaddingSide() throws {
+        let split = try FastVLM.splitTextTokensForMultimodal(
+            inputIds: [1, 2, -200, 3, 4, 5],
+            imageTokenId: -200,
+            imageLength: 3,
+            maxLength: 6,
+            paddingSide: "left")
+
+        XCTAssertEqual(split.beforeTokens, [])
+        XCTAssertEqual(split.afterTokens, [3, 4, 5])
+    }
+
+    func testFastVLMTextTokenSplittingRequiresImageToken() {
+        XCTAssertThrowsError(
+            try FastVLM.splitTextTokensForMultimodal(
+                inputIds: [1, 2, 3],
+                imageTokenId: -200,
+                imageLength: 2,
+                maxLength: 8,
+                paddingSide: "right")
+        ) { error in
+            guard case VLMError.processing(let message) = error else {
+                return XCTFail("Expected VLMError.processing, got \(error)")
+            }
+            XCTAssertTrue(message.contains("missing image token"))
+        }
+    }
+
+    func testFastVLMTextTokenSplittingRejectsOversizedImageBlock() {
+        XCTAssertThrowsError(
+            try FastVLM.splitTextTokensForMultimodal(
+                inputIds: [1, -200, 2],
+                imageTokenId: -200,
+                imageLength: 9,
+                maxLength: 8,
+                paddingSide: "right")
+        ) { error in
+            guard case VLMError.processing(let message) = error else {
+                return XCTFail("Expected VLMError.processing, got \(error)")
+            }
+            XCTAssertTrue(message.contains("exceed tokenizer_model_max_length"))
+        }
+    }
+
+    func testSmolVLMProcessorConfigurationDecodesImageSequenceLengthAliases() throws {
+        let decoder = JSONDecoder()
+
+        let imageSeqLen = try decoder.decode(
+            SmolVLMProcessorConfiguration.self,
+            from: smolProcessorConfigJSON(sequenceKey: "image_seq_len", sequenceLength: 81))
+        let imageSequenceLength = try decoder.decode(
+            SmolVLMProcessorConfiguration.self,
+            from: smolProcessorConfigJSON(sequenceKey: "image_sequence_length", sequenceLength: 82))
+        let imageSequenceLen = try decoder.decode(
+            SmolVLMProcessorConfiguration.self,
+            from: smolProcessorConfigJSON(sequenceKey: "image_sequence_len", sequenceLength: 83))
+
+        XCTAssertEqual(imageSeqLen.imageSequenceLength, 81)
+        XCTAssertEqual(imageSequenceLength.imageSequenceLength, 82)
+        XCTAssertEqual(imageSequenceLen.imageSequenceLength, 83)
+    }
+
+    func testSmolVLMProcessorConfigurationRejectsNonPositiveImageSequenceLength() {
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(
+                SmolVLMProcessorConfiguration.self,
+                from: smolProcessorConfigJSON(sequenceKey: "image_seq_len", sequenceLength: 0)))
+    }
+
+    func testSmolVLMMessageGeneratorUsesSmolMediaOrdering() throws {
+        let input = UserInput(
+            prompt: "Describe the media.",
+            images: [.ciImage(testImage())],
+            videos: [.frames(testVideoFrames(count: 1))])
+
+        let message = try XCTUnwrap(SmolVLM2MessageGenerator().generate(from: input).first)
+        XCTAssertEqual(message["role"] as? String, "user")
+        let content = try XCTUnwrap(message["content"] as? [[String: any Sendable]])
+
+        XCTAssertEqual(content.count, 3)
+        XCTAssertEqual(content[0]["type"] as? String, "image")
+        XCTAssertEqual(content[1]["type"] as? String, "video")
+        XCTAssertEqual(content[2]["type"] as? String, "text")
+        XCTAssertEqual(content[2]["text"] as? String, "Describe the media.")
+    }
+
+    func testSmolVLMProcessorUsesTokenizerImageTokenIdWithFallback() {
+        let config = smolProcessorConfig()
+        let mappedProcessor = SmolVLMProcessor(
+            config, tokenizer: FixedTokenizer(tokenIds: ["<image>": 777]))
+        let fallbackProcessor = SmolVLMProcessor(config, tokenizer: FixedTokenizer())
+
+        XCTAssertEqual(mappedProcessor.imageTokenId, 777)
+        XCTAssertEqual(fallbackProcessor.imageTokenId, 49190)
+    }
+
+    func testSmolVLMProcessorClampsConfiguredVideoFramesToAtLeastOne() {
+        let processor = SmolVLMProcessor(
+            smolProcessorConfig(maxFrames: 0),
+            tokenizer: FixedTokenizer())
+
+        XCTAssertEqual(processor.maxVideoFrames, 1)
+    }
+
+    func testMediaProcessingSampledFrameCountHonorsMaxFramesForInMemoryVideoFrames() {
+        let duration = CMTime(value: 9, timescale: 1)
+
+        XCTAssertEqual(
+            MediaProcessing.sampledFrameCount(
+                fps: 30, duration: duration, maxFrames: 3, availableFrames: 10),
+            3)
+        XCTAssertEqual(
+            MediaProcessing.sampledFrameCount(
+                fps: 30, duration: duration, maxFrames: 12, availableFrames: 10),
+            10)
+        XCTAssertEqual(
+            MediaProcessing.sampledFrameCount(
+                fps: 30, duration: duration, maxFrames: 0, availableFrames: 10),
+            1)
+    }
+}

--- a/Tests/MLXLMTests/VLMProcessorTests.swift
+++ b/Tests/MLXLMTests/VLMProcessorTests.swift
@@ -10,6 +10,7 @@ private struct FixedTokenizer: Tokenizer {
     var encodedTokens: [Int] = [11, 12, 13]
     var decodedText: String = "User: describe"
     var tokenIds: [String: Int] = [:]
+    var returnsUnknownTokenIdForMissingTokens = false
     var bosToken: String?
     var eosToken: String?
     var unknownToken: String?
@@ -23,7 +24,13 @@ private struct FixedTokenizer: Tokenizer {
     }
 
     func convertTokenToId(_ token: String) -> Int? {
-        tokenIds[token]
+        if let tokenId = tokenIds[token] {
+            return tokenId
+        }
+        guard returnsUnknownTokenIdForMissingTokens, let unknownToken else {
+            return nil
+        }
+        return tokenIds[unknownToken]
     }
 
     func convertIdToToken(_ id: Int) -> String? {
@@ -206,9 +213,16 @@ final class VLMProcessorTests: XCTestCase {
         let mappedProcessor = SmolVLMProcessor(
             config, tokenizer: FixedTokenizer(tokenIds: ["<image>": 777]))
         let fallbackProcessor = SmolVLMProcessor(config, tokenizer: FixedTokenizer())
+        let unknownFallbackProcessor = SmolVLMProcessor(
+            config,
+            tokenizer: FixedTokenizer(
+                tokenIds: ["<unk>": 102],
+                returnsUnknownTokenIdForMissingTokens: true,
+                unknownToken: "<unk>"))
 
         XCTAssertEqual(mappedProcessor.imageTokenId, 777)
         XCTAssertEqual(fallbackProcessor.imageTokenId, 49190)
+        XCTAssertEqual(unknownFallbackProcessor.imageTokenId, 49190)
     }
 
     func testSmolVLMProcessorClampsConfiguredVideoFramesToAtLeastOne() {
@@ -234,5 +248,24 @@ final class VLMProcessorTests: XCTestCase {
             MediaProcessing.sampledFrameCount(
                 fps: 30, duration: duration, maxFrames: 0, availableFrames: 10),
             1)
+        XCTAssertEqual(
+            MediaProcessing.sampledFrameCount(
+                fps: 30, duration: duration, maxFrames: 3, availableFrames: 0),
+            0)
+    }
+
+    func testMediaProcessingRejectsEmptyInMemoryVideoFrames() async {
+        do {
+            _ = try await MediaProcessing.asProcessedSequence(
+                .frames([]),
+                targetFPS: { _ in 30 },
+                maxFrames: 3)
+            XCTFail("Expected empty video frames to throw")
+        } catch {
+            guard case VLMError.processing(let message) = error else {
+                return XCTFail("Expected VLMError.processing, got \(error)")
+            }
+            XCTAssertTrue(message.contains("at least one frame"))
+        }
     }
 }

--- a/Tests/MLXLMTests/VLMProcessorTests.swift
+++ b/Tests/MLXLMTests/VLMProcessorTests.swift
@@ -10,6 +10,7 @@ private struct FixedTokenizer: Tokenizer {
     var encodedTokens: [Int] = [11, 12, 13]
     var decodedText: String = "User: describe"
     var tokenIds: [String: Int] = [:]
+    var returnsUnknownTokenIdForMissingTokens = false
     var bosToken: String?
     var eosToken: String?
     var unknownToken: String?
@@ -23,7 +24,13 @@ private struct FixedTokenizer: Tokenizer {
     }
 
     func convertTokenToId(_ token: String) -> Int? {
-        tokenIds[token]
+        if let tokenId = tokenIds[token] {
+            return tokenId
+        }
+        guard returnsUnknownTokenIdForMissingTokens, let unknownToken else {
+            return nil
+        }
+        return tokenIds[unknownToken]
     }
 
     func convertIdToToken(_ id: Int) -> String? {
@@ -206,9 +213,16 @@ final class VLMProcessorTests: XCTestCase {
         let mappedProcessor = SmolVLMProcessor(
             config, tokenizer: FixedTokenizer(tokenIds: ["<image>": 777]))
         let fallbackProcessor = SmolVLMProcessor(config, tokenizer: FixedTokenizer())
+        let unknownFallbackProcessor = SmolVLMProcessor(
+            config,
+            tokenizer: FixedTokenizer(
+                tokenIds: ["<unk>": 102],
+                returnsUnknownTokenIdForMissingTokens: true,
+                unknownToken: "<unk>"))
 
         XCTAssertEqual(mappedProcessor.imageTokenId, 777)
         XCTAssertEqual(fallbackProcessor.imageTokenId, 49190)
+        XCTAssertEqual(unknownFallbackProcessor.imageTokenId, 49190)
     }
 
     func testSmolVLMProcessorClampsConfiguredVideoFramesToAtLeastOne() {
@@ -223,16 +237,45 @@ final class VLMProcessorTests: XCTestCase {
         let duration = CMTime(value: 9, timescale: 1)
 
         XCTAssertEqual(
-            MediaProcessing.sampledFrameCount(
-                fps: 30, duration: duration, maxFrames: 3, availableFrames: 10),
+            MediaProcessing.sampleTimes(
+                duration: duration, processing: .init(), targetFPS: { _ in 30 },
+                maxFrames: 3, totalAvailableFrames: 10
+            ).count,
             3)
         XCTAssertEqual(
-            MediaProcessing.sampledFrameCount(
-                fps: 30, duration: duration, maxFrames: 12, availableFrames: 10),
+            MediaProcessing.sampleTimes(
+                duration: duration, processing: .init(), targetFPS: { _ in 30 },
+                maxFrames: 12, totalAvailableFrames: 10
+            ).count,
             10)
         XCTAssertEqual(
-            MediaProcessing.sampledFrameCount(
-                fps: 30, duration: duration, maxFrames: 0, availableFrames: 10),
+            MediaProcessing.sampleTimes(
+                duration: duration, processing: .init(), targetFPS: { _ in 30 },
+                maxFrames: 0, totalAvailableFrames: 10
+            ).count,
             1)
+    }
+
+    func testMediaProcessingLimitsInMemoryVideoFrames() async throws {
+        let result = try await MediaProcessing.asProcessedSequence(
+            .frames(testVideoFrames(count: 10)),
+            targetFPS: { _ in 30 },
+            maxFrames: 3)
+        XCTAssertEqual(result.frames.count, 3)
+    }
+
+    func testMediaProcessingRejectsEmptyInMemoryVideoFrames() async {
+        do {
+            _ = try await MediaProcessing.asProcessedSequence(
+                .frames([]),
+                targetFPS: { _ in 30 },
+                maxFrames: 3)
+            XCTFail("Expected empty video frames to throw")
+        } catch {
+            guard case VLMError.processing(let message) = error else {
+                return XCTFail("Expected VLMError.processing, got \(error)")
+            }
+            XCTAssertTrue(message.contains("at least one frame"))
+        }
     }
 }


### PR DESCRIPTION
## Summary

Complete the FastVLM and SmolVLM2 processor TODOs so their processor configuration paths are implemented instead of placeholder behavior.

## Changes

- Wire FastVLM multimodal token splitting through `tokenizer_model_max_length`, tokenizer padding side, and explicit missing-image-token validation.
- Complete SmolVLM2 processor configuration handling for image sequence-length aliases, validation, media ordering, tokenizer image-token lookup, and bounded video-frame settings.
- Fix in-memory `UserInput.Video.frames` processing so `maxFrames` is honored consistently with asset-backed videos.
- Add focused VLM processor regression coverage for the completed behavior.

## Validation

- `pre-commit run --all-files`
- `swift build --target MLXVLM`
- `swift test --filter VLMProcessorTests`
- `swift test --filter SmolVLM2TilingTests`
- `swift test --filter UserInputTests`
- `xcodebuild build-for-testing -scheme mlx-swift-lm-Package -destination 'platform=macOS'`
- `xcrun xctest ~/Library/Developer/Xcode/DerivedData/mlx-swift-lm-vlm-processors-*/Build/Products/Debug/MLXLMTests.xctest`
