### PR TITLE
fix Gemma 4 tool calls in `ml-explore/mlx-swift-lm`

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/ToolCallIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/ToolCallIntegrationTests.swift
@@ -99,4 +99,18 @@ struct ToolCallIntegrationTests {
             for: .init(id: IntegrationTestModelIDs.qwen35))
         try await ToolCallTests.qwen35MultiToolGeneration(container: container)
     }
+
+    // MARK: - Gemma 4
+
+    @Test func gemma4FormatAutoDetection() async throws {
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.gemma4))
+        try await ToolCallTests.gemma4FormatAutoDetection(container: container)
+    }
+
+    @Test func gemma4EndToEnd() async throws {
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.gemma4))
+        try await ToolCallTests.gemma4EndToEndGeneration(container: container)
+    }
 }

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -38,6 +38,7 @@ public enum IntegrationTestModelIDs {
     public static let mistral3 = "mlx-community/Ministral-3-3B-Instruct-2512-4bit"
     public static let nemotron = "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit"
     public static let qwen35 = "mlx-community/Qwen3.5-2B-4bit"
+    public static let gemma4 = "mlx-community/gemma-4-e2b-it-4bit"
 }
 
 // MARK: - Model Loading
@@ -750,6 +751,39 @@ public enum ToolCallTests {
         try check(
             toolCalls.count > 1,
             "Expected multiple tool calls, got \(toolCalls.count)"
+        )
+    }
+
+    // MARK: Gemma 4
+
+    public static func gemma4FormatAutoDetection(container: LLModelContainer) async throws {
+        let config = await container.configuration
+        try check(
+            config.toolCallFormat == ToolCallFormat.gemma4,
+            "Expected .gemma4 tool call format, got: \(String(describing: config.toolCallFormat))"
+        )
+    }
+
+    public static func gemma4EndToEndGeneration(container: LLModelContainer) async throws {
+        let (result, toolCalls) = try await generateWithTools(
+            container: container,
+            userMessage: "What's the weather in Tokyo?")
+
+        print("Gemma4 Output:", result)
+        print("Gemma4 Tool Calls:", toolCalls)
+
+        try check(!toolCalls.isEmpty, "Expected at least one tool call, got none")
+        let toolCall = toolCalls[0]
+        try check(
+            toolCall.function.name == "get_weather",
+            "Expected tool name 'get_weather', got: \(toolCall.function.name)"
+        )
+        guard case .string(let location) = toolCall.function.arguments["location"] else {
+            throw IntegrationTestFailure("Expected string 'location' argument")
+        }
+        try check(
+            location.lowercased().contains("tokyo"),
+            "Expected location containing 'Tokyo', got: \(location)"
         )
     }
 

