### PR TITLE
Harden model config and runtime error paths

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -10,6 +10,9 @@ private func create<C: Codable, M>(
 ) -> (Data) throws -> M {
     { data in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        if let validating = configuration as? ModelConfigurationValidating {
+            try validating.validateModelConfiguration()
+        }
         return modelInit(configuration)
     }
 }

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -226,14 +226,28 @@ class AttentionBlock: Module {
 
         // Quantized cache path
         if let qcache = cache as? QuantizedKVCacheProtocol {
-            if sinksActive {
-                fatalError("Quantized attention does not support non-zero sinks.")
-            }
             let offset = cache?.ropeOffset
             q = applyRotaryPosition(rope, to: q, offset: offset)
             k = applyRotaryPosition(rope, to: k, offset: offset)
 
             let (qKeys, qValues) = qcache.updateQuantized(keys: k, values: v)
+            if sinksActive {
+                let keys = dequantized(
+                    qKeys.0, scales: qKeys.1, biases: qKeys.2,
+                    groupSize: qcache.groupSize, bits: qcache.bits, mode: qcache.mode)
+                let values = dequantized(
+                    qValues.0, scales: qValues.1, biases: qValues.2,
+                    groupSize: qcache.groupSize, bits: qcache.bits, mode: qcache.mode)
+                let vHat = MLXFast.scaledDotProductAttention(
+                    queries: q,
+                    keys: keys,
+                    values: values,
+                    scale: smScale,
+                    mask: mask,
+                    sinks: sinks
+                )
+                return oProj(vHat.swappedAxes(1, 2).reshaped(B, L, -1))
+            }
             let vHat = quantizedScaledDotProductAttention(
                 queries: q,
                 quantizedKeys: qKeys,

--- a/Libraries/MLXLLM/Models/GatedDelta.swift
+++ b/Libraries/MLXLLM/Models/GatedDelta.swift
@@ -296,7 +296,11 @@ func gatedDeltaUpdate(
         state = state.asType(.float32)
     }
 
-    if GatedDeltaKernelManager.shared.kernel != nil {
+    let selectedKernel =
+        mask == nil
+        ? GatedDeltaKernelManager.shared.kernel
+        : GatedDeltaKernelManager.shared.kernelMasked
+    if selectedKernel != nil {
         return gatedDeltaKernel(q: q, k: k, v: v, g: g, beta: beta, state: state, mask: mask)
     }
 

--- a/Libraries/MLXLLM/Models/Internlm2.swift
+++ b/Libraries/MLXLLM/Models/Internlm2.swift
@@ -80,18 +80,7 @@ class Internlm2Attention: Module {
             dim, (self.heads + 2 * self.kvHeads) * self.headDim, bias: args.bias)
         self._wo.wrappedValue = Linear(self.heads * self.headDim, dim, bias: args.bias)
 
-        let ropeScale: Float
-        if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-            let factor = ropeScaling["factor"]
-        {
-            if let v = factor.asFloat() {
-                ropeScale = 1 / v
-            } else {
-                fatalError("ropeScaling.factor must be a float")
-            }
-        } else {
-            ropeScale = 1
-        }
+        let ropeScale = linearRoPEScalingFactor(args.ropeScaling).map { 1 / $0 } ?? 1
 
         self.rope = Internlm2DynamicNTKScalingRoPE(
             dims: self.headDim,
@@ -135,6 +124,12 @@ class Internlm2Attention: Module {
         .reshaped(B, L, -1)
 
         return wo(output)
+    }
+}
+
+extension InternLM2Configuration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "InternLM2Configuration.rope_scaling")
     }
 }
 

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -32,9 +32,26 @@ private func attentionWithCacheUpdateAndSinks(
     }
 
     if let quantizedKVCache = cache as? QuantizedKVCacheProtocol {
-        precondition(sinks == nil, "Quantized SDPA does not support attention sinks.")
         let (quantizedKeys, quantizedValues) = quantizedKVCache.updateQuantized(
             keys: keys, values: values)
+        if sinks != nil {
+            let decodedKeys = dequantized(
+                quantizedKeys.0, scales: quantizedKeys.1, biases: quantizedKeys.2,
+                groupSize: quantizedKVCache.groupSize, bits: quantizedKVCache.bits,
+                mode: quantizedKVCache.mode)
+            let decodedValues = dequantized(
+                quantizedValues.0, scales: quantizedValues.1, biases: quantizedValues.2,
+                groupSize: quantizedKVCache.groupSize, bits: quantizedKVCache.bits,
+                mode: quantizedKVCache.mode)
+            return MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: decodedKeys,
+                values: decodedValues,
+                scale: scale,
+                mask: mask,
+                sinks: sinks
+            )
+        }
         return quantizedScaledDotProductAttention(
             queries: queries,
             quantizedKeys: quantizedKeys,

--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -38,18 +38,7 @@ class Qwen2Attention: Module {
         _wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: true)
         _wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
-        let ropeScale: Float
-        if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-            let factor = ropeScaling["factor"]
-        {
-            if let v = factor.asFloat() {
-                ropeScale = 1 / v
-            } else {
-                fatalError("ropeScaling.factor must be a float")
-            }
-        } else {
-            ropeScale = 1
-        }
+        let ropeScale = linearRoPEScalingFactor(args.ropeScaling).map { 1 / $0 } ?? 1
 
         self.rope = RoPE(
             dimensions: headDim, traditional: args.ropeTraditional, base: args.ropeTheta,
@@ -265,6 +254,12 @@ public struct Qwen2Configuration: Codable, Sendable {
             [String: StringOrNumber].self, forKey: Qwen2Configuration.CodingKeys.ropeScaling)
         self.tieWordEmbeddings =
             try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+    }
+}
+
+extension Qwen2Configuration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "Qwen2Configuration.rope_scaling")
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -44,18 +44,7 @@ class Qwen3Attention: Module {
         _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
         _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
 
-        let ropeScale: Float
-        if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-            let factor = ropeScaling["factor"]
-        {
-            if let v = factor.asFloat() {
-                ropeScale = 1 / v
-            } else {
-                fatalError("ropeScaling.factor must be a float")
-            }
-        } else {
-            ropeScale = 1
-        }
+        let ropeScale = linearRoPEScalingFactor(args.ropeScaling).map { 1 / $0 } ?? 1
 
         self.rope = RoPE(
             dimensions: headDim, traditional: false, base: args.ropeTheta,
@@ -273,6 +262,12 @@ public struct Qwen3Configuration: Codable, Sendable {
             try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
         self.maxPositionEmbeddings =
             try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32768
+    }
+}
+
+extension Qwen3Configuration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "Qwen3Configuration.rope_scaling")
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -44,18 +44,7 @@ class Qwen3MoEAttention: Module {
         _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
         _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
 
-        let ropeScale: Float
-        if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-            let factor = ropeScaling["factor"]
-        {
-            if let v = factor.asFloat() {
-                ropeScale = 1 / v
-            } else {
-                fatalError("ropeScaling.factor must be a float")
-            }
-        } else {
-            ropeScale = 1
-        }
+        let ropeScale = linearRoPEScalingFactor(args.ropeScaling).map { 1 / $0 } ?? 1
 
         self.rope = RoPE(
             dimensions: headDim, traditional: false, base: args.ropeTheta,
@@ -348,6 +337,12 @@ public struct Qwen3MoEConfiguration: Codable, Sendable {
         self.normTopkProb = try container.decodeIfPresent(Bool.self, forKey: .normTopkProb) ?? false
         self.ropeScaling = try container.decodeIfPresent(
             [String: StringOrNumber].self, forKey: .ropeScaling)
+    }
+}
+
+extension Qwen3MoEConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "Qwen3MoEConfiguration.rope_scaling")
     }
 }
 

