### PR TITLE
Add TurboQuant KV cache strategy

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -78,6 +78,9 @@ public struct GenerateParameters: Sendable {
     /// TurboQuant preset used when ``kvCacheStrategy`` is ``KVCacheStrategy/turboQuant``.
     public var turboQuantPreset: TurboQuantPreset
 
+    /// TurboQuant backend requested when ``kvCacheStrategy`` is ``KVCacheStrategy/turboQuant``.
+    public var turboQuantBackend: TurboQuantBackend
+
     /// Sampling temperature
     public var temperature: Float
 
@@ -116,6 +119,7 @@ public struct GenerateParameters: Sendable {
         quantizedKVStart: Int = 0,
         kvCacheStrategy: KVCacheStrategy = .mlxAffine,
         turboQuantPreset: TurboQuantPreset = .turbo3_5,
+        turboQuantBackend: TurboQuantBackend = .mlxPacked,
         temperature: Float = 0.6,
         topP: Float = 1.0,
         topK: Int = 0,
@@ -135,6 +139,7 @@ public struct GenerateParameters: Sendable {
         self.quantizedKVStart = quantizedKVStart
         self.kvCacheStrategy = kvCacheStrategy
         self.turboQuantPreset = turboQuantPreset
+        self.turboQuantBackend = turboQuantBackend
         self.temperature = temperature
         self.topP = topP
         self.topK = topK
@@ -548,6 +553,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     let quantizedKVStart: Int
     let kvCacheStrategy: KVCacheStrategy
     let turboQuantPreset: TurboQuantPreset
+    let turboQuantBackend: TurboQuantBackend
 
     // Internal metrics
     public var promptPrefillTime: TimeInterval = 0.0
@@ -578,6 +584,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.quantizedKVStart = parameters.quantizedKVStart
         self.kvCacheStrategy = parameters.kvCacheStrategy
         self.turboQuantPreset = parameters.turboQuantPreset
+        self.turboQuantBackend = parameters.turboQuantBackend
 
         self.promptPrefillTime = try measure {
             try prepare(input: .init(text: y), windowSize: parameters.prefillStepSize)
@@ -613,6 +620,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.quantizedKVStart = parameters.quantizedKVStart
         self.kvCacheStrategy = parameters.kvCacheStrategy
         self.turboQuantPreset = parameters.turboQuantPreset
+        self.turboQuantBackend = parameters.turboQuantBackend
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: parameters.prefillStepSize)
@@ -648,6 +656,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.quantizedKVStart = 0
         self.kvCacheStrategy = .none
         self.turboQuantPreset = .turbo3_5
+        self.turboQuantBackend = .mlxPacked
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: prefillStepSize)
@@ -700,7 +709,8 @@ public struct TokenIterator: TokenIteratorProtocol {
             kvGroupSize: kvGroupSize,
             quantizedKVStart: quantizedKVStart,
             kvCacheStrategy: kvCacheStrategy,
-            turboQuantPreset: turboQuantPreset
+            turboQuantPreset: turboQuantPreset,
+            turboQuantBackend: turboQuantBackend
         )
 
         return convertToToken(logits: result.logits)
@@ -820,7 +830,8 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
                 kvGroupSize: parameters.kvGroupSize,
                 quantizedKVStart: parameters.quantizedKVStart,
                 kvCacheStrategy: parameters.kvCacheStrategy,
-                turboQuantPreset: parameters.turboQuantPreset
+                turboQuantPreset: parameters.turboQuantPreset,
+                turboQuantBackend: parameters.turboQuantBackend
             )
         }
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -72,6 +72,12 @@ public struct GenerateParameters: Sendable {
     /// Step to begin using a quantized KV cache when kvBits is non-nil (default: 0)
     public var quantizedKVStart: Int
 
+    /// Strategy used to construct and dynamically convert KV caches.
+    public var kvCacheStrategy: KVCacheStrategy
+
+    /// TurboQuant preset used when ``kvCacheStrategy`` is ``KVCacheStrategy/turboQuant``.
+    public var turboQuantPreset: TurboQuantPreset
+
     /// Sampling temperature
     public var temperature: Float
 
@@ -108,6 +114,8 @@ public struct GenerateParameters: Sendable {
         kvBits: Int? = nil,
         kvGroupSize: Int = 64,
         quantizedKVStart: Int = 0,
+        kvCacheStrategy: KVCacheStrategy = .mlxAffine,
+        turboQuantPreset: TurboQuantPreset = .turbo3_5,
         temperature: Float = 0.6,
         topP: Float = 1.0,
         topK: Int = 0,
@@ -125,6 +133,8 @@ public struct GenerateParameters: Sendable {
         self.kvBits = kvBits
         self.kvGroupSize = kvGroupSize
         self.quantizedKVStart = quantizedKVStart
+        self.kvCacheStrategy = kvCacheStrategy
+        self.turboQuantPreset = turboQuantPreset
         self.temperature = temperature
         self.topP = topP
         self.topK = topK
@@ -536,6 +546,8 @@ public struct TokenIterator: TokenIteratorProtocol {
     let kvBits: Int?
     let kvGroupSize: Int
     let quantizedKVStart: Int
+    let kvCacheStrategy: KVCacheStrategy
+    let turboQuantPreset: TurboQuantPreset
 
     // Internal metrics
     public var promptPrefillTime: TimeInterval = 0.0
@@ -564,6 +576,8 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
         self.quantizedKVStart = parameters.quantizedKVStart
+        self.kvCacheStrategy = parameters.kvCacheStrategy
+        self.turboQuantPreset = parameters.turboQuantPreset
 
         self.promptPrefillTime = try measure {
             try prepare(input: .init(text: y), windowSize: parameters.prefillStepSize)
@@ -597,6 +611,8 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
         self.quantizedKVStart = parameters.quantizedKVStart
+        self.kvCacheStrategy = parameters.kvCacheStrategy
+        self.turboQuantPreset = parameters.turboQuantPreset
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: parameters.prefillStepSize)
@@ -630,6 +646,8 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvBits = nil
         self.kvGroupSize = 64
         self.quantizedKVStart = 0
+        self.kvCacheStrategy = .none
+        self.turboQuantPreset = .turbo3_5
 
         self.promptPrefillTime = try measure {
             try prepare(input: input, windowSize: prefillStepSize)
@@ -680,7 +698,9 @@ public struct TokenIterator: TokenIteratorProtocol {
             cache: &cache,
             kvBits: kvBits,
             kvGroupSize: kvGroupSize,
-            quantizedKVStart: quantizedKVStart
+            quantizedKVStart: quantizedKVStart,
+            kvCacheStrategy: kvCacheStrategy,
+            turboQuantPreset: turboQuantPreset
         )
 
         return convertToToken(logits: result.logits)
@@ -798,7 +818,9 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
                 cache: &cache,
                 kvBits: parameters.kvBits,
                 kvGroupSize: parameters.kvGroupSize,
-                quantizedKVStart: parameters.quantizedKVStart
+                quantizedKVStart: parameters.quantizedKVStart,
+                kvCacheStrategy: parameters.kvCacheStrategy,
+                turboQuantPreset: parameters.turboQuantPreset
             )
         }
 

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1383,7 +1383,9 @@ private func cacheClassName(_ cache: KVCache) -> String {
     case is ChunkedKVCache: return "ChunkedKVCache"
     case is MambaCache: return "MambaCache"
     case is ArraysCache: return "ArraysCache"
+    case is RotatingTurboQuantKVCache: return "RotatingTurboQuantKVCache"
     case is RotatingKVCache: return "RotatingKVCache"
+    case is TurboQuantKVCache: return "TurboQuantKVCache"
     case is QuantizedKVCache: return "QuantizedKVCache"
     case is KVCacheSimple: return "KVCache"
     case is CacheList: return "CacheList"
@@ -1522,6 +1524,33 @@ private func restoreCacheFromMetaState(
         cache.metaState = metaState
         return cache
 
+    case "TurboQuantKVCache":
+        let preset = metaState.last.flatMap(TurboQuantPreset.init(rawValue:)) ?? .turbo3_5
+        let cache = TurboQuantKVCache(preset: preset)
+        cache.state = state
+        cache.metaState = metaState
+        return cache
+
+    case "RotatingTurboQuantKVCache":
+        guard metaState.count >= 7 else {
+            throw KVCacheError(
+                message: "Invalid RotatingTurboQuantKVCache metaState - expected 7 values")
+        }
+        guard let maxSize = Int(metaState[1]) else {
+            throw KVCacheError(
+                message: "Failed to parse RotatingTurboQuantKVCache maxSize from: \(metaState[1])")
+        }
+        let preset = TurboQuantPreset(rawValue: metaState[5]) ?? .turbo3_5
+        let groupSize = Int(metaState[6]) ?? 64
+        let cache = RotatingTurboQuantKVCache(
+            maxSize: maxSize,
+            preset: preset,
+            groupSize: groupSize
+        )
+        cache.state = state
+        cache.metaState = metaState
+        return cache
+
     case "ChunkedKVCache":
         let cache = ChunkedKVCache()
         cache.state = state
@@ -1655,8 +1684,22 @@ public func makePromptCache(
 /// Use this when `makePromptCache` cannot determine the layer count automatically.
 public func makePromptCacheWithLayerCount(
     numLayers: Int,
-    maxKVSize: Int? = nil
+    maxKVSize: Int? = nil,
+    parameters: GenerateParameters? = nil
 ) -> [KVCache] {
+    if parameters?.kvCacheStrategy == .turboQuant {
+        let preset = parameters?.turboQuantPreset ?? .turbo3_5
+        let groupSize = parameters?.kvGroupSize ?? 64
+        if let maxKVSize = parameters?.maxKVSize ?? maxKVSize {
+            return (0 ..< numLayers).map { _ in
+                RotatingTurboQuantKVCache(maxSize: maxKVSize, preset: preset, groupSize: groupSize)
+            }
+        }
+        return (0 ..< numLayers).map { _ in
+            TurboQuantKVCache(preset: preset, groupSize: groupSize)
+        }
+    }
+
     if let maxKVSize = maxKVSize {
         return (0 ..< numLayers).map { _ in
             RotatingKVCache(maxSize: maxKVSize, keep: 4)
@@ -1797,9 +1840,14 @@ public func maybeQuantizeKVCache(
     cache: inout [KVCache],
     kvBits: Int?,
     kvGroupSize: Int = 64,
-    quantizedKVStart: Int = 0
+    quantizedKVStart: Int = 0,
+    kvCacheStrategy: KVCacheStrategy = .mlxAffine,
+    turboQuantPreset: TurboQuantPreset = .turbo3_5
 ) {
-    guard let kvBits = kvBits, !cache.isEmpty else { return }
+    guard !cache.isEmpty else { return }
+    if kvCacheStrategy == .none { return }
+    let resolvedBits = kvCacheStrategy == .turboQuant ? turboQuantPreset.effectiveBits : kvBits
+    guard let kvBits = resolvedBits else { return }
 
     // Find the first quantizable (non-Mamba, non-already-quantized) cache entry
     guard let firstQuantizable = cache.first(where: { $0 is KVCacheSimple }),
@@ -1812,7 +1860,14 @@ public func maybeQuantizeKVCache(
     for i in 0 ..< cache.count {
         // Handle cache types that support quantization
         if let simpleCache = cache[i] as? KVCacheSimple {
-            cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
+            if kvCacheStrategy == .turboQuant {
+                cache[i] = simpleCache.toTurboQuant(
+                    preset: turboQuantPreset,
+                    groupSize: kvGroupSize
+                )
+            } else {
+                cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
+            }
         }
         // TODO: RotatingKVCache.toQuantized() is not implemented yet, like in Python.
         // When implemented, add: else if let rotatingCache = cache[i] as? RotatingKVCache { ... }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -332,9 +332,11 @@ public func createSSMMask(h: MLXArray, cache: MambaCache?) -> MLXArray? {
 public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     internal var keys: MLXArray?
     internal var values: MLXArray?
+    private let stream: StreamOrDevice
     public var step = 256
 
-    public override init() {
+    public init(stream: StreamOrDevice = .default) {
+        self.stream = stream
         super.init()
     }
 
@@ -360,16 +362,16 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
             let nSteps = (step + keys.dim(2) - 1) / step
             let kShape = [B, kvHeads, nSteps * step, kHeadDim]
             let vShape = [B, kvHeads, nSteps * step, vHeadDim]
-            let newK = MLXArray.zeros(kShape, dtype: keys.dtype)
-            let newV = MLXArray.zeros(vShape, dtype: values.dtype)
+            let newK = MLXArray.zeros(kShape, dtype: keys.dtype, stream: stream)
+            let newV = MLXArray.zeros(vShape, dtype: values.dtype, stream: stream)
 
             if var currentKeys = self.keys, var currentValues = self.values {
                 if previous % step != 0 {
                     currentKeys = currentKeys[.ellipsis, ..<previous, 0...]
                     currentValues = currentValues[.ellipsis, ..<previous, 0...]
                 }
-                self.keys = concatenated([currentKeys, newK], axis: 2)
-                self.values = concatenated([currentValues, newV], axis: 2)
+                self.keys = concatenated([currentKeys, newK], axis: 2, stream: stream)
+                self.values = concatenated([currentValues, newV], axis: 2, stream: stream)
             } else {
                 self.keys = newK
                 self.values = newV
@@ -422,7 +424,7 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     ///
     /// Use `updateQuantized()` and `quantizedScaledDotProductAttention()` for zero-overhead operation.
     public func toQuantized(groupSize: Int = 64, bits: Int = 4) -> QuantizedKVCache {
-        let quantizedCache = QuantizedKVCache(groupSize: groupSize, bits: bits)
+        let quantizedCache = QuantizedKVCache(groupSize: groupSize, bits: bits, stream: stream)
         quantizedCache.offset = self.offset
 
         if let keys = self.keys, let values = self.values {
@@ -430,8 +432,10 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
             let currentKeys = keys[.ellipsis, ..<offset, 0...]
             let currentValues = values[.ellipsis, ..<offset, 0...]
 
-            let quantizedKeys = quantized(currentKeys, groupSize: groupSize, bits: bits)
-            let quantizedValues = quantized(currentValues, groupSize: groupSize, bits: bits)
+            let quantizedKeys = quantized(
+                currentKeys, groupSize: groupSize, bits: bits, stream: stream)
+            let quantizedValues = quantized(
+                currentValues, groupSize: groupSize, bits: bits, stream: stream)
 
             // Set the quantized state
             quantizedCache.state = [
@@ -444,7 +448,7 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public override func copy() -> any KVCache {
-        let new = KVCacheSimple()
+        let new = KVCacheSimple(stream: stream)
         new.step = self.step
         let s = self.state
         if !s.isEmpty {
@@ -466,13 +470,20 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     private var maxCacheSize: Int
     private var step: Int
     private var idx: Int = 0
+    private let stream: StreamOrDevice
 
     public override var maxSize: Int? { maxCacheSize }
 
-    public init(maxSize: Int, keep: Int = 0, step: Int = 256) {
+    public init(
+        maxSize: Int,
+        keep: Int = 0,
+        step: Int = 256,
+        stream: StreamOrDevice = .default
+    ) {
         self.maxCacheSize = maxSize
         self.keep = keep
         self.step = step
+        self.stream = stream
         super.init()
     }
 
@@ -493,7 +504,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         if let append {
             toCat.append(append)
         }
-        return concatenated(toCat, axis: 2)
+        return concatenated(toCat, axis: 2, stream: stream)
     }
 
     private func temporalOrder(_ array: MLXArray) -> MLXArray {
@@ -506,7 +517,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
                     array[.ellipsis, ..<keep, 0...],
                     array[.ellipsis, idx..., 0...],
                     array[.ellipsis, keep ..< idx, 0...],
-                ], axis: 2)
+                ], axis: 2, stream: stream)
         } else {
             return array[.ellipsis, ..<idx, 0...]
         }
@@ -552,12 +563,12 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
 
             let kShape = [B, nKVHeads, newSize, kHeadDim]
             let vShape = [B, nKVHeads, newSize, vHeadDim]
-            let newK = MLXArray.zeros(kShape, dtype: keys.dtype)
-            let newV = MLXArray.zeros(vShape, dtype: values.dtype)
+            let newK = MLXArray.zeros(kShape, dtype: keys.dtype, stream: stream)
+            let newV = MLXArray.zeros(vShape, dtype: values.dtype, stream: stream)
 
             if let currentKeys = self.keys, let currentValues = self.values {
-                self.keys = concatenated([currentKeys, newK], axis: 2)
-                self.values = concatenated([currentValues, newV], axis: 2)
+                self.keys = concatenated([currentKeys, newK], axis: 2, stream: stream)
+                self.values = concatenated([currentValues, newV], axis: 2, stream: stream)
             } else {
                 self.keys = newK
                 self.values = newV
@@ -715,7 +726,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public override func copy() -> any KVCache {
-        let new = RotatingKVCache(maxSize: maxCacheSize, keep: keep, step: step)
+        let new = RotatingKVCache(maxSize: maxCacheSize, keep: keep, step: step, stream: stream)
         let s = self.state
         if !s.isEmpty {
             new.state = s.map { $0[.ellipsis] }
@@ -746,15 +757,22 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     private var keys: (MLXArray, MLXArray, MLXArray?)?
     private var values: (MLXArray, MLXArray, MLXArray?)?
     private let step: Int
+    private let stream: StreamOrDevice
     public let groupSize: Int
     public let bits: Int
     public let mode: QuantizationMode
 
-    public init(groupSize: Int = 64, bits: Int = 8, mode: QuantizationMode = .affine) {
+    public init(
+        groupSize: Int = 64,
+        bits: Int = 8,
+        mode: QuantizationMode = .affine,
+        stream: StreamOrDevice = .default
+    ) {
         self.groupSize = groupSize
         self.bits = bits
         self.step = 256
         self.mode = mode
+        self.stream = stream
         super.init()
     }
 
@@ -793,8 +811,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     private func initQuant(dim: Int, shape: [Int], dtype: DType) -> (MLXArray, MLXArray, MLXArray?)
     {
         // Create temporary zero arrays and quantize them using native MLX Swift
-        let tempArray = MLXArray.zeros(shape + [dim], dtype: dtype)
-        let quantized = quantized(tempArray, groupSize: groupSize, bits: bits)
+        let tempArray = MLXArray.zeros(shape + [dim], dtype: dtype, stream: stream)
+        let quantized = quantized(tempArray, groupSize: groupSize, bits: bits, stream: stream)
 
         return (quantized.wq, quantized.scales, quantized.biases)
     }
@@ -805,7 +823,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     ) {
         return treeMap(
             { array in
-                let newArray = MLXArray.zeros(newShape + [array.dim(-1)], dtype: array.dtype)
+                let newArray = MLXArray.zeros(
+                    newShape + [array.dim(-1)], dtype: array.dtype, stream: self.stream)
                 return concatenated([array, newArray], axis: -2)
             }, quantTuple)
     }
@@ -870,8 +889,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
 
         offset += numSteps
 
-        let quantizedKeys = quantized(keys, groupSize: groupSize, bits: bits)
-        let quantizedValues = quantized(values, groupSize: groupSize, bits: bits)
+        let quantizedKeys = quantized(keys, groupSize: groupSize, bits: bits, stream: stream)
+        let quantizedValues = quantized(values, groupSize: groupSize, bits: bits, stream: stream)
 
         // Convert named tuples to positional tuples
         let qKeys = (quantizedKeys.wq, quantizedKeys.scales, quantizedKeys.biases)
@@ -970,7 +989,7 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     }
 
     public override func copy() -> any KVCache {
-        let new = QuantizedKVCache(groupSize: groupSize, bits: bits, mode: mode)
+        let new = QuantizedKVCache(groupSize: groupSize, bits: bits, mode: mode, stream: stream)
         let s = self.state
         if !s.isEmpty {
             new.state = s.map { $0[.ellipsis] }
@@ -991,10 +1010,10 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
 
             let dequantizedKeys = dequantized(
                 currentKeys.0, scales: currentKeys.1, biases: currentKeys.2,
-                groupSize: groupSize, bits: bits, mode: mode)
+                groupSize: groupSize, bits: bits, mode: mode, stream: stream)
             let dequantizedValues = dequantized(
                 currentValues.0, scales: currentValues.1, biases: currentValues.2,
-                groupSize: groupSize, bits: bits, mode: mode)
+                groupSize: groupSize, bits: bits, mode: mode, stream: stream)
 
             // Set the unquantized state
             simpleCache.state = [dequantizedKeys, dequantizedValues]
@@ -1527,9 +1546,11 @@ private func restoreCacheFromMetaState(
     case "TurboQuantKVCache":
         let preset =
             metaState.count > 4 ? TurboQuantPreset(rawValue: metaState[4]) ?? .turbo3_5 : .turbo3_5
+        let groupSize =
+            metaState.count > 2 ? Int(metaState[2]) ?? 64 : 64
         let backend =
             metaState.count > 5 ? TurboQuantBackend(rawValue: metaState[5]) ?? .mlxPacked : .mlxPacked
-        let cache = TurboQuantKVCache(preset: preset, backend: backend)
+        let cache = TurboQuantKVCache(preset: preset, groupSize: groupSize, backend: backend)
         cache.state = state
         cache.metaState = metaState
         return cache

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1525,8 +1525,11 @@ private func restoreCacheFromMetaState(
         return cache
 
     case "TurboQuantKVCache":
-        let preset = metaState.last.flatMap(TurboQuantPreset.init(rawValue:)) ?? .turbo3_5
-        let cache = TurboQuantKVCache(preset: preset)
+        let preset =
+            metaState.count > 4 ? TurboQuantPreset(rawValue: metaState[4]) ?? .turbo3_5 : .turbo3_5
+        let backend =
+            metaState.count > 5 ? TurboQuantBackend(rawValue: metaState[5]) ?? .mlxPacked : .mlxPacked
+        let cache = TurboQuantKVCache(preset: preset, backend: backend)
         cache.state = state
         cache.metaState = metaState
         return cache
@@ -1542,10 +1545,13 @@ private func restoreCacheFromMetaState(
         }
         let preset = TurboQuantPreset(rawValue: metaState[5]) ?? .turbo3_5
         let groupSize = Int(metaState[6]) ?? 64
+        let backend =
+            metaState.count > 7 ? TurboQuantBackend(rawValue: metaState[7]) ?? .mlxPacked : .mlxPacked
         let cache = RotatingTurboQuantKVCache(
             maxSize: maxSize,
             preset: preset,
-            groupSize: groupSize
+            groupSize: groupSize,
+            backend: backend
         )
         cache.state = state
         cache.metaState = metaState
@@ -1689,14 +1695,20 @@ public func makePromptCacheWithLayerCount(
 ) -> [KVCache] {
     if parameters?.kvCacheStrategy == .turboQuant {
         let preset = parameters?.turboQuantPreset ?? .turbo3_5
+        let backend = parameters?.turboQuantBackend ?? .mlxPacked
         let groupSize = parameters?.kvGroupSize ?? 64
         if let maxKVSize = parameters?.maxKVSize ?? maxKVSize {
             return (0 ..< numLayers).map { _ in
-                RotatingTurboQuantKVCache(maxSize: maxKVSize, preset: preset, groupSize: groupSize)
+                RotatingTurboQuantKVCache(
+                    maxSize: maxKVSize,
+                    preset: preset,
+                    groupSize: groupSize,
+                    backend: backend
+                )
             }
         }
         return (0 ..< numLayers).map { _ in
-            TurboQuantKVCache(preset: preset, groupSize: groupSize)
+            TurboQuantKVCache(preset: preset, groupSize: groupSize, backend: backend)
         }
     }
 
@@ -1842,7 +1854,8 @@ public func maybeQuantizeKVCache(
     kvGroupSize: Int = 64,
     quantizedKVStart: Int = 0,
     kvCacheStrategy: KVCacheStrategy = .mlxAffine,
-    turboQuantPreset: TurboQuantPreset = .turbo3_5
+    turboQuantPreset: TurboQuantPreset = .turbo3_5,
+    turboQuantBackend: TurboQuantBackend = .mlxPacked
 ) {
     guard !cache.isEmpty else { return }
     if kvCacheStrategy == .none { return }
@@ -1863,7 +1876,8 @@ public func maybeQuantizeKVCache(
             if kvCacheStrategy == .turboQuant {
                 cache[i] = simpleCache.toTurboQuant(
                     preset: turboQuantPreset,
-                    groupSize: kvGroupSize
+                    groupSize: kvGroupSize,
+                    backend: turboQuantBackend
                 )
             } else {
                 cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1549,7 +1549,8 @@ private func restoreCacheFromMetaState(
         let groupSize =
             metaState.count > 2 ? Int(metaState[2]) ?? 64 : 64
         let backend =
-            metaState.count > 5 ? TurboQuantBackend(rawValue: metaState[5]) ?? .mlxPacked : .mlxPacked
+            metaState.count > 5
+            ? TurboQuantBackend(rawValue: metaState[5]) ?? .mlxPacked : .mlxPacked
         let cache = TurboQuantKVCache(preset: preset, groupSize: groupSize, backend: backend)
         cache.state = state
         cache.metaState = metaState
@@ -1567,7 +1568,8 @@ private func restoreCacheFromMetaState(
         let preset = TurboQuantPreset(rawValue: metaState[5]) ?? .turbo3_5
         let groupSize = Int(metaState[6]) ?? 64
         let backend =
-            metaState.count > 7 ? TurboQuantBackend(rawValue: metaState[7]) ?? .mlxPacked : .mlxPacked
+            metaState.count > 7
+            ? TurboQuantBackend(rawValue: metaState[7]) ?? .mlxPacked : .mlxPacked
         let cache = RotatingTurboQuantKVCache(
             maxSize: maxSize,
             preset: preset,

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -221,6 +221,24 @@ extension LanguageModel where Self: KVCacheDimensionProvider {
         // The number of heads per layer (kvHeads[i]) is not used for cache creation
         let numLayers = kvHeads.count
 
+        if parameters?.kvCacheStrategy == .turboQuant {
+            let preset = parameters?.turboQuantPreset ?? .turbo3_5
+            let groupSize = parameters?.kvGroupSize ?? 64
+            if let maxKVSize = parameters?.maxKVSize {
+                return (0 ..< numLayers).map { _ in
+                    RotatingTurboQuantKVCache(
+                        maxSize: maxKVSize,
+                        keep: 4,
+                        preset: preset,
+                        groupSize: groupSize
+                    )
+                }
+            }
+            return (0 ..< numLayers).map { _ in
+                TurboQuantKVCache(preset: preset, groupSize: groupSize)
+            }
+        }
+
         // Follow Python logic: use RotatingKVCache if maxKVSize is provided
         if let maxKVSize = parameters?.maxKVSize {
             return (0 ..< numLayers).map { _ in

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -223,6 +223,7 @@ extension LanguageModel where Self: KVCacheDimensionProvider {
 
         if parameters?.kvCacheStrategy == .turboQuant {
             let preset = parameters?.turboQuantPreset ?? .turbo3_5
+            let backend = parameters?.turboQuantBackend ?? .mlxPacked
             let groupSize = parameters?.kvGroupSize ?? 64
             if let maxKVSize = parameters?.maxKVSize {
                 return (0 ..< numLayers).map { _ in
@@ -230,12 +231,13 @@ extension LanguageModel where Self: KVCacheDimensionProvider {
                         maxSize: maxKVSize,
                         keep: 4,
                         preset: preset,
-                        groupSize: groupSize
+                        groupSize: groupSize,
+                        backend: backend
                     )
                 }
             }
             return (0 ..< numLayers).map { _ in
-                TurboQuantKVCache(preset: preset, groupSize: groupSize)
+                TurboQuantKVCache(preset: preset, groupSize: groupSize, backend: backend)
             }
         }
 

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -4,6 +4,8 @@ import Foundation
 import MLX
 
 public typealias TurboQuantPreset = MLX.TurboQuantPreset
+public typealias TurboQuantBackend = MLX.TurboQuantBackend
+public typealias TurboQuantKernelAvailability = MLX.TurboQuantKernelAvailability
 
 public enum KVCacheStrategy: String, Codable, Sendable, CaseIterable {
     case none
@@ -11,27 +13,62 @@ public enum KVCacheStrategy: String, Codable, Sendable, CaseIterable {
     case turboQuant
 }
 
+public struct TurboQuantKVCacheDiagnostics: Equatable, Codable, Sendable {
+    public var preset: TurboQuantPreset
+    public var requestedBackend: TurboQuantBackend
+    public var activeBackend: TurboQuantBackend
+    public var fallbackReason: String?
+    public var groupSize: Int
+    public var bits: Int
+    public var maxSize: Int?
+}
+
 public final class TurboQuantKVCache: QuantizedKVCache {
     public let preset: TurboQuantPreset
+    public let requestedBackend: TurboQuantBackend
+    public let activeBackend: TurboQuantBackend
+    public let backendFallbackReason: String?
 
     public init(
         preset: TurboQuantPreset = .turbo3_5,
         groupSize: Int = 64,
-        mode: QuantizationMode = .affine
+        mode: QuantizationMode = .affine,
+        backend: TurboQuantBackend = .mlxPacked
     ) {
         self.preset = preset
+        self.requestedBackend = backend
+        let availability = TurboQuantKernelAvailability.current
+        self.activeBackend = availability.runtimeBackend(for: backend)
+        self.backendFallbackReason = availability.fallbackReason(for: backend)
         super.init(groupSize: groupSize, bits: preset.effectiveBits, mode: mode)
     }
 
     public override var metaState: [String] {
-        get { super.metaState + [preset.rawValue] }
+        get { super.metaState + [preset.rawValue, requestedBackend.rawValue] }
         set {
             super.metaState = Array(newValue.prefix(4))
         }
     }
 
+    public var diagnostics: TurboQuantKVCacheDiagnostics {
+        TurboQuantKVCacheDiagnostics(
+            preset: preset,
+            requestedBackend: requestedBackend,
+            activeBackend: activeBackend,
+            fallbackReason: backendFallbackReason,
+            groupSize: groupSize,
+            bits: bits,
+            maxSize: nil
+        )
+    }
+
     public override func copy() -> any KVCache {
-        let new = TurboQuantKVCache(preset: preset, groupSize: groupSize, mode: mode)
+        let new = TurboQuantKVCache(
+            preset: preset,
+            groupSize: groupSize,
+            mode: mode,
+            backend: requestedBackend
+        )
         let s = self.state
         if !s.isEmpty {
             new.state = s.map { $0[.ellipsis] }
@@ -49,6 +86,9 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
     private var packedValues: TurboQuantPackedTensor?
 
     public let preset: TurboQuantPreset
+    public let requestedBackend: TurboQuantBackend
+    public let activeBackend: TurboQuantBackend
+    public let backendFallbackReason: String?
     public let groupSize: Int
     public let bits: Int
     public let mode: QuantizationMode
@@ -63,10 +103,15 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
         step: Int = 256,
         preset: TurboQuantPreset = .turbo3_5,
         groupSize: Int = 64,
-        mode: QuantizationMode = .affine
+        mode: QuantizationMode = .affine,
+        backend: TurboQuantBackend = .mlxPacked
     ) {
         self.rawCache = RotatingKVCache(maxSize: maxSize, keep: keep, step: step)
         self.preset = preset
+        self.requestedBackend = backend
+        let availability = TurboQuantKernelAvailability.current
+        self.activeBackend = availability.runtimeBackend(for: backend)
+        self.backendFallbackReason = availability.fallbackReason(for: backend)
         self.groupSize = groupSize
         self.bits = preset.effectiveBits
         self.mode = mode
@@ -80,9 +125,9 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
         offset = rawCache.offset
 
         let keyConfiguration = TurboQuantConfiguration(
-            preset: preset, role: .key, groupSize: groupSize, mode: mode)
+            preset: preset, role: .key, groupSize: groupSize, mode: mode, backend: activeBackend)
         let valueConfiguration = TurboQuantConfiguration(
-            preset: preset, role: .value, groupSize: groupSize, mode: mode)
+            preset: preset, role: .value, groupSize: groupSize, mode: mode, backend: activeBackend)
         packedKeys = turboQuantized(cachedKeys, configuration: keyConfiguration)
         packedValues = turboQuantized(cachedValues, configuration: valueConfiguration)
 
@@ -119,7 +164,7 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
     }
 
     public override var metaState: [String] {
-        get { rawCache.metaState + [preset.rawValue, String(groupSize)] }
+        get { rawCache.metaState + [preset.rawValue, String(groupSize), requestedBackend.rawValue] }
         set {
             rawCache.metaState = Array(newValue.prefix(5))
             offset = rawCache.offset
@@ -155,7 +200,8 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
             maxSize: maxSize,
             preset: preset,
             groupSize: groupSize,
-            mode: mode
+            mode: mode,
+            backend: requestedBackend
         )
         let s = state
         if !s.isEmpty {
@@ -165,8 +211,20 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
         return new
     }
 
+    public var diagnostics: TurboQuantKVCacheDiagnostics {
+        TurboQuantKVCacheDiagnostics(
+            preset: preset,
+            requestedBackend: requestedBackend,
+            activeBackend: activeBackend,
+            fallbackReason: backendFallbackReason,
+            groupSize: groupSize,
+            bits: bits,
+            maxSize: maxSize
+        )
+    }
+
     public var debugDescription: String {
-        "\(String(describing: Self.self)) offset: \(offset), maxSize: \(maxSize?.description ?? "-"), preset: \(preset.rawValue)"
+        "\(String(describing: Self.self)) offset: \(offset), maxSize: \(maxSize?.description ?? "-"), preset: \(preset.rawValue), backend: \(activeBackend.rawValue)"
     }
 }
 
@@ -174,17 +232,33 @@ public extension KVCacheSimple {
     func toTurboQuant(
         preset: TurboQuantPreset = .turbo3_5,
         groupSize: Int = 64,
-        mode: QuantizationMode = .affine
+        mode: QuantizationMode = .affine,
+        backend: TurboQuantBackend = .mlxPacked
     ) -> TurboQuantKVCache {
-        let cache = TurboQuantKVCache(preset: preset, groupSize: groupSize, mode: mode)
+        let cache = TurboQuantKVCache(
+            preset: preset,
+            groupSize: groupSize,
+            mode: mode,
+            backend: backend
+        )
         cache.offset = self.offset
 
         let currentState = self.state
         if currentState.count == 2 {
             let keyConfiguration = TurboQuantConfiguration(
-                preset: preset, role: .key, groupSize: groupSize, mode: mode)
+                preset: preset,
+                role: .key,
+                groupSize: groupSize,
+                mode: mode,
+                backend: cache.activeBackend
+            )
             let valueConfiguration = TurboQuantConfiguration(
-                preset: preset, role: .value, groupSize: groupSize, mode: mode)
+                preset: preset,
+                role: .value,
+                groupSize: groupSize,
+                mode: mode,
+                backend: cache.activeBackend
+            )
             let keys = turboQuantized(currentState[0], configuration: keyConfiguration)
             let values = turboQuantized(currentState[1], configuration: valueConfiguration)
             cache.state = [

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1,9 +1,152 @@
 import Foundation
 import MLX
 
-public typealias TurboQuantPreset = MLX.TurboQuantPreset
-public typealias TurboQuantBackend = MLX.TurboQuantBackend
-public typealias TurboQuantKernelAvailability = MLX.TurboQuantKernelAvailability
+public enum TurboQuantPreset: String, Codable, Sendable, CaseIterable {
+    case turbo2_5
+    case turbo3_5
+
+    public var effectiveBits: Int {
+        switch self {
+        case .turbo2_5: 2
+        case .turbo3_5: 4
+        }
+    }
+}
+
+public enum TurboQuantBackend: String, Codable, Sendable, CaseIterable {
+    case mlxPacked
+    case polarQJLReference
+    case metalPolarQJL
+}
+
+public enum TurboQuantTensorRole: String, Codable, Sendable, CaseIterable {
+    case key
+    case value
+    case vector
+}
+
+public struct TurboQuantKernelAvailability: Equatable, Codable, Sendable {
+    public var supportsMLXPacked: Bool
+    public var supportsPolarQJLReference: Bool
+    public var supportsMetalPolarQJLCodec: Bool
+    public var supportsMetalPolarQJLAttention: Bool
+    public var supportsMetalPolarQJL: Bool
+
+    public init(
+        supportsMLXPacked: Bool = true,
+        supportsPolarQJLReference: Bool = false,
+        supportsMetalPolarQJLCodec: Bool = false,
+        supportsMetalPolarQJLAttention: Bool = false,
+        supportsMetalPolarQJL: Bool = false
+    ) {
+        self.supportsMLXPacked = supportsMLXPacked
+        self.supportsPolarQJLReference = supportsPolarQJLReference
+        self.supportsMetalPolarQJLCodec = supportsMetalPolarQJLCodec
+        self.supportsMetalPolarQJLAttention = supportsMetalPolarQJLAttention
+        self.supportsMetalPolarQJL = supportsMetalPolarQJL
+    }
+
+    public static var current: TurboQuantKernelAvailability {
+        TurboQuantKernelAvailability()
+    }
+
+    public func supports(_ backend: TurboQuantBackend) -> Bool {
+        switch backend {
+        case .mlxPacked:
+            supportsMLXPacked
+        case .polarQJLReference:
+            supportsPolarQJLReference
+        case .metalPolarQJL:
+            supportsMetalPolarQJL
+        }
+    }
+
+    public func runtimeBackend(for requestedBackend: TurboQuantBackend) -> TurboQuantBackend {
+        supports(requestedBackend) ? requestedBackend : .mlxPacked
+    }
+
+    public func fallbackReason(for requestedBackend: TurboQuantBackend) -> String? {
+        guard !supports(requestedBackend) else { return nil }
+
+        switch requestedBackend {
+        case .mlxPacked:
+            return nil
+        case .polarQJLReference:
+            return "PolarQuant/QJL reference backend is not part of mlx-swift-lm; using MLX packed quantized lanes."
+        case .metalPolarQJL:
+            return "TurboQuant Metal kernels are not part of mlx-swift-lm; using MLX packed quantized lanes."
+        }
+    }
+}
+
+public struct TurboQuantConfiguration: Hashable, Codable, Sendable {
+    public var preset: TurboQuantPreset
+    public var role: TurboQuantTensorRole
+    public var groupSize: Int
+    public var mode: QuantizationMode
+    public var backend: TurboQuantBackend
+
+    public init(
+        preset: TurboQuantPreset = .turbo3_5,
+        role: TurboQuantTensorRole = .vector,
+        groupSize: Int = 64,
+        mode: QuantizationMode = .affine,
+        backend: TurboQuantBackend = .mlxPacked
+    ) {
+        self.preset = preset
+        self.role = role
+        self.groupSize = groupSize
+        self.mode = mode
+        self.backend = backend
+    }
+
+    public var effectiveBits: Int { preset.effectiveBits }
+    public var runtimeBackend: TurboQuantBackend {
+        TurboQuantKernelAvailability.current.runtimeBackend(for: backend)
+    }
+    public var runtimeFallbackReason: String? {
+        TurboQuantKernelAvailability.current.fallbackReason(for: backend)
+    }
+}
+
+public typealias TurboQuantPackedTensor = (
+    weight: MLXArray,
+    scales: MLXArray,
+    biases: MLXArray?
+)
+
+public func turboQuantized(
+    _ array: MLXArray,
+    configuration: TurboQuantConfiguration = TurboQuantConfiguration(),
+    stream: StreamOrDevice = .cpu
+) -> TurboQuantPackedTensor {
+    let packed = quantized(
+        array,
+        groupSize: configuration.groupSize,
+        bits: configuration.effectiveBits,
+        mode: configuration.mode,
+        stream: stream
+    )
+    return (packed.wq, packed.scales, packed.biases)
+}
+
+public func turboDequantized(
+    _ packed: TurboQuantPackedTensor,
+    configuration: TurboQuantConfiguration = TurboQuantConfiguration(),
+    dtype: DType? = nil,
+    stream: StreamOrDevice = .cpu
+) -> MLXArray {
+    dequantized(
+        packed.weight,
+        scales: packed.scales,
+        biases: packed.biases,
+        groupSize: configuration.groupSize,
+        bits: configuration.effectiveBits,
+        mode: configuration.mode,
+        dtype: dtype,
+        stream: stream
+    )
+}
 
 public enum KVCacheStrategy: String, Codable, Sendable, CaseIterable {
     case none
@@ -39,7 +182,7 @@ public final class TurboQuantKVCache: QuantizedKVCache {
         let availability = TurboQuantKernelAvailability.current
         self.activeBackend = availability.runtimeBackend(for: backend)
         self.backendFallbackReason = availability.fallbackReason(for: backend)
-        super.init(groupSize: groupSize, bits: preset.effectiveBits, mode: mode)
+        super.init(groupSize: groupSize, bits: preset.effectiveBits, mode: mode, stream: .cpu)
     }
 
     public override var metaState: [String] {
@@ -106,7 +249,7 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
         mode: QuantizationMode = .affine,
         backend: TurboQuantBackend = .mlxPacked
     ) {
-        self.rawCache = RotatingKVCache(maxSize: maxSize, keep: keep, step: step)
+        self.rawCache = RotatingKVCache(maxSize: maxSize, keep: keep, step: step, stream: .cpu)
         self.preset = preset
         self.requestedBackend = backend
         let availability = TurboQuantKernelAvailability.current

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -72,9 +72,11 @@ public struct TurboQuantKernelAvailability: Equatable, Codable, Sendable {
         case .mlxPacked:
             return nil
         case .polarQJLReference:
-            return "PolarQuant/QJL reference backend is not part of mlx-swift-lm; using MLX packed quantized lanes."
+            return
+                "PolarQuant/QJL reference backend is not part of mlx-swift-lm; using MLX packed quantized lanes."
         case .metalPolarQJL:
-            return "TurboQuant Metal kernels are not part of mlx-swift-lm; using MLX packed quantized lanes."
+            return
+                "TurboQuant Metal kernels are not part of mlx-swift-lm; using MLX packed quantized lanes."
         }
     }
 }
@@ -307,7 +309,9 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
     }
 
     public override var metaState: [String] {
-        get { rawCache.metaState + [preset.rawValue, String(groupSize), requestedBackend.rawValue] }
+        get {
+            rawCache.metaState + [preset.rawValue, String(groupSize), requestedBackend.rawValue]
+        }
         set {
             rawCache.metaState = Array(newValue.prefix(5))
             offset = rawCache.offset
@@ -372,8 +376,8 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
     }
 }
 
-public extension KVCacheSimple {
-    func toTurboQuant(
+extension KVCacheSimple {
+    public func toTurboQuant(
         preset: TurboQuantPreset = .turbo3_5,
         groupSize: Int = 64,
         mode: QuantizationMode = .affine,

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -18,6 +18,7 @@ public struct TurboQuantKVCacheDiagnostics: Equatable, Codable, Sendable {
     public var requestedBackend: TurboQuantBackend
     public var activeBackend: TurboQuantBackend
     public var fallbackReason: String?
+    public var metalCodecAvailable: Bool
     public var groupSize: Int
     public var bits: Int
     public var maxSize: Int?
@@ -56,6 +57,7 @@ public final class TurboQuantKVCache: QuantizedKVCache {
             requestedBackend: requestedBackend,
             activeBackend: activeBackend,
             fallbackReason: backendFallbackReason,
+            metalCodecAvailable: TurboQuantKernelAvailability.current.supportsMetalPolarQJLCodec,
             groupSize: groupSize,
             bits: bits,
             maxSize: nil
@@ -217,6 +219,7 @@ public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProto
             requestedBackend: requestedBackend,
             activeBackend: activeBackend,
             fallbackReason: backendFallbackReason,
+            metalCodecAvailable: TurboQuantKernelAvailability.current.supportsMetalPolarQJLCodec,
             groupSize: groupSize,
             bits: bits,
             maxSize: maxSize

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1,0 +1,198 @@
+// Copyright © 2026 Schtack.
+
+import Foundation
+import MLX
+
+public typealias TurboQuantPreset = MLX.TurboQuantPreset
+
+public enum KVCacheStrategy: String, Codable, Sendable, CaseIterable {
+    case none
+    case mlxAffine
+    case turboQuant
+}
+
+public final class TurboQuantKVCache: QuantizedKVCache {
+    public let preset: TurboQuantPreset
+
+    public init(
+        preset: TurboQuantPreset = .turbo3_5,
+        groupSize: Int = 64,
+        mode: QuantizationMode = .affine
+    ) {
+        self.preset = preset
+        super.init(groupSize: groupSize, bits: preset.effectiveBits, mode: mode)
+    }
+
+    public override var metaState: [String] {
+        get { super.metaState + [preset.rawValue] }
+        set {
+            super.metaState = Array(newValue.prefix(4))
+        }
+    }
+
+    public override func copy() -> any KVCache {
+        let new = TurboQuantKVCache(preset: preset, groupSize: groupSize, mode: mode)
+        let s = self.state
+        if !s.isEmpty {
+            new.state = s.map { $0[.ellipsis] }
+        }
+        new.metaState = self.metaState
+        return new
+    }
+}
+
+public final class RotatingTurboQuantKVCache: BaseKVCache, QuantizedKVCacheProtocol,
+    CustomDebugStringConvertible
+{
+    private let rawCache: RotatingKVCache
+    private var packedKeys: TurboQuantPackedTensor?
+    private var packedValues: TurboQuantPackedTensor?
+
+    public let preset: TurboQuantPreset
+    public let groupSize: Int
+    public let bits: Int
+    public let mode: QuantizationMode
+
+    public override var maxSize: Int? { rawCache.maxSize }
+    public override var isTrimmable: Bool { rawCache.isTrimmable }
+    public var ropeOffset: RoPEOffset { rawCache.ropeOffset }
+
+    public init(
+        maxSize: Int,
+        keep: Int = 4,
+        step: Int = 256,
+        preset: TurboQuantPreset = .turbo3_5,
+        groupSize: Int = 64,
+        mode: QuantizationMode = .affine
+    ) {
+        self.rawCache = RotatingKVCache(maxSize: maxSize, keep: keep, step: step)
+        self.preset = preset
+        self.groupSize = groupSize
+        self.bits = preset.effectiveBits
+        self.mode = mode
+        super.init()
+    }
+
+    public func updateQuantized(keys: MLXArray, values: MLXArray) -> (
+        (MLXArray, MLXArray, MLXArray?), (MLXArray, MLXArray, MLXArray?)
+    ) {
+        let (cachedKeys, cachedValues) = rawCache.update(keys: keys, values: values)
+        offset = rawCache.offset
+
+        let keyConfiguration = TurboQuantConfiguration(
+            preset: preset, role: .key, groupSize: groupSize, mode: mode)
+        let valueConfiguration = TurboQuantConfiguration(
+            preset: preset, role: .value, groupSize: groupSize, mode: mode)
+        packedKeys = turboQuantized(cachedKeys, configuration: keyConfiguration)
+        packedValues = turboQuantized(cachedValues, configuration: valueConfiguration)
+
+        return (
+            (packedKeys!.weight, packedKeys!.scales, packedKeys!.biases),
+            (packedValues!.weight, packedValues!.scales, packedValues!.biases)
+        )
+    }
+
+    public func getQuantizedState() -> (
+        (MLXArray, MLXArray, MLXArray?), (MLXArray, MLXArray, MLXArray?)
+    )? {
+        guard let packedKeys, let packedValues else { return nil }
+        return (
+            (packedKeys.weight, packedKeys.scales, packedKeys.biases),
+            (packedValues.weight, packedValues.scales, packedValues.biases)
+        )
+    }
+
+    public override func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        let result = rawCache.update(keys: keys, values: values)
+        offset = rawCache.offset
+        return result
+    }
+
+    public override var state: [MLXArray] {
+        get { rawCache.state }
+        set {
+            rawCache.state = newValue
+            offset = rawCache.offset
+            packedKeys = nil
+            packedValues = nil
+        }
+    }
+
+    public override var metaState: [String] {
+        get { rawCache.metaState + [preset.rawValue, String(groupSize)] }
+        set {
+            rawCache.metaState = Array(newValue.prefix(5))
+            offset = rawCache.offset
+        }
+    }
+
+    public override func innerState() -> [MLXArray] {
+        rawCache.innerState()
+    }
+
+    public override func makeMask(
+        n: Int,
+        windowSize: Int?,
+        returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        rawCache.makeMask(n: n, windowSize: windowSize, returnArray: returnArray)
+    }
+
+    @discardableResult
+    public override func trim(_ n: Int) -> Int {
+        let trimmed = rawCache.trim(n)
+        offset = rawCache.offset
+        packedKeys = nil
+        packedValues = nil
+        return trimmed
+    }
+
+    public override func copy() -> any KVCache {
+        guard let maxSize else {
+            fatalError("RotatingTurboQuantKVCache requires maxSize")
+        }
+        let new = RotatingTurboQuantKVCache(
+            maxSize: maxSize,
+            preset: preset,
+            groupSize: groupSize,
+            mode: mode
+        )
+        let s = state
+        if !s.isEmpty {
+            new.state = s.map { $0[.ellipsis] }
+        }
+        new.metaState = metaState
+        return new
+    }
+
+    public var debugDescription: String {
+        "\(String(describing: Self.self)) offset: \(offset), maxSize: \(maxSize?.description ?? "-"), preset: \(preset.rawValue)"
+    }
+}
+
+public extension KVCacheSimple {
+    func toTurboQuant(
+        preset: TurboQuantPreset = .turbo3_5,
+        groupSize: Int = 64,
+        mode: QuantizationMode = .affine
+    ) -> TurboQuantKVCache {
+        let cache = TurboQuantKVCache(preset: preset, groupSize: groupSize, mode: mode)
+        cache.offset = self.offset
+
+        let currentState = self.state
+        if currentState.count == 2 {
+            let keyConfiguration = TurboQuantConfiguration(
+                preset: preset, role: .key, groupSize: groupSize, mode: mode)
+            let valueConfiguration = TurboQuantConfiguration(
+                preset: preset, role: .value, groupSize: groupSize, mode: mode)
+            let keys = turboQuantized(currentState[0], configuration: keyConfiguration)
+            let values = turboQuantized(currentState[1], configuration: valueConfiguration)
+            cache.state = [
+                keys.weight, keys.scales, keys.biases,
+                values.weight, values.scales, values.biases,
+            ].compactMap { $0 }
+        }
+
+        return cache
+    }
+}

--- a/Libraries/MLXLMCommon/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKVCache.swift
@@ -1,5 +1,3 @@
-// Copyright © 2026 Schtack.
-
 import Foundation
 import MLX
 

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -106,7 +106,9 @@ public enum WiredMemoryUtils {
                 cache: &cache,
                 kvBits: parameters.kvBits,
                 kvGroupSize: parameters.kvGroupSize,
-                quantizedKVStart: parameters.quantizedKVStart
+                quantizedKVStart: parameters.quantizedKVStart,
+                kvCacheStrategy: parameters.kvCacheStrategy,
+                turboQuantPreset: parameters.turboQuantPreset
             )
             eval(result.logits)
         case .logits(let result):
@@ -114,7 +116,9 @@ public enum WiredMemoryUtils {
                 cache: &cache,
                 kvBits: parameters.kvBits,
                 kvGroupSize: parameters.kvGroupSize,
-                quantizedKVStart: parameters.quantizedKVStart
+                quantizedKVStart: parameters.quantizedKVStart,
+                kvCacheStrategy: parameters.kvCacheStrategy,
+                turboQuantPreset: parameters.turboQuantPreset
             )
             eval(result.logits)
         }

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -108,7 +108,8 @@ public enum WiredMemoryUtils {
                 kvGroupSize: parameters.kvGroupSize,
                 quantizedKVStart: parameters.quantizedKVStart,
                 kvCacheStrategy: parameters.kvCacheStrategy,
-                turboQuantPreset: parameters.turboQuantPreset
+                turboQuantPreset: parameters.turboQuantPreset,
+                turboQuantBackend: parameters.turboQuantBackend
             )
             eval(result.logits)
         case .logits(let result):
@@ -118,7 +119,8 @@ public enum WiredMemoryUtils {
                 kvGroupSize: parameters.kvGroupSize,
                 quantizedKVStart: parameters.quantizedKVStart,
                 kvCacheStrategy: parameters.kvCacheStrategy,
-                turboQuantPreset: parameters.turboQuantPreset
+                turboQuantPreset: parameters.turboQuantPreset,
+                turboQuantBackend: parameters.turboQuantBackend
             )
             eval(result.logits)
         }

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["IntegrationTestHelpers"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RNT56/mlx-swift", branch: "pr/turboquant-swift-support"),
+        .package(url: "https://github.com/RNT56/mlx-swift", branch: "pr/turboquant-metal-runtime-completion"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["IntegrationTestHelpers"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
+        .package(url: "https://github.com/RNT56/mlx-swift", branch: "schtack/turboquant-kv"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["IntegrationTestHelpers"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RNT56/mlx-swift", branch: "schtack/turboquant-kv"),
+        .package(url: "https://github.com/RNT56/mlx-swift", branch: "pr/turboquant-swift-support"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["IntegrationTestHelpers"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RNT56/mlx-swift", branch: "pr/turboquant-swift-support"),
+        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             targets: ["IntegrationTestHelpers"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/RNT56/mlx-swift", branch: "pr/turboquant-metal-runtime-completion"),
+        .package(url: "https://github.com/RNT56/mlx-swift", branch: "pr/turboquant-swift-support"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -143,30 +143,6 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     }
 }
 
-@Test func testTurboQuantCompressedAttentionStateWhenAvailable() throws {
-    guard TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention else { return }
-
-    let cache = TurboQuantKVCache(backend: .metalPolarQJL)
-    let keys = MLXArray.ones([1, 2, 2, 64], dtype: .float32)
-    let values = MLXArray.ones([1, 2, 2, 64], dtype: .float32)
-    let queries = MLXArray.ones([1, 4, 1, 64], dtype: .float32)
-
-    #expect(
-        cache.supportsCompressedAttention(
-            queries: queries,
-            keys: keys,
-            values: values,
-            mask: .none
-        )
-    )
-    let (compressedKeys, compressedValues) = try cache.updateCompressed(keys: keys, values: values)
-
-    #expect(cache.compressedState != nil)
-    #expect(compressedKeys.layout.logicalLength == 2)
-    #expect(compressedValues.layout.logicalLength == 2)
-    #expect(cache.attentionDiagnostics.activeAttentionPath == .onlineFused)
-}
-
 // MARK: - MambaCache type preservation
 
 @Test func testMambaCacheRoundTrip() throws {

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -125,12 +125,16 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
         kvGroupSize: 64,
         quantizedKVStart: 0,
         kvCacheStrategy: .turboQuant,
-        turboQuantPreset: .turbo3_5
+        turboQuantPreset: .turbo3_5,
+        turboQuantBackend: .metalPolarQJL
     )
 
     #expect(cache[0] is TurboQuantKVCache)
     let turbo = try #require(cache[0] as? TurboQuantKVCache)
     #expect(turbo.preset == .turbo3_5)
+    #expect(turbo.requestedBackend == .metalPolarQJL)
+    #expect(turbo.activeBackend == .mlxPacked)
+    #expect(turbo.backendFallbackReason != nil)
 }
 
 // MARK: - MambaCache type preservation

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -53,8 +53,8 @@ private func withCPUTest(_ body: () async throws -> Void) async rethrows {
 func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     try withCPUTest {
         let cache = (0 ..< 10).map { _ in creator() }
-        let keys = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16)
+        let keys = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16, stream: .cpu)
+        let values = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16, stream: .cpu)
         for item in cache {
             switch item {
             case let arrays as ArraysCache:
@@ -90,8 +90,8 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 @Test func testArraysCacheSparseSlots() throws {
     try withCPUTest {
         let cache = ArraysCache(size: 3)
-        let a = MLXArray.ones([2, 4], dtype: .float32) * 3.0
-        let b = MLXArray.ones([2, 4], dtype: .float32) * 7.0
+        let a = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 3.0
+        let b = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 7.0
         cache[0] = a
         // slot 1 stays nil
         cache[2] = b
@@ -116,8 +116,8 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 @Test func testArraysCacheLeftPadding() throws {
     try withCPUTest {
         let cache = ArraysCache(size: 2, leftPadding: [0, 5])
-        let a = MLXArray.ones([2, 4], dtype: .float32)
-        let b = MLXArray.ones([2, 4], dtype: .float32) * 2.0
+        let a = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu)
+        let b = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 2.0
         cache[0] = a
         cache[1] = b
 
@@ -132,143 +132,135 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 }
 
 @Test func testTurboQuantCacheStrategyConvertsSimpleCache() throws {
-    try withCPUTest {
-        var cache: [KVCache] = [KVCacheSimple()]
-        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-        _ = cache[0].update(keys: keys, values: values)
+    var cache: [KVCache] = [KVCacheSimple(stream: .cpu)]
+    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
+    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
+    _ = cache[0].update(keys: keys, values: values)
 
-        maybeQuantizeKVCache(
-            cache: &cache,
-            kvBits: nil,
-            kvGroupSize: 64,
-            quantizedKVStart: 0,
-            kvCacheStrategy: .turboQuant,
-            turboQuantPreset: .turbo3_5,
-            turboQuantBackend: .metalPolarQJL
-        )
+    maybeQuantizeKVCache(
+        cache: &cache,
+        kvBits: nil,
+        kvGroupSize: 64,
+        quantizedKVStart: 0,
+        kvCacheStrategy: .turboQuant,
+        turboQuantPreset: .turbo3_5,
+        turboQuantBackend: .metalPolarQJL
+    )
 
-        #expect(cache[0] is TurboQuantKVCache)
-        let turbo = try #require(cache[0] as? TurboQuantKVCache)
-        #expect(turbo.preset == .turbo3_5)
-        #expect(turbo.requestedBackend == .metalPolarQJL)
-        let expectedBackend: TurboQuantBackend =
-            TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention
-            ? .metalPolarQJL
-            : .mlxPacked
-        #expect(turbo.activeBackend == expectedBackend)
-        if expectedBackend == .mlxPacked {
-            #expect(turbo.backendFallbackReason != nil)
-        }
+    #expect(cache[0] is TurboQuantKVCache)
+    let turbo = try #require(cache[0] as? TurboQuantKVCache)
+    #expect(turbo.preset == .turbo3_5)
+    #expect(turbo.requestedBackend == .metalPolarQJL)
+    let expectedBackend: TurboQuantBackend =
+        TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention
+        ? .metalPolarQJL
+        : .mlxPacked
+    #expect(turbo.activeBackend == expectedBackend)
+    if expectedBackend == .mlxPacked {
+        #expect(turbo.backendFallbackReason != nil)
     }
 }
 
 @Test func testTurboQuantSimpleConversionKeepsUsableCompressedState() throws {
-    withCPUTest {
-        let simple = KVCacheSimple()
-        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16) * 2.0
-        _ = simple.update(keys: keys, values: values)
+    let simple = KVCacheSimple(stream: .cpu)
+    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
+    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu) * 2.0
+    _ = simple.update(keys: keys, values: values)
 
-        let turbo = simple.toTurboQuant(
-            preset: .turbo3_5,
-            groupSize: 64,
-            backend: .metalPolarQJL
-        )
-        let state = turbo.state
-        eval(state)
+    let turbo = simple.toTurboQuant(
+        preset: .turbo3_5,
+        groupSize: 64,
+        backend: .metalPolarQJL
+    )
+    let state = turbo.state
+    eval(state)
 
-        #expect(turbo.offset == simple.offset)
-        #expect(state.count == 6)
-        #expect(byteCount(state) < byteCount(simple.state))
+    #expect(turbo.offset == simple.offset)
+    #expect(state.count == 6)
+    #expect(byteCount(state) < byteCount(simple.state))
 
-        let configuration = TurboQuantConfiguration(
-            preset: turbo.preset,
-            groupSize: turbo.groupSize,
-            backend: turbo.activeBackend
-        )
-        let decodedKeys = turboDequantized(
-            (weight: state[0], scales: state[1], biases: state[2]),
-            configuration: configuration,
-            dtype: .bfloat16
-        )
-        let decodedValues = turboDequantized(
-            (weight: state[3], scales: state[4], biases: state[5]),
-            configuration: configuration,
-            dtype: .bfloat16
-        )
-        eval([decodedKeys, decodedValues])
+    let configuration = TurboQuantConfiguration(
+        preset: turbo.preset,
+        groupSize: turbo.groupSize,
+        backend: turbo.activeBackend
+    )
+    let decodedKeys = turboDequantized(
+        (weight: state[0], scales: state[1], biases: state[2]),
+        configuration: configuration,
+        dtype: .bfloat16
+    )
+    let decodedValues = turboDequantized(
+        (weight: state[3], scales: state[4], biases: state[5]),
+        configuration: configuration,
+        dtype: .bfloat16
+    )
+    eval([decodedKeys, decodedValues])
 
-        #expect(decodedKeys.shape == keys.shape)
-        #expect(decodedValues.shape == values.shape)
-        #expect(allClose(decodedKeys, keys, rtol: 0.2, atol: 0.2).item(Bool.self))
-        #expect(allClose(decodedValues, values, rtol: 0.2, atol: 0.2).item(Bool.self))
-    }
+    #expect(decodedKeys.shape == keys.shape)
+    #expect(decodedValues.shape == values.shape)
+    #expect(allClose(decodedKeys, keys, rtol: 0.2, atol: 0.2).item(Bool.self))
+    #expect(allClose(decodedValues, values, rtol: 0.2, atol: 0.2).item(Bool.self))
 }
 
 @Test func testTurboQuantDiagnosticsMatchBackendAvailability() throws {
-    withCPUTest {
-        let cache = TurboQuantKVCache(
-            preset: .turbo3_5,
-            groupSize: 64,
-            backend: .metalPolarQJL
-        )
-        let diagnostics = cache.diagnostics
-        let availability = TurboQuantKernelAvailability.current
+    let cache = TurboQuantKVCache(
+        preset: .turbo3_5,
+        groupSize: 64,
+        backend: .metalPolarQJL
+    )
+    let diagnostics = cache.diagnostics
+    let availability = TurboQuantKernelAvailability.current
 
-        #expect(diagnostics.preset == .turbo3_5)
-        #expect(diagnostics.groupSize == 64)
-        #expect(diagnostics.bits == TurboQuantPreset.turbo3_5.effectiveBits)
-        #expect(diagnostics.requestedBackend == .metalPolarQJL)
-        #expect(diagnostics.activeBackend == availability.runtimeBackend(for: .metalPolarQJL))
-        #expect(diagnostics.fallbackReason == availability.fallbackReason(for: .metalPolarQJL))
-        #expect(diagnostics.metalCodecAvailable == availability.supportsMetalPolarQJLCodec)
-    }
+    #expect(diagnostics.preset == .turbo3_5)
+    #expect(diagnostics.groupSize == 64)
+    #expect(diagnostics.bits == TurboQuantPreset.turbo3_5.effectiveBits)
+    #expect(diagnostics.requestedBackend == .metalPolarQJL)
+    #expect(diagnostics.activeBackend == availability.runtimeBackend(for: .metalPolarQJL))
+    #expect(diagnostics.fallbackReason == availability.fallbackReason(for: .metalPolarQJL))
+    #expect(diagnostics.metalCodecAvailable == availability.supportsMetalPolarQJLCodec)
 }
 
 @Test func testRotatingTurboQuantMaintainsWindowAndClearsPackedStateOnMutation() throws {
-    withCPUTest {
-        let cache = RotatingTurboQuantKVCache(
-            maxSize: 6,
-            keep: 2,
-            step: 2,
-            preset: .turbo3_5,
-            groupSize: 64,
-            backend: .metalPolarQJL
-        )
+    let cache = RotatingTurboQuantKVCache(
+        maxSize: 6,
+        keep: 2,
+        step: 2,
+        preset: .turbo3_5,
+        groupSize: 64,
+        backend: .metalPolarQJL
+    )
 
-        for token in 0 ..< 10 {
-            let key = MLXArray(
-                Array(repeating: Float(token + 1), count: 64),
-                [1, 1, 1, 64]
-            ).asType(.bfloat16)
-            let value = MLXArray(
-                Array(repeating: Float(token + 2), count: 64),
-                [1, 1, 1, 64]
-            ).asType(.bfloat16)
-            _ = cache.updateQuantized(keys: key, values: value)
-        }
+    for token in 0 ..< 10 {
+        let key = MLXArray(
+            Array(repeating: Float(token + 1), count: 64),
+            [1, 1, 1, 64]
+        ).asType(.bfloat16, stream: .cpu)
+        let value = MLXArray(
+            Array(repeating: Float(token + 2), count: 64),
+            [1, 1, 1, 64]
+        ).asType(.bfloat16, stream: .cpu)
+        _ = cache.updateQuantized(keys: key, values: value)
+    }
 
-        let state = cache.state
-        eval(state)
+    let state = cache.state
+    eval(state)
 
-        #expect(cache.offset == 10)
-        #expect(cache.maxSize == 6)
-        #expect(state.count == 2)
-        #expect(state[0].shape == [1, 1, 6, 64])
-        #expect(state[1].shape == [1, 1, 6, 64])
+    #expect(cache.offset == 10)
+    #expect(cache.maxSize == 6)
+    #expect(state.count == 2)
+    #expect(state[0].shape == [1, 1, 6, 64])
+    #expect(state[1].shape == [1, 1, 6, 64])
 
-        guard let packed = cache.getQuantizedState() else {
-            Issue.record("Expected rotating TurboQuant cache to expose packed state")
-            return
-        }
-        #expect(packed.0.0.nbytes > 0)
-        #expect(packed.1.0.nbytes > 0)
+    guard let packed = cache.getQuantizedState() else {
+        Issue.record("Expected rotating TurboQuant cache to expose packed state")
+        return
+    }
+    #expect(packed.0.0.nbytes > 0)
+    #expect(packed.1.0.nbytes > 0)
 
-        cache.state = state
-        if cache.getQuantizedState() != nil {
-            Issue.record("Expected assigning raw state to invalidate packed TurboQuant state")
-        }
+    cache.state = state
+    if cache.getQuantizedState() != nil {
+        Issue.record("Expected assigning raw state to invalidate packed TurboQuant state")
     }
 }
 
@@ -277,8 +269,8 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 @Test func testMambaCacheRoundTrip() throws {
     try withCPUTest {
         let cache = MambaCache()
-        let a = MLXArray.ones([2, 4], dtype: .float32) * 5.0
-        let b = MLXArray.ones([2, 4], dtype: .float32) * 9.0
+        let a = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 5.0
+        let b = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 9.0
         cache[0] = a
         cache[1] = b
 
@@ -300,8 +292,8 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
         let simple = KVCacheSimple()
         let rotating = RotatingKVCache(maxSize: 32)
 
-        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
         _ = simple.update(keys: keys, values: values)
         _ = rotating.update(keys: keys * 2.0, values: values * 2.0)
 
@@ -327,12 +319,12 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 @Test func testCacheListHybrid() throws {
     try withCPUTest {
         let mamba = MambaCache()
-        mamba[0] = MLXArray.ones([2, 4], dtype: .float32) * 3.0
-        mamba[1] = MLXArray.ones([2, 4], dtype: .float32) * 4.0
+        mamba[0] = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 3.0
+        mamba[1] = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 4.0
 
         let simple = KVCacheSimple()
-        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
         _ = simple.update(keys: keys, values: values)
 
         let cacheList = CacheList(mamba, simple)
@@ -356,8 +348,8 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 @Test func testSimpleCacheRoundTrip() throws {
     try withCPUTest {
         let cache = KVCacheSimple()
-        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16, stream: .cpu)
         _ = cache.update(keys: keys, values: values)
 
         let url = tempURL()
@@ -373,8 +365,8 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 @Test func testArraysCacheFullyPopulated() throws {
     try withCPUTest {
         let cache = ArraysCache(size: 2)
-        cache[0] = MLXArray.ones([2, 4], dtype: .float32)
-        cache[1] = MLXArray.ones([2, 4], dtype: .float32) * 2.0
+        cache[0] = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu)
+        cache[1] = MLXArray.ones([2, 4], dtype: .float32, stream: .cpu) * 2.0
 
         let url = tempURL()
         try savePromptCache(url: url, cache: [cache], metadata: [:])
@@ -396,8 +388,8 @@ func testCacheCopyIsIndependent(creator: (() -> any KVCache)) async throws {
     withCPUTest {
         let original = creator()
 
-        let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
+        let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16, stream: .cpu)
+        let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16, stream: .cpu)
 
         // populate the original
         switch original {
@@ -439,8 +431,8 @@ func testCacheCopyIsIndependent(creator: (() -> any KVCache)) async throws {
         }
 
         // mutate the copy — push more tokens through it
-        let moreKeys = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
-        let moreValues = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
+        let moreKeys = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16, stream: .cpu)
+        let moreValues = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16, stream: .cpu)
 
         switch copied {
         case let arrays as ArraysCache:
@@ -488,8 +480,8 @@ func testCacheListCopyIsIndependent() async throws {
         let sub2 = RotatingKVCache(maxSize: 32)
         let composite = CacheList(sub1, sub2)
 
-        let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
-        let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
+        let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16, stream: .cpu)
+        let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16, stream: .cpu)
         _ = sub1.update(keys: keys, values: values)
         _ = sub2.update(keys: keys, values: values)
 
@@ -513,8 +505,8 @@ func testCacheListCopyIsIndependent() async throws {
         // mutate inside the copy
         let copiedList = copied as! CacheList
         _ = copiedList[0].update(
-            keys: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16),
-            values: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
+            keys: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16, stream: .cpu),
+            values: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16, stream: .cpu)
         )
 
         // originals unchanged

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -8,6 +8,8 @@ private let cacheCreators: [@Sendable () -> any KVCache] = [
     { KVCacheSimple() },
     { RotatingKVCache(maxSize: 32) },
     { QuantizedKVCache() },
+    { TurboQuantKVCache() },
+    { RotatingTurboQuantKVCache(maxSize: 32) },
     { ChunkedKVCache(chunkSize: 16) },
     { ArraysCache(size: 2) },
     { MambaCache() },
@@ -45,6 +47,10 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
         case let arrays as ArraysCache:
             arrays[0] = keys
             arrays[1] = values
+        case let turbo as TurboQuantKVCache:
+            _ = turbo.updateQuantized(keys: keys, values: values)
+        case let turbo as RotatingTurboQuantKVCache:
+            _ = turbo.updateQuantized(keys: keys, values: values)
         case let quantized as QuantizedKVCache:
             _ = quantized.updateQuantized(keys: keys, values: values)
         default:
@@ -105,6 +111,26 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     let restored = try #require(loaded[0] as? ArraysCache)
     #expect(restored.leftPaddingValues == [0, 5])
     assertArraysClose(restored.state, cache.state)
+}
+
+@Test func testTurboQuantCacheStrategyConvertsSimpleCache() throws {
+    var cache: [KVCache] = [KVCacheSimple()]
+    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+    _ = cache[0].update(keys: keys, values: values)
+
+    maybeQuantizeKVCache(
+        cache: &cache,
+        kvBits: nil,
+        kvGroupSize: 64,
+        quantizedKVStart: 0,
+        kvCacheStrategy: .turboQuant,
+        turboQuantPreset: .turbo3_5
+    )
+
+    #expect(cache[0] is TurboQuantKVCache)
+    let turbo = try #require(cache[0] as? TurboQuantKVCache)
+    #expect(turbo.preset == .turbo3_5)
 }
 
 // MARK: - MambaCache type preservation
@@ -228,6 +254,10 @@ func testCacheCopyIsIndependent(creator: (() -> any KVCache)) async throws {
     case let arrays as ArraysCache:
         arrays[0] = keys
         arrays[1] = values
+    case let turbo as TurboQuantKVCache:
+        _ = turbo.updateQuantized(keys: keys, values: values)
+    case let turbo as RotatingTurboQuantKVCache:
+        _ = turbo.updateQuantized(keys: keys, values: values)
     case let quantized as QuantizedKVCache:
         _ = quantized.updateQuantized(keys: keys, values: values)
     default:

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -33,17 +33,374 @@ private func assertArraysClose(_ lhs: [MLXArray], _ rhs: [MLXArray], label: Stri
     }
 }
 
+private func byteCount(_ arrays: [MLXArray]) -> Int {
+    arrays.reduce(0) { $0 + $1.nbytes }
+}
+
+private func withCPUTest(_ body: () throws -> Void) rethrows {
+    try Device.withDefaultDevice(.cpu, body)
+}
+
+private func withCPUTest(_ body: () async throws -> Void) async rethrows {
+    try await Device.withDefaultDevice(.cpu, body)
+}
+
 // MARK: - Original parameterized test (updated with value assertions)
 
 @Test(
     .serialized,
     arguments: cacheCreators)
 func testCacheSerialization(creator: (() -> any KVCache)) async throws {
-    let cache = (0 ..< 10).map { _ in creator() }
-    let keys = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16)
-    for item in cache {
-        switch item {
+    try withCPUTest {
+        let cache = (0 ..< 10).map { _ in creator() }
+        let keys = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 32, 64], dtype: .bfloat16)
+        for item in cache {
+            switch item {
+            case let arrays as ArraysCache:
+                arrays[0] = keys
+                arrays[1] = values
+            case let turbo as TurboQuantKVCache:
+                _ = turbo.updateQuantized(keys: keys, values: values)
+            case let turbo as RotatingTurboQuantKVCache:
+                _ = turbo.updateQuantized(keys: keys, values: values)
+            case let quantized as QuantizedKVCache:
+                _ = quantized.updateQuantized(keys: keys, values: values)
+            default:
+                _ = item.update(keys: keys, values: values)
+            }
+        }
+
+        let url = tempURL()
+
+        try savePromptCache(url: url, cache: cache, metadata: [:])
+        let (loadedCache, _) = try loadPromptCache(url: url)
+
+        #expect(cache.count == loadedCache.count)
+        for (lhs, rhs) in zip(cache, loadedCache) {
+            #expect(type(of: lhs) == type(of: rhs))
+            #expect(lhs.metaState == rhs.metaState)
+            assertArraysClose(lhs.state, rhs.state)
+        }
+    }
+}
+
+// MARK: - ArraysCache sparse slot round-trip
+
+@Test func testArraysCacheSparseSlots() throws {
+    try withCPUTest {
+        let cache = ArraysCache(size: 3)
+        let a = MLXArray.ones([2, 4], dtype: .float32) * 3.0
+        let b = MLXArray.ones([2, 4], dtype: .float32) * 7.0
+        cache[0] = a
+        // slot 1 stays nil
+        cache[2] = b
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cache], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+
+        #expect(loaded.count == 1)
+        let restored = try #require(loaded[0] as? ArraysCache)
+        #expect(restored.slotCount == 3)
+        #expect(restored[0] != nil)
+        #expect(restored[1] == nil)
+        #expect(restored[2] != nil)
+        #expect(allClose(restored[0]!, a).item(Bool.self))
+        #expect(allClose(restored[2]!, b).item(Bool.self))
+    }
+}
+
+// MARK: - ArraysCache leftPadding round-trip
+
+@Test func testArraysCacheLeftPadding() throws {
+    try withCPUTest {
+        let cache = ArraysCache(size: 2, leftPadding: [0, 5])
+        let a = MLXArray.ones([2, 4], dtype: .float32)
+        let b = MLXArray.ones([2, 4], dtype: .float32) * 2.0
+        cache[0] = a
+        cache[1] = b
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cache], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+
+        let restored = try #require(loaded[0] as? ArraysCache)
+        #expect(restored.leftPaddingValues == [0, 5])
+        assertArraysClose(restored.state, cache.state)
+    }
+}
+
+@Test func testTurboQuantCacheStrategyConvertsSimpleCache() throws {
+    try withCPUTest {
+        var cache: [KVCache] = [KVCacheSimple()]
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        _ = cache[0].update(keys: keys, values: values)
+
+        maybeQuantizeKVCache(
+            cache: &cache,
+            kvBits: nil,
+            kvGroupSize: 64,
+            quantizedKVStart: 0,
+            kvCacheStrategy: .turboQuant,
+            turboQuantPreset: .turbo3_5,
+            turboQuantBackend: .metalPolarQJL
+        )
+
+        #expect(cache[0] is TurboQuantKVCache)
+        let turbo = try #require(cache[0] as? TurboQuantKVCache)
+        #expect(turbo.preset == .turbo3_5)
+        #expect(turbo.requestedBackend == .metalPolarQJL)
+        let expectedBackend: TurboQuantBackend =
+            TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention
+            ? .metalPolarQJL
+            : .mlxPacked
+        #expect(turbo.activeBackend == expectedBackend)
+        if expectedBackend == .mlxPacked {
+            #expect(turbo.backendFallbackReason != nil)
+        }
+    }
+}
+
+@Test func testTurboQuantSimpleConversionKeepsUsableCompressedState() throws {
+    withCPUTest {
+        let simple = KVCacheSimple()
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16) * 2.0
+        _ = simple.update(keys: keys, values: values)
+
+        let turbo = simple.toTurboQuant(
+            preset: .turbo3_5,
+            groupSize: 64,
+            backend: .metalPolarQJL
+        )
+        let state = turbo.state
+        eval(state)
+
+        #expect(turbo.offset == simple.offset)
+        #expect(state.count == 6)
+        #expect(byteCount(state) < byteCount(simple.state))
+
+        let configuration = TurboQuantConfiguration(
+            preset: turbo.preset,
+            groupSize: turbo.groupSize,
+            backend: turbo.activeBackend
+        )
+        let decodedKeys = turboDequantized(
+            (weight: state[0], scales: state[1], biases: state[2]),
+            configuration: configuration,
+            dtype: .bfloat16
+        )
+        let decodedValues = turboDequantized(
+            (weight: state[3], scales: state[4], biases: state[5]),
+            configuration: configuration,
+            dtype: .bfloat16
+        )
+        eval([decodedKeys, decodedValues])
+
+        #expect(decodedKeys.shape == keys.shape)
+        #expect(decodedValues.shape == values.shape)
+        #expect(allClose(decodedKeys, keys, rtol: 0.2, atol: 0.2).item(Bool.self))
+        #expect(allClose(decodedValues, values, rtol: 0.2, atol: 0.2).item(Bool.self))
+    }
+}
+
+@Test func testTurboQuantDiagnosticsMatchBackendAvailability() throws {
+    withCPUTest {
+        let cache = TurboQuantKVCache(
+            preset: .turbo3_5,
+            groupSize: 64,
+            backend: .metalPolarQJL
+        )
+        let diagnostics = cache.diagnostics
+        let availability = TurboQuantKernelAvailability.current
+
+        #expect(diagnostics.preset == .turbo3_5)
+        #expect(diagnostics.groupSize == 64)
+        #expect(diagnostics.bits == TurboQuantPreset.turbo3_5.effectiveBits)
+        #expect(diagnostics.requestedBackend == .metalPolarQJL)
+        #expect(diagnostics.activeBackend == availability.runtimeBackend(for: .metalPolarQJL))
+        #expect(diagnostics.fallbackReason == availability.fallbackReason(for: .metalPolarQJL))
+        #expect(diagnostics.metalCodecAvailable == availability.supportsMetalPolarQJLCodec)
+    }
+}
+
+@Test func testRotatingTurboQuantMaintainsWindowAndClearsPackedStateOnMutation() throws {
+    withCPUTest {
+        let cache = RotatingTurboQuantKVCache(
+            maxSize: 6,
+            keep: 2,
+            step: 2,
+            preset: .turbo3_5,
+            groupSize: 64,
+            backend: .metalPolarQJL
+        )
+
+        for token in 0 ..< 10 {
+            let key = MLXArray(
+                Array(repeating: Float(token + 1), count: 64),
+                [1, 1, 1, 64]
+            ).asType(.bfloat16)
+            let value = MLXArray(
+                Array(repeating: Float(token + 2), count: 64),
+                [1, 1, 1, 64]
+            ).asType(.bfloat16)
+            _ = cache.updateQuantized(keys: key, values: value)
+        }
+
+        let state = cache.state
+        eval(state)
+
+        #expect(cache.offset == 10)
+        #expect(cache.maxSize == 6)
+        #expect(state.count == 2)
+        #expect(state[0].shape == [1, 1, 6, 64])
+        #expect(state[1].shape == [1, 1, 6, 64])
+
+        guard let packed = cache.getQuantizedState() else {
+            Issue.record("Expected rotating TurboQuant cache to expose packed state")
+            return
+        }
+        #expect(packed.0.0.nbytes > 0)
+        #expect(packed.1.0.nbytes > 0)
+
+        cache.state = state
+        if cache.getQuantizedState() != nil {
+            Issue.record("Expected assigning raw state to invalidate packed TurboQuant state")
+        }
+    }
+}
+
+// MARK: - MambaCache type preservation
+
+@Test func testMambaCacheRoundTrip() throws {
+    try withCPUTest {
+        let cache = MambaCache()
+        let a = MLXArray.ones([2, 4], dtype: .float32) * 5.0
+        let b = MLXArray.ones([2, 4], dtype: .float32) * 9.0
+        cache[0] = a
+        cache[1] = b
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cache], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+
+        #expect(loaded.count == 1)
+        let restored = try #require(loaded[0] as? MambaCache)
+        #expect(restored.slotCount == 2)
+        assertArraysClose(restored.state, cache.state)
+    }
+}
+
+// MARK: - CacheList with KV caches
+
+@Test func testCacheListKVCaches() throws {
+    try withCPUTest {
+        let simple = KVCacheSimple()
+        let rotating = RotatingKVCache(maxSize: 32)
+
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        _ = simple.update(keys: keys, values: values)
+        _ = rotating.update(keys: keys * 2.0, values: values * 2.0)
+
+        let cacheList = CacheList(simple, rotating)
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cacheList], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+
+        #expect(loaded.count == 1)
+        let restored = try #require(loaded[0] as? CacheList)
+        let child0 = try #require(restored[0] as? KVCacheSimple)
+        let child1 = try #require(restored[1] as? RotatingKVCache)
+
+        assertArraysClose(child0.state, simple.state, label: "child0")
+        assertArraysClose(child1.state, rotating.state, label: "child1")
+        #expect(child1.metaState == rotating.metaState)
+    }
+}
+
+// MARK: - CacheList with hybrid (MambaCache + KVCacheSimple)
+
+@Test func testCacheListHybrid() throws {
+    try withCPUTest {
+        let mamba = MambaCache()
+        mamba[0] = MLXArray.ones([2, 4], dtype: .float32) * 3.0
+        mamba[1] = MLXArray.ones([2, 4], dtype: .float32) * 4.0
+
+        let simple = KVCacheSimple()
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        _ = simple.update(keys: keys, values: values)
+
+        let cacheList = CacheList(mamba, simple)
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cacheList], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+
+        #expect(loaded.count == 1)
+        let restored = try #require(loaded[0] as? CacheList)
+        let restoredMamba = try #require(restored[0] as? MambaCache)
+        let restoredSimple = try #require(restored[1] as? KVCacheSimple)
+
+        assertArraysClose(restoredMamba.state, mamba.state, label: "mamba")
+        assertArraysClose(restoredSimple.state, simple.state, label: "simple")
+    }
+}
+
+// MARK: - Simple cache round-trip with value assertions
+
+@Test func testSimpleCacheRoundTrip() throws {
+    try withCPUTest {
+        let cache = KVCacheSimple()
+        let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
+        _ = cache.update(keys: keys, values: values)
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cache], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+        #expect(loaded.count == 1)
+        assertArraysClose(loaded[0].state, cache.state)
+    }
+}
+
+// MARK: - ArraysCache fully populated round-trip
+
+@Test func testArraysCacheFullyPopulated() throws {
+    try withCPUTest {
+        let cache = ArraysCache(size: 2)
+        cache[0] = MLXArray.ones([2, 4], dtype: .float32)
+        cache[1] = MLXArray.ones([2, 4], dtype: .float32) * 2.0
+
+        let url = tempURL()
+        try savePromptCache(url: url, cache: [cache], metadata: [:])
+        let (loaded, _) = try loadPromptCache(url: url)
+
+        #expect(loaded.count == 1)
+        let restored = try #require(loaded[0] as? ArraysCache)
+        #expect(restored.slotCount == 2)
+        assertArraysClose(restored.state, cache.state)
+    }
+}
+
+/// Verify that copy() produces an independent cache: same type, same state,
+/// but mutating the copy does not affect the original.
+@Test(
+    .serialized,
+    arguments: cacheCreators)
+func testCacheCopyIsIndependent(creator: (() -> any KVCache)) async throws {
+    withCPUTest {
+        let original = creator()
+
+        let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
+
+        // populate the original
+        switch original {
         case let arrays as ArraysCache:
             arrays[0] = keys
             arrays[1] = values
@@ -54,273 +411,57 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
         case let quantized as QuantizedKVCache:
             _ = quantized.updateQuantized(keys: keys, values: values)
         default:
-            _ = item.update(keys: keys, values: values)
+            _ = original.update(keys: keys, values: values)
         }
-    }
 
-    let url = tempURL()
+        let originalOffset = original.offset
+        let originalState = original.state
+        eval(originalState)
+        let originalMeta = original.metaState
 
-    try savePromptCache(url: url, cache: cache, metadata: [:])
-    let (loadedCache, _) = try loadPromptCache(url: url)
+        // copy
+        let copied = original.copy()
 
-    #expect(cache.count == loadedCache.count)
-    for (lhs, rhs) in zip(cache, loadedCache) {
-        #expect(type(of: lhs) == type(of: rhs))
-        #expect(lhs.metaState == rhs.metaState)
-        assertArraysClose(lhs.state, rhs.state)
-    }
-}
+        // same type
+        #expect(type(of: original) == type(of: copied))
 
-// MARK: - ArraysCache sparse slot round-trip
+        // same offset and metadata
+        #expect(copied.offset == originalOffset)
+        #expect(copied.metaState == originalMeta)
 
-@Test func testArraysCacheSparseSlots() throws {
-    let cache = ArraysCache(size: 3)
-    let a = MLXArray.ones([2, 4], dtype: .float32) * 3.0
-    let b = MLXArray.ones([2, 4], dtype: .float32) * 7.0
-    cache[0] = a
-    // slot 1 stays nil
-    cache[2] = b
+        // same state values
+        let copiedState = copied.state
+        eval(copiedState)
+        #expect(copiedState.count == originalState.count)
+        for (origArr, copyArr) in zip(originalState, copiedState) {
+            #expect(origArr.shape == copyArr.shape)
+            #expect(allClose(origArr, copyArr).item(Bool.self))
+        }
 
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cache], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
+        // mutate the copy — push more tokens through it
+        let moreKeys = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
+        let moreValues = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
 
-    #expect(loaded.count == 1)
-    let restored = try #require(loaded[0] as? ArraysCache)
-    #expect(restored.slotCount == 3)
-    #expect(restored[0] != nil)
-    #expect(restored[1] == nil)
-    #expect(restored[2] != nil)
-    #expect(allClose(restored[0]!, a).item(Bool.self))
-    #expect(allClose(restored[2]!, b).item(Bool.self))
-}
+        switch copied {
+        case let arrays as ArraysCache:
+            // overwrite slot 0 with a different array
+            arrays[0] = moreKeys
+        case let quantized as QuantizedKVCache:
+            _ = quantized.updateQuantized(keys: moreKeys, values: moreValues)
+        default:
+            _ = copied.update(keys: moreKeys, values: moreValues)
+        }
 
-// MARK: - ArraysCache leftPadding round-trip
-
-@Test func testArraysCacheLeftPadding() throws {
-    let cache = ArraysCache(size: 2, leftPadding: [0, 5])
-    let a = MLXArray.ones([2, 4], dtype: .float32)
-    let b = MLXArray.ones([2, 4], dtype: .float32) * 2.0
-    cache[0] = a
-    cache[1] = b
-
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cache], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
-
-    let restored = try #require(loaded[0] as? ArraysCache)
-    #expect(restored.leftPaddingValues == [0, 5])
-    assertArraysClose(restored.state, cache.state)
-}
-
-@Test func testTurboQuantCacheStrategyConvertsSimpleCache() throws {
-    var cache: [KVCache] = [KVCacheSimple()]
-    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    _ = cache[0].update(keys: keys, values: values)
-
-    maybeQuantizeKVCache(
-        cache: &cache,
-        kvBits: nil,
-        kvGroupSize: 64,
-        quantizedKVStart: 0,
-        kvCacheStrategy: .turboQuant,
-        turboQuantPreset: .turbo3_5,
-        turboQuantBackend: .metalPolarQJL
-    )
-
-    #expect(cache[0] is TurboQuantKVCache)
-    let turbo = try #require(cache[0] as? TurboQuantKVCache)
-    #expect(turbo.preset == .turbo3_5)
-    #expect(turbo.requestedBackend == .metalPolarQJL)
-    let expectedBackend: TurboQuantBackend =
-        TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention
-        ? .metalPolarQJL
-        : .mlxPacked
-    #expect(turbo.activeBackend == expectedBackend)
-    if expectedBackend == .mlxPacked {
-        #expect(turbo.backendFallbackReason != nil)
-    }
-}
-
-// MARK: - MambaCache type preservation
-
-@Test func testMambaCacheRoundTrip() throws {
-    let cache = MambaCache()
-    let a = MLXArray.ones([2, 4], dtype: .float32) * 5.0
-    let b = MLXArray.ones([2, 4], dtype: .float32) * 9.0
-    cache[0] = a
-    cache[1] = b
-
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cache], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
-
-    #expect(loaded.count == 1)
-    let restored = try #require(loaded[0] as? MambaCache)
-    #expect(restored.slotCount == 2)
-    assertArraysClose(restored.state, cache.state)
-}
-
-// MARK: - CacheList with KV caches
-
-@Test func testCacheListKVCaches() throws {
-    let simple = KVCacheSimple()
-    let rotating = RotatingKVCache(maxSize: 32)
-
-    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    _ = simple.update(keys: keys, values: values)
-    _ = rotating.update(keys: keys * 2.0, values: values * 2.0)
-
-    let cacheList = CacheList(simple, rotating)
-
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cacheList], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
-
-    #expect(loaded.count == 1)
-    let restored = try #require(loaded[0] as? CacheList)
-    let child0 = try #require(restored[0] as? KVCacheSimple)
-    let child1 = try #require(restored[1] as? RotatingKVCache)
-
-    assertArraysClose(child0.state, simple.state, label: "child0")
-    assertArraysClose(child1.state, rotating.state, label: "child1")
-    #expect(child1.metaState == rotating.metaState)
-}
-
-// MARK: - CacheList with hybrid (MambaCache + KVCacheSimple)
-
-@Test func testCacheListHybrid() throws {
-    let mamba = MambaCache()
-    mamba[0] = MLXArray.ones([2, 4], dtype: .float32) * 3.0
-    mamba[1] = MLXArray.ones([2, 4], dtype: .float32) * 4.0
-
-    let simple = KVCacheSimple()
-    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    _ = simple.update(keys: keys, values: values)
-
-    let cacheList = CacheList(mamba, simple)
-
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cacheList], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
-
-    #expect(loaded.count == 1)
-    let restored = try #require(loaded[0] as? CacheList)
-    let restoredMamba = try #require(restored[0] as? MambaCache)
-    let restoredSimple = try #require(restored[1] as? KVCacheSimple)
-
-    assertArraysClose(restoredMamba.state, mamba.state, label: "mamba")
-    assertArraysClose(restoredSimple.state, simple.state, label: "simple")
-}
-
-// MARK: - Simple cache round-trip with value assertions
-
-@Test func testSimpleCacheRoundTrip() throws {
-    let cache = KVCacheSimple()
-    let keys = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 16, 64], dtype: .bfloat16)
-    _ = cache.update(keys: keys, values: values)
-
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cache], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
-    #expect(loaded.count == 1)
-    assertArraysClose(loaded[0].state, cache.state)
-}
-
-// MARK: - ArraysCache fully populated round-trip
-
-@Test func testArraysCacheFullyPopulated() throws {
-    let cache = ArraysCache(size: 2)
-    cache[0] = MLXArray.ones([2, 4], dtype: .float32)
-    cache[1] = MLXArray.ones([2, 4], dtype: .float32) * 2.0
-
-    let url = tempURL()
-    try savePromptCache(url: url, cache: [cache], metadata: [:])
-    let (loaded, _) = try loadPromptCache(url: url)
-
-    #expect(loaded.count == 1)
-    let restored = try #require(loaded[0] as? ArraysCache)
-    #expect(restored.slotCount == 2)
-    assertArraysClose(restored.state, cache.state)
-}
-
-/// Verify that copy() produces an independent cache: same type, same state,
-/// but mutating the copy does not affect the original.
-@Test(
-    .serialized,
-    arguments: cacheCreators)
-func testCacheCopyIsIndependent(creator: (() -> any KVCache)) async throws {
-    let original = creator()
-
-    let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
-
-    // populate the original
-    switch original {
-    case let arrays as ArraysCache:
-        arrays[0] = keys
-        arrays[1] = values
-    case let turbo as TurboQuantKVCache:
-        _ = turbo.updateQuantized(keys: keys, values: values)
-    case let turbo as RotatingTurboQuantKVCache:
-        _ = turbo.updateQuantized(keys: keys, values: values)
-    case let quantized as QuantizedKVCache:
-        _ = quantized.updateQuantized(keys: keys, values: values)
-    default:
-        _ = original.update(keys: keys, values: values)
-    }
-
-    let originalOffset = original.offset
-    let originalState = original.state
-    eval(originalState)
-    let originalMeta = original.metaState
-
-    // copy
-    let copied = original.copy()
-
-    // same type
-    #expect(type(of: original) == type(of: copied))
-
-    // same offset and metadata
-    #expect(copied.offset == originalOffset)
-    #expect(copied.metaState == originalMeta)
-
-    // same state values
-    let copiedState = copied.state
-    eval(copiedState)
-    #expect(copiedState.count == originalState.count)
-    for (origArr, copyArr) in zip(originalState, copiedState) {
-        #expect(origArr.shape == copyArr.shape)
-        #expect(allClose(origArr, copyArr).item(Bool.self))
-    }
-
-    // mutate the copy — push more tokens through it
-    let moreKeys = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
-    let moreValues = MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
-
-    switch copied {
-    case let arrays as ArraysCache:
-        // overwrite slot 0 with a different array
-        arrays[0] = moreKeys
-    case let quantized as QuantizedKVCache:
-        _ = quantized.updateQuantized(keys: moreKeys, values: moreValues)
-    default:
-        _ = copied.update(keys: moreKeys, values: moreValues)
-    }
-
-    // original must be unchanged
-    #expect(original.offset == originalOffset)
-    #expect(original.metaState == originalMeta)
-    let currentState = original.state
-    eval(currentState)
-    #expect(currentState.count == originalState.count)
-    for (origArr, savedArr) in zip(currentState, originalState) {
-        #expect(origArr.shape == savedArr.shape)
-        #expect(allClose(origArr, savedArr).item(Bool.self))
+        // original must be unchanged
+        #expect(original.offset == originalOffset)
+        #expect(original.metaState == originalMeta)
+        let currentState = original.state
+        eval(currentState)
+        #expect(currentState.count == originalState.count)
+        for (origArr, savedArr) in zip(currentState, originalState) {
+            #expect(origArr.shape == savedArr.shape)
+            #expect(allClose(origArr, savedArr).item(Bool.self))
+        }
     }
 }
 
@@ -329,58 +470,62 @@ func testCacheCopyIsIndependent(creator: (() -> any KVCache)) async throws {
     .serialized,
     arguments: cacheCreators)
 func testCacheCopyOnEmptyCache(creator: (() -> any KVCache)) async throws {
-    let empty = creator()
-    let copied = empty.copy()
+    withCPUTest {
+        let empty = creator()
+        let copied = empty.copy()
 
-    #expect(type(of: empty) == type(of: copied))
-    #expect(copied.offset == 0)
-    #expect(copied.state.count == empty.state.count)
+        #expect(type(of: empty) == type(of: copied))
+        #expect(copied.offset == 0)
+        #expect(copied.state.count == empty.state.count)
+    }
 }
 
 /// CacheList.copy() produces independent sub-caches.
 @Test
 func testCacheListCopyIsIndependent() async throws {
-    let sub1 = KVCacheSimple()
-    let sub2 = RotatingKVCache(maxSize: 32)
-    let composite = CacheList(sub1, sub2)
+    withCPUTest {
+        let sub1 = KVCacheSimple()
+        let sub2 = RotatingKVCache(maxSize: 32)
+        let composite = CacheList(sub1, sub2)
 
-    let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
-    let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
-    _ = sub1.update(keys: keys, values: values)
-    _ = sub2.update(keys: keys, values: values)
+        let keys = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
+        let values = MLXArray.ones([1, 8, 4, 64], dtype: .bfloat16)
+        _ = sub1.update(keys: keys, values: values)
+        _ = sub2.update(keys: keys, values: values)
 
-    // snapshot original state — eval to materialize before copy
-    let originalState = composite.state
-    eval(originalState)
-    let originalOffset0 = sub1.offset
-    let originalOffset1 = sub2.offset
+        // snapshot original state — eval to materialize before copy
+        let originalState = composite.state
+        eval(originalState)
+        let originalOffset0 = sub1.offset
+        let originalOffset1 = sub2.offset
 
-    let copied = composite.copy()
+        let copied = composite.copy()
 
-    #expect(copied is CacheList)
-    let copiedState = copied.state
-    eval(copiedState)
-    #expect(copiedState.count == originalState.count)
-    for (orig, copy) in zip(originalState, copiedState) {
-        #expect(orig.shape == copy.shape)
-        #expect(allClose(orig, copy).item(Bool.self))
-    }
+        #expect(copied is CacheList)
+        let copiedState = copied.state
+        eval(copiedState)
+        #expect(copiedState.count == originalState.count)
+        for (orig, copy) in zip(originalState, copiedState) {
+            #expect(orig.shape == copy.shape)
+            #expect(allClose(orig, copy).item(Bool.self))
+        }
 
-    // mutate inside the copy
-    let copiedList = copied as! CacheList
-    _ = copiedList[0].update(
-        keys: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16),
-        values: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
-    )
+        // mutate inside the copy
+        let copiedList = copied as! CacheList
+        _ = copiedList[0].update(
+            keys: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16),
+            values: MLXArray.zeros([1, 8, 2, 64], dtype: .bfloat16)
+        )
 
-    // originals unchanged
-    #expect(sub1.offset == originalOffset0)
-    #expect(sub2.offset == originalOffset1)
-    let currentState = composite.state
-    eval(currentState)
-    #expect(currentState.count == originalState.count)
-    for (orig, saved) in zip(currentState, originalState) {
-        #expect(orig.shape == saved.shape)
-        #expect(allClose(orig, saved).item(Bool.self))
+        // originals unchanged
+        #expect(sub1.offset == originalOffset0)
+        #expect(sub2.offset == originalOffset1)
+        let currentState = composite.state
+        eval(currentState)
+        #expect(currentState.count == originalState.count)
+        for (orig, saved) in zip(currentState, originalState) {
+            #expect(orig.shape == saved.shape)
+            #expect(allClose(orig, saved).item(Bool.self))
+        }
     }
 }

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -133,8 +133,38 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     let turbo = try #require(cache[0] as? TurboQuantKVCache)
     #expect(turbo.preset == .turbo3_5)
     #expect(turbo.requestedBackend == .metalPolarQJL)
-    #expect(turbo.activeBackend == .mlxPacked)
-    #expect(turbo.backendFallbackReason != nil)
+    let expectedBackend: TurboQuantBackend =
+        TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention
+        ? .metalPolarQJL
+        : .mlxPacked
+    #expect(turbo.activeBackend == expectedBackend)
+    if expectedBackend == .mlxPacked {
+        #expect(turbo.backendFallbackReason != nil)
+    }
+}
+
+@Test func testTurboQuantCompressedAttentionStateWhenAvailable() throws {
+    guard TurboQuantKernelAvailability.current.supportsMetalPolarQJLAttention else { return }
+
+    let cache = TurboQuantKVCache(backend: .metalPolarQJL)
+    let keys = MLXArray.ones([1, 2, 2, 64], dtype: .float32)
+    let values = MLXArray.ones([1, 2, 2, 64], dtype: .float32)
+    let queries = MLXArray.ones([1, 4, 1, 64], dtype: .float32)
+
+    #expect(
+        cache.supportsCompressedAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            mask: .none
+        )
+    )
+    let (compressedKeys, compressedValues) = try cache.updateCompressed(keys: keys, values: values)
+
+    #expect(cache.compressedState != nil)
+    #expect(compressedKeys.layout.logicalLength == 2)
+    #expect(compressedValues.layout.logicalLength == 2)
+    #expect(cache.attentionDiagnostics.activeAttentionPath == .onlineFused)
 }
 
 // MARK: - MambaCache type preservation


### PR DESCRIPTION
## Summary

Draft TurboQuant KV-cache integration branch.

Current status after upstream feedback on `mlx-swift#412`:

- the previous `mlx-swift` support PR has been closed
- this branch is decoupled from lower-level Cmlx/MLX-kernel work
- the intended upstream shape is LM-side cache plumbing only
- lower-level TurboQuant kernel work belongs in a custom extension/custom kernel path, or behind the generic quantized SDPA direction in `mlx`

The branch is intentionally still draft while that split is completed.

## Validation

Current validation:

- `pre-commit run --all-files` passed
- `xcodebuild -quiet test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -only-testing:MLXLMTests/KVCacheTests` passed

Earlier full validation before the split:

- `swift test --filter TurboQuant` passed: 4 Swift Testing tests, 0 failures
- `swift test --filter KVCacheTests` passed: 15 Swift Testing tests, 0 failures
- `swift test` passed: 101 XCTest tests and 69 Swift Testing tests, 0 failures

The separate SwiftPM `default.metallib` resource-loading issue remains tracked in ml-explore/mlx#3562.