--- a/Libraries/MLXLMCommon/Tool/Parsers/Gemma4FunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Gemma4FunctionParser.swift
@@ -1,0 +1,75 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+
+/// Parser for Gemma 4 format: `<|tool_call>call:name{key:value,k:<|"|>str<|"|>}<tool_call|>`
+///
+/// Differs from Gemma 1–3 (`GemmaFunctionParser`) in two ways:
+/// - Tool-call tokens are `<|tool_call>` / `<tool_call|>` (asymmetric `|` placement),
+///   matching `stc_token` / `etc_token` in Gemma 4's tokenizer config.
+/// - The escape marker around string values is `<|"|>` (Gemma 4's `escape_token`)
+///   rather than `<escape>`.
+public struct Gemma4FunctionParser: ToolCallParser, Sendable {
+    public let startTag: String? = "<|tool_call>"
+    public let endTag: String? = "<tool_call|>"
+
+    private let escapeMarker = "<|\"|>"
+
+    public init() {}
+
+    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        var text = content
+        if let start = startTag {
+            text = text.replacingOccurrences(of: start, with: "")
+        }
+        if let end = endTag {
+            text = text.replacingOccurrences(of: end, with: "")
+        }
+
+        guard let callRange = text.range(of: "call:") else { return nil }
+        let remaining = String(text[callRange.upperBound...])
+
+        guard let braceStart = remaining.firstIndex(of: "{") else { return nil }
+        let funcName = String(remaining[..<braceStart])
+        guard !funcName.isEmpty else { return nil }
+
+        guard let braceEnd = remaining.lastIndex(of: "}") else { return nil }
+        var argsStr = String(remaining[remaining.index(after: braceStart) ..< braceEnd])
+
+        var arguments: [String: any Sendable] = [:]
+
+        while !argsStr.isEmpty {
+            guard let colonIdx = argsStr.firstIndex(of: ":") else { break }
+            let key = String(argsStr[..<colonIdx])
+            argsStr = String(argsStr[argsStr.index(after: colonIdx)...])
+
+            if argsStr.hasPrefix(escapeMarker) {
+                argsStr = String(argsStr.dropFirst(escapeMarker.count))
+                guard let endEscape = argsStr.range(of: escapeMarker) else { break }
+                let value = String(argsStr[..<endEscape.lowerBound])
+                arguments[key] = value
+                argsStr = String(argsStr[endEscape.upperBound...])
+                if argsStr.hasPrefix(",") {
+                    argsStr = String(argsStr.dropFirst())
+                }
+                continue
+            }
+
+            let commaIdx = argsStr.firstIndex(of: ",") ?? argsStr.endIndex
+            let value = String(argsStr[..<commaIdx])
+            argsStr =
+                commaIdx < argsStr.endIndex
+                ? String(argsStr[argsStr.index(after: commaIdx)...]) : ""
+
+            if let data = value.data(using: .utf8),
+                let json = deserializeJSON(data)
+            {
+                arguments[key] = json
+            } else {
+                arguments[key] = value
+            }
+        }
+
+        return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -82,6 +82,10 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// Example: `call:name{key:value,k:<escape>str<escape>}`
     case gemma
 
+    /// Gemma 4 function call format.
+    /// Example: `<|tool_call>call:name{key:value,k:<|"|>str<|"|>}<tool_call|>`
+    case gemma4
+
     /// Kimi K2 format with functions prefix.
     /// Example: `functions.name:0<|tool_call_argument_begin|>{"key": "value"}`
     case kimiK2 = "kimi_k2"
@@ -115,6 +119,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return GLM4ToolCallParser()
         case .gemma:
             return GemmaFunctionParser()
+        case .gemma4:
+            return Gemma4FunctionParser()
         case .kimiK2:
             return KimiK2ToolCallParser()
         case .minimaxM2:
@@ -168,6 +174,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // GLM4 family (glm4, glm4_moe, glm4_moe_lite, etc.)
         if type.hasPrefix("glm4") {
             return .glm4
+        }
+
+        // Gemma 4 (must precede the generic "gemma" check; uses different tool-call
+        // tokens and escape marker than Gemma 1–3).
+        if type.hasPrefix("gemma4") {
+            return .gemma4
         }
 
         // Gemma

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -505,6 +505,69 @@ struct ToolTests {
         #expect(toolCall.function.arguments["expression"] == .string("2+2"))
     }
 
+    // MARK: - Gemma 4 Format Tests
+
+    @Test("Test Gemma 4 Function Parser")
+    func testGemma4Parser() throws {
+        let parser = Gemma4FunctionParser()
+        let content =
+            "<|tool_call>call:get_weather{location:Paris,unit:celsius}<tool_call|>"
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+        #expect(toolCall.function.arguments["unit"] == .string("celsius"))
+    }
+
+    @Test("Test Gemma 4 Function Parser - Escaped Strings")
+    func testGemma4ParserEscapedStrings() throws {
+        let parser = Gemma4FunctionParser()
+        // Gemma 4's escape token is <|"|> (escape_token in tokenizer_config),
+        // surrounding string values that may contain commas, braces, or other delimiters.
+        let content =
+            "<|tool_call>call:search_journal{query:<|\"|>Asparaginase-Reaktion<|\"|>}<tool_call|>"
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "search_journal")
+        #expect(toolCall.function.arguments["query"] == .string("Asparaginase-Reaktion"))
+    }
+
+    @Test("Test Gemma 4 Format via ToolCallProcessor")
+    func testGemma4FormatProcessor() throws {
+        let processor = ToolCallProcessor(format: .gemma4)
+        let content =
+            "<|tool_call>call:search_journal{query:<|\"|>Asparaginase-Reaktion<|\"|>}<tool_call|>"
+
+        _ = processor.processChunk(content)
+
+        #expect(processor.toolCalls.count == 1)
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "search_journal")
+        #expect(toolCall.function.arguments["query"] == .string("Asparaginase-Reaktion"))
+    }
+
+    @Test("Test Gemma 4 Format via ToolCallProcessor - leading thinking channel")
+    func testGemma4FormatProcessorWithThinkingChannel() throws {
+        // Mirrors real Gemma 4 output: the thinking channel comes first, then the tool call.
+        // The processor's tagged path looks for the start character `<`, so the channel
+        // tags get probed but should fail the partial-match check and be returned as text.
+        let processor = ToolCallProcessor(format: .gemma4)
+        let chunk1 = "<|channel>thought\nUser wants journal search.<channel|>"
+        let chunk2 = "<|tool_call>call:search{q:hello}<tool_call|>"
+
+        let out1 = processor.processChunk(chunk1)
+        let out2 = processor.processChunk(chunk2)
+
+        #expect(out1 == chunk1)
+        #expect(out2 == nil || out2?.isEmpty == true)
+        #expect(processor.toolCalls.count == 1)
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "search")
+        #expect(toolCall.function.arguments["q"] == .string("hello"))
+    }
+
     // MARK: - Kimi K2 Format Tests
 
     @Test("Test Kimi K2 Tool Call Parser")
