### PR TITLE
Fix nomic-embed-text-v1.5 'Key embeddings.position_embeddings.weight not found'

### DIFF
--- a/Libraries/MLXEmbedders/Models/NomicBert.swift
+++ b/Libraries/MLXEmbedders/Models/NomicBert.swift
@@ -59,8 +59,10 @@ class NomicEmbedding: Module {
             )
         }
 
-        // Conditionally initialize Position Embeddings
-        if config.maxPositionEmbeddings > 0 {
+        // Conditionally initialize position embeddings (no RoPE or fractional RoPE)
+        // Models like nomic-embed-text-v1.5 rely entirely on
+        // rotary positional embeddings and ship no `position_embeddings.weight` tensor.
+        if config.maxPositionEmbeddings > 0 && config.rotaryEmbFraction < 1.0 {
             _positionEmbeddings.wrappedValue = Embedding(
                 embeddingCount: config.maxPositionEmbeddings,
                 dimensions: config.embedDim

--- a/Tests/MLXLMTests/NomicBertTests.swift
+++ b/Tests/MLXLMTests/NomicBertTests.swift
@@ -1,0 +1,53 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXEmbedders
+
+struct NomicBertTests {
+
+    @Test
+    func testFullRoPESkipsLearnedPositions() throws {
+        // NomicEmbedding skips learned position table when rotary_emb_fraction == 1.0
+        // nomic-embed-text-v1.5 has rotary_emb_fraction == 1.0 and no learned position_embeddings.weight
+        // tensor.
+        // Loading the module unconditionally caused weight loading
+        // to fail with "Key embeddings.position_embeddings.weight not found".
+        let json = """
+            {
+              "vocab_size": 100,
+              "n_embd": 32,
+              "n_head": 4,
+              "n_layer": 1,
+              "max_position_embeddings": 2048,
+              "rotary_emb_fraction": 1.0
+            }
+            """
+        let config = try JSONDecoder().decode(
+            NomicBertConfiguration.self, from: Data(json.utf8))
+        let embedding = NomicEmbedding(config)
+
+        #expect(embedding.positionEmbeddings == nil)
+    }
+
+    @Test
+    func testPartialOrNoRoPEAllocatesLearnedPositions() throws {
+        // NomicEmbedding allocates learned position table when rotary_emb_fraction < 1.0
+        let partialRopeJson = """
+            {
+              "vocab_size": 100,
+              "n_embd": 32,
+              "n_head": 4,
+              "n_layer": 1,
+              "max_position_embeddings": 512,
+              "rotary_emb_fraction": 0.4
+            }
+            """
+        let config = try JSONDecoder().decode(
+            NomicBertConfiguration.self, from: Data(partialRopeJson.utf8))
+        let embedding = NomicEmbedding(config)
+
+        #expect(embedding.positionEmbeddings != nil)
+    }
+}


### PR DESCRIPTION
## Proposed changes

When I tried using `nomic-embed-text-v1.5`, I got the following failure: `Key embeddings.position_embeddings.weight not found'`
This change addresses the issue by conditionally initializing position embeddings (only for no RoPE or fractional RoPE)

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
