### PR TITLE
[codex] Add OpenAI-compatible inference server

### DIFF
--- a/Executables/mlx-server/main.swift
+++ b/Executables/mlx-server/main.swift
@@ -1,0 +1,17 @@
+import Foundation
+import MLXLMServer
+
+do {
+    switch try MLXServerCLI.parse() {
+    case .help:
+        print(MLXServerCLI.help)
+    case .listRoutes:
+        let data = try JSONEncoder.openAIServer.encode(MLXServerRoute.manifest)
+        print(String(decoding: data, as: UTF8.self))
+    case .run(let configuration):
+        try await MLXServer.run(configuration: configuration)
+    }
+} catch {
+    FileHandle.standardError.write(Data("mlx-server: \(error.localizedDescription)\n".utf8))
+    Foundation.exit(1)
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -5,21 +5,25 @@ import Foundation
 /// Parser for Gemma format: call:name{key:value,k:<escape>str<escape>}
 /// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/function_gemma.py
 public struct GemmaFunctionParser: ToolCallParser, Sendable {
-    public let startTag: String? = "<start_function_call>"
-    public let endTag: String? = "<end_function_call>"
+    public let startTag: String? = "<|tool_call>"
+    public let endTag: String? = "<tool_call|>"
+    public let alternateStartTags: [String] = ["<start_function_call>"]
+    public let alternateEndTags: [String] = ["<end_function_call>"]
 
-    private let escapeMarker = "<escape>"
+    private let escapeMarkers = ["<|\"|>", "<escape>"]
+    private let wrapperTags = [
+        "<|tool_call>",
+        "<tool_call|>",
+        "<start_function_call>",
+        "<end_function_call>",
+    ]
 
     public init() {}
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
-        // Strip tags if present
         var text = content
-        if let start = startTag {
-            text = text.replacingOccurrences(of: start, with: "")
-        }
-        if let end = endTag {
-            text = text.replacingOccurrences(of: end, with: "")
+        for tag in wrapperTags {
+            text = text.replacingOccurrences(of: tag, with: "")
         }
 
         // Pattern: call:(\w+)\{(.*?)\}
@@ -47,8 +51,7 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
             let key = String(argsStr[..<colonIdx])
             argsStr = String(argsStr[argsStr.index(after: colonIdx)...])
 
-            // Handle escaped strings
-            if argsStr.hasPrefix(escapeMarker) {
+            if let escapeMarker = escapeMarkers.first(where: { argsStr.hasPrefix($0) }) {
                 argsStr = String(argsStr.dropFirst(escapeMarker.count))
                 guard let endEscape = argsStr.range(of: escapeMarker) else { break }
                 let value = String(argsStr[..<endEscape.lowerBound])

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -19,6 +19,12 @@ public protocol ToolCallParser: Sendable {
     /// Returns `nil` for inline formats that don't use wrapper tags.
     var endTag: String? { get }
 
+    /// Additional model-specific start tags accepted by this parser.
+    var alternateStartTags: [String] { get }
+
+    /// Additional model-specific end tags accepted by this parser.
+    var alternateEndTags: [String] { get }
+
     /// Parse the content into a `ToolCall`.
     /// - Parameters:
     ///   - content: The text content to parse (may include tags)
@@ -35,10 +41,26 @@ public protocol ToolCallParser: Sendable {
 }
 
 extension ToolCallParser {
+    public var alternateStartTags: [String] { [] }
+    public var alternateEndTags: [String] { [] }
+
+    package var acceptedStartTags: [String] {
+        ([startTag].compactMap { $0 } + alternateStartTags)
+    }
+
+    package var acceptedEndTags: [String] {
+        ([endTag].compactMap { $0 } + alternateEndTags)
+    }
+
     public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
-        if let startTag {
+        let startTags = acceptedStartTags
+        if let startTag = startTags.first {
+            var normalized = toolCallBuffer
+            for alternateStartTag in startTags.dropFirst() {
+                normalized = normalized.replacingOccurrences(of: alternateStartTag, with: startTag)
+            }
             return
-                toolCallBuffer
+                normalized
                 .components(separatedBy: startTag)
                 .filter { !$0.isEmpty }
                 .compactMap { parse(content: $0, tools: tools) }
@@ -79,7 +101,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     case glm4
 
     /// Gemma function call format.
-    /// Example: `call:name{key:value,k:<escape>str<escape>}`
+    /// Example: `<|tool_call>call:name{key:value,k:<|"|>str<|"|>}<tool_call|>`
     case gemma
 
     /// Kimi K2 format with functions prefix.
@@ -171,7 +193,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         }
 
         // Gemma
-        if type == "gemma" {
+        if type.hasPrefix("gemma") {
             return .gemma
         }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -57,12 +57,12 @@ public class ToolCallProcessor {
 
     /// Whether this processor uses inline format (no start tag).
     private var isInlineFormat: Bool {
-        parser.startTag == nil
+        parser.acceptedStartTags.isEmpty
     }
 
-    /// The first character of the start tag for quick detection.
-    private var startTagFirstChar: Character? {
-        parser.startTag?.first
+    /// The first characters of accepted start tags for quick detection.
+    private var startTagFirstChars: [Character] {
+        Array(Set(parser.acceptedStartTags.compactMap(\.first)))
     }
 
     // MARK: - Public Methods
@@ -171,13 +171,17 @@ public class ToolCallProcessor {
 
     /// Process chunk for tagged formats.
     private func processTaggedChunk(_ chunk: String) -> String? {
-        guard let startTag = parser.startTag,
-            let startChar = startTagFirstChar
-        else {
+        let startTags = parser.acceptedStartTags
+        let endTags = parser.acceptedEndTags
+
+        guard !startTags.isEmpty else {
             return chunk
         }
 
-        guard (state == .normal && chunk.contains(startChar)) || state != .normal else {
+        guard
+            (state == .normal && startTagFirstChars.contains(where: { chunk.contains($0) }))
+                || state != .normal
+        else {
             return chunk
         }
 
@@ -190,11 +194,11 @@ public class ToolCallProcessor {
             state = .potentialToolCall
 
             leadingToken = separateToken(
-                from: &toolCallBuffer, separator: String(startChar), returnLeading: true)
+                from: &toolCallBuffer, separators: startTags, returnLeading: true)
 
             fallthrough
         case .potentialToolCall:
-            if partialMatch(buffer: toolCallBuffer, tag: startTag) {
+            if let startTag = partialMatch(buffer: toolCallBuffer, tags: startTags) {
                 if toolCallBuffer.starts(with: startTag) {
                     state = .collectingToolCall
                     fallthrough
@@ -209,14 +213,14 @@ public class ToolCallProcessor {
                 return (leadingToken ?? "") + buffer
             }
         case .collectingToolCall:
-            guard let endTag = parser.endTag else {
+            guard !endTags.isEmpty else {
                 return nil
             }
 
-            if toolCallBuffer.contains(endTag) {
+            if endTags.contains(where: { toolCallBuffer.contains($0) }) {
                 // Separate the trailing token
                 let trailingToken = separateToken(
-                    from: &toolCallBuffer, separator: endTag, returnLeading: false)
+                    from: &toolCallBuffer, separators: endTags, returnLeading: false)
 
                 // Parse the tool call using the parser
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
@@ -227,8 +231,8 @@ public class ToolCallProcessor {
                 toolCallBuffer = ""
 
                 // If the token contains the start character, there may be more tool calls to come
-                if let trailingToken, let startChar = startTagFirstChar,
-                    trailingToken.contains(startChar)
+                if let trailingToken,
+                    startTagFirstChars.contains(where: { trailingToken.contains($0) })
                 {
                     return processChunk(trailingToken)
                 } else {
@@ -239,6 +243,15 @@ public class ToolCallProcessor {
                 return nil
             }
         }
+    }
+
+    private func separateToken(
+        from buffer: inout String, separators: [String], returnLeading: Bool
+    ) -> String? {
+        guard let separator = firstSeparator(in: buffer, separators: separators) else {
+            return nil
+        }
+        return separateToken(from: &buffer, separator: separator, returnLeading: returnLeading)
     }
 
     /// Separates a token from a string buffer based on a separator
@@ -272,5 +285,20 @@ public class ToolCallProcessor {
         }
 
         return true
+    }
+
+    private func partialMatch(buffer: String, tags: [String]) -> String? {
+        tags.first { partialMatch(buffer: buffer, tag: $0) }
+    }
+
+    private func firstSeparator(in buffer: String, separators: [String]) -> String? {
+        var match: (range: Range<String.Index>, separator: String)?
+        for separator in separators {
+            guard let range = buffer.range(of: separator) else { continue }
+            if match == nil || range.lowerBound < match!.range.lowerBound {
+                match = (range, separator)
+            }
+        }
+        return match?.separator
     }
 }

--- a/Libraries/MLXLMServer/CLI/MLXServerRunner.swift
+++ b/Libraries/MLXLMServer/CLI/MLXServerRunner.swift
@@ -1,0 +1,52 @@
+// Copyright © 2026 Apple Inc.
+
+import Hummingbird
+import MLXLMCommon
+
+public enum MLXServer {
+    public static func run(configuration: MLXServerConfiguration) async throws {
+        var modelConfiguration = ModelConfiguration(
+            id: configuration.model,
+            revision: configuration.revision
+        )
+        if let parser = configuration.toolCallParser {
+            modelConfiguration.toolCallFormat = try ServerToolParser.resolve(
+                requested: parser,
+                modelType: configuration.modelType
+            )
+        }
+
+        let model = try await MLXServerModelLoader.load(
+            configuration: modelConfiguration
+        )
+        let engine = MLXModelContainerEngine(
+            modelID: configuration.model,
+            model: model,
+            modelType: configuration.modelType,
+            defaultToolCallParser: configuration.toolCallParser
+        )
+        let embeddingEngine: MLXEmbedderContainerEngine?
+        if let embeddingModelID = configuration.embeddingModel {
+            let embeddingModel = try await MLXServerEmbedderLoader.load(
+                configuration: .init(id: embeddingModelID)
+            )
+            embeddingEngine = MLXEmbedderContainerEngine(
+                modelID: embeddingModelID,
+                model: embeddingModel
+            )
+        } else {
+            embeddingEngine = nil
+        }
+        let service = MLXOpenAIService(
+            engine: engine,
+            embeddingEngine: embeddingEngine,
+            defaultReasoningParser: configuration.reasoningParser
+        )
+        let app = MLXServerApplication.buildApplication(
+            service: service,
+            host: configuration.host,
+            port: configuration.port
+        )
+        try await app.runService()
+    }
+}

--- a/Libraries/MLXLMServer/CLI/ServerConfiguration.swift
+++ b/Libraries/MLXLMServer/CLI/ServerConfiguration.swift
@@ -1,0 +1,167 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+public struct MLXServerConfiguration: Sendable, Equatable {
+    public var model: String
+    public var revision: String
+    public var host: String
+    public var port: Int
+    public var modelType: String?
+    public var toolCallParser: String?
+    public var reasoningParser: ReasoningParserFormat?
+    public var embeddingModel: String?
+
+    public init(
+        model: String,
+        revision: String = "main",
+        host: String = "127.0.0.1",
+        port: Int = 8080,
+        modelType: String? = nil,
+        toolCallParser: String? = nil,
+        reasoningParser: ReasoningParserFormat? = nil,
+        embeddingModel: String? = nil
+    ) {
+        self.model = model
+        self.revision = revision
+        self.host = host
+        self.port = port
+        self.modelType = modelType
+        self.toolCallParser = toolCallParser
+        self.reasoningParser = reasoningParser
+        self.embeddingModel = embeddingModel
+    }
+}
+
+public enum MLXServerCLICommand: Sendable, Equatable {
+    case run(MLXServerConfiguration)
+    case help
+    case listRoutes
+}
+
+public enum MLXServerCLIError: Error, LocalizedError, Equatable {
+    case missingValue(String)
+    case invalidPort(String)
+    case unknownOption(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingValue(let option):
+            return "Missing value for \(option)"
+        case .invalidPort(let value):
+            return "Invalid port '\(value)'"
+        case .unknownOption(let option):
+            return "Unknown option '\(option)'"
+        }
+    }
+}
+
+public enum MLXServerCLI {
+    public static func parse(
+        arguments: [String] = CommandLine.arguments,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> MLXServerCLICommand {
+        var model = environment["MLX_SERVER_MODEL"] ?? "mlx-community/Qwen3-0.6B-4bit"
+        var revision = environment["MLX_SERVER_REVISION"] ?? "main"
+        var host = environment["MLX_SERVER_HOST"] ?? "127.0.0.1"
+        var port = Int(environment["MLX_SERVER_PORT"] ?? "") ?? 8080
+        var modelType = environment["MLX_SERVER_MODEL_TYPE"]
+        var toolCallParser = environment["MLX_SERVER_TOOL_CALL_PARSER"]
+        var embeddingModel = environment["MLX_SERVER_EMBEDDING_MODEL"]
+        var reasoningParser: ReasoningParserFormat?
+        if let raw = environment["MLX_SERVER_REASONING_PARSER"] {
+            reasoningParser = try decodeReasoningParser(raw)
+        }
+
+        var index = 1
+        while index < arguments.count {
+            let option = arguments[index]
+            switch option {
+            case "-h", "--help":
+                return .help
+            case "--list-routes":
+                return .listRoutes
+            case "--model", "-m":
+                model = try value(after: option, arguments: arguments, index: &index)
+            case "--revision":
+                revision = try value(after: option, arguments: arguments, index: &index)
+            case "--host":
+                host = try value(after: option, arguments: arguments, index: &index)
+            case "--port":
+                let raw = try value(after: option, arguments: arguments, index: &index)
+                guard let parsed = Int(raw) else {
+                    throw MLXServerCLIError.invalidPort(raw)
+                }
+                port = parsed
+            case "--model-type":
+                modelType = try value(after: option, arguments: arguments, index: &index)
+            case "--tool-call-parser":
+                toolCallParser = try value(after: option, arguments: arguments, index: &index)
+            case "--reasoning-parser":
+                reasoningParser = try decodeReasoningParser(
+                    try value(after: option, arguments: arguments, index: &index)
+                )
+            case "--embedding-model":
+                embeddingModel = try value(after: option, arguments: arguments, index: &index)
+            default:
+                if option.hasPrefix("-") {
+                    throw MLXServerCLIError.unknownOption(option)
+                }
+                model = option
+            }
+            index += 1
+        }
+
+        return .run(
+            .init(
+                model: model,
+                revision: revision,
+                host: host,
+                port: port,
+                modelType: modelType,
+                toolCallParser: toolCallParser,
+                reasoningParser: reasoningParser,
+                embeddingModel: embeddingModel
+            )
+        )
+    }
+
+    public static let help = """
+        Usage: mlx-server [options] [model-id]
+
+        Options:
+          -m, --model <id>                 Hugging Face model id to load
+              --revision <revision>        Model revision (default: main)
+              --host <host>                Bind host (default: 127.0.0.1)
+              --port <port>                Bind port (default: 8080)
+              --model-type <type>          Hint for automatic tool-call parser selection
+              --tool-call-parser <parser>  auto, json, lfm2, xml_function, glm4, gemma, gemma4, kimi_k2, minimax_m2, mistral, llama3_json
+              --reasoning-parser <parser>  none, deepseek_r1, qwen3, harmony
+              --embedding-model <id>       Optional embedding model id for /v1/embeddings
+              --list-routes                Print the server route manifest
+          -h, --help                       Print this help
+
+        Environment:
+          MLX_SERVER_MODEL, MLX_SERVER_REVISION, MLX_SERVER_HOST, MLX_SERVER_PORT,
+          MLX_SERVER_MODEL_TYPE, MLX_SERVER_TOOL_CALL_PARSER, MLX_SERVER_REASONING_PARSER,
+          MLX_SERVER_EMBEDDING_MODEL
+        """
+
+    private static func value(
+        after option: String,
+        arguments: [String],
+        index: inout Int
+    ) throws -> String {
+        let valueIndex = index + 1
+        guard valueIndex < arguments.count else {
+            throw MLXServerCLIError.missingValue(option)
+        }
+        index = valueIndex
+        return arguments[valueIndex]
+    }
+
+    private static func decodeReasoningParser(_ raw: String) throws -> ReasoningParserFormat {
+        let data = try JSONEncoder().encode(raw)
+        return try JSONDecoder().decode(ReasoningParserFormat.self, from: data)
+    }
+}

--- a/Libraries/MLXLMServer/HTTP/MLXServerApplication.swift
+++ b/Libraries/MLXLMServer/HTTP/MLXServerApplication.swift
@@ -1,0 +1,277 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Hummingbird
+
+public struct ServerHealthResponse: Codable, Sendable, Equatable {
+    public var status: String
+    public var server: String
+
+    public init(status: String = "ok", server: String = MLXLMServer.defaultServerName) {
+        self.status = status
+        self.server = server
+    }
+}
+
+public struct ServerPropsResponse: Codable, Sendable, Equatable {
+    public var server: String
+    public var routes: [MLXServerRoute]
+    public var supportsChatCompletions: Bool
+    public var supportsResponses: Bool
+    public var supportsTokenUtilities: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case server
+        case routes
+        case supportsChatCompletions = "supports_chat_completions"
+        case supportsResponses = "supports_responses"
+        case supportsTokenUtilities = "supports_token_utilities"
+    }
+
+    public init(server: String = MLXLMServer.defaultServerName) {
+        self.server = server
+        self.routes = MLXServerRoute.manifest
+        self.supportsChatCompletions = true
+        self.supportsResponses = true
+        self.supportsTokenUtilities = true
+    }
+}
+
+public enum MLXServerApplication {
+    public static func buildRouter(service: MLXOpenAIService) -> Router<BasicRequestContext> {
+        let router = Router()
+
+        router.get("/health") { _, _ async throws -> Response in
+            try jsonResponse(ServerHealthResponse())
+        }
+        router.get("/v1/health") { _, _ async throws -> Response in
+            try jsonResponse(ServerHealthResponse())
+        }
+        router.get("/props") { _, _ async throws -> Response in
+            try jsonResponse(ServerPropsResponse())
+        }
+        router.get("/metrics") { _, _ async -> Response in
+            textResponse(await service.prometheusMetrics(), contentType: "text/plain; charset=utf-8")
+        }
+        router.get("/models") { _, _ async throws -> Response in
+            try jsonResponse(try await service.availableModels())
+        }
+        router.get("/v1/models") { _, _ async throws -> Response in
+            try jsonResponse(try await service.availableModels())
+        }
+
+        registerChatRoutes(router, service: service)
+        registerCompletionRoutes(router, service: service)
+        registerResponseRoutes(router, service: service)
+        registerTokenRoutes(router, service: service)
+        registerEmbeddingRoutes(router, service: service)
+
+        return router
+    }
+
+    public static func buildApplication(
+        service: MLXOpenAIService,
+        host: String,
+        port: Int
+    ) -> Application<RouterResponder<BasicRequestContext>> {
+        let router = buildRouter(service: service)
+        return Application(
+            router: router,
+            configuration: .init(
+                address: .hostname(host, port: port),
+                serverName: MLXLMServer.defaultServerName
+            )
+        )
+    }
+
+    private static func registerChatRoutes(
+        _ router: Router<BasicRequestContext>,
+        service: MLXOpenAIService
+    ) {
+        let handler:
+            @Sendable (Request, BasicRequestContext) async throws -> Response =
+            { request, context in
+                let chatRequest = try await request.decode(
+                    as: OpenAIChatCompletionRequest.self,
+                    context: context
+                )
+                if chatRequest.stream == true {
+                    let frames = try await service.streamChatCompletionFrames(request: chatRequest)
+                    return sseResponse(frames)
+                }
+                return try jsonResponse(try await service.createChatCompletion(request: chatRequest))
+            }
+
+        router.post("/v1/chat/completions", use: handler)
+        router.post("/chat/completions", use: handler)
+        router.post("/v1/chat/completions/batch") { request, context async throws -> Response in
+            let requests = try await request.decode(
+                as: [OpenAIChatCompletionRequest].self,
+                context: context
+            )
+            var responses: [OpenAIChatCompletionResponse] = []
+            for chatRequest in requests {
+                responses.append(try await service.createChatCompletion(request: chatRequest))
+            }
+            return try jsonResponse(responses)
+        }
+    }
+
+    private static func registerCompletionRoutes(
+        _ router: Router<BasicRequestContext>,
+        service: MLXOpenAIService
+    ) {
+        let handler:
+            @Sendable (Request, BasicRequestContext) async throws -> Response =
+            { request, context in
+                let completionRequest = try await request.decode(
+                    as: OpenAICompletionRequest.self,
+                    context: context
+                )
+                let chatRequest = completionRequest.chatCompletionRequest
+                if completionRequest.stream == true {
+                    let frames = try await service.streamChatCompletionFrames(request: chatRequest)
+                    return sseResponse(frames)
+                }
+                let chatResponse = try await service.createChatCompletion(request: chatRequest)
+                return try jsonResponse(OpenAICompletionResponse(from: chatResponse))
+            }
+
+        router.post("/v1/completions", use: handler)
+        router.post("/completions", use: handler)
+        router.post("/completion", use: handler)
+    }
+
+    private static func registerResponseRoutes(
+        _ router: Router<BasicRequestContext>,
+        service: MLXOpenAIService
+    ) {
+        let create:
+            @Sendable (Request, BasicRequestContext) async throws -> Response =
+            { request, context in
+                let responseRequest = try await request.decode(
+                    as: OpenAIResponseRequest.self,
+                    context: context
+                )
+                if responseRequest.stream == true {
+                    let frames = try await service.streamChatCompletionFrames(
+                        request: responseRequest.chatCompletionRequest
+                    )
+                    return sseResponse(frames)
+                }
+                return try jsonResponse(try await service.createResponse(request: responseRequest))
+            }
+
+        router.post("/v1/responses", use: create)
+        router.post("/responses", use: create)
+        router.get("/v1/responses/:response_id") { _, context async throws -> Response in
+            let id = try context.parameters.require("response_id")
+            return try jsonResponse(try await service.retrieveResponse(id: id))
+        }
+        router.post("/v1/responses/:response_id/cancel") { _, context async throws -> Response in
+            let id = try context.parameters.require("response_id")
+            return try jsonResponse(try await service.cancelResponse(id: id))
+        }
+    }
+
+    private static func registerTokenRoutes(
+        _ router: Router<BasicRequestContext>,
+        service: MLXOpenAIService
+    ) {
+        router.post("/tokenize") { request, context async throws -> Response in
+            let tokenRequest = try await request.decode(as: TokenizeRequest.self, context: context)
+            return try jsonResponse(try await service.tokenize(tokenRequest))
+        }
+        router.post("/detokenize") { request, context async throws -> Response in
+            let detokenizeRequest = try await request.decode(
+                as: DetokenizeRequest.self,
+                context: context
+            )
+            return try jsonResponse(try await service.detokenize(detokenizeRequest))
+        }
+        router.post("/apply-template") { request, context async throws -> Response in
+            let templateRequest = try await request.decode(
+                as: ApplyTemplateRequest.self,
+                context: context
+            )
+            return try jsonResponse(try await service.applyTemplate(templateRequest))
+        }
+    }
+
+    private static func registerEmbeddingRoutes(
+        _ router: Router<BasicRequestContext>,
+        service: MLXOpenAIService
+    ) {
+        let handler:
+            @Sendable (Request, BasicRequestContext) async throws -> Response =
+            { request, context in
+                let embeddingRequest = try await request.decode(
+                    as: OpenAIEmbeddingRequest.self,
+                    context: context
+                )
+                do {
+                    return try jsonResponse(
+                        try await service.createEmbedding(request: embeddingRequest)
+                    )
+                } catch MLXOpenAIServiceError.embeddingsNotConfigured {
+                    return try jsonResponse(
+                        OpenAIErrorResponse(
+                            message: MLXOpenAIServiceError.embeddingsNotConfigured.localizedDescription,
+                            type: "unsupported_endpoint",
+                            code: "embeddings_not_configured"
+                        ),
+                        status: .notImplemented
+                    )
+                }
+            }
+        router.post("/v1/embeddings", use: handler)
+        router.post("/embeddings", use: handler)
+        router.post("/embedding", use: handler)
+    }
+}
+
+private func jsonResponse<T: Encodable>(
+    _ value: T,
+    status: HTTPResponse.Status = .ok
+) throws -> Response {
+    let data = try JSONEncoder.openAIServer.encode(value)
+    return Response(
+        status: status,
+        headers: [.contentType: "application/json"],
+        body: .init(byteBuffer: ByteBuffer(bytes: data))
+    )
+}
+
+private func textResponse(_ text: String, contentType: String) -> Response {
+    Response(
+        status: .ok,
+        headers: [.contentType: contentType],
+        body: .init(byteBuffer: ByteBuffer(string: text))
+    )
+}
+
+private func sseResponse(_ frames: AsyncThrowingStream<String, Error>) -> Response {
+    let body = AsyncThrowingStream<ByteBuffer, Error> { continuation in
+        let task = Task {
+            do {
+                for try await frame in frames {
+                    continuation.yield(ByteBuffer(string: frame))
+                }
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        continuation.onTermination = { _ in
+            task.cancel()
+        }
+    }
+    return Response(
+        status: .ok,
+        headers: [
+            .contentType: "text/event-stream; charset=utf-8",
+            .cacheControl: "no-cache",
+        ],
+        body: .init(asyncSequence: body)
+    )
+}

--- a/Libraries/MLXLMServer/MLXLMServer.swift
+++ b/Libraries/MLXLMServer/MLXLMServer.swift
@@ -1,0 +1,6 @@
+// Copyright © 2026 Apple Inc.
+
+/// Namespace for helpers exported by the MLXLM server module.
+public enum MLXLMServer {
+    public static let defaultServerName = "mlx-server"
+}

--- a/Libraries/MLXLMServer/Parsing/ReasoningParser.swift
+++ b/Libraries/MLXLMServer/Parsing/ReasoningParser.swift
@@ -1,0 +1,125 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+public enum ReasoningParserFormat: String, Codable, Sendable, CaseIterable {
+    case none
+    case deepseekR1 = "deepseek_r1"
+    case qwen3
+    case harmony
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+
+        switch raw {
+        case "none", "off", "disabled":
+            self = .none
+        case "deepseek_r1", "deepseek", "r1", "think":
+            self = .deepseekR1
+        case "qwen3", "qwen":
+            self = .qwen3
+        case "harmony", "gpt_oss", "openai_harmony":
+            self = .harmony
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported reasoning parser '\(raw)'"
+            )
+        }
+    }
+}
+
+public struct ParsedReasoning: Sendable, Equatable {
+    public var content: String
+    public var reasoningContent: String?
+}
+
+public struct ReasoningParser: Sendable {
+    public var format: ReasoningParserFormat
+
+    public init(format: ReasoningParserFormat) {
+        self.format = format
+    }
+
+    public func parse(_ text: String) -> ParsedReasoning {
+        switch format {
+        case .none:
+            return .init(content: text, reasoningContent: nil)
+        case .deepseekR1, .qwen3:
+            return parseThinkTags(text)
+        case .harmony:
+            return parseHarmony(text)
+        }
+    }
+
+    private func parseThinkTags(_ text: String) -> ParsedReasoning {
+        var remaining = text
+        var reasoning: [String] = []
+
+        while let start = remaining.range(of: "<think>"),
+            let end = remaining.range(of: "</think>", range: start.upperBound..<remaining.endIndex)
+        {
+            reasoning.append(String(remaining[start.upperBound..<end.lowerBound]))
+            remaining.removeSubrange(start.lowerBound..<end.upperBound)
+        }
+
+        let reasoningText = reasoning.joined(separator: "\n").trimmedForReasoning
+        return .init(
+            content: remaining.trimmedForReasoning,
+            reasoningContent: reasoningText.isEmpty ? nil : reasoningText
+        )
+    }
+
+    private func parseHarmony(_ text: String) -> ParsedReasoning {
+        let channelMarker = "<|channel|>"
+        let messageMarker = "<|message|>"
+        let endMarker = "<|end|>"
+        var final: [String] = []
+        var analysis: [String] = []
+        var cursor = text.startIndex
+
+        while let channelStart = text.range(of: channelMarker, range: cursor..<text.endIndex) {
+            let channelNameStart = channelStart.upperBound
+            guard let messageStart = text.range(
+                of: messageMarker,
+                range: channelNameStart..<text.endIndex
+            ) else { break }
+
+            let channel = String(text[channelNameStart..<messageStart.lowerBound])
+            let contentStart = messageStart.upperBound
+            let contentEnd = text.range(of: endMarker, range: contentStart..<text.endIndex)
+            let messageEnd = contentEnd?.lowerBound ?? text.endIndex
+            let content = String(text[contentStart..<messageEnd])
+
+            switch channel {
+            case "analysis":
+                analysis.append(content)
+            case "final":
+                final.append(content)
+            default:
+                break
+            }
+
+            cursor = contentEnd?.upperBound ?? text.endIndex
+        }
+
+        if final.isEmpty && analysis.isEmpty {
+            return .init(content: text, reasoningContent: nil)
+        }
+
+        let reasoningText = analysis.joined(separator: "\n").trimmedForReasoning
+        return .init(
+            content: final.joined(separator: "\n").trimmedForReasoning,
+            reasoningContent: reasoningText.isEmpty ? nil : reasoningText
+        )
+    }
+}
+
+extension String {
+    fileprivate var trimmedForReasoning: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Libraries/MLXLMServer/Parsing/ServerToolParser.swift
+++ b/Libraries/MLXLMServer/Parsing/ServerToolParser.swift
@@ -1,0 +1,53 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public enum ServerToolParserError: Error, LocalizedError, Equatable {
+    case unsupported(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupported(let name):
+            return "Unsupported tool_call_parser '\(name)'"
+        }
+    }
+}
+
+public enum ServerToolParser {
+    public static func resolve(requested: String?, modelType: String?) throws -> ToolCallFormat {
+        let normalized = requested?.lowercased().replacingOccurrences(of: "-", with: "_")
+
+        if normalized == nil || normalized == "auto" {
+            if let modelType, let inferred = ToolCallFormat.infer(from: modelType) {
+                return inferred
+            }
+            return .json
+        }
+
+        switch normalized {
+        case "json", "default":
+            return .json
+        case "lfm2", "lfm2_5", "lfm25":
+            return .lfm2
+        case "xml", "xml_function", "qwen_xml", "hermes", "nemotron":
+            return .xmlFunction
+        case "glm4", "glm_4":
+            return .glm4
+        case "gemma", "gemma4", "gemma_4":
+            return .gemma
+        case "kimi_k2", "kimi":
+            return .kimiK2
+        case "minimax_m2", "minimax":
+            return .minimaxM2
+        case "mistral", "mistral_v11":
+            return .mistral
+        case "llama3", "llama3_json", "llama_3":
+            return .llama3
+        case .some(let name):
+            throw ServerToolParserError.unsupported(name)
+        case .none:
+            return .json
+        }
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/OpenAIChatCompletionResponse.swift
+++ b/Libraries/MLXLMServer/Protocol/OpenAIChatCompletionResponse.swift
@@ -1,0 +1,82 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public struct OpenAIChatCompletionResponse: Codable, Sendable, Equatable {
+    public struct Choice: Codable, Sendable, Equatable {
+        public var index: Int
+        public var message: OpenAIChatMessage
+        public var finishReason: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case index
+            case message
+            case finishReason = "finish_reason"
+        }
+
+        public init(index: Int, message: OpenAIChatMessage, finishReason: String?) {
+            self.index = index
+            self.message = message
+            self.finishReason = finishReason
+        }
+    }
+
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [Choice]
+    public var usage: OpenAIUsage
+
+    public init(
+        id: String,
+        model: String,
+        choices: [Choice],
+        usage: OpenAIUsage,
+        created: Int = Int(Date().timeIntervalSince1970)
+    ) {
+        self.id = id
+        self.object = "chat.completion"
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}
+
+public struct OpenAIModelListResponse: Codable, Sendable, Equatable {
+    public var object: String
+    public var data: [MLXServerModel]
+
+    public init(data: [MLXServerModel]) {
+        self.object = "list"
+        self.data = data
+    }
+}
+
+public struct OpenAIErrorResponse: Codable, Sendable, Equatable {
+    public struct Payload: Codable, Sendable, Equatable {
+        public var message: String
+        public var type: String
+        public var param: String?
+        public var code: String?
+    }
+
+    public var error: Payload
+
+    public init(message: String, type: String = "server_error", param: String? = nil, code: String? = nil) {
+        self.error = .init(message: message, type: type, param: param, code: code)
+    }
+}
+
+extension OpenAIToolCall {
+    init(toolCall: ToolCall, id: String) throws {
+        let data = try JSONEncoder.openAIServer.encode(toolCall.function.arguments)
+        let arguments = String(decoding: data, as: UTF8.self)
+        self.init(
+            id: id,
+            function: .init(name: toolCall.function.name, arguments: arguments)
+        )
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/OpenAICompletionsProtocol.swift
+++ b/Libraries/MLXLMServer/Protocol/OpenAICompletionsProtocol.swift
@@ -1,0 +1,97 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+public enum OpenAICompletionPrompt: Codable, Sendable, Equatable {
+    case text(String)
+    case texts([String])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let text = try? container.decode(String.self) {
+            self = .text(text)
+            return
+        }
+        self = .texts(try container.decode([String].self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let text):
+            try container.encode(text)
+        case .texts(let texts):
+            try container.encode(texts)
+        }
+    }
+
+    public var firstText: String {
+        switch self {
+        case .text(let text):
+            return text
+        case .texts(let texts):
+            return texts.first ?? ""
+        }
+    }
+}
+
+public struct OpenAICompletionRequest: Codable, Sendable, Equatable {
+    public var model: String
+    public var prompt: OpenAICompletionPrompt
+    public var stream: Bool?
+    public var temperature: Float?
+    public var topP: Float?
+    public var maxTokens: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case prompt
+        case stream
+        case temperature
+        case topP = "top_p"
+        case maxTokens = "max_tokens"
+    }
+
+    public var chatCompletionRequest: OpenAIChatCompletionRequest {
+        .init(
+            model: model,
+            messages: [.init(role: .user, content: .text(prompt.firstText))],
+            stream: stream,
+            temperature: temperature,
+            topP: topP,
+            maxTokens: maxTokens
+        )
+    }
+}
+
+public struct OpenAICompletionResponse: Codable, Sendable, Equatable {
+    public struct Choice: Codable, Sendable, Equatable {
+        public var text: String
+        public var index: Int
+        public var finishReason: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case text
+            case index
+            case finishReason = "finish_reason"
+        }
+    }
+
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [Choice]
+    public var usage: OpenAIUsage
+
+    public init(from chatResponse: OpenAIChatCompletionResponse) {
+        self.id = chatResponse.id.replacingOccurrences(of: "chatcmpl", with: "cmpl")
+        self.object = "text_completion"
+        self.created = chatResponse.created
+        self.model = chatResponse.model
+        self.choices = chatResponse.choices.map {
+            .init(text: $0.message.textContent, index: $0.index, finishReason: $0.finishReason)
+        }
+        self.usage = chatResponse.usage
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/OpenAIEmbeddingsProtocol.swift
+++ b/Libraries/MLXLMServer/Protocol/OpenAIEmbeddingsProtocol.swift
@@ -1,0 +1,88 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+public enum OpenAIEmbeddingInput: Codable, Sendable, Equatable {
+    case text(String)
+    case texts([String])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let text = try? container.decode(String.self) {
+            self = .text(text)
+            return
+        }
+        self = .texts(try container.decode([String].self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let text):
+            try container.encode(text)
+        case .texts(let texts):
+            try container.encode(texts)
+        }
+    }
+
+    public var texts: [String] {
+        switch self {
+        case .text(let text):
+            return [text]
+        case .texts(let texts):
+            return texts
+        }
+    }
+}
+
+public struct OpenAIEmbeddingRequest: Codable, Sendable, Equatable {
+    public var model: String
+    public var input: OpenAIEmbeddingInput
+    public var encodingFormat: String?
+    public var normalize: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case input
+        case encodingFormat = "encoding_format"
+        case normalize
+    }
+
+    public init(
+        model: String,
+        input: OpenAIEmbeddingInput,
+        encodingFormat: String? = nil,
+        normalize: Bool? = nil
+    ) {
+        self.model = model
+        self.input = input
+        self.encodingFormat = encodingFormat
+        self.normalize = normalize
+    }
+}
+
+public struct OpenAIEmbeddingResponse: Codable, Sendable, Equatable {
+    public struct Item: Codable, Sendable, Equatable {
+        public var object: String
+        public var embedding: [Float]
+        public var index: Int
+
+        public init(embedding: [Float], index: Int) {
+            self.object = "embedding"
+            self.embedding = embedding
+            self.index = index
+        }
+    }
+
+    public var object: String
+    public var data: [Item]
+    public var model: String
+    public var usage: OpenAIUsage
+
+    public init(data: [Item], model: String, usage: OpenAIUsage) {
+        self.object = "list"
+        self.data = data
+        self.model = model
+        self.usage = usage
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/OpenAIProtocol.swift
+++ b/Libraries/MLXLMServer/Protocol/OpenAIProtocol.swift
@@ -1,0 +1,473 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public enum OpenAIRole: String, Codable, Sendable {
+    case system
+    case user
+    case assistant
+    case tool
+}
+
+public enum OpenAIContentPart: Codable, Sendable, Equatable {
+    case text(String)
+    case imageURL(String)
+    case unsupported(type: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case imageURL = "image_url"
+        case url
+    }
+
+    private enum PartType: String, Codable {
+        case text
+        case imageURL = "image_url"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case PartType.text.rawValue:
+            self = .text(try container.decode(String.self, forKey: .text))
+        case PartType.imageURL.rawValue:
+            let image = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .imageURL)
+            self = .imageURL(try image.decode(String.self, forKey: .url))
+        default:
+            self = .unsupported(type: type)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let text):
+            try container.encode(PartType.text.rawValue, forKey: .type)
+            try container.encode(text, forKey: .text)
+        case .imageURL(let url):
+            try container.encode(PartType.imageURL.rawValue, forKey: .type)
+            var image = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .imageURL)
+            try image.encode(url, forKey: .url)
+        case .unsupported(let type):
+            try container.encode(type, forKey: .type)
+        }
+    }
+}
+
+public enum OpenAIMessageContent: Codable, Sendable, Equatable {
+    case text(String)
+    case parts([OpenAIContentPart])
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let text = try? container.decode(String.self) {
+            self = .text(text)
+        } else {
+            self = .parts(try container.decode([OpenAIContentPart].self))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let text):
+            try container.encode(text)
+        case .parts(let parts):
+            try container.encode(parts)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    public var text: String {
+        switch self {
+        case .text(let text):
+            return text
+        case .parts(let parts):
+            return parts.compactMap {
+                if case .text(let text) = $0 { return text }
+                return nil
+            }.joined()
+        case .null:
+            return ""
+        }
+    }
+}
+
+public struct OpenAIChatMessage: Codable, Sendable, Equatable {
+    public var role: OpenAIRole
+    public var content: OpenAIMessageContent
+    public var name: String?
+    public var toolCallID: String?
+    public var toolCalls: [OpenAIToolCall]?
+    public var reasoningContent: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case role
+        case content
+        case name
+        case toolCallID = "tool_call_id"
+        case toolCalls = "tool_calls"
+        case reasoningContent = "reasoning_content"
+    }
+
+    public init(
+        role: OpenAIRole,
+        content: OpenAIMessageContent,
+        name: String? = nil,
+        toolCallID: String? = nil,
+        toolCalls: [OpenAIToolCall]? = nil,
+        reasoningContent: String? = nil
+    ) {
+        self.role = role
+        self.content = content
+        self.name = name
+        self.toolCallID = toolCallID
+        self.toolCalls = toolCalls
+        self.reasoningContent = reasoningContent
+    }
+
+    public var textContent: String {
+        content.text
+    }
+
+    public func chatMessage() -> Chat.Message {
+        switch role {
+        case .system:
+            return .system(textContent)
+        case .user:
+            return .user(textContent)
+        case .assistant:
+            return .assistant(textContent)
+        case .tool:
+            return .tool(textContent)
+        }
+    }
+}
+
+public struct OpenAIFunctionDefinition: Codable, Sendable, Equatable {
+    public var name: String
+    public var description: String?
+    public var parameters: JSONValue?
+
+    public init(name: String, description: String? = nil, parameters: JSONValue? = nil) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+    }
+}
+
+public struct OpenAITool: Codable, Sendable, Equatable {
+    public var type: String
+    public var function: OpenAIFunctionDefinition
+
+    public init(type: String = "function", function: OpenAIFunctionDefinition) {
+        self.type = type
+        self.function = function
+    }
+
+    public func toolSpec() -> ToolSpec {
+        var functionObject: [String: any Sendable] = ["name": function.name]
+        if let description = function.description {
+            functionObject["description"] = description
+        }
+        if let parameters = function.parameters {
+            functionObject["parameters"] = parameters.sendableValue
+        }
+        return [
+            "type": type,
+            "function": functionObject,
+        ]
+    }
+}
+
+extension JSONValue {
+    fileprivate var sendableValue: any Sendable {
+        switch self {
+        case .null:
+            return JSONNull()
+        case .bool(let value):
+            return value
+        case .int(let value):
+            return value
+        case .double(let value):
+            return value
+        case .string(let value):
+            return value
+        case .array(let values):
+            return values.map(\.sendableValue)
+        case .object(let object):
+            return object.mapValues(\.sendableValue)
+        }
+    }
+}
+
+private struct JSONNull: Sendable, Hashable {}
+
+public struct OpenAIToolCall: Codable, Sendable, Equatable {
+    public struct Function: Codable, Sendable, Equatable {
+        public var name: String
+        public var arguments: String
+
+        public init(name: String, arguments: String) {
+            self.name = name
+            self.arguments = arguments
+        }
+    }
+
+    public var id: String
+    public var type: String
+    public var function: Function
+
+    public init(id: String, type: String = "function", function: Function) {
+        self.id = id
+        self.type = type
+        self.function = function
+    }
+}
+
+public enum OpenAIToolChoice: Codable, Sendable, Equatable {
+    public enum Mode: String, Codable, Sendable {
+        case none
+        case auto
+        case required
+    }
+
+    case mode(Mode)
+    case function(name: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case function
+        case name
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let raw = try? container.decode(String.self),
+            let mode = Mode(rawValue: raw)
+        {
+            self = .mode(mode)
+            return
+        }
+
+        let object = try decoder.container(keyedBy: CodingKeys.self)
+        let function = try object.nestedContainer(keyedBy: CodingKeys.self, forKey: .function)
+        self = .function(name: try function.decode(String.self, forKey: .name))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .mode(let mode):
+            var container = encoder.singleValueContainer()
+            try container.encode(mode.rawValue)
+        case .function(let name):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("function", forKey: .type)
+            var function = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .function)
+            try function.encode(name, forKey: .name)
+        }
+    }
+}
+
+public struct OpenAIChatCompletionRequest: Codable, Sendable, Equatable {
+    public var model: String
+    public var messages: [OpenAIChatMessage]
+    public var tools: [OpenAITool]?
+    public var toolChoice: OpenAIToolChoice?
+    public var toolCallParser: String?
+    public var reasoningParser: ReasoningParserFormat?
+    public var responseFormat: OpenAIResponseFormat?
+    public var stream: Bool?
+    public var temperature: Float?
+    public var topP: Float?
+    public var topK: Int?
+    public var minP: Float?
+    public var maxTokens: Int?
+    public var presencePenalty: Float?
+    public var frequencyPenalty: Float?
+    public var repetitionPenalty: Float?
+    public var stop: [String]?
+    public var streamOptions: OpenAIStreamOptions?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case tools
+        case toolChoice = "tool_choice"
+        case toolCallParser = "tool_call_parser"
+        case reasoningParser = "reasoning_parser"
+        case responseFormat = "response_format"
+        case stream
+        case temperature
+        case topP = "top_p"
+        case topK = "top_k"
+        case minP = "min_p"
+        case maxTokens = "max_tokens"
+        case presencePenalty = "presence_penalty"
+        case frequencyPenalty = "frequency_penalty"
+        case repetitionPenalty = "repetition_penalty"
+        case stop
+        case streamOptions = "stream_options"
+    }
+
+    public init(
+        model: String,
+        messages: [OpenAIChatMessage],
+        tools: [OpenAITool]? = nil,
+        toolChoice: OpenAIToolChoice? = nil,
+        toolCallParser: String? = nil,
+        reasoningParser: ReasoningParserFormat? = nil,
+        responseFormat: OpenAIResponseFormat? = nil,
+        stream: Bool? = nil,
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        topK: Int? = nil,
+        minP: Float? = nil,
+        maxTokens: Int? = nil,
+        presencePenalty: Float? = nil,
+        frequencyPenalty: Float? = nil,
+        repetitionPenalty: Float? = nil,
+        stop: [String]? = nil,
+        streamOptions: OpenAIStreamOptions? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.tools = tools
+        self.toolChoice = toolChoice
+        self.toolCallParser = toolCallParser
+        self.reasoningParser = reasoningParser
+        self.responseFormat = responseFormat
+        self.stream = stream
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.maxTokens = maxTokens
+        self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
+        self.repetitionPenalty = repetitionPenalty
+        self.stop = stop
+        self.streamOptions = streamOptions
+    }
+
+    public var generationParameters: GenerateParameters {
+        GenerateParameters(
+            maxTokens: maxTokens,
+            temperature: temperature ?? 0.6,
+            topP: topP ?? 1.0,
+            topK: topK ?? 0,
+            minP: minP ?? 0,
+            repetitionPenalty: repetitionPenalty,
+            presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty
+        )
+    }
+}
+
+public struct OpenAIStreamOptions: Codable, Sendable, Equatable {
+    public var includeUsage: Bool?
+    public var continuousUsageStats: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case includeUsage = "include_usage"
+        case continuousUsageStats = "continuous_usage_stats"
+    }
+
+    public init(includeUsage: Bool? = nil, continuousUsageStats: Bool? = nil) {
+        self.includeUsage = includeUsage
+        self.continuousUsageStats = continuousUsageStats
+    }
+}
+
+public struct OpenAIUsage: Codable, Sendable, Equatable {
+    public var promptTokens: Int
+    public var completionTokens: Int
+    public var totalTokens: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case completionTokens = "completion_tokens"
+        case totalTokens = "total_tokens"
+    }
+
+    public init(promptTokens: Int, completionTokens: Int) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+        self.totalTokens = promptTokens + completionTokens
+    }
+}
+
+public struct OpenAIChatCompletionChunk: Codable, Sendable, Equatable {
+    public struct Choice: Codable, Sendable, Equatable {
+        public var index: Int
+        public var delta: Delta
+        public var finishReason: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case index
+            case delta
+            case finishReason = "finish_reason"
+        }
+
+        public init(index: Int, delta: Delta, finishReason: String?) {
+            self.index = index
+            self.delta = delta
+            self.finishReason = finishReason
+        }
+    }
+
+    public struct Delta: Codable, Sendable, Equatable {
+        public var role: String?
+        public var content: String?
+        public var reasoningContent: String?
+        public var toolCalls: [OpenAIToolCall]?
+
+        private enum CodingKeys: String, CodingKey {
+            case role
+            case content
+            case reasoningContent = "reasoning_content"
+            case toolCalls = "tool_calls"
+        }
+
+        public init(
+            role: String?,
+            content: String?,
+            reasoningContent: String?,
+            toolCalls: [OpenAIToolCall]?
+        ) {
+            self.role = role
+            self.content = content
+            self.reasoningContent = reasoningContent
+            self.toolCalls = toolCalls
+        }
+    }
+
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [Choice]
+    public var usage: OpenAIUsage?
+
+    public init(
+        id: String,
+        model: String,
+        choices: [Choice],
+        usage: OpenAIUsage?,
+        created: Int = Int(Date().timeIntervalSince1970)
+    ) {
+        self.id = id
+        self.object = "chat.completion.chunk"
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/OpenAIResponseFormat.swift
+++ b/Libraries/MLXLMServer/Protocol/OpenAIResponseFormat.swift
@@ -1,0 +1,60 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public enum OpenAIResponseFormatType: String, Codable, Sendable {
+    case text
+    case jsonObject = "json_object"
+    case jsonSchema = "json_schema"
+}
+
+public struct OpenAIJSONSchemaResponseFormat: Codable, Sendable, Equatable {
+    public var name: String?
+    public var description: String?
+    public var strict: Bool?
+    public var schema: JSONValue
+
+    public init(
+        name: String? = nil,
+        description: String? = nil,
+        strict: Bool? = nil,
+        schema: JSONValue
+    ) {
+        self.name = name
+        self.description = description
+        self.strict = strict
+        self.schema = schema
+    }
+}
+
+public struct OpenAIResponseFormat: Codable, Sendable, Equatable {
+    public var type: OpenAIResponseFormatType
+    public var jsonSchema: OpenAIJSONSchemaResponseFormat?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case jsonSchema = "json_schema"
+    }
+
+    public init(type: OpenAIResponseFormatType, jsonSchema: OpenAIJSONSchemaResponseFormat? = nil) {
+        self.type = type
+        self.jsonSchema = jsonSchema
+    }
+
+    public static func text() -> OpenAIResponseFormat {
+        .init(type: .text)
+    }
+
+    public static func jsonObject() -> OpenAIResponseFormat {
+        .init(type: .jsonObject)
+    }
+
+    public static func jsonSchema(_ schema: OpenAIJSONSchemaResponseFormat) -> OpenAIResponseFormat {
+        .init(type: .jsonSchema, jsonSchema: schema)
+    }
+
+    public var requiresJSONOutput: Bool {
+        type == .jsonObject || type == .jsonSchema
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/OpenAIResponsesProtocol.swift
+++ b/Libraries/MLXLMServer/Protocol/OpenAIResponsesProtocol.swift
@@ -1,0 +1,234 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public enum OpenAIResponseInput: Codable, Sendable, Equatable {
+    case text(String)
+    case messages([OpenAIChatMessage])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let text = try? container.decode(String.self) {
+            self = .text(text)
+            return
+        }
+        self = .messages(try container.decode([OpenAIChatMessage].self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let text):
+            try container.encode(text)
+        case .messages(let messages):
+            try container.encode(messages)
+        }
+    }
+
+    public func messages(instructions: String?) -> [OpenAIChatMessage] {
+        var result: [OpenAIChatMessage] = []
+        if let instructions, !instructions.isEmpty {
+            result.append(.init(role: .system, content: .text(instructions)))
+        }
+        switch self {
+        case .text(let text):
+            result.append(.init(role: .user, content: .text(text)))
+        case .messages(let messages):
+            result.append(contentsOf: messages)
+        }
+        return result
+    }
+}
+
+public struct OpenAIResponseReasoningOptions: Codable, Sendable, Equatable {
+    public var parser: ReasoningParserFormat?
+    public var effort: String?
+
+    public init(parser: ReasoningParserFormat? = nil, effort: String? = nil) {
+        self.parser = parser
+        self.effort = effort
+    }
+}
+
+public struct OpenAIResponseRequest: Codable, Sendable, Equatable {
+    public var model: String
+    public var input: OpenAIResponseInput
+    public var instructions: String?
+    public var tools: [OpenAITool]?
+    public var toolChoice: OpenAIToolChoice?
+    public var reasoning: OpenAIResponseReasoningOptions?
+    public var stream: Bool?
+    public var store: Bool?
+    public var temperature: Float?
+    public var topP: Float?
+    public var maxOutputTokens: Int?
+    public var metadata: [String: JSONValue]?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case input
+        case instructions
+        case tools
+        case toolChoice = "tool_choice"
+        case reasoning
+        case stream
+        case store
+        case temperature
+        case topP = "top_p"
+        case maxOutputTokens = "max_output_tokens"
+        case metadata
+    }
+
+    public init(
+        model: String,
+        input: OpenAIResponseInput,
+        instructions: String? = nil,
+        tools: [OpenAITool]? = nil,
+        toolChoice: OpenAIToolChoice? = nil,
+        reasoning: OpenAIResponseReasoningOptions? = nil,
+        stream: Bool? = nil,
+        store: Bool? = nil,
+        temperature: Float? = nil,
+        topP: Float? = nil,
+        maxOutputTokens: Int? = nil,
+        metadata: [String: JSONValue]? = nil
+    ) {
+        self.model = model
+        self.input = input
+        self.instructions = instructions
+        self.tools = tools
+        self.toolChoice = toolChoice
+        self.reasoning = reasoning
+        self.stream = stream
+        self.store = store
+        self.temperature = temperature
+        self.topP = topP
+        self.maxOutputTokens = maxOutputTokens
+        self.metadata = metadata
+    }
+
+    public var chatCompletionRequest: OpenAIChatCompletionRequest {
+        .init(
+            model: model,
+            messages: input.messages(instructions: instructions),
+            tools: tools,
+            toolChoice: toolChoice,
+            reasoningParser: reasoning?.parser,
+            stream: stream,
+            temperature: temperature,
+            topP: topP,
+            maxTokens: maxOutputTokens
+        )
+    }
+}
+
+public enum OpenAIResponseStatus: String, Codable, Sendable, Equatable {
+    case inProgress = "in_progress"
+    case completed
+    case cancelled
+    case failed
+}
+
+public struct OpenAIResponseOutputContent: Codable, Sendable, Equatable {
+    public var type: String
+    public var text: String
+
+    public init(type: String = "output_text", text: String) {
+        self.type = type
+        self.text = text
+    }
+}
+
+public struct OpenAIResponseOutputItem: Codable, Sendable, Equatable {
+    public var id: String
+    public var type: String
+    public var status: OpenAIResponseStatus?
+    public var role: OpenAIRole?
+    public var content: [OpenAIResponseOutputContent]?
+    public var callID: String?
+    public var name: String?
+    public var arguments: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case status
+        case role
+        case content
+        case callID = "call_id"
+        case name
+        case arguments
+    }
+
+    public static func message(id: String, text: String) -> Self {
+        .init(
+            id: id,
+            type: "message",
+            status: .completed,
+            role: .assistant,
+            content: [.init(text: text)],
+            callID: nil,
+            name: nil,
+            arguments: nil
+        )
+    }
+
+    public static func functionCall(id: String, toolCall: OpenAIToolCall) -> Self {
+        .init(
+            id: id,
+            type: "function_call",
+            status: .completed,
+            role: nil,
+            content: nil,
+            callID: toolCall.id,
+            name: toolCall.function.name,
+            arguments: toolCall.function.arguments
+        )
+    }
+}
+
+public struct OpenAIResponse: Codable, Sendable, Equatable {
+    public var id: String
+    public var object: String
+    public var createdAt: Int
+    public var status: OpenAIResponseStatus
+    public var model: String
+    public var output: [OpenAIResponseOutputItem]
+    public var outputText: String
+    public var usage: OpenAIUsage?
+    public var metadata: [String: JSONValue]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case createdAt = "created_at"
+        case status
+        case model
+        case output
+        case outputText = "output_text"
+        case usage
+        case metadata
+    }
+
+    public init(
+        id: String,
+        status: OpenAIResponseStatus,
+        model: String,
+        output: [OpenAIResponseOutputItem],
+        outputText: String,
+        usage: OpenAIUsage?,
+        metadata: [String: JSONValue]? = nil,
+        createdAt: Int = Int(Date().timeIntervalSince1970)
+    ) {
+        self.id = id
+        self.object = "response"
+        self.createdAt = createdAt
+        self.status = status
+        self.model = model
+        self.output = output
+        self.outputText = outputText
+        self.usage = usage
+        self.metadata = metadata
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/ServerSentEventEncoder.swift
+++ b/Libraries/MLXLMServer/Protocol/ServerSentEventEncoder.swift
@@ -1,0 +1,28 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+public enum ServerSentEventEncoder {
+    public static let done = "data: [DONE]\n\n"
+
+    public static func encode<T: Encodable>(_ value: T, encoder: JSONEncoder = .openAIServer)
+        throws -> String
+    {
+        let data = try encoder.encode(value)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw EncodingError.invalidValue(
+                value,
+                .init(codingPath: [], debugDescription: "Unable to encode SSE frame as UTF-8")
+            )
+        }
+        return "data: \(json)\n\n"
+    }
+}
+
+extension JSONEncoder {
+    public static var openAIServer: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+}

--- a/Libraries/MLXLMServer/Protocol/TokenUtilityProtocol.swift
+++ b/Libraries/MLXLMServer/Protocol/TokenUtilityProtocol.swift
@@ -1,0 +1,65 @@
+// Copyright © 2026 Apple Inc.
+
+public struct TokenizeRequest: Codable, Sendable, Equatable {
+    public var model: String?
+    public var prompt: String
+    public var addSpecialTokens: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case prompt
+        case addSpecialTokens = "add_special_tokens"
+    }
+
+    public init(model: String? = nil, prompt: String, addSpecialTokens: Bool? = nil) {
+        self.model = model
+        self.prompt = prompt
+        self.addSpecialTokens = addSpecialTokens
+    }
+}
+
+public struct TokenizeResponse: Codable, Sendable, Equatable {
+    public var tokens: [Int]
+
+    public init(tokens: [Int]) {
+        self.tokens = tokens
+    }
+}
+
+public struct DetokenizeRequest: Codable, Sendable, Equatable {
+    public var model: String?
+    public var tokens: [Int]
+    public var skipSpecialTokens: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case tokens
+        case skipSpecialTokens = "skip_special_tokens"
+    }
+
+    public init(model: String? = nil, tokens: [Int], skipSpecialTokens: Bool? = nil) {
+        self.model = model
+        self.tokens = tokens
+        self.skipSpecialTokens = skipSpecialTokens
+    }
+}
+
+public struct DetokenizeResponse: Codable, Sendable, Equatable {
+    public var text: String
+
+    public init(text: String) {
+        self.text = text
+    }
+}
+
+public struct ApplyTemplateRequest: Codable, Sendable, Equatable {
+    public var model: String?
+    public var messages: [OpenAIChatMessage]
+    public var tools: [OpenAITool]?
+
+    public init(model: String? = nil, messages: [OpenAIChatMessage], tools: [OpenAITool]? = nil) {
+        self.model = model
+        self.messages = messages
+        self.tools = tools
+    }
+}

--- a/Libraries/MLXLMServer/Routing/MLXServerRoute.swift
+++ b/Libraries/MLXLMServer/Routing/MLXServerRoute.swift
@@ -1,0 +1,41 @@
+// Copyright © 2026 Apple Inc.
+
+public enum HTTPMethod: String, Codable, Sendable, Hashable {
+    case get = "GET"
+    case post = "POST"
+}
+
+public struct MLXServerRoute: Codable, Sendable, Hashable {
+    public let method: HTTPMethod
+    public let path: String
+
+    public init(_ method: HTTPMethod, _ path: String) {
+        self.method = method
+        self.path = path
+    }
+
+    public static let manifest: [MLXServerRoute] = [
+        .init(.get, "/health"),
+        .init(.get, "/v1/health"),
+        .init(.get, "/metrics"),
+        .init(.get, "/props"),
+        .init(.get, "/v1/models"),
+        .init(.get, "/models"),
+        .init(.post, "/v1/chat/completions"),
+        .init(.post, "/chat/completions"),
+        .init(.post, "/v1/chat/completions/batch"),
+        .init(.post, "/v1/completions"),
+        .init(.post, "/completions"),
+        .init(.post, "/completion"),
+        .init(.post, "/v1/responses"),
+        .init(.post, "/responses"),
+        .init(.get, "/v1/responses/{response_id}"),
+        .init(.post, "/v1/responses/{response_id}/cancel"),
+        .init(.post, "/v1/embeddings"),
+        .init(.post, "/embeddings"),
+        .init(.post, "/embedding"),
+        .init(.post, "/tokenize"),
+        .init(.post, "/detokenize"),
+        .init(.post, "/apply-template"),
+    ]
+}

--- a/Libraries/MLXLMServer/Runtime/InMemoryResponseStore.swift
+++ b/Libraries/MLXLMServer/Runtime/InMemoryResponseStore.swift
@@ -1,0 +1,24 @@
+// Copyright © 2026 Apple Inc.
+
+public actor InMemoryResponseStore {
+    private var responses: [String: OpenAIResponse] = [:]
+
+    public init() {}
+
+    public func save(_ response: OpenAIResponse) {
+        responses[response.id] = response
+    }
+
+    public func get(id: String) -> OpenAIResponse? {
+        responses[id]
+    }
+
+    public func cancel(id: String) -> OpenAIResponse? {
+        guard var response = responses[id] else {
+            return nil
+        }
+        response.status = .cancelled
+        responses[id] = response
+        return response
+    }
+}

--- a/Libraries/MLXLMServer/Runtime/MLXEmbeddingServerEngine.swift
+++ b/Libraries/MLXLMServer/Runtime/MLXEmbeddingServerEngine.swift
@@ -1,0 +1,82 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import HuggingFace
+import MLX
+import MLXEmbedders
+import MLXHuggingFace
+import MLXLMCommon
+import Tokenizers
+
+public protocol MLXEmbeddingServerEngine: Sendable {
+    func availableModels() async throws -> [MLXServerModel]
+    func createEmbedding(request: OpenAIEmbeddingRequest) async throws -> OpenAIEmbeddingResponse
+}
+
+public struct MLXEmbedderContainerEngine: MLXEmbeddingServerEngine {
+    private let modelID: String
+    private let model: EmbedderModelContainer
+
+    public init(modelID: String, model: EmbedderModelContainer) {
+        self.modelID = modelID
+        self.model = model
+    }
+
+    public func availableModels() async throws -> [MLXServerModel] {
+        [.init(id: modelID)]
+    }
+
+    public func createEmbedding(request: OpenAIEmbeddingRequest) async throws -> OpenAIEmbeddingResponse {
+        let texts = request.input.texts
+        let normalize = request.normalize ?? true
+        let embeddings = await model.perform { context in
+            let encoded = texts.map {
+                context.tokenizer.encode(text: $0, addSpecialTokens: true)
+            }
+            let padToken = context.tokenizer.eosTokenId ?? 0
+            let maxLength = max(1, encoded.map(\.count).max() ?? 1)
+            let padded = stacked(
+                encoded.map { tokens in
+                    MLXArray(tokens + Array(repeating: padToken, count: maxLength - tokens.count))
+                }
+            )
+            let mask = (padded .!= padToken)
+            let tokenTypes = MLXArray.zeros(like: padded)
+            let result = context.pooling(
+                context.model(
+                    padded,
+                    positionIds: nil,
+                    tokenTypeIds: tokenTypes,
+                    attentionMask: mask
+                ),
+                normalize: normalize,
+                applyLayerNorm: true
+            )
+            result.eval()
+            return result.map { $0.asArray(Float.self) }
+        }
+        let promptTokens = await promptTokenCount(texts)
+        return .init(
+            data: embeddings.enumerated().map { .init(embedding: $0.element, index: $0.offset) },
+            model: request.model,
+            usage: .init(promptTokens: promptTokens, completionTokens: 0)
+        )
+    }
+
+    private func promptTokenCount(_ texts: [String]) async -> Int {
+        let tokenizer = await model.tokenizer
+        return texts.reduce(0) { total, text in
+            total + tokenizer.encode(text: text, addSpecialTokens: true).count
+        }
+    }
+}
+
+public enum MLXServerEmbedderLoader {
+    public static func load(configuration: ModelConfiguration) async throws -> EmbedderModelContainer {
+        try await EmbedderModelFactory.shared.loadContainer(
+            from: #hubDownloader(),
+            using: #huggingFaceTokenizerLoader(),
+            configuration: configuration
+        )
+    }
+}

--- a/Libraries/MLXLMServer/Runtime/MLXModelContainerEngine.swift
+++ b/Libraries/MLXLMServer/Runtime/MLXModelContainerEngine.swift
@@ -1,0 +1,126 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import HuggingFace
+import MLXHuggingFace
+import MLXLMCommon
+import Tokenizers
+
+public struct MLXModelContainerEngine: MLXServerEngine {
+    private let modelID: String
+    private let model: ModelContainer
+    private let modelType: String?
+    private let defaultToolCallParser: String?
+
+    public init(
+        modelID: String,
+        model: ModelContainer,
+        modelType: String? = nil,
+        defaultToolCallParser: String? = nil
+    ) {
+        self.modelID = modelID
+        self.model = model
+        self.modelType = modelType
+        self.defaultToolCallParser = defaultToolCallParser
+    }
+
+    public func availableModels() async throws -> [MLXServerModel] {
+        [.init(id: modelID)]
+    }
+
+    public func streamChatCompletion(
+        request: OpenAIChatCompletionRequest
+    ) async throws -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
+        try await configureToolParser(for: request)
+
+        let userInput = UserInput(
+            chat: request.messages.map { $0.chatMessage() },
+            tools: request.tools?.map { $0.toolSpec() }
+        )
+        let input = try await model.prepare(input: userInput)
+        let stream = try await model.generate(input: input, parameters: request.generationParameters)
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                for await item in stream {
+                    switch item {
+                    case .chunk(let text):
+                        continuation.yield(.content(text))
+                    case .toolCall(let toolCall):
+                        continuation.yield(.toolCall(toolCall))
+                    case .info(let info):
+                        continuation.yield(.info(.init(info)))
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    public func tokenize(_ request: TokenizeRequest) async throws -> TokenizeResponse {
+        let tokenizer = await model.tokenizer
+        return .init(
+            tokens: tokenizer.encode(
+                text: request.prompt,
+                addSpecialTokens: request.addSpecialTokens ?? true
+            )
+        )
+    }
+
+    public func detokenize(_ request: DetokenizeRequest) async throws -> DetokenizeResponse {
+        let tokenizer = await model.tokenizer
+        return .init(
+            text: tokenizer.decode(
+                tokenIds: request.tokens,
+                skipSpecialTokens: request.skipSpecialTokens ?? false
+            )
+        )
+    }
+
+    public func applyTemplate(_ request: ApplyTemplateRequest) async throws -> TokenizeResponse {
+        let messages = request.messages.map { message in
+            [
+                "role": message.role.rawValue,
+                "content": message.textContent,
+            ] as [String: any Sendable]
+        }
+        let tools = request.tools?.map { $0.toolSpec() }
+        let tokens = try await model.perform { context in
+            try context.tokenizer.applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: nil
+            )
+        }
+        return .init(tokens: tokens)
+    }
+
+    private func configureToolParser(for request: OpenAIChatCompletionRequest) async throws {
+        let configuration = await model.configuration
+        let format: ToolCallFormat
+        let requested = request.toolCallParser ?? defaultToolCallParser
+        if requested == nil, let existing = configuration.toolCallFormat {
+            format = existing
+        } else {
+            format = try ServerToolParser.resolve(
+                requested: requested,
+                modelType: modelType
+            )
+        }
+
+        await model.update { context in
+            context.configuration.toolCallFormat = format
+        }
+    }
+}
+
+public enum MLXServerModelLoader {
+    public static func load(
+        configuration: ModelConfiguration
+    ) async throws -> ModelContainer {
+        try await #huggingFaceLoadModelContainer(configuration: configuration)
+    }
+}

--- a/Libraries/MLXLMServer/Runtime/MLXOpenAIService.swift
+++ b/Libraries/MLXLMServer/Runtime/MLXOpenAIService.swift
@@ -1,0 +1,372 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public enum MLXOpenAIServiceError: Error, LocalizedError, Equatable {
+    case responseNotFound(String)
+    case embeddingsNotConfigured
+    case invalidResponseFormatOutput(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .responseNotFound(let id):
+            return "Response '\(id)' was not found"
+        case .embeddingsNotConfigured:
+            return "Embeddings require an embedding model engine; this server instance was started without one."
+        case .invalidResponseFormatOutput(let message):
+            return "Generated output did not satisfy response_format: \(message)"
+        }
+    }
+}
+
+public struct MLXOpenAIService: Sendable {
+    private struct CollectedChatOutput: Sendable {
+        var content: String = ""
+        var toolCalls: [OpenAIToolCall] = []
+        var usage: OpenAIUsage?
+        var finishReason = "stop"
+    }
+
+    private let engine: any MLXServerEngine
+    private let embeddingEngine: (any MLXEmbeddingServerEngine)?
+    private let responseStore: InMemoryResponseStore
+    private let metrics: ServerMetrics
+    private let defaultReasoningParser: ReasoningParserFormat?
+    private let idProvider: @Sendable (String) -> String
+
+    public init(
+        engine: any MLXServerEngine,
+        embeddingEngine: (any MLXEmbeddingServerEngine)? = nil,
+        responseStore: InMemoryResponseStore = .init(),
+        metrics: ServerMetrics = .init(),
+        defaultReasoningParser: ReasoningParserFormat? = nil,
+        idProvider: @escaping @Sendable (String) -> String = { prefix in
+            "\(prefix)_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(24))"
+        }
+    ) {
+        self.engine = engine
+        self.embeddingEngine = embeddingEngine
+        self.responseStore = responseStore
+        self.metrics = metrics
+        self.defaultReasoningParser = defaultReasoningParser
+        self.idProvider = idProvider
+    }
+
+    public func availableModels() async throws -> OpenAIModelListResponse {
+        await metrics.recordOtherRequest()
+        var models = try await engine.availableModels()
+        if let embeddingEngine {
+            models.append(contentsOf: try await embeddingEngine.availableModels())
+        }
+        return .init(data: models)
+    }
+
+    public func createChatCompletion(
+        request: OpenAIChatCompletionRequest
+    ) async throws -> OpenAIChatCompletionResponse {
+        await metrics.recordChatRequest()
+        do {
+            let output = try await collectChatOutput(request: request)
+            let response = try chatCompletionResponse(request: request, output: output)
+            await metrics.recordUsage(response.usage)
+            return response
+        } catch {
+            await metrics.recordError()
+            throw error
+        }
+    }
+
+    public func streamChatCompletionFrames(
+        request: OpenAIChatCompletionRequest
+    ) async throws -> AsyncThrowingStream<String, Error> {
+        await metrics.recordChatRequest()
+        let generationRequest = try OpenAIResponseFormatSupport.preparedRequest(request)
+        let stream = try await engine.streamChatCompletion(request: generationRequest)
+        let id = idProvider("chatcmpl")
+        let created = Int(Date().timeIntervalSince1970)
+        let includeUsage = request.streamOptions?.includeUsage == true
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                var usage: OpenAIUsage?
+                var finishReason = "stop"
+                do {
+                    continuation.yield(
+                        try ServerSentEventEncoder.encode(
+                            OpenAIChatCompletionChunk(
+                                id: id,
+                                model: request.model,
+                                choices: [
+                                    .init(
+                                        index: 0,
+                                        delta: .init(
+                                            role: "assistant",
+                                            content: nil,
+                                            reasoningContent: nil,
+                                            toolCalls: nil
+                                        ),
+                                        finishReason: nil
+                                    )
+                                ],
+                                usage: nil,
+                                created: created
+                            )
+                        )
+                    )
+
+                    for try await event in stream {
+                        switch event {
+                        case .content(let text):
+                            continuation.yield(
+                                try ServerSentEventEncoder.encode(
+                                    OpenAIChatCompletionChunk(
+                                        id: id,
+                                        model: request.model,
+                                        choices: [
+                                            .init(
+                                                index: 0,
+                                                delta: .init(
+                                                    role: nil,
+                                                    content: text,
+                                                    reasoningContent: nil,
+                                                    toolCalls: nil
+                                                ),
+                                                finishReason: nil
+                                            )
+                                        ],
+                                        usage: nil,
+                                        created: created
+                                    )
+                                )
+                            )
+                        case .toolCall(let toolCall):
+                            finishReason = "tool_calls"
+                            let openAIToolCall = try OpenAIToolCall(
+                                toolCall: toolCall,
+                                id: idProvider("call")
+                            )
+                            continuation.yield(
+                                try ServerSentEventEncoder.encode(
+                                    OpenAIChatCompletionChunk(
+                                        id: id,
+                                        model: request.model,
+                                        choices: [
+                                            .init(
+                                                index: 0,
+                                                delta: .init(
+                                                    role: nil,
+                                                    content: nil,
+                                                    reasoningContent: nil,
+                                                    toolCalls: [openAIToolCall]
+                                                ),
+                                                finishReason: nil
+                                            )
+                                        ],
+                                        usage: nil,
+                                        created: created
+                                    )
+                                )
+                            )
+                        case .info(let info):
+                            usage = .init(
+                                promptTokens: info.promptTokens,
+                                completionTokens: info.completionTokens
+                            )
+                            if finishReason != "tool_calls" {
+                                finishReason = info.stopReason
+                            }
+                        }
+                    }
+
+                    continuation.yield(
+                        try ServerSentEventEncoder.encode(
+                            OpenAIChatCompletionChunk(
+                                id: id,
+                                model: request.model,
+                                choices: [
+                                    .init(
+                                        index: 0,
+                                        delta: .init(
+                                            role: nil,
+                                            content: nil,
+                                            reasoningContent: nil,
+                                            toolCalls: nil
+                                        ),
+                                        finishReason: finishReason
+                                    )
+                                ],
+                                usage: includeUsage ? usage : nil,
+                                created: created
+                            )
+                        )
+                    )
+                    await metrics.recordUsage(usage)
+                    continuation.yield(ServerSentEventEncoder.done)
+                    continuation.finish()
+                } catch {
+                    await metrics.recordError()
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    public func createResponse(request: OpenAIResponseRequest) async throws -> OpenAIResponse {
+        await metrics.recordResponseRequest()
+        do {
+            let output = try await collectChatOutput(request: request.chatCompletionRequest)
+            let response = responseObject(request: request, output: output)
+            if request.store != false {
+                await responseStore.save(response)
+            }
+            await metrics.recordUsage(response.usage)
+            return response
+        } catch {
+            await metrics.recordError()
+            throw error
+        }
+    }
+
+    public func retrieveResponse(id: String) async throws -> OpenAIResponse {
+        guard let response = await responseStore.get(id: id) else {
+            throw MLXOpenAIServiceError.responseNotFound(id)
+        }
+        return response
+    }
+
+    public func cancelResponse(id: String) async throws -> OpenAIResponse {
+        guard let response = await responseStore.cancel(id: id) else {
+            throw MLXOpenAIServiceError.responseNotFound(id)
+        }
+        return response
+    }
+
+    public func tokenize(_ request: TokenizeRequest) async throws -> TokenizeResponse {
+        await metrics.recordOtherRequest()
+        return try await engine.tokenize(request)
+    }
+
+    public func detokenize(_ request: DetokenizeRequest) async throws -> DetokenizeResponse {
+        await metrics.recordOtherRequest()
+        return try await engine.detokenize(request)
+    }
+
+    public func applyTemplate(_ request: ApplyTemplateRequest) async throws -> TokenizeResponse {
+        await metrics.recordOtherRequest()
+        return try await engine.applyTemplate(request)
+    }
+
+    public func createEmbedding(
+        request: OpenAIEmbeddingRequest
+    ) async throws -> OpenAIEmbeddingResponse {
+        await metrics.recordOtherRequest()
+        guard let embeddingEngine else {
+            await metrics.recordError()
+            throw MLXOpenAIServiceError.embeddingsNotConfigured
+        }
+        do {
+            let response = try await embeddingEngine.createEmbedding(request: request)
+            await metrics.recordUsage(response.usage)
+            return response
+        } catch {
+            await metrics.recordError()
+            throw error
+        }
+    }
+
+    public func metricsSnapshot() async -> ServerMetricsSnapshot {
+        await metrics.snapshot()
+    }
+
+    public func prometheusMetrics() async -> String {
+        await metrics.prometheusText()
+    }
+
+    private func collectChatOutput(
+        request: OpenAIChatCompletionRequest
+    ) async throws -> CollectedChatOutput {
+        let generationRequest = try OpenAIResponseFormatSupport.preparedRequest(request)
+        let stream = try await engine.streamChatCompletion(request: generationRequest)
+        var output = CollectedChatOutput()
+
+        for try await event in stream {
+            switch event {
+            case .content(let text):
+                output.content += text
+            case .toolCall(let toolCall):
+                output.toolCalls.append(
+                    try OpenAIToolCall(toolCall: toolCall, id: idProvider("call"))
+                )
+                output.finishReason = "tool_calls"
+            case .info(let info):
+                output.usage = .init(
+                    promptTokens: info.promptTokens,
+                    completionTokens: info.completionTokens
+                )
+                if output.finishReason != "tool_calls" {
+                    output.finishReason = info.stopReason
+                }
+            }
+        }
+
+        return output
+    }
+
+    private func chatCompletionResponse(
+        request: OpenAIChatCompletionRequest,
+        output: CollectedChatOutput
+    ) throws -> OpenAIChatCompletionResponse {
+        let parsed = ReasoningParser(format: request.reasoningParser ?? defaultReasoningParser ?? .none)
+            .parse(output.content)
+        let content = output.toolCalls.isEmpty
+            ? try OpenAIResponseFormatSupport.normalizedContent(
+                parsed.content,
+                for: request.responseFormat
+            )
+            : parsed.content
+        let message = OpenAIChatMessage(
+            role: .assistant,
+            content: .text(content),
+            toolCalls: output.toolCalls.isEmpty ? nil : output.toolCalls,
+            reasoningContent: parsed.reasoningContent
+        )
+
+        return .init(
+            id: idProvider("chatcmpl"),
+            model: request.model,
+            choices: [
+                .init(index: 0, message: message, finishReason: output.finishReason)
+            ],
+            usage: output.usage ?? .init(promptTokens: 0, completionTokens: 0)
+        )
+    }
+
+    private func responseObject(
+        request: OpenAIResponseRequest,
+        output: CollectedChatOutput
+    ) -> OpenAIResponse {
+        let parsed = ReasoningParser(format: request.reasoning?.parser ?? defaultReasoningParser ?? .none)
+            .parse(output.content)
+        var outputItems: [OpenAIResponseOutputItem] = []
+        if !parsed.content.isEmpty {
+            outputItems.append(.message(id: idProvider("msg"), text: parsed.content))
+        }
+        for toolCall in output.toolCalls {
+            outputItems.append(.functionCall(id: idProvider("fc"), toolCall: toolCall))
+        }
+
+        return .init(
+            id: idProvider("resp"),
+            status: .completed,
+            model: request.model,
+            output: outputItems,
+            outputText: parsed.content,
+            usage: output.usage,
+            metadata: request.metadata
+        )
+    }
+}

--- a/Libraries/MLXLMServer/Runtime/MLXServerEngine.swift
+++ b/Libraries/MLXLMServer/Runtime/MLXServerEngine.swift
@@ -1,0 +1,91 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+public struct MLXServerModel: Codable, Sendable, Equatable {
+    public var id: String
+    public var object: String
+    public var created: Int?
+    public var ownedBy: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case created
+        case ownedBy = "owned_by"
+    }
+
+    public init(
+        id: String,
+        object: String = "model",
+        created: Int? = nil,
+        ownedBy: String = "local"
+    ) {
+        self.id = id
+        self.object = object
+        self.created = created
+        self.ownedBy = ownedBy
+    }
+}
+
+public struct ServerGenerationInfo: Sendable, Equatable {
+    public var promptTokens: Int
+    public var completionTokens: Int
+    public var promptTime: TimeInterval
+    public var generationTime: TimeInterval
+    public var stopReason: String
+
+    public init(
+        promptTokens: Int,
+        completionTokens: Int,
+        promptTime: TimeInterval,
+        generationTime: TimeInterval,
+        stopReason: String
+    ) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+        self.promptTime = promptTime
+        self.generationTime = generationTime
+        self.stopReason = stopReason
+    }
+
+    public init(_ info: GenerateCompletionInfo) {
+        self.init(
+            promptTokens: info.promptTokenCount,
+            completionTokens: info.generationTokenCount,
+            promptTime: info.promptTime,
+            generationTime: info.generateTime,
+            stopReason: info.stopReason.openAIFinishReason
+        )
+    }
+}
+
+public enum MLXServerGenerationEvent: Sendable, Equatable {
+    case content(String)
+    case toolCall(ToolCall)
+    case info(ServerGenerationInfo)
+}
+
+public protocol MLXServerEngine: Sendable {
+    func availableModels() async throws -> [MLXServerModel]
+    func streamChatCompletion(
+        request: OpenAIChatCompletionRequest
+    ) async throws -> AsyncThrowingStream<MLXServerGenerationEvent, Error>
+    func tokenize(_ request: TokenizeRequest) async throws -> TokenizeResponse
+    func detokenize(_ request: DetokenizeRequest) async throws -> DetokenizeResponse
+    func applyTemplate(_ request: ApplyTemplateRequest) async throws -> TokenizeResponse
+}
+
+extension GenerateStopReason {
+    var openAIFinishReason: String {
+        switch self {
+        case .stop:
+            return "stop"
+        case .length:
+            return "length"
+        case .cancelled:
+            return "stop"
+        }
+    }
+}

--- a/Libraries/MLXLMServer/Runtime/OpenAIResponseFormatSupport.swift
+++ b/Libraries/MLXLMServer/Runtime/OpenAIResponseFormatSupport.swift
@@ -1,0 +1,373 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+enum OpenAIResponseFormatSupport {
+    static func preparedRequest(_ request: OpenAIChatCompletionRequest) throws -> OpenAIChatCompletionRequest {
+        guard let responseFormat = request.responseFormat,
+            responseFormat.requiresJSONOutput
+        else {
+            return request
+        }
+
+        var prepared = request
+        prepared.messages = request.messages.insertingResponseFormatInstruction(
+            try instruction(for: responseFormat)
+        )
+        return prepared
+    }
+
+    static func normalizedContent(
+        _ content: String,
+        for responseFormat: OpenAIResponseFormat?
+    ) throws -> String {
+        guard let responseFormat,
+            responseFormat.requiresJSONOutput
+        else {
+            return content
+        }
+
+        let decoded = try decodeJSONCandidate(from: content, rootMustBeObject: responseFormat.type == .jsonObject)
+        switch responseFormat.type {
+        case .text:
+            return content
+        case .jsonObject:
+            guard case .object = decoded.value else {
+                throw MLXOpenAIServiceError.invalidResponseFormatOutput(
+                    "response_format json_object requires a JSON object"
+                )
+            }
+        case .jsonSchema:
+            guard let schema = responseFormat.jsonSchema else {
+                throw MLXOpenAIServiceError.invalidResponseFormatOutput(
+                    "response_format json_schema requires a json_schema payload"
+                )
+            }
+            try JSONSchemaSubsetValidator.validate(decoded.value, schema: schema.schema)
+        }
+
+        return decoded.text
+    }
+
+    private static func instruction(for responseFormat: OpenAIResponseFormat) throws -> String {
+        switch responseFormat.type {
+        case .text:
+            return ""
+        case .jsonObject:
+            return """
+                You must respond with a single valid JSON object. Do not include markdown, code fences, comments, \
+                explanations, or extra text. The first non-whitespace character must be "{" and the final \
+                non-whitespace character must be "}".
+                """
+        case .jsonSchema:
+            guard let schema = responseFormat.jsonSchema else {
+                throw MLXOpenAIServiceError.invalidResponseFormatOutput(
+                    "response_format json_schema requires a json_schema payload"
+                )
+            }
+            let schemaText = try schema.schema.encodedJSONString()
+            let strictText = schema.strict == true
+                ? " The output must strictly conform to the schema."
+                : ""
+            let description = schema.description.map { " Description: \($0)" } ?? ""
+            let name = schema.name.map { " Schema name: \($0)." } ?? ""
+            return """
+                You must respond with a single valid JSON value that conforms to the supplied JSON Schema. Do not \
+                include markdown, code fences, comments, explanations, or extra text.\(name)\(description)\(strictText)
+                JSON Schema:
+                \(schemaText)
+                """
+        }
+    }
+
+    private static func decodeJSONCandidate(
+        from content: String,
+        rootMustBeObject: Bool
+    ) throws -> (value: JSONValue, text: String) {
+        let candidates = jsonCandidates(from: content, rootMustBeObject: rootMustBeObject)
+        for candidate in candidates {
+            if let value = try? JSONDecoder().decode(JSONValue.self, from: Data(candidate.utf8)) {
+                return (value, candidate)
+            }
+        }
+
+        throw MLXOpenAIServiceError.invalidResponseFormatOutput(
+            "model output was not valid JSON"
+        )
+    }
+
+    private static func jsonCandidates(from content: String, rootMustBeObject: Bool) -> [String] {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        var candidates: [String] = []
+        if !trimmed.isEmpty {
+            candidates.append(trimmed)
+        }
+        if let unfenced = trimmed.unfencedMarkdownJSON(), !unfenced.isEmpty {
+            candidates.append(unfenced)
+        }
+        if let balanced = trimmed.firstBalancedJSONValue(rootMustBeObject: rootMustBeObject),
+            !balanced.isEmpty
+        {
+            candidates.append(balanced)
+        }
+        return candidates.uniqued()
+    }
+}
+
+private struct JSONSchemaSubsetValidator {
+    static func validate(_ value: JSONValue, schema: JSONValue) throws {
+        guard case .object(let object) = schema else {
+            return
+        }
+
+        if let enumValues = object["enum"], case .array(let allowedValues) = enumValues,
+            !allowedValues.contains(value)
+        {
+            throw invalid("value is not one of the schema enum values")
+        }
+
+        if let constValue = object["const"], constValue != value {
+            throw invalid("value does not match schema const")
+        }
+
+        if let typeValue = object["type"] {
+            try validateType(value, typeValue: typeValue)
+        }
+
+        switch value {
+        case .object(let valueObject):
+            try validateObject(valueObject, schemaObject: object)
+        case .array(let values):
+            if let itemsSchema = object["items"] {
+                for item in values {
+                    try validate(item, schema: itemsSchema)
+                }
+            }
+        case .int(let value):
+            try validateNumber(Double(value), schemaObject: object)
+        case .double(let value):
+            try validateNumber(value, schemaObject: object)
+        case .string(let value):
+            try validateString(value, schemaObject: object)
+        case .null, .bool:
+            break
+        }
+    }
+
+    private static func validateObject(
+        _ value: [String: JSONValue],
+        schemaObject: [String: JSONValue]
+    ) throws {
+        let properties = schemaObject["properties"]?.objectValue ?? [:]
+        let required = schemaObject["required"]?.stringArrayValue ?? []
+
+        for key in required where value[key] == nil {
+            throw invalid("required property '\(key)' is missing")
+        }
+
+        for (key, propertySchema) in properties {
+            if let propertyValue = value[key] {
+                try validate(propertyValue, schema: propertySchema)
+            }
+        }
+
+        if schemaObject["additionalProperties"] == .bool(false) {
+            let extraKeys = Set(value.keys).subtracting(properties.keys)
+            if let extraKey = extraKeys.sorted().first {
+                throw invalid("additional property '\(extraKey)' is not allowed")
+            }
+        } else if let additionalSchema = schemaObject["additionalProperties"],
+            case .object = additionalSchema
+        {
+            for (key, propertyValue) in value where properties[key] == nil {
+                try validate(propertyValue, schema: additionalSchema)
+            }
+        }
+    }
+
+    private static func validateType(_ value: JSONValue, typeValue: JSONValue) throws {
+        switch typeValue {
+        case .string(let type):
+            guard matches(value, type: type) else {
+                throw invalid("value does not match schema type '\(type)'")
+            }
+        case .array(let types):
+            let rawTypes = types.compactMap(\.stringValue)
+            guard rawTypes.contains(where: { matches(value, type: $0) }) else {
+                throw invalid("value does not match any schema type")
+            }
+        default:
+            break
+        }
+    }
+
+    private static func validateNumber(_ value: Double, schemaObject: [String: JSONValue]) throws {
+        if let minimum = schemaObject["minimum"]?.doubleCompatibleValue,
+            value < minimum
+        {
+            throw invalid("number is below schema minimum")
+        }
+        if let maximum = schemaObject["maximum"]?.doubleCompatibleValue,
+            value > maximum
+        {
+            throw invalid("number is above schema maximum")
+        }
+    }
+
+    private static func validateString(_ value: String, schemaObject: [String: JSONValue]) throws {
+        if let minLength = schemaObject["minLength"]?.intValue,
+            value.count < minLength
+        {
+            throw invalid("string is shorter than schema minLength")
+        }
+        if let maxLength = schemaObject["maxLength"]?.intValue,
+            value.count > maxLength
+        {
+            throw invalid("string is longer than schema maxLength")
+        }
+    }
+
+    private static func matches(_ value: JSONValue, type: String) -> Bool {
+        switch (value, type) {
+        case (.object, "object"), (.array, "array"), (.string, "string"),
+            (.bool, "boolean"), (.null, "null"), (.int, "integer"):
+            return true
+        case (.int, "number"), (.double, "number"):
+            return true
+        case (.double(let value), "integer"):
+            return value.rounded() == value
+        default:
+            return false
+        }
+    }
+
+    private static func invalid(_ message: String) -> MLXOpenAIServiceError {
+        .invalidResponseFormatOutput(message)
+    }
+}
+
+private extension JSONValue {
+    var objectValue: [String: JSONValue]? {
+        if case .object(let value) = self { return value }
+        return nil
+    }
+
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    var stringArrayValue: [String]? {
+        guard case .array(let values) = self else { return nil }
+        return values.compactMap(\.stringValue)
+    }
+
+    var intValue: Int? {
+        if case .int(let value) = self { return value }
+        return nil
+    }
+
+    var doubleCompatibleValue: Double? {
+        switch self {
+        case .int(let value):
+            return Double(value)
+        case .double(let value):
+            return value
+        default:
+            return nil
+        }
+    }
+
+    func encodedJSONString() throws -> String {
+        let data = try JSONEncoder.openAIServer.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+private extension Array where Element == OpenAIChatMessage {
+    func insertingResponseFormatInstruction(_ instruction: String) -> [OpenAIChatMessage] {
+        let message = OpenAIChatMessage(
+            role: .system,
+            content: .text(instruction)
+        )
+        let insertionIndex = firstIndex { $0.role != .system } ?? endIndex
+        var messages = self
+        messages.insert(message, at: insertionIndex)
+        return messages
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}
+
+private extension String {
+    func unfencedMarkdownJSON() -> String? {
+        guard hasPrefix("```") else {
+            return nil
+        }
+
+        var lines = components(separatedBy: .newlines)
+        guard !lines.isEmpty else {
+            return nil
+        }
+        lines.removeFirst()
+        if lines.last?.trimmingCharacters(in: .whitespacesAndNewlines) == "```" {
+            lines.removeLast()
+        }
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func firstBalancedJSONValue(rootMustBeObject: Bool) -> String? {
+        let scalars = Array(unicodeScalars)
+        guard let start = scalars.firstIndex(where: { scalar in
+            rootMustBeObject ? scalar == "{" : (scalar == "{" || scalar == "[")
+        }) else {
+            return nil
+        }
+
+        var stack: [UnicodeScalar] = []
+        var inString = false
+        var escaped = false
+
+        for index in start..<scalars.endIndex {
+            let scalar = scalars[index]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if scalar == "\\" {
+                    escaped = true
+                } else if scalar == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            switch scalar {
+            case "\"":
+                inString = true
+            case "{":
+                stack.append("}")
+            case "[":
+                stack.append("]")
+            case "}", "]":
+                guard stack.last == scalar else {
+                    return nil
+                }
+                stack.removeLast()
+                if stack.isEmpty {
+                    let substring = String(String.UnicodeScalarView(scalars[start...index]))
+                    return substring.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            default:
+                break
+            }
+        }
+
+        return nil
+    }
+}

--- a/Libraries/MLXLMServer/Runtime/ServerMetrics.swift
+++ b/Libraries/MLXLMServer/Runtime/ServerMetrics.swift
@@ -1,0 +1,112 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+public struct ServerMetricsSnapshot: Codable, Sendable, Equatable {
+    public var requestsTotal: Int
+    public var chatCompletionsTotal: Int
+    public var responsesTotal: Int
+    public var errorsTotal: Int
+    public var promptTokensTotal: Int
+    public var completionTokensTotal: Int
+    public var uptimeSeconds: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case requestsTotal = "requests_total"
+        case chatCompletionsTotal = "chat_completions_total"
+        case responsesTotal = "responses_total"
+        case errorsTotal = "errors_total"
+        case promptTokensTotal = "prompt_tokens_total"
+        case completionTokensTotal = "completion_tokens_total"
+        case uptimeSeconds = "uptime_seconds"
+    }
+}
+
+public actor ServerMetrics {
+    private enum RequestKind {
+        case chat
+        case response
+        case other
+    }
+
+    private let startedAt: Date
+    private var requestsTotal = 0
+    private var chatCompletionsTotal = 0
+    private var responsesTotal = 0
+    private var errorsTotal = 0
+    private var promptTokensTotal = 0
+    private var completionTokensTotal = 0
+
+    public init(startedAt: Date = Date()) {
+        self.startedAt = startedAt
+    }
+
+    func recordChatRequest() {
+        record(.chat)
+    }
+
+    func recordResponseRequest() {
+        record(.response)
+    }
+
+    func recordOtherRequest() {
+        record(.other)
+    }
+
+    private func record(_ kind: RequestKind) {
+        requestsTotal += 1
+        switch kind {
+        case .chat:
+            chatCompletionsTotal += 1
+        case .response:
+            responsesTotal += 1
+        case .other:
+            break
+        }
+    }
+
+    func recordError() {
+        errorsTotal += 1
+    }
+
+    func recordUsage(_ usage: OpenAIUsage?) {
+        guard let usage else {
+            return
+        }
+        promptTokensTotal += usage.promptTokens
+        completionTokensTotal += usage.completionTokens
+    }
+
+    public func snapshot(now: Date = Date()) -> ServerMetricsSnapshot {
+        .init(
+            requestsTotal: requestsTotal,
+            chatCompletionsTotal: chatCompletionsTotal,
+            responsesTotal: responsesTotal,
+            errorsTotal: errorsTotal,
+            promptTokensTotal: promptTokensTotal,
+            completionTokensTotal: completionTokensTotal,
+            uptimeSeconds: now.timeIntervalSince(startedAt)
+        )
+    }
+
+    public func prometheusText(now: Date = Date()) -> String {
+        let snapshot = snapshot(now: now)
+        return """
+            # TYPE mlx_server_requests_total counter
+            mlx_server_requests_total \(snapshot.requestsTotal)
+            # TYPE mlx_server_chat_completions_total counter
+            mlx_server_chat_completions_total \(snapshot.chatCompletionsTotal)
+            # TYPE mlx_server_responses_total counter
+            mlx_server_responses_total \(snapshot.responsesTotal)
+            # TYPE mlx_server_errors_total counter
+            mlx_server_errors_total \(snapshot.errorsTotal)
+            # TYPE mlx_server_prompt_tokens_total counter
+            mlx_server_prompt_tokens_total \(snapshot.promptTokensTotal)
+            # TYPE mlx_server_completion_tokens_total counter
+            mlx_server_completion_tokens_total \(snapshot.completionTokensTotal)
+            # TYPE mlx_server_uptime_seconds gauge
+            mlx_server_uptime_seconds \(snapshot.uptimeSeconds)
+
+            """
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,12 @@ let package = Package(
             name: "MLXHuggingFace",
             targets: ["MLXHuggingFace"]),
         .library(
+            name: "MLXLMServer",
+            targets: ["MLXLMServer"]),
+        .executable(
+            name: "mlx-server",
+            targets: ["mlx-server"]),
+        .library(
             name: "BenchmarkHelpers",
             targets: ["BenchmarkHelpers"]),
         .library(
@@ -37,6 +43,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.3")),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.23.0"),
+        .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
     ],
     targets: [
@@ -91,6 +100,26 @@ let package = Package(
             ]
         ),
         .target(
+            name: "MLXLMServer",
+            dependencies: [
+                "MLXLLM",
+                "MLXVLM",
+                "MLXLMCommon",
+                "MLXEmbedders",
+                "MLXHuggingFace",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
+            ],
+            path: "Libraries/MLXLMServer"
+        ),
+        .executableTarget(
+            name: "mlx-server",
+            dependencies: ["MLXLMServer"],
+            path: "Executables/mlx-server"
+        ),
+        .target(
             name: "BenchmarkHelpers",
             dependencies: [
                 "MLXLMCommon",
@@ -129,6 +158,15 @@ let package = Package(
                 "README.md"
             ],
             resources: [.process("Resources/1080p_30.mov"), .process("Resources/audio_only.mov")]
+        ),
+        .testTarget(
+            name: "MLXLMServerTests",
+            dependencies: [
+                "MLXLMServer",
+                "MLXLMCommon",
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
+            ],
+            path: "Tests/MLXLMServerTests"
         ),
         .macro(
             name: "MLXHuggingFaceMacros",

--- a/Tests/MLXLMServerTests/OpenAIServiceTests.swift
+++ b/Tests/MLXLMServerTests/OpenAIServiceTests.swift
@@ -1,0 +1,524 @@
+import Foundation
+import Hummingbird
+import HummingbirdTesting
+import MLXLMCommon
+@testable import MLXLMServer
+import Testing
+
+struct OpenAIServiceTests {
+    @Test("chat completion collects generated content, reasoning, tool calls, usage, and metrics")
+    func chatCompletionCollectsContentReasoningToolCallsUsageAndMetrics() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .content("<think>check constraints</think>Hello "),
+            .content("there"),
+            .toolCall(
+                ToolCall(
+                    function: .init(
+                        name: "get_weather",
+                        arguments: ["location": .string("San Francisco")]
+                    )
+                )
+            ),
+            .info(.init(promptTokens: 9, completionTokens: 3)),
+        ])
+        let service = MLXOpenAIService(engine: engine)
+
+        let response = try await service.createChatCompletion(
+            request: .test(
+                messages: [.init(role: .user, content: .text("hi"))],
+                tools: [.weatherTool],
+                reasoningParser: .deepseekR1
+            )
+        )
+
+        #expect(response.object == "chat.completion")
+        #expect(response.model == "local-model")
+        #expect(response.choices.first?.message.role == .assistant)
+        #expect(response.choices.first?.message.content == .text("Hello there"))
+        #expect(response.choices.first?.message.reasoningContent == "check constraints")
+        #expect(response.choices.first?.message.toolCalls?.first?.function.name == "get_weather")
+        #expect(response.choices.first?.finishReason == "tool_calls")
+        #expect(response.usage.promptTokens == 9)
+        #expect(response.usage.completionTokens == 3)
+
+        let snapshot = await service.metricsSnapshot()
+        #expect(snapshot.requestsTotal == 1)
+        #expect(snapshot.chatCompletionsTotal == 1)
+        #expect(snapshot.promptTokensTotal == 9)
+        #expect(snapshot.completionTokensTotal == 3)
+
+        let lastRequest = await engine.lastChatRequest
+        #expect(lastRequest?.tools?.first?.function.name == "get_weather")
+    }
+
+    @Test("streaming chat completion emits OpenAI SSE frames, usage, and done sentinel")
+    func streamingChatCompletionEmitsSSEFramesUsageAndDone() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .content("hel"),
+            .content("lo"),
+            .info(.init(promptTokens: 2, completionTokens: 2)),
+        ])
+        let service = MLXOpenAIService(engine: engine)
+
+        let stream = try await service.streamChatCompletionFrames(
+            request: .test(
+                stream: true,
+                streamOptions: .init(includeUsage: true, continuousUsageStats: nil)
+            )
+        )
+        var frames: [String] = []
+        for try await frame in stream {
+            frames.append(frame)
+        }
+
+        #expect(frames.first?.contains("\"role\":\"assistant\"") == true)
+        #expect(frames.contains { $0.contains("\"content\":\"hel\"") })
+        #expect(frames.contains { $0.contains("\"content\":\"lo\"") })
+        #expect(frames.contains { $0.contains("\"prompt_tokens\":2") })
+        #expect(frames.last == ServerSentEventEncoder.done)
+    }
+
+    @Test("streaming tool calls finish with tool_calls even when generation info follows")
+    func streamingToolCallsPreserveFinishReason() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .toolCall(
+                ToolCall(
+                    function: .init(
+                        name: "get_weather",
+                        arguments: ["location": .string("San Francisco")]
+                    )
+                )
+            ),
+            .info(.init(promptTokens: 3, completionTokens: 1)),
+        ])
+        let service = MLXOpenAIService(engine: engine)
+
+        let stream = try await service.streamChatCompletionFrames(request: .test(stream: true))
+        var frames: [String] = []
+        for try await frame in stream {
+            frames.append(frame)
+        }
+
+        #expect(frames.contains { $0.contains("\"tool_calls\"") })
+        #expect(frames.contains { $0.contains("\"finish_reason\":\"tool_calls\"") })
+    }
+
+    @Test("JSON object response format injects instructions and returns normalized JSON")
+    func jsonObjectResponseFormatInjectsInstructionsAndNormalizesJSON() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .content("```json\n{\"city\":\"San Francisco\"}\n```"),
+            .info(.init(promptTokens: 8, completionTokens: 4)),
+        ])
+        let service = MLXOpenAIService(engine: engine)
+
+        let response = try await service.createChatCompletion(
+            request: .test(responseFormat: .jsonObject())
+        )
+
+        #expect(response.choices.first?.message.content == .text(#"{"city":"San Francisco"}"#))
+
+        let lastRequest = await engine.lastChatRequest
+        #expect(lastRequest?.messages.contains {
+            $0.role == .system && $0.textContent.contains("single valid JSON object")
+        } == true)
+    }
+
+    @Test("JSON schema response format validates required properties")
+    func jsonSchemaResponseFormatValidatesRequiredProperties() async throws {
+        let schema = OpenAIJSONSchemaResponseFormat(
+            name: "city",
+            strict: true,
+            schema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "city": .object(["type": .string("string")])
+                ]),
+                "required": .array([.string("city")]),
+                "additionalProperties": .bool(false),
+            ])
+        )
+        let service = MLXOpenAIService(
+            engine: ScriptedServerEngine(events: [
+                .content(#"{"country":"US"}"#),
+                .info(.init(promptTokens: 8, completionTokens: 4)),
+            ])
+        )
+
+        await #expect(throws: MLXOpenAIServiceError.self) {
+            try await service.createChatCompletion(
+                request: .test(responseFormat: .jsonSchema(schema))
+            )
+        }
+    }
+
+    @Test("JSON schema response format accepts matching output")
+    func jsonSchemaResponseFormatAcceptsMatchingOutput() async throws {
+        let schema = OpenAIJSONSchemaResponseFormat(
+            name: "city",
+            strict: true,
+            schema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "city": .object(["type": .string("string")])
+                ]),
+                "required": .array([.string("city")]),
+                "additionalProperties": .bool(false),
+            ])
+        )
+        let service = MLXOpenAIService(
+            engine: ScriptedServerEngine(events: [
+                .content(#"Here is the object: {"city":"San Francisco"}"#),
+                .info(.init(promptTokens: 8, completionTokens: 4)),
+            ])
+        )
+
+        let response = try await service.createChatCompletion(
+            request: .test(responseFormat: .jsonSchema(schema))
+        )
+
+        #expect(response.choices.first?.message.content == .text(#"{"city":"San Francisco"}"#))
+    }
+
+    @Test("response format rejects malformed JSON output")
+    func responseFormatRejectsMalformedJSONOutput() async throws {
+        let service = MLXOpenAIService(
+            engine: ScriptedServerEngine(events: [
+                .content(#"{"city":"San Francisco""#),
+                .info(.init(promptTokens: 8, completionTokens: 4)),
+            ])
+        )
+
+        await #expect(throws: MLXOpenAIServiceError.self) {
+            try await service.createChatCompletion(
+                request: .test(responseFormat: .jsonObject())
+            )
+        }
+    }
+
+    @Test("response format does not reject tool call completions without content")
+    func responseFormatDoesNotRejectToolCallCompletionsWithoutContent() async throws {
+        let service = MLXOpenAIService(
+            engine: ScriptedServerEngine(events: [
+                .toolCall(
+                    ToolCall(
+                        function: .init(
+                            name: "get_weather",
+                            arguments: ["location": .string("San Francisco")]
+                        )
+                    )
+                ),
+                .info(.init(promptTokens: 8, completionTokens: 4)),
+            ])
+        )
+
+        let response = try await service.createChatCompletion(
+            request: .test(
+                tools: [.weatherTool],
+                responseFormat: .jsonObject()
+            )
+        )
+
+        #expect(response.choices.first?.finishReason == "tool_calls")
+        #expect(response.choices.first?.message.toolCalls?.first?.function.name == "get_weather")
+    }
+
+    @Test("responses API creates, stores, retrieves, and cancels responses")
+    func responsesAPICreatesStoresRetrievesAndCancelsResponses() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .content("response text"),
+            .info(.init(promptTokens: 4, completionTokens: 2)),
+        ])
+        let service = MLXOpenAIService(engine: engine)
+
+        let created = try await service.createResponse(
+            request: .init(
+                model: "local-model",
+                input: .text("Say hi"),
+                instructions: "Be short.",
+                tools: nil,
+                toolChoice: nil,
+                reasoning: nil,
+                stream: nil,
+                store: true,
+                temperature: nil,
+                topP: nil,
+                maxOutputTokens: nil,
+                metadata: nil
+            )
+        )
+
+        #expect(created.object == "response")
+        #expect(created.status == .completed)
+        #expect(created.outputText == "response text")
+        #expect(created.output.first?.content?.first?.text == "response text")
+
+        let retrieved = try await service.retrieveResponse(id: created.id)
+        #expect(retrieved.id == created.id)
+        #expect(retrieved.outputText == "response text")
+
+        let cancelled = try await service.cancelResponse(id: created.id)
+        #expect(cancelled.status == .cancelled)
+
+        let snapshot = await service.metricsSnapshot()
+        #expect(snapshot.responsesTotal == 1)
+    }
+
+    @Test("token utility requests delegate through the engine")
+    func tokenUtilityRequestsDelegateThroughTheEngine() async throws {
+        let engine = ScriptedServerEngine(events: [])
+        let service = MLXOpenAIService(engine: engine)
+
+        let tokenized = try await service.tokenize(.init(model: "local-model", prompt: "hello"))
+        let detokenized = try await service.detokenize(.init(model: "local-model", tokens: [1, 2]))
+        let templated = try await service.applyTemplate(
+            .init(model: "local-model", messages: [.init(role: .user, content: .text("hello"))], tools: nil)
+        )
+
+        #expect(tokenized.tokens == [1, 2])
+        #expect(detokenized.text == "hello")
+        #expect(templated.tokens == [7, 8, 9])
+    }
+
+    @Test("embeddings endpoint delegates to optional embedding engine")
+    func embeddingsEndpointDelegatesToOptionalEmbeddingEngine() async throws {
+        let service = MLXOpenAIService(
+            engine: ScriptedServerEngine(events: []),
+            embeddingEngine: ScriptedEmbeddingEngine()
+        )
+
+        let response = try await service.createEmbedding(
+            request: .init(model: "embed-model", input: .texts(["a", "b"]))
+        )
+
+        #expect(response.object == "list")
+        #expect(response.model == "embed-model")
+        #expect(response.data.count == 2)
+        #expect(response.data[0].embedding == [0.1, 0.2])
+        #expect(response.usage.promptTokens == 2)
+    }
+
+    @Test("embeddings endpoint reports not configured without embedding engine")
+    func embeddingsEndpointReportsNotConfiguredWithoutEmbeddingEngine() async throws {
+        let service = MLXOpenAIService(engine: ScriptedServerEngine(events: []))
+
+        await #expect(throws: MLXOpenAIServiceError.embeddingsNotConfigured) {
+            try await service.createEmbedding(
+                request: .init(model: "embed-model", input: .text("a"))
+            )
+        }
+    }
+
+    @Test("Hummingbird application serves health, models, chat, and responses routes")
+    func hummingbirdApplicationServesCoreRoutes() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .content("route ok"),
+            .info(.init(promptTokens: 1, completionTokens: 2)),
+        ])
+        let service = MLXOpenAIService(
+            engine: engine,
+            embeddingEngine: ScriptedEmbeddingEngine()
+        )
+        let app = MLXServerApplication.buildApplication(service: service, host: "127.0.0.1", port: 8080)
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/health", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains("\"status\":\"ok\""))
+            }
+
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains("\"id\":\"local-model\""))
+            }
+
+            let chatBody = ByteBuffer(
+                string:
+                    #"{"model":"local-model","messages":[{"role":"user","content":"hi"}]}"#
+            )
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: chatBody
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains("\"route ok\""))
+            }
+
+            let responseBody = ByteBuffer(string: #"{"model":"local-model","input":"hi"}"#)
+            try await client.execute(
+                uri: "/v1/responses",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: responseBody
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains("\"object\":\"response\""))
+            }
+
+            let embeddingBody = ByteBuffer(string: #"{"model":"embed-model","input":["a","b"]}"#)
+            try await client.execute(
+                uri: "/v1/embeddings",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: embeddingBody
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains("\"embedding\":[0.1,0.2]"))
+            }
+        }
+    }
+
+    @Test("Hummingbird chat route forwards response format to generation")
+    func hummingbirdChatRouteForwardsResponseFormatToGeneration() async throws {
+        let engine = ScriptedServerEngine(events: [
+            .content(#"{"answer":"OK"}"#),
+            .info(.init(promptTokens: 1, completionTokens: 2)),
+        ])
+        let service = MLXOpenAIService(engine: engine)
+        let app = MLXServerApplication.buildApplication(service: service, host: "127.0.0.1", port: 8080)
+
+        try await app.test(.router) { client in
+            let chatBody = ByteBuffer(
+                string:
+                    #"{"model":"local-model","messages":[{"role":"user","content":"Return JSON"}],"response_format":{"type":"json_object"}}"#
+            )
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: chatBody
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(String(buffer: response.body).contains(#""content":"{\"answer\":\"OK\"}""#))
+            }
+        }
+
+        let lastRequest = await engine.lastChatRequest
+        #expect(lastRequest?.responseFormat?.type == .jsonObject)
+        #expect(lastRequest?.messages.contains {
+            $0.role == .system && $0.textContent.contains("single valid JSON object")
+        } == true)
+    }
+}
+
+private actor ScriptedServerEngine: MLXServerEngine {
+    var lastChatRequest: OpenAIChatCompletionRequest?
+    private let events: [MLXServerGenerationEvent]
+
+    init(events: [MLXServerGenerationEvent]) {
+        self.events = events
+    }
+
+    func availableModels() async throws -> [MLXServerModel] {
+        [.init(id: "local-model")]
+    }
+
+    func streamChatCompletion(
+        request: OpenAIChatCompletionRequest
+    ) async throws -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
+        lastChatRequest = request
+        let events = self.events
+        return AsyncThrowingStream { continuation in
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        }
+    }
+
+    func tokenize(_ request: TokenizeRequest) async throws -> TokenizeResponse {
+        .init(tokens: [1, 2])
+    }
+
+    func detokenize(_ request: DetokenizeRequest) async throws -> DetokenizeResponse {
+        .init(text: "hello")
+    }
+
+    func applyTemplate(_ request: ApplyTemplateRequest) async throws -> TokenizeResponse {
+        .init(tokens: [7, 8, 9])
+    }
+}
+
+private struct ScriptedEmbeddingEngine: MLXEmbeddingServerEngine {
+    func availableModels() async throws -> [MLXServerModel] {
+        [.init(id: "embed-model")]
+    }
+
+    func createEmbedding(request: OpenAIEmbeddingRequest) async throws -> OpenAIEmbeddingResponse {
+        .init(
+            data: request.input.texts.enumerated().map { index, _ in
+                .init(embedding: index == 0 ? [0.1, 0.2] : [0.3, 0.4], index: index)
+            },
+            model: request.model,
+            usage: .init(promptTokens: request.input.texts.count, completionTokens: 0)
+        )
+    }
+}
+
+private extension ServerGenerationInfo {
+    init(promptTokens: Int, completionTokens: Int) {
+        self.init(
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            promptTime: 0.01,
+            generationTime: 0.01,
+            stopReason: "stop"
+        )
+    }
+}
+
+private extension OpenAIChatCompletionRequest {
+    static func test(
+        model: String = "local-model",
+        messages: [OpenAIChatMessage] = [.init(role: .user, content: .text("hello"))],
+        tools: [OpenAITool]? = nil,
+        reasoningParser: ReasoningParserFormat? = nil,
+        responseFormat: OpenAIResponseFormat? = nil,
+        stream: Bool? = nil,
+        streamOptions: OpenAIStreamOptions? = nil
+    ) -> OpenAIChatCompletionRequest {
+        .init(
+            model: model,
+            messages: messages,
+            tools: tools,
+            toolChoice: nil,
+            toolCallParser: nil,
+            reasoningParser: reasoningParser,
+            responseFormat: responseFormat,
+            stream: stream,
+            temperature: nil,
+            topP: nil,
+            topK: nil,
+            minP: nil,
+            maxTokens: nil,
+            presencePenalty: nil,
+            frequencyPenalty: nil,
+            repetitionPenalty: nil,
+            stop: nil,
+            streamOptions: streamOptions
+        )
+    }
+}
+
+private extension OpenAIChatMessage {
+    init(role: OpenAIRole, content: OpenAIMessageContent) {
+        self.init(role: role, content: content, name: nil, toolCallID: nil, toolCalls: nil)
+    }
+}
+
+private extension OpenAITool {
+    static let weatherTool = OpenAITool(
+        type: "function",
+        function: .init(
+            name: "get_weather",
+            description: "Get weather",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "location": .object(["type": .string("string")])
+                ]),
+            ])
+        )
+    )
+}