@@ -638,6 +701,7 @@ struct ToolTests {
         #expect(ToolCallFormat.xmlFunction.rawValue == "xml_function")
         #expect(ToolCallFormat.glm4.rawValue == "glm4")
         #expect(ToolCallFormat.gemma.rawValue == "gemma")
+        #expect(ToolCallFormat.gemma4.rawValue == "gemma4")
         #expect(ToolCallFormat.kimiK2.rawValue == "kimi_k2")
         #expect(ToolCallFormat.minimaxM2.rawValue == "minimax_m2")
         #expect(ToolCallFormat.mistral.rawValue == "mistral")
@@ -670,6 +734,14 @@ struct ToolTests {
         // Gemma models
         #expect(ToolCallFormat.infer(from: "gemma") == .gemma)
         #expect(ToolCallFormat.infer(from: "GEMMA") == .gemma)
+
+        // Gemma 4 family (top-level config has model_type = "gemma4";
+        // sub-configs use gemma4_text / gemma4_audio / gemma4_vision)
+        #expect(ToolCallFormat.infer(from: "gemma4") == .gemma4)
+        #expect(ToolCallFormat.infer(from: "GEMMA4") == .gemma4)
+        #expect(ToolCallFormat.infer(from: "gemma4_text") == .gemma4)
+        // Confirm Gemma 1–3 still routes to .gemma, not .gemma4
+        #expect(ToolCallFormat.infer(from: "gemma") == .gemma)
 
         // Nemotron models (prefix matching)
         #expect(ToolCallFormat.infer(from: "nemotron_h") == .xmlFunction)


### PR DESCRIPTION
# PR fix Gemma 4 tool calls in `ml-explore/mlx-swift-lm`

## Summary

Gemma 4 models such as `mlx-community/gemma-4-e2b-it-4bit` and `...-e4b-it-4bit` emit native tool calls, but `ChatSession` did not invoke `toolDispatch`. Instead, the generated `<|tool_call>...<tool_call|>` text was returned as ordinary content.

This happened because `ToolCallFormat.infer` did not recognise `model_type = "gemma4"`, and the existing Gemma parser listens for Gemma 1-3 tags (`<start_function_call>` / `<end_function_call>`) rather than Gemma 4's tokenizer-defined tool-call tokens.

## Changes

- Adds a new `.gemma4` `ToolCallFormat` case backed by `Gemma4FunctionParser`.
- Infers `.gemma4` for model types starting with `gemma4`, including `gemma4`, `gemma4_text`, `gemma4_audio`, and `gemma4_vision`.
- Parses Gemma 4 calls using `<|tool_call>` / `<tool_call|>` and the `<|"|>` escape marker from `tokenizer_config.json`.
- Leaves the existing `.gemma` parser unchanged so Gemma 1-3 behavior is preserved.
- Adds focused unit tests for parser behavior, streaming `ToolCallProcessor` behavior, leading thinking-channel output, format inference, and Gemma 1-3 routing.
- Adds Gemma 4 integration test coverage for auto-detection and end-to-end tool-call parsing.

## Verification

Local Apple Silicon, `swift-driver 1.148.6 / Apple Swift 6.3.1`.

- `swift build` - clean.
- `pre-commit run --all-files` - clean (`swift-format` passed).
- `xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS'` - all unit tests pass: 101 XCTest cases + 69 Swift Testing cases across 5 suites, 0 failures. `ToolTests` covers all four new Gemma 4 cases plus the unchanged Gemma 1-3 cases.
- `xcodebuild test -only-testing:IntegrationTestingTests/ToolCallIntegrationTests/gemma4FormatAutoDetection()` against `mlx-community/gemma-4-e2b-it-4bit` - passed.
- `xcodebuild test -only-testing:IntegrationTestingTests/ToolCallIntegrationTests/gemma4EndToEnd()` against the same model - passed.

Observed real-model tool call:

```swift
Gemma4 Tool Calls: [MLXLMCommon.ToolCall(function: MLXLMCommon.ToolCall.Function(
    name: "get_weather",
    arguments: ["location": MLXLMCommon.JSONValue.string("Tokyo")]))]
```

The tool call is parsed correctly and the tool-call wrapper text no longer leaks into the response.

## Notes

- Token source: `mlx-community/gemma-4-e2b-it-4bit/tokenizer_config.json`, which defines `stc_token = "<|tool_call>"`, `etc_token = "<tool_call|>"`, `escape_token = "<|\"|>"`, and `response_schema.x-regex-iterator = "<\\|tool_call>(.*?)<tool_call\\|>"`.
- I used a new `.gemma4` case rather than changing `.gemma` because Gemma 4 uses different wrapper tokens and a different escape marker.
- I have not added a live multi-tool Gemma 4 integration test. The streaming processor supports adjacent tagged calls, but I have not exercised parallel tool calls against the live model.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