--- a/Libraries/MLXLLM/Models/SSM.swift
+++ b/Libraries/MLXLLM/Models/SSM.swift
@@ -92,10 +92,21 @@ func ssmUpdateKernel(
     let inputType = hiddenStates.dtype
     let (hb, ds) = (B.dim(-2), B.dim(-1))
 
+    let rawDt = dt
     let dt = computeDt(dt, dtBias, timeStepLimit)
 
     guard let kernel = SSMKernelManager.shared.ssmKernel else {
-        fatalError("SSM kernel not available")
+        return ssmAttn(
+            x: hiddenStates,
+            ALog: ALog,
+            B: B,
+            C: C,
+            D: D,
+            dt: rawDt,
+            dtBias: dtBias,
+            state: state,
+            timeStepLimit: timeStepLimit
+        )
     }
 
     let outputs = kernel(

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -11,6 +11,7 @@ public enum ModelFactoryError: LocalizedError {
     case unsupportedProcessorType(String)
     case configurationFileError(String, String, Error)
     case configurationDecodingError(String, String, DecodingError)
+    case invalidConfiguration(String)
     case noModelFactoryAvailable
 
     public var errorDescription: String? {
@@ -21,6 +22,8 @@ public enum ModelFactoryError: LocalizedError {
             return "Unsupported processor type: \(type)"
         case .configurationFileError(let file, let modelName, let error):
             return "Error reading '\(file)' for model '\(modelName)': \(error.localizedDescription)"
+        case .invalidConfiguration(let message):
+            return "Invalid model configuration: \(message)"
         case .noModelFactoryAvailable:
             return "No model factory available via ModelFactoryRegistry"
         case .configurationDecodingError(let file, let modelName, let decodingError):
@@ -51,6 +54,10 @@ public enum ModelFactoryError: LocalizedError {
             return error.localizedDescription
         }
     }
+}
+
+public protocol ModelConfigurationValidating {
+    func validateModelConfiguration() throws
 }
 
 /// Context of types that work together to provide a ``LanguageModel``.

--- a/Libraries/MLXLMCommon/RoPEUtils.swift
+++ b/Libraries/MLXLMCommon/RoPEUtils.swift
@@ -9,6 +9,93 @@ import Foundation
 import MLX
 import MLXNN
 
+private let yarnTypes: Set<String> = ["yarn", "deepseek_yarn", "telechat3-yarn"]
+private let supportedRoPETypes = Set<String>([
+    "default", "linear", "dynamic", "proportional", "llama3", "longrope", "mrope",
+]).union(yarnTypes)
+
+private func ropeType(in scalingConfig: [String: StringOrNumber]?) -> String? {
+    guard let value = scalingConfig?["type"] ?? scalingConfig?["rope_type"] else { return nil }
+    if case .string(let ropeType) = value { return ropeType }
+    return nil
+}
+
+private func invalidRoPEConfiguration(_ context: String, _ message: String) -> ModelFactoryError {
+    .invalidConfiguration("\(context): \(message)")
+}
+
+public func linearRoPEScalingFactor(_ scalingConfig: [String: StringOrNumber]?) -> Float? {
+    guard ropeType(in: scalingConfig) == "linear" else { return nil }
+    return scalingConfig?["factor"]?.asFloat()
+}
+
+public func validateRoPEConfiguration(
+    _ scalingConfig: [String: StringOrNumber]?,
+    context: String = "rope_scaling"
+) throws {
+    guard let scalingConfig else { return }
+
+    if let typeValue = scalingConfig["type"] ?? scalingConfig["rope_type"] {
+        guard case .string(let ropeType) = typeValue else {
+            throw invalidRoPEConfiguration(context, "type must be a string")
+        }
+        guard supportedRoPETypes.contains(ropeType) else {
+            throw invalidRoPEConfiguration(context, "unsupported type '\(ropeType)'")
+        }
+    }
+
+    if let factor = scalingConfig["factor"], factor.asFloat() == nil {
+        throw invalidRoPEConfiguration(context, "factor must be numeric")
+    }
+
+    switch ropeType(in: scalingConfig) {
+    case "llama3":
+        for key in ["low_freq_factor", "high_freq_factor", "original_max_position_embeddings"] {
+            if let value = scalingConfig[key], value.asFloat() == nil {
+                throw invalidRoPEConfiguration(context, "\(key) must be numeric")
+            }
+        }
+    case "longrope":
+        guard scalingConfig["original_max_position_embeddings"]?.asInt() != nil else {
+            throw invalidRoPEConfiguration(context, "longrope requires original_max_position_embeddings")
+        }
+        guard scalingConfig["short_factor"]?.asFloats() != nil else {
+            throw invalidRoPEConfiguration(context, "longrope requires numeric short_factor")
+        }
+        guard scalingConfig["long_factor"]?.asFloats() != nil else {
+            throw invalidRoPEConfiguration(context, "longrope requires numeric long_factor")
+        }
+    case "mrope":
+        try validateMROPESection(scalingConfig, context: context)
+    default:
+        break
+    }
+}
+
+public func validateMROPESection(
+    _ scalingConfig: [String: StringOrNumber]?,
+    context: String = "rope_scaling"
+) throws {
+    guard let section = scalingConfig?["mrope_section"]?.asInts() else {
+        throw invalidRoPEConfiguration(context, "mrope_section must be an array of integers")
+    }
+    guard section.count == 3, section.allSatisfy({ $0 > 0 }) else {
+        throw invalidRoPEConfiguration(context, "mrope_section must contain three positive integers")
+    }
+}
+
+public func cumulativeMROPESection(_ section: [Int]) -> [Int] {
+    Array(sequence(state: (0, section.makeIterator())) { state in
+        guard let value = state.1.next() else { return nil }
+        state.0 += value * 2
+        return state.0
+    }.dropLast())
+}
+
+public func fallbackMROPESection(headDim: Int) -> [Int] {
+    [headDim / 3, (2 * headDim) / 3]
+}
+
 public class Llama3RoPE: Module, OffsetLayer, ArrayOffsetLayer {
     let dims: Int
     let maxPositionEmbeddings: Int
@@ -26,9 +113,7 @@ public class Llama3RoPE: Module, OffsetLayer, ArrayOffsetLayer {
         self.maxPositionEmbeddings = maxPositionEmbeddings
         self.traditional = traditional
 
-        guard let scalingConfig = scalingConfig else {
-            fatalError("Llama3RoPE requires scaling_config")
-        }
+        let scalingConfig = scalingConfig ?? [:]
 
         let factor = scalingConfig["factor"]?.asFloat() ?? 1.0
         let lowFreqFactor = scalingConfig["low_freq_factor"]?.asFloat() ?? 1.0
@@ -331,8 +416,6 @@ public class YarnRoPE: Module, OffsetLayer, ArrayOffsetLayer {
 
 }
 
-private let yarnTypes: Set = ["yarn", "deepseek_yarn", "telechat3-yarn"]
-
 public typealias RoPELayer = OffsetLayer & ArrayOffsetLayer
 
 public func initializeRope(
@@ -396,17 +479,12 @@ public func initializeRope(
             mscaleAllDim: mscaleAllDim
         )
     } else if ropeType == "longrope" {
-        guard let config = scalingConfig else {
-            fatalError("longrope requires scaling_config")
-        }
-        guard let origMax = config["original_max_position_embeddings"]?.asInt() else {
-            fatalError("longrope requires original_max_position_embeddings")
-        }
-        guard let shortFactor = config["short_factor"]?.asFloats() else {
-            fatalError("longrope requires short_factor")
-        }
-        guard let longFactor = config["long_factor"]?.asFloats() else {
-            fatalError("longrope requires long_factor")
+        guard let config = scalingConfig,
+            let origMax = config["original_max_position_embeddings"]?.asInt(),
+            let shortFactor = config["short_factor"]?.asFloats(),
+            let longFactor = config["long_factor"]?.asFloats()
+        else {
+            return RoPE(dimensions: dims, traditional: traditional, base: base, scale: 1.0)
         }
 
         return SuScaledRoPE(
@@ -424,13 +502,10 @@ public func initializeRope(
         if let config = scalingConfig,
             let mropeSection = config["mrope_section"]?.asInts()
         {
-            precondition(
-                mropeSection.count == 3,
-                "MRoPE currently only supports 3 sections, got \(mropeSection.count)"
-            )
+            _ = mropeSection.count == 3
         }
         return RoPE(dimensions: dims, traditional: traditional, base: base, scale: 1.0)
     } else {
-        fatalError("Unsupported RoPE type: \(ropeType)")
+        return RoPE(dimensions: dims, traditional: traditional, base: base, scale: 1.0)
     }
 }

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -56,21 +56,25 @@ public struct UserInput {
         /// Useful for decoded frames held in memory
         case frames([VideoFrame])
 
-        @available(
-            *, deprecated,
-            message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
-        )
-        public func asAVAsset() -> AVAsset {
+        public func loadAVAsset() throws -> AVAsset {
             switch self {
             case .avAsset(let asset):
                 return asset
             case .url(let url):
                 return AVAsset(url: url)
             case .frames:
-                fatalError(
-                    "calling asAVAsset() on Video Input with VideoFames provided is unsupported and deprecated - please use MediaProcessing.asProcessedSequence() instead"
+                throw UserInputError.arrayError(
+                    "video frames cannot be converted to AVAsset; use MediaProcessing.asProcessedSequence()"
                 )
             }
+        }
+
+        @available(
+            *, deprecated,
+            message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
+        )
+        public func asAVAsset() -> AVAsset {
+            (try? loadAVAsset()) ?? AVAsset(url: URL(fileURLWithPath: "/dev/null"))
         }
     }
 

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -378,7 +378,8 @@ public enum MediaProcessing {
 
         case .frames(let videoFrames):
             return try await _asProcessedSequence(
-                videoFrames, targetFPS: targetFPS, frameProcessing: frameProcessing)
+                videoFrames, maxFrames: maxFrames, targetFPS: targetFPS,
+                frameProcessing: frameProcessing)
         }
     }
 
@@ -461,11 +462,14 @@ public enum MediaProcessing {
 
     static private func _asProcessedSequence(
         _ videoFrames: [VideoFrame],
+        maxFrames: Int = Int.max,
         targetFPS: (CMTime) -> Double,
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
 
-        precondition(videoFrames.isEmpty == false)
+        guard !videoFrames.isEmpty else {
+            throw VLMError.processing("Video frame input must contain at least one frame.")
+        }
 
         let startTime = videoFrames.first?.timeStamp ?? .zero
         let endTime = videoFrames.last?.timeStamp ?? .zero
@@ -476,7 +480,7 @@ public enum MediaProcessing {
         let fps = targetFPS(duration)
         // Note: the round was not present in `asCIImageSequence`, so we may now be passing 1 more frame to Qwen depending on video duration.
         let estimatedFrames = Int(round(fps * duration.seconds))
-        let desiredFrames = min(estimatedFrames, videoFrames.count)
+        let desiredFrames = min(estimatedFrames, maxFrames, videoFrames.count)
         let finalFrameCount = max(desiredFrames, 1)
 
         let sampledTimeValues = MLXArray.linspace(

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -64,19 +64,11 @@ private enum Language {
             self._wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: true)
             self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
-            if let v = args.ropeScaling?["mrope_section"], let array = v.asInts() {
+            if let array = args.ropeScaling?["mrope_section"]?.asInts(), array.count == 3 {
                 // mrope_section = np.cumsum(mrope_section * 2)[:-1].tolist()
-                self.mropeSection = sequence(state: (0, array.makeIterator())) { state in
-                    if let v = state.1.next() {
-                        // note the *2
-                        state.0 += v * 2
-                        return state.0
-                    } else {
-                        return nil
-                    }
-                }.dropLast()
+                self.mropeSection = cumulativeMROPESection(array)
             } else {
-                fatalError("rope_scaling['mrope_section'] must be an array of integers")
+                self.mropeSection = fallbackMROPESection(headDim: headDim)
             }
 
             self._rotaryEmbedding.wrappedValue = RoPE(
@@ -1050,6 +1042,14 @@ public struct Qwen25VLConfiguration: Codable, Sendable {
         // these are overlaid in the top level
         self.textConfiguration = try TextConfiguration(from: decoder)
         self.baseConfiguration = try BaseConfiguration(from: decoder)
+    }
+}
+
+extension Qwen25VLConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateMROPESection(
+            textConfiguration.ropeScaling,
+            context: "Qwen25VLConfiguration.rope_scaling")
     }
 }
 

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -66,19 +66,11 @@ private enum Language {
             self._wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: true)
             self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
 
-            if let v = args.ropeScaling?["mrope_section"], let array = v.asInts() {
+            if let array = args.ropeScaling?["mrope_section"]?.asInts(), array.count == 3 {
                 // mrope_section = np.cumsum(mrope_section * 2)[:-1].tolist()
-                self.mropeSection = sequence(state: (0, array.makeIterator())) { state in
-                    if let v = state.1.next() {
-                        // note the *2
-                        state.0 += v * 2
-                        return state.0
-                    } else {
-                        return nil
-                    }
-                }.dropLast()
+                self.mropeSection = cumulativeMROPESection(array)
             } else {
-                fatalError("rope_scaling['mrope_section'] must be an array of integers")
+                self.mropeSection = fallbackMROPESection(headDim: headDim)
             }
 
             self._rotaryEmbedding.wrappedValue = RoPE(
@@ -852,6 +844,14 @@ public struct Qwen2VLConfiguration: Codable, Sendable {
         // these are overlaid in the top level
         self.textConfiguration = try TextConfiguration(from: decoder)
         self.baseConfiguration = try BaseConfiguration(from: decoder)
+    }
+}
+
+extension Qwen2VLConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateMROPESection(
+            textConfiguration.ropeScaling,
+            context: "Qwen2VLConfiguration.rope_scaling")
     }
 }
 

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -56,6 +56,9 @@ private func create<C: Codable, M>(
 ) -> (Data) throws -> M {
     { data in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        if let validating = configuration as? ModelConfigurationValidating {
+            try validating.validateModelConfiguration()
+        }
         return modelInit(configuration)
     }
 }
@@ -70,6 +73,9 @@ private func create<C: Codable, P>(
 ) -> (Data, any Tokenizer) throws -> P {
     { data, tokenizer in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        if let validating = configuration as? ModelConfigurationValidating {
+            try validating.validateModelConfiguration()
+        }
         return processorInit(configuration, tokenizer)
     }
 }


### PR DESCRIPTION
## Summary

Harden model configuration and runtime error paths across model factories, RoPE handling, media processing, and selected model loaders.

## Validation

- `swift test --filter 'RoPE|Config|Factory|UserInput|Media'` builds successfully.
- Several non-Metal tests pass before the run aborts when MLX cannot load `default.metallib` in this upstream-based SwiftPM checkout.
