### PR TITLE
Add structured ChatSession continuation

### DIFF
--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -230,9 +230,9 @@ public enum ChatSessionTests {
         // If we got tool calls, feed back a tool result and verify the model responds
         if !toolCalls.isEmpty {
             let followUp = try await streamAndCollect(
-                session.streamResponse(
-                    to: "Foggy with a high in the low 60s, clearing later in the day",
-                    role: .tool, images: [], videos: []),
+                session.streamResponse(to: [
+                    .tool("Foggy with a high in the low 60s, clearing later in the day")
+                ]),
                 label: "Tool result")
             try check(
                 !followUp.isEmpty,

--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -41,6 +41,38 @@ for try await item in session.streamResponse(to: "Why is the sky blue?") {
 print()
 ```
 
+## Structured Chat Continuation
+
+`ChatSession` can also continue from structured `Chat.Message` values. This
+is useful for agent loops that consume tool calls from `streamDetails(to:role:images:videos:)`
+and then append one or more `.tool` messages without rebuilding the whole
+conversation history:
+
+```swift
+var toolResults: [Chat.Message] = []
+
+for try await item in session.streamDetails(
+    to: "What is the weather in Paris?",
+    images: [],
+    videos: []
+) {
+    if case .toolCall(let toolCall) = item {
+        let toolResult = try await callTool(toolCall)
+        toolResults.append(.tool(toolResult))
+    }
+}
+
+if !toolResults.isEmpty {
+    let answer = try await session.respond(to: toolResults)
+    print(answer)
+}
+```
+
+When a session is initialized with history, the first generation must tokenize
+and prefill that history to create a KV cache. Reuse the same `ChatSession` and
+continue with structured messages to avoid paying that full prefill cost on
+each tool turn.
+
 ## VLMs (Vision Language Models)
 
 This same API supports VLMs as well.  Simply present the image or video

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -352,6 +352,28 @@ public final class ChatSession {
         )
     }
 
+    /// Produces a response after appending a batch of structured chat messages.
+    ///
+    /// Use this to continue an existing session with non-user roles, such as one
+    /// or more tool results, while preserving the session's KV cache.
+    ///
+    /// - Important: Initializing a new session from history must prefill that
+    ///   history once. Reuse the same session with this method for subsequent
+    ///   tool or agent turns to avoid repeatedly pre-filling the accumulated
+    ///   transcript.
+    ///
+    /// - Parameter messages: chat messages to append before generation
+    /// - Returns: the model's response
+    public func respond(
+        to messages: consuming [Chat.Message]
+    ) async throws -> String {
+        var output = ""
+        for try await chunk in streamResponse(to: messages) {
+            output += chunk
+        }
+        return output
+    }
+
     /// Produces a streaming response to a prompt as Strings.
     ///
     /// - Parameters:
@@ -367,6 +389,21 @@ public final class ChatSession {
         videos: consuming [UserInput.Video]
     ) -> AsyncThrowingStream<String, Error> {
         streamMap(to: prompt, role: role, images: images, videos: videos) {
+            $0.chunk
+        }
+    }
+
+    /// Produces a streaming response after appending a batch of structured chat messages.
+    ///
+    /// Use this to continue an existing session with non-user roles, such as one
+    /// or more tool results, while preserving the session's KV cache.
+    ///
+    /// - Parameter messages: chat messages to append before generation
+    /// - Returns: a stream of string chunks from the model
+    public func streamResponse(
+        to messages: consuming [Chat.Message]
+    ) -> AsyncThrowingStream<String, Error> {
+        streamMap(messages: messages) {
             $0.chunk
         }
     }
@@ -390,6 +427,21 @@ public final class ChatSession {
         }
     }
 
+    /// Produces a streaming response after appending a batch of structured chat messages as `Generation`.
+    ///
+    /// Use this to continue an existing session with non-user roles, such as one
+    /// or more tool results, while preserving the session's KV cache.
+    ///
+    /// - Parameter messages: chat messages to append before generation
+    /// - Returns: a stream of `Generation` from the model
+    public func streamDetails(
+        to messages: consuming [Chat.Message]
+    ) -> AsyncThrowingStream<Generation, Error> {
+        streamMap(messages: messages) {
+            $0
+        }
+    }
+
     /// Produces a streaming response to a prompt by transforming the
     /// raw `Generation` values.
     ///
@@ -405,13 +457,21 @@ public final class ChatSession {
         videos: consuming [UserInput.Video],
         transform: @Sendable @escaping (Generation) -> R?
     ) -> AsyncThrowingStream<R, Error> {
+        streamMap(
+            messages: [.init(role: role, content: prompt, images: images, videos: videos)],
+            transform: transform
+        )
+    }
+
+    private func streamMap<R: Sendable>(
+        messages: consuming [Chat.Message],
+        transform: @Sendable @escaping (Generation) -> R?
+    ) -> AsyncThrowingStream<R, Error> {
         let (stream, continuation) = AsyncThrowingStream<R, Error>.makeStream()
 
         // images and videos are not Sendable (MLXArray) but they are consumed
         // and are only being sent to the inner async
-        let message = SendableBox<Chat.Message>(
-            .init(role: role, content: prompt, images: images, videos: videos)
-        )
+        let inputMessages = SendableBox<[Chat.Message]>(messages)
 
         let task = Task {
             [
@@ -468,7 +528,7 @@ public final class ChatSession {
                     }
 
                     // prepare the input
-                    messages.append(message.consume())
+                    messages.append(contentsOf: inputMessages.consume())
 
                     // loop can restart on tool calls
                     restart: while !messages.isEmpty {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -12,7 +12,22 @@ import XCTest
 /// See also ChatSessionIntegrationTests
 public class ChatSessionTests: XCTestCase {
 
-    private func model() -> ModelContext {
+    private struct RecordedMessage: Equatable, Sendable {
+        var role: Chat.Message.Role
+        var content: String
+    }
+
+    private struct RecordingMessageGenerator: MessageGenerator {
+        let continuation: AsyncStream<[RecordedMessage]>.Continuation
+
+        func generate(messages: [Chat.Message]) -> [Message] {
+            continuation.yield(messages.map { .init(role: $0.role, content: $0.content) })
+
+            return DefaultMessageGenerator().generate(messages: messages)
+        }
+    }
+
+    private func model(processor: TestInputProcessor = TestInputProcessor()) -> ModelContext {
         let config = Gemma3TextConfiguration(
             modelType: "text",
             hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64, attentionHeads: 4,
@@ -29,8 +44,6 @@ public class ChatSessionTests: XCTestCase {
         // Force evaluation of all model weights before concurrent usage
         // This ensures all weight promises are realized and avoids race conditions
         eval(model)
-
-        let processor = TestInputProcessor()
 
         return .init(
             configuration: processor.configuration,
@@ -68,6 +81,75 @@ public class ChatSessionTests: XCTestCase {
             result2 += part
         }
         XCTAssertGreaterThan(result2.count, targetLength, result2)
+    }
+
+    func testChatSessionRespondToMessages() async throws {
+        let session = ChatSession(model(), generateParameters: generationParameters)
+
+        let result = try await session.respond(to: [
+            .user("hello"),
+            .assistant("hi"),
+            .user("hello again"),
+        ])
+        XCTAssertGreaterThan(result.count, targetLength, result)
+    }
+
+    func testChatSessionStreamResponseToMessages() async throws {
+        let session = ChatSession(model(), generateParameters: generationParameters)
+
+        var result = ""
+        for try await part in session.streamResponse(to: [
+            .user("hello"),
+            .assistant("hi"),
+            .user("hello again"),
+        ]) {
+            result += part
+        }
+        XCTAssertGreaterThan(result.count, targetLength, result)
+    }
+
+    func testStructuredContinuationAvoidsReplayingHistoryAcrossToolTurns() async throws {
+        let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: TestTokenizer(),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: RecordingMessageGenerator(continuation: continuation))
+        let history: [Chat.Message] = (0 ..< 8).flatMap { index in
+            [
+                .user("question \(index)"),
+                .assistant("answer \(index)"),
+            ]
+        }
+        let continuations: [[Chat.Message]] = [
+            [.tool("first tool result")],
+            [.tool("second tool result")],
+            [.user("final answer")],
+        ]
+        let session = ChatSession(
+            model(processor: processor),
+            history: history,
+            generateParameters: GenerateParameters(maxTokens: 1))
+
+        for messages in continuations {
+            _ = try await session.respond(to: messages)
+        }
+        continuation.finish()
+
+        var calls: [[RecordedMessage]] = []
+        for await call in recordedMessages {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(calls.map(\.count), [history.count + 1, 1, 1])
+        XCTAssertEqual(calls[0].map(\.role), history.map(\.role) + [.tool])
+        XCTAssertEqual(calls[1].map(\.role), [.tool])
+        XCTAssertEqual(calls[2].map(\.role), [.user])
+
+        let actualPreparedMessageCount = calls.reduce(0) { $0 + $1.count }
+        let replayedHistoryPreparedMessageCount = continuations.indices.reduce(0) {
+            $0 + history.count + $1 + 1
+        }
+        XCTAssertLessThan(actualPreparedMessageCount, replayedHistoryPreparedMessageCount)
     }
 
     func testChatSessionAsyncInterrupt() async throws {


### PR DESCRIPTION
## Proposed changes

Adds structured `ChatSession` continuation APIs so callers can append one or more `Chat.Message` values directly to an existing session. This lets agent and tool-call loops continue a live cached session with `.tool`, `.assistant`, or `.user` messages without rebuilding a new session from the full accumulated transcript each turn.

### Motivation

A `ChatSession` initialized with history has to tokenize and prefill that history once to build the KV cache. Before this change, callers that needed to append structured tool messages often had to rebuild accumulated history externally, which could repeatedly re-apply the chat template, re-tokenize, and prefill the entire prompt across tool turns.

The new overloads expose the natural continuation path: keep using the same `ChatSession`, append structured messages, and preserve the existing KV cache.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