--- a/Tests/MLXLMServerTests/ServerSurfaceTests.swift
+++ b/Tests/MLXLMServerTests/ServerSurfaceTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import MLXLMCommon
+@testable import MLXLMServer
+import Testing
+
+struct ServerSurfaceTests {
+    @Test("server route manifest exposes production inference endpoints")
+    func routeManifestExposesProductionInferenceEndpoints() {
+        let routes = MLXServerRoute.manifest
+        let pairs = Set(routes.map { "\($0.method.rawValue) \($0.path)" })
+
+        #expect(pairs.contains("GET /health"))
+        #expect(pairs.contains("GET /v1/health"))
+        #expect(pairs.contains("GET /metrics"))
+        #expect(pairs.contains("GET /v1/models"))
+        #expect(pairs.contains("POST /v1/chat/completions"))
+        #expect(pairs.contains("POST /chat/completions"))
+        #expect(pairs.contains("POST /v1/completions"))
+        #expect(pairs.contains("POST /completion"))
+        #expect(pairs.contains("POST /v1/responses"))
+        #expect(pairs.contains("POST /responses"))
+        #expect(pairs.contains("GET /v1/responses/{response_id}"))
+        #expect(pairs.contains("POST /v1/responses/{response_id}/cancel"))
+        #expect(pairs.contains("POST /v1/embeddings"))
+        #expect(pairs.contains("POST /tokenize"))
+        #expect(pairs.contains("POST /detokenize"))
+    }
+
+    @Test("OpenAI chat request decodes tools, stream flag, tool parser, and reasoning parser")
+    func openAIChatRequestDecodesAgentFields() throws {
+        let json = """
+            {
+              "model": "mlx-community/Qwen3-4B-4bit",
+              "messages": [
+                {"role": "system", "content": "You are terse."},
+                {"role": "user", "content": "weather in SF?"}
+              ],
+              "tools": [
+                {
+                  "type": "function",
+                  "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                      "type": "object",
+                      "properties": {"location": {"type": "string"}},
+                      "required": ["location"]
+                    }
+                  }
+                }
+              ],
+              "tool_choice": "auto",
+              "tool_call_parser": "mistral",
+              "reasoning_parser": "deepseek_r1",
+              "response_format": {"type": "json_object"},
+              "stream": true,
+              "temperature": 0.2,
+              "top_p": 0.95,
+              "max_tokens": 128
+            }
+            """
+
+        let request = try JSONDecoder().decode(
+            OpenAIChatCompletionRequest.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(request.model == "mlx-community/Qwen3-4B-4bit")
+        #expect(request.messages.count == 2)
+        #expect(request.messages[1].textContent == "weather in SF?")
+        #expect(request.tools?.first?.function.name == "get_weather")
+        #expect(request.toolChoice == .mode(.auto))
+        #expect(request.toolCallParser == "mistral")
+        #expect(request.reasoningParser == .deepseekR1)
+        #expect(request.responseFormat?.type == .jsonObject)
+        #expect(request.stream == true)
+        #expect(request.generationParameters.maxTokens == 128)
+        #expect(request.generationParameters.temperature == 0.2)
+        #expect(request.generationParameters.topP == 0.95)
+    }
+
+    @Test("OpenAI chat request decodes JSON schema response format")
+    func openAIChatRequestDecodesJSONSchemaResponseFormat() throws {
+        let json = """
+            {
+              "model": "local-model",
+              "messages": [{"role": "user", "content": "extract"}],
+              "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                  "name": "city",
+                  "description": "City extraction result",
+                  "strict": true,
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "city": {"type": "string"}
+                    },
+                    "required": ["city"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """
+
+        let request = try JSONDecoder().decode(
+            OpenAIChatCompletionRequest.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(request.responseFormat?.type == .jsonSchema)
+        #expect(request.responseFormat?.jsonSchema?.name == "city")
+        #expect(request.responseFormat?.jsonSchema?.strict == true)
+        #expect(request.responseFormat?.jsonSchema?.schema == .object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")])
+            ]),
+            "required": .array([.string("city")]),
+            "additionalProperties": .bool(false),
+        ]))
+    }
+
+    @Test("server tool parser resolver supports named and auto formats")
+    func serverToolParserResolverSupportsNamedAndAutoFormats() throws {
+        #expect(try ServerToolParser.resolve(requested: "mistral", modelType: nil) == .mistral)
+        #expect(try ServerToolParser.resolve(requested: "llama3_json", modelType: nil) == .llama3)
+        #expect(try ServerToolParser.resolve(requested: "gemma4", modelType: nil) == .gemma)
+        #expect(try ServerToolParser.resolve(requested: nil, modelType: "gemma4") == .gemma)
+        #expect(try ServerToolParser.resolve(requested: "auto", modelType: "qwen3_5") == .xmlFunction)
+        #expect(try ServerToolParser.resolve(requested: nil, modelType: "lfm2") == .lfm2)
+    }
+
+    @Test("reasoning parser extracts think blocks without leaking them into final content")
+    func reasoningParserExtractsThinkBlocks() {
+        let parser = ReasoningParser(format: .deepseekR1)
+        let parsed = parser.parse("<think>check constraints</think>The answer is 42.")
+
+        #expect(parsed.reasoningContent == "check constraints")
+        #expect(parsed.content == "The answer is 42.")
+    }
+
+    @Test("reasoning parser extracts harmony analysis and final channels")
+    func reasoningParserExtractsHarmonyChannels() {
+        let parser = ReasoningParser(format: .harmony)
+        let parsed = parser.parse(
+            "<|channel|>analysis<|message|>use tool first<|end|><|channel|>final<|message|>done<|end|>"
+        )
+
+        #expect(parsed.reasoningContent == "use tool first")
+        #expect(parsed.content == "done")
+    }
+
+    @Test("SSE encoder formats OpenAI data frames and done sentinel")
+    func sseEncoderFormatsDataFramesAndDoneSentinel() throws {
+        let frame = try ServerSentEventEncoder.encode(
+            OpenAIChatCompletionChunk(
+                id: "chatcmpl-test",
+                model: "local-model",
+                choices: [
+                    .init(
+                        index: 0,
+                        delta: .init(role: nil, content: "hello", reasoningContent: nil, toolCalls: nil),
+                        finishReason: nil
+                    )
+                ],
+                usage: nil
+            )
+        )
+
+        #expect(frame.hasPrefix("data: {"))
+        #expect(frame.contains("\"object\":\"chat.completion.chunk\""))
+        #expect(frame.contains("\"content\":\"hello\""))
+        #expect(ServerSentEventEncoder.done == "data: [DONE]\n\n")
+    }
+}

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -431,7 +431,7 @@ struct ToolTests {
     func testGemmaParser() throws {
         let parser = GemmaFunctionParser()
         let content =
-            "<start_function_call>call:get_weather{location:Paris,unit:celsius}<end_function_call>"
+            "<|tool_call>call:get_weather{location:Paris,unit:celsius}<tool_call|>"
 
         let toolCall = try #require(parser.parse(content: content, tools: nil))
 
@@ -443,9 +443,8 @@ struct ToolTests {
     @Test("Test Gemma Function Parser - Escaped Strings")
     func testGemmaParserEscapedStrings() throws {
         let parser = GemmaFunctionParser()
-        // Note: Gemma uses <escape> for both start and end markers (not </escape>)
         let content =
-            "<start_function_call>call:search{query:<escape>hello, world!<escape>}<end_function_call>"
+            "<|tool_call>call:search{query:<|\"|>hello, world!<|\"|>}<tool_call|>"
 
         let toolCall = try #require(parser.parse(content: content, tools: nil))
 
@@ -456,7 +455,7 @@ struct ToolTests {
     @Test("Test Gemma Format via ToolCallProcessor")
     func testGemmaFormatProcessor() throws {
         let processor = ToolCallProcessor(format: .gemma)
-        let content = "<start_function_call>call:calculator{expression:2+2}<end_function_call>"
+        let content = "<|tool_call>call:calculator{expression:2+2}<tool_call|>"
 
         _ = processor.processChunk(content)
 
@@ -464,6 +463,32 @@ struct ToolTests {
         let toolCall = try #require(processor.toolCalls.first)
         #expect(toolCall.function.name == "calculator")
         #expect(toolCall.function.arguments["expression"] == .string("2+2"))
+    }
+
+    @Test("Test Gemma Function Parser - Legacy Tags")
+    func testGemmaParserLegacyTags() throws {
+        let parser = GemmaFunctionParser()
+        let content =
+            "<start_function_call>call:get_weather{location:<escape>San Francisco<escape>}<end_function_call>"
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("San Francisco"))
+    }
+
+    @Test("Test Gemma Legacy Tags via ToolCallProcessor")
+    func testGemmaLegacyFormatProcessor() throws {
+        let processor = ToolCallProcessor(format: .gemma)
+        let content =
+            "<start_function_call>call:get_weather{location:<escape>San Francisco<escape>}<end_function_call>"
+
+        _ = processor.processChunk(content)
+
+        #expect(processor.toolCalls.count == 1)
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("San Francisco"))
     }
 
     // MARK: - Kimi K2 Format Tests
@@ -631,6 +656,8 @@ struct ToolTests {
         // Gemma models
         #expect(ToolCallFormat.infer(from: "gemma") == .gemma)
         #expect(ToolCallFormat.infer(from: "GEMMA") == .gemma)
+        #expect(ToolCallFormat.infer(from: "gemma4") == .gemma)
+        #expect(ToolCallFormat.infer(from: "gemma4_text") == .gemma)
 
         // Nemotron models (prefix matching)
         #expect(ToolCallFormat.infer(from: "nemotron_h") == .xmlFunction)


### PR DESCRIPTION
## Summary

Adds an OpenAI-compatible MLX inference server executable and library surface.

- Adds `mlx-server` with health, models, metrics, chat completions, completions, responses, embeddings, tokenization, detokenization, and chat-template routes.
- Adds OpenAI-compatible protocol DTOs, SSE framing, response store, metrics, and MLX-backed generation / embedding engines.
- Adds `response_format` support for AI SDK `generateObject` in both `json_object` and `json_schema` modes, including prompt injection, JSON cleanup, and post-generation validation.
- Updates Gemma tool-call parsing for current Gemma 4 tags and parser inference aliases.
- Adds server and parser tests covering route surface, streaming, tools, responses, embeddings, response format, and Gemma 4 tool tags.

## Why

The repo did not have a production server entrypoint that AI SDK or OpenAI-compatible clients could exercise end-to-end. AI SDK `generateObject` also sent `response_format`, but the server request/response path did not decode or enforce it.

## Validation

- `swift test` passed: 85 XCTest tests and 84 Swift Testing tests, 0 failures.
- `swift build --product mlx-server` passed.
- Ran real `mlx-server` with `mlx-community/gemma-4-26b-a4b-it-4bit` plus `mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ`.
- Ran AI SDK smoke with `ai@6.0.191` and `@ai-sdk/openai-compatible@2.0.48`: 11 checks, 0 failures, including `generateObject JSON object mode` and `generateObject JSON schema mode`.

## Notes

`response_format` support is prompt-plus-validation based. It is usable for AI SDK `generateObject`, but it is not token-level constrained decoding yet.