### PR TITLE
Add speculative decoding telemetry and memory gating

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -8,7 +8,7 @@ import MLX
 ///
 /// Speculative decoding uses a small draft model to propose candidate tokens
 /// that the main model then verifies in a single forward pass, providing a
-/// ~2–3× generation speedup with no quality degradation.
+/// speedup with no quality degradation when both models fit comfortably in memory.
 ///
 /// Both models must share the same tokenizer vocabulary.
 ///
@@ -22,18 +22,99 @@ import MLX
 ///     speculativeDecoding: SpeculativeDecodingConfig(draftModel: draft, numDraftTokens: 5)
 /// )
 /// ```
+///
+/// To avoid loading a draft model that would exceed a memory policy, pass a
+/// byte estimate and a loader closure:
+///
+/// ```swift
+/// let session = ChatSession(
+///     main,
+///     speculativeDecoding: SpeculativeDecodingConfig(
+///         draftModelBytes: estimatedDraftBytes,
+///         memoryPolicy: .recommendedWorkingSet
+///     ) {
+///         try await LLMModelFactory.shared.loadContainer(configuration: draftConfig)
+///     }
+/// )
+/// ```
 public struct SpeculativeDecodingConfig: Sendable {
 
-    /// The lightweight model used to propose candidate tokens.
-    public let draftModel: ModelContainer
+    package enum DraftModelSource: Sendable {
+        case loaded(ModelContainer)
+        case deferred(bytes: Int, @Sendable () async throws -> ModelContainer)
+    }
+
+    package let draftModelSource: DraftModelSource
+
+    /// The lightweight model used to propose candidate tokens, when it was provided eagerly.
+    ///
+    /// Configurations initialized with a loader closure return `nil` because the
+    /// draft model is loaded asynchronously by ``ChatSession`` only when speculation
+    /// is admitted by the memory policy.
+    public var draftModel: ModelContainer? {
+        if case .loaded(let draftModel) = draftModelSource {
+            return draftModel
+        }
+        return nil
+    }
 
     /// Number of tokens proposed by the draft model per verification cycle.
     /// The default value of 5 offers a good balance between speed and accuracy.
     public let numDraftTokens: Int
 
-    public init(draftModel: ModelContainer, numDraftTokens: Int = 5) {
-        self.draftModel = draftModel
+    /// Optional memory policy used to decide whether auxiliary-model speculation should run.
+    /// Pass `.recommendedWorkingSet` to fall back to regular generation when
+    /// the combined main and draft model parameters exceed the recommended
+    /// working set.
+    public let memoryPolicy: SpeculativeDecodingMemoryPolicy?
+
+    public init(
+        draftModel: ModelContainer,
+        numDraftTokens: Int = 5,
+        memoryPolicy: SpeculativeDecodingMemoryPolicy? = nil
+    ) {
+        self.draftModelSource = .loaded(draftModel)
         self.numDraftTokens = numDraftTokens
+        self.memoryPolicy = memoryPolicy
+    }
+
+    /// Initialize speculative decoding with a draft model loader.
+    ///
+    /// When a memory policy is present, `draftModelBytes` lets `ChatSession`
+    /// decide whether to use speculative decoding before it loads the draft
+    /// model. This is the preferred initializer when the draft model may not fit
+    /// comfortably beside the main model.
+    ///
+    /// - Parameters:
+    ///   - draftModelBytes: estimated resident parameter bytes for the draft model
+    ///   - numDraftTokens: number of tokens proposed by the draft model per verification cycle
+    ///   - memoryPolicy: optional memory policy used before loading the draft model
+    ///   - loadDraftModel: closure that loads the draft model only if speculation is admitted
+    public init(
+        draftModelBytes: Int,
+        numDraftTokens: Int = 5,
+        memoryPolicy: SpeculativeDecodingMemoryPolicy? = nil,
+        loadDraftModel: @escaping @Sendable () async throws -> ModelContainer
+    ) {
+        self.draftModelSource = .deferred(bytes: max(0, draftModelBytes), loadDraftModel)
+        self.numDraftTokens = numDraftTokens
+        self.memoryPolicy = memoryPolicy
+    }
+
+    package var estimatedDraftModelBytes: Int? {
+        guard case .deferred(let bytes, _) = draftModelSource else {
+            return nil
+        }
+        return bytes
+    }
+
+    package func loadDraftModel() async throws -> ModelContainer {
+        switch draftModelSource {
+        case .loaded(let draftModel):
+            draftModel
+        case .deferred(_, let load):
+            try await load()
+        }
     }
 }
 
@@ -72,6 +153,7 @@ public final class ChatSession {
     private let model: ModelContainer
     public var instructions: String?
     private let cache: SerialAccessContainer<Cache>
+    private let loadedDraftModel: SerialAccessContainer<ModelContainer?>
     public var processing: UserInput.Processing
     public var generateParameters: GenerateParameters
     public var additionalContext: [String: any Sendable]?
@@ -105,6 +187,7 @@ public final class ChatSession {
         self.model = model
         self.instructions = instructions
         self.cache = .init(.empty)
+        self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
         self.tools = tools
@@ -137,6 +220,7 @@ public final class ChatSession {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
         self.cache = .init(.empty)
+        self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
         self.tools = tools
@@ -173,6 +257,7 @@ public final class ChatSession {
         self.model = model
         self.instructions = instructions
         self.cache = .init(.history(history))
+        self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
         self.tools = tools
@@ -209,6 +294,7 @@ public final class ChatSession {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
         self.cache = .init(.history(history))
+        self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
         self.tools = tools
@@ -254,6 +340,7 @@ public final class ChatSession {
         self.model = model
         self.instructions = instructions
         self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
         self.tools = tools
@@ -299,6 +386,7 @@ public final class ChatSession {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
         self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
         self.tools = tools
@@ -490,7 +578,7 @@ public final class ChatSession {
             [
                 model,
                 instructions, processing, tools, toolDispatch,
-                additionalContext, cache, generateParameters, speculativeDecoding
+                additionalContext, cache, loadedDraftModel, generateParameters, speculativeDecoding
             ] in
             do {
                 try await cache.update { cache in
@@ -554,52 +642,113 @@ public final class ChatSession {
 
                         // Select the token iterator based on speculative decoding configuration.
                         let (genStream, genTask): (AsyncStream<Generation>, Task<Void, Never>)
-
-                        if let speculativeDecoding {
-                            // Extract the draft model from its container (same pattern as the main model).
-                            let draftModel = await speculativeDecoding.draftModel.perform {
-                                context in
-                                SendableBox(context.model)
-                            }.consume()
-
-                            // Allocate the draft KV cache once and reuse it across turns,
-                            // exactly like the main model's KV cache.
-                            if draftKVCache == nil {
-                                draftKVCache = draftModel.newCache(parameters: generateParameters)
-                                cache = .kvcache(kvCache, draftKVCache: draftKVCache)
-                            }
-                            let draftCache = draftKVCache!
-
-                            let iterator = try SpeculativeTokenIterator(
-                                input: input,
-                                mainModel: model,
-                                draftModel: draftModel,
-                                mainCache: kvCache,
-                                draftCache: draftCache,
-                                parameters: generateParameters,
-                                numDraftTokens: speculativeDecoding.numDraftTokens
-                            )
-
-                            (genStream, genTask) = MLXLMCommon.generateTask(
-                                promptTokenCount: input.text.tokens.size,
-                                modelConfiguration: modelConfiguration,
-                                tokenizer: tokenizer,
-                                iterator: iterator,
-                                tools: tools
-                            )
-                        } else {
-                            // Standard path with no speculative decoding.
+                        func defaultGeneration() throws -> (
+                            AsyncStream<Generation>, Task<Void, Never>
+                        ) {
                             let iterator = try TokenIterator(
                                 input: input, model: model, cache: kvCache,
                                 parameters: generateParameters)
 
-                            (genStream, genTask) = MLXLMCommon.generateTask(
+                            return MLXLMCommon.generateTask(
                                 promptTokenCount: input.text.tokens.size,
                                 modelConfiguration: modelConfiguration,
                                 tokenizer: tokenizer,
                                 iterator: iterator,
                                 tools: tools
                             )
+                        }
+
+                        if let speculativeDecoding {
+                            var shouldFallBackBeforeLoadingDraft = false
+                            if let memoryPolicy = speculativeDecoding.memoryPolicy,
+                                let draftModelBytes =
+                                    speculativeDecoding.estimatedDraftModelBytes
+                            {
+                                let memoryEvaluation = memoryPolicy.evaluate(
+                                    mainModelBytes:
+                                        SpeculativeDecodingMemoryPolicy
+                                        .modelWeightBytes(model),
+                                    draftModelBytes: draftModelBytes
+                                )
+                                if !memoryEvaluation.shouldUseSpeculativeDecoding {
+                                    if memoryEvaluation.action == .fail {
+                                        throw SpeculativeDecodingMemoryError(
+                                            evaluation: memoryEvaluation)
+                                    }
+
+                                    shouldFallBackBeforeLoadingDraft = true
+                                }
+                            }
+
+                            if shouldFallBackBeforeLoadingDraft {
+                                (genStream, genTask) = try defaultGeneration()
+                            } else {
+                                let cachedDraftContainer = await loadedDraftModel.read { $0 }
+                                let draftContainer: ModelContainer
+                                if let cachedDraftContainer {
+                                    draftContainer = cachedDraftContainer
+                                } else {
+                                    draftContainer = try await speculativeDecoding.loadDraftModel()
+                                }
+
+                                // Extract the draft model from its container (same pattern as the main model).
+                                let draftModel = await draftContainer.perform { context in
+                                    SendableBox(context.model)
+                                }.consume()
+
+                                let memoryEvaluation = speculativeDecoding.memoryPolicy?.evaluate(
+                                    mainModel: model,
+                                    draftModel: draftModel
+                                )
+                                if let memoryEvaluation,
+                                    !memoryEvaluation.shouldUseSpeculativeDecoding
+                                {
+                                    if memoryEvaluation.action == .fail {
+                                        throw SpeculativeDecodingMemoryError(
+                                            evaluation: memoryEvaluation)
+                                    }
+
+                                    (genStream, genTask) = try defaultGeneration()
+                                } else {
+                                    if cachedDraftContainer == nil {
+                                        await loadedDraftModel.update { storedDraftModel in
+                                            if storedDraftModel == nil {
+                                                storedDraftModel = draftContainer
+                                            }
+                                        }
+                                    }
+
+                                    // Allocate the draft KV cache once and reuse it across turns,
+                                    // exactly like the main model's KV cache.
+                                    if draftKVCache == nil {
+                                        draftKVCache = draftModel.newCache(
+                                            parameters: generateParameters)
+                                        cache = .kvcache(kvCache, draftKVCache: draftKVCache)
+                                    }
+                                    let draftCache = draftKVCache!
+
+                                    let iterator = try SpeculativeTokenIterator(
+                                        input: input,
+                                        mainModel: model,
+                                        draftModel: draftModel,
+                                        mainCache: kvCache,
+                                        draftCache: draftCache,
+                                        parameters: generateParameters,
+                                        numDraftTokens: speculativeDecoding.numDraftTokens
+                                    )
+
+                                    (genStream, genTask) = MLXLMCommon.generateTask(
+                                        promptTokenCount: input.text.tokens.size,
+                                        modelConfiguration: modelConfiguration,
+                                        tokenizer: tokenizer,
+                                        iterator: iterator,
+                                        tools: tools
+                                    )
+                                }
+                            }
+                        } else {
+                            // Standard path with no speculative decoding.
+                            (genStream, genTask) = try defaultGeneration()
                         }
 
                         var pendingToolCalls: [ToolCall] = []

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -496,6 +496,13 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
     var maxTokens: Int? { get }
     var tokenCount: Int { get }
     var promptPrefillTime: TimeInterval { get }
+    var speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? { get }
+    mutating func discardGeneratedToken()
+}
+
+extension TokenIteratorProtocol {
+    public var speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? { nil }
+    public mutating func discardGeneratedToken() {}
 }
 
 /// Generator of tokens.
@@ -748,7 +755,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
     var processor: LogitProcessor?
     let sampler: LogitSampler
 
-    public var tokenCount = 0
+    public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
     let numDraftTokens: Int
 
@@ -758,6 +765,14 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
     // Internal metrics
     public var promptPrefillTime: TimeInterval = 0.0
+    private var telemetry = SpeculativeDecodingTelemetry()
+    public var speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? {
+        telemetry.roundCount > 0 ? telemetry : nil
+    }
+
+    public mutating func discardGeneratedToken() {
+        telemetry.discardGeneratedToken()
+    }
 
     /// Initialize a `SpeculativeTokenIterator` with the given input.
     ///
@@ -911,6 +926,12 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         processor?.didSample(token: finalToken)
         pendingTokens.append(mainTokensList[accepted])
 
+        telemetry.recordRound(
+            drafted: numDraft,
+            accepted: accepted,
+            targetVerified: numDraft + 1
+        )
+
         // Rewind caches for rejected tokens
         trimPromptCache(mainCache, numTokens: numDraft - accepted)
         trimPromptCache(draftCache, numTokens: Swift.max(numDraft - accepted - 1, 0))
@@ -944,7 +965,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         if pendingIndex < pendingTokens.count {
             let token = pendingTokens[pendingIndex]
             pendingIndex += 1
-            tokenCount += 1
+            telemetry.recordGeneratedToken()
             return token
         }
 
@@ -959,7 +980,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
         let token = pendingTokens[pendingIndex]
         pendingIndex += 1
-        tokenCount += 1
+        telemetry.recordGeneratedToken()
         return token
     }
 }
@@ -1809,6 +1830,8 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                             stopReason = .cancelled
                             break
                         }
+                    } else {
+                        iterator.discardGeneratedToken()
                     }
                     stopReason = .stop
                     break
@@ -1845,7 +1868,8 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 stopReason: stopReason ?? .cancelled,
                 proposedDraftTokens: mtpStats?.proposedDraftTokens,
                 acceptedDraftTokens: mtpStats?.acceptedDraftTokens,
-                passthroughReason: mtpStats?.passthroughReason
+                passthroughReason: mtpStats?.passthroughReason,
+                speculativeDecodingTelemetry: iterator.speculativeDecodingTelemetry
             )
             _ = continuation.yield(handler.infoEvent(info))
 
@@ -1932,6 +1956,9 @@ public struct GenerateCompletionInfo: Sendable {
     /// speculative for the full stream or for non-MTP streams.
     public let passthroughReason: String?
 
+    /// Speculative decoding telemetry, when generation used speculative decoding.
+    public let speculativeDecodingTelemetry: SpeculativeDecodingTelemetry?
+
     /// The number of tokens processed per second during the prompt phase.
     public var promptTokensPerSecond: Double {
         Double(promptTokenCount) / promptTime
@@ -1950,7 +1977,8 @@ public struct GenerateCompletionInfo: Sendable {
         stopReason: GenerateStopReason = .stop,
         proposedDraftTokens: Int? = nil,
         acceptedDraftTokens: Int? = nil,
-        passthroughReason: String? = nil
+        passthroughReason: String? = nil,
+        speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? = nil
     ) {
         self.promptTokenCount = promptTokenCount
         self.generationTokenCount = generationTokenCount
@@ -1960,6 +1988,7 @@ public struct GenerateCompletionInfo: Sendable {
         self.proposedDraftTokens = proposedDraftTokens
         self.acceptedDraftTokens = acceptedDraftTokens
         self.passthroughReason = passthroughReason
+        self.speculativeDecodingTelemetry = speculativeDecodingTelemetry
     }
 
     public func summary() -> String {

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -44,7 +44,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     var processor: LogitProcessor?
     let sampler: LogitSampler
 
-    public var tokenCount = 0
+    public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
     /// Total tokens proposed per round (`blockSize - 1` drafted, plus the
     /// bonus token from the previous verify). Mirrors mlx-vlm's
@@ -74,6 +74,14 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     private var lastRoundAccepted: Int? = nil
 
     public var promptPrefillTime: TimeInterval = 0.0
+    private var telemetry = SpeculativeDecodingTelemetry()
+    public var speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? {
+        telemetry.roundCount > 0 ? telemetry : nil
+    }
+
+    public mutating func discardGeneratedToken() {
+        telemetry.discardGeneratedToken()
+    }
 
     // Optional instrumentation used by acceptance-rate floor tests.
     // Public read-only so test cases can compute `acceptedCount /
@@ -331,6 +339,12 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         proposedCount += numDraft
         acceptedCount += accepted
         lastRoundAccepted = accepted
+        telemetry.recordRound(
+            drafted: numDraft,
+            accepted: accepted,
+            targetVerified: numDraft + 1,
+            draftModelCalls: 1
+        )
 
         // Rewind the main cache and the emitted sharedKV snapshot by the
         // rejected count, in lockstep. The drafter has no cache of its own,
@@ -390,7 +404,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         if passthrough {
             if let token = passthroughStep() {
-                tokenCount += 1
+                telemetry.recordGeneratedToken()
                 return token
             }
             return nil
@@ -400,7 +414,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         if pendingIndex < pendingTokens.count {
             let token = pendingTokens[pendingIndex]
             pendingIndex += 1
-            tokenCount += 1
+            telemetry.recordGeneratedToken()
             return token
         }
 
@@ -413,7 +427,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             // speculateRound chose passthrough -- fall through.
             if passthrough {
                 if let token = passthroughStep() {
-                    tokenCount += 1
+                    telemetry.recordGeneratedToken()
                     return token
                 }
             }
@@ -422,7 +436,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         let token = pendingTokens[pendingIndex]
         pendingIndex += 1
-        tokenCount += 1
+        telemetry.recordGeneratedToken()
         return token
     }
 }

--- a/Libraries/MLXLMCommon/SpeculativeDecoding.swift
+++ b/Libraries/MLXLMCommon/SpeculativeDecoding.swift
@@ -1,0 +1,207 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+private func defaultSpeculativeDecodingMemoryLimit() -> Int? {
+    guard let bytes = GPU.maxRecommendedWorkingSetBytes(), bytes > 0 else {
+        return nil
+    }
+    return bytes
+}
+
+/// Runtime counters for a speculative decoding pass.
+public struct SpeculativeDecodingTelemetry: Sendable, Equatable {
+    /// Number of speculative decoding rounds.
+    public private(set) var roundCount: Int
+
+    /// Number of tokens proposed by the draft model.
+    public private(set) var draftTokenCount: Int
+
+    /// Number of draft tokens accepted by the target model.
+    public private(set) var acceptedDraftTokenCount: Int
+
+    /// Number of target-model verification calls.
+    public private(set) var targetModelCallCount: Int
+
+    /// Number of draft-model calls.
+    public private(set) var draftModelCallCount: Int
+
+    /// Number of token positions evaluated by the target model during verification.
+    public private(set) var targetVerifiedTokenCount: Int
+
+    /// Number of tokens emitted from speculative rounds, including correction and bonus tokens.
+    public private(set) var emittedTokenCount: Int
+
+    public init(
+        roundCount: Int = 0,
+        draftTokenCount: Int = 0,
+        acceptedDraftTokenCount: Int = 0,
+        targetModelCallCount: Int = 0,
+        draftModelCallCount: Int = 0,
+        targetVerifiedTokenCount: Int = 0,
+        emittedTokenCount: Int = 0
+    ) {
+        self.roundCount = roundCount
+        self.draftTokenCount = draftTokenCount
+        self.acceptedDraftTokenCount = acceptedDraftTokenCount
+        self.targetModelCallCount = targetModelCallCount
+        self.draftModelCallCount = draftModelCallCount
+        self.targetVerifiedTokenCount = targetVerifiedTokenCount
+        self.emittedTokenCount = emittedTokenCount
+    }
+
+    /// Number of draft tokens rejected by the target model.
+    public var rejectedDraftTokenCount: Int {
+        max(0, draftTokenCount - acceptedDraftTokenCount)
+    }
+
+    /// Fraction of drafted tokens accepted by the target model.
+    public var acceptanceRate: Double {
+        guard draftTokenCount > 0 else { return 0 }
+        return Double(acceptedDraftTokenCount) / Double(draftTokenCount)
+    }
+
+    /// Mean accepted draft tokens per speculative round.
+    public var meanAcceptedDraftTokensPerRound: Double {
+        guard roundCount > 0 else { return 0 }
+        return Double(acceptedDraftTokenCount) / Double(roundCount)
+    }
+
+    /// Mean emitted tokens per target-model verification call.
+    public var meanEmittedTokensPerTargetCall: Double {
+        guard targetModelCallCount > 0 else { return 0 }
+        return Double(emittedTokenCount) / Double(targetModelCallCount)
+    }
+
+    package mutating func recordRound(
+        drafted: Int,
+        accepted: Int,
+        targetVerified: Int,
+        draftModelCalls: Int? = nil
+    ) {
+        roundCount += 1
+        draftTokenCount += drafted
+        acceptedDraftTokenCount += accepted
+        targetModelCallCount += 1
+        draftModelCallCount += draftModelCalls ?? drafted
+        targetVerifiedTokenCount += targetVerified
+    }
+
+    package mutating func recordGeneratedToken() {
+        emittedTokenCount += 1
+    }
+
+    package mutating func discardGeneratedToken() {
+        emittedTokenCount = max(0, emittedTokenCount - 1)
+    }
+}
+
+/// Action to take when speculative decoding exceeds a memory budget.
+public enum SpeculativeDecodingMemoryAction: Sendable, Hashable {
+    /// Use speculative decoding even if the estimate exceeds the budget.
+    case allow
+
+    /// Fall back to regular generation.
+    case fallbackToDefault
+
+    /// Throw an error instead of silently falling back.
+    case fail
+}
+
+/// Result of evaluating speculative decoding against a memory policy.
+public struct SpeculativeDecodingMemoryEvaluation: Sendable, Equatable {
+    /// Estimated main-model parameter bytes.
+    public let mainModelBytes: Int
+
+    /// Estimated draft-model parameter bytes.
+    public let draftModelBytes: Int
+
+    /// Additional caller-provided budget for KV cache, workspace, or other resident data.
+    public let additionalBytes: Int
+
+    /// Total estimated resident bytes for speculative decoding.
+    public var estimatedBytes: Int {
+        mainModelBytes + draftModelBytes + additionalBytes
+    }
+
+    /// Memory budget used for the decision. `nil` means no budget was available.
+    public let limitBytes: Int?
+
+    /// Action selected by the policy.
+    public let action: SpeculativeDecodingMemoryAction
+
+    /// Whether speculative decoding is within the available budget.
+    public var isWithinBudget: Bool {
+        guard let limitBytes else { return true }
+        return estimatedBytes <= limitBytes
+    }
+
+    /// Whether speculative decoding should be used.
+    public var shouldUseSpeculativeDecoding: Bool {
+        isWithinBudget || action == .allow
+    }
+}
+
+/// Policy for gating auxiliary-model speculative decoding by resident memory estimates.
+public struct SpeculativeDecodingMemoryPolicy: Sendable, Hashable {
+    /// Optional absolute budget in bytes. When nil, no budget is enforced.
+    public let limitBytes: Int?
+
+    /// Extra bytes to reserve for KV cache, workspace, or application memory.
+    public let additionalBytes: Int
+
+    /// Action to take when the estimate exceeds the budget.
+    public let action: SpeculativeDecodingMemoryAction
+
+    public init(
+        limitBytes: Int? = nil,
+        additionalBytes: Int = 0,
+        action: SpeculativeDecodingMemoryAction = .fallbackToDefault
+    ) {
+        self.limitBytes = limitBytes
+        self.additionalBytes = max(0, additionalBytes)
+        self.action = action
+    }
+
+    /// Default policy using `GPU.maxRecommendedWorkingSetBytes()` when available.
+    public static var recommendedWorkingSet: Self {
+        Self(limitBytes: defaultSpeculativeDecodingMemoryLimit())
+    }
+
+    /// Evaluate explicit byte estimates. This is useful before loading a draft model.
+    public func evaluate(
+        mainModelBytes: Int,
+        draftModelBytes: Int
+    ) -> SpeculativeDecodingMemoryEvaluation {
+        SpeculativeDecodingMemoryEvaluation(
+            mainModelBytes: max(0, mainModelBytes),
+            draftModelBytes: max(0, draftModelBytes),
+            additionalBytes: additionalBytes,
+            limitBytes: limitBytes,
+            action: action
+        )
+    }
+
+    package func evaluate(
+        mainModel: any LanguageModel,
+        draftModel: any LanguageModel
+    ) -> SpeculativeDecodingMemoryEvaluation {
+        evaluate(
+            mainModelBytes: Self.modelWeightBytes(mainModel),
+            draftModelBytes: Self.modelWeightBytes(draftModel)
+        )
+    }
+
+    package static func modelWeightBytes(_ model: any LanguageModel) -> Int {
+        model.parameters().flattened().reduce(0) { $0 + $1.1.nbytes }
+    }
+}
+
+public struct SpeculativeDecodingMemoryError: Error, Sendable {
+    public let evaluation: SpeculativeDecodingMemoryEvaluation
+
+    public init(evaluation: SpeculativeDecodingMemoryEvaluation) {
+        self.evaluation = evaluation
+    }
+}

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -27,7 +27,23 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
-    private func model(processor: TestInputProcessor = TestInputProcessor()) -> ModelContext {
+    private struct UnexpectedDraftModelLoadError: Error {}
+
+    private actor DraftModelLoadCounter {
+        private var count = 0
+
+        func increment() {
+            count += 1
+        }
+
+        var value: Int {
+            count
+        }
+    }
+
+    private static func makeModel(processor: TestInputProcessor = TestInputProcessor())
+        -> ModelContext
+    {
         let config = Gemma3TextConfiguration(
             modelType: "text",
             hiddenSize: 64, hiddenLayers: 8, intermediateSize: 64, attentionHeads: 4,
@@ -50,6 +66,10 @@ public class ChatSessionTests: XCTestCase {
             model: model,
             processor: processor,
             tokenizer: processor.tokenizer)
+    }
+
+    private func model(processor: TestInputProcessor = TestInputProcessor()) -> ModelContext {
+        Self.makeModel(processor: processor)
     }
 
     private let generationParameters = GenerateParameters(maxTokens: 50)
@@ -239,6 +259,155 @@ public class ChatSessionTests: XCTestCase {
             result += part
         }
         XCTAssertGreaterThan(result.count, targetLength, result)
+    }
+
+    func testSpeculativeDecodingMemoryPolicyFallbackUsesDefaultGeneration() async throws {
+        let draft = ModelContainer(context: model())
+        let session = ChatSession(
+            model(),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModel: draft,
+                numDraftTokens: 2,
+                memoryPolicy: SpeculativeDecodingMemoryPolicy(
+                    limitBytes: 0,
+                    action: .fallbackToDefault
+                )
+            ),
+            generateParameters: GenerateParameters(maxTokens: 4, temperature: 0.0)
+        )
+
+        var info: GenerateCompletionInfo?
+        for try await generation in session.streamDetails(
+            to: "hello",
+            role: .user,
+            images: [] as [UserInput.Image],
+            videos: [] as [UserInput.Video]
+        ) {
+            if let generationInfo = generation.info {
+                info = generationInfo
+            }
+        }
+
+        let completionInfo = try XCTUnwrap(info)
+        XCTAssertNil(completionInfo.speculativeDecodingTelemetry)
+    }
+
+    func testSpeculativeDecodingMemoryPolicyFailThrows() async throws {
+        let draft = ModelContainer(context: model())
+        let session = ChatSession(
+            model(),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModel: draft,
+                numDraftTokens: 2,
+                memoryPolicy: SpeculativeDecodingMemoryPolicy(
+                    limitBytes: 0,
+                    action: .fail
+                )
+            ),
+            generateParameters: GenerateParameters(maxTokens: 4, temperature: 0.0)
+        )
+
+        do {
+            for try await _ in session.streamDetails(
+                to: "hello",
+                role: .user,
+                images: [] as [UserInput.Image],
+                videos: [] as [UserInput.Video]
+            ) {}
+            XCTFail("expected SpeculativeDecodingMemoryError")
+        } catch let error as SpeculativeDecodingMemoryError {
+            XCTAssertFalse(error.evaluation.isWithinBudget)
+            XCTAssertFalse(error.evaluation.shouldUseSpeculativeDecoding)
+        } catch {
+            XCTFail("expected SpeculativeDecodingMemoryError, got \(error)")
+        }
+    }
+
+    func testDeferredSpeculativeDecodingMemoryPolicyFallbackDoesNotLoadDraftModel() async throws {
+        let session = ChatSession(
+            model(),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModelBytes: 1,
+                numDraftTokens: 2,
+                memoryPolicy: SpeculativeDecodingMemoryPolicy(
+                    limitBytes: 0,
+                    action: .fallbackToDefault
+                )
+            ) {
+                throw UnexpectedDraftModelLoadError()
+            },
+            generateParameters: GenerateParameters(maxTokens: 4, temperature: 0.0)
+        )
+
+        var info: GenerateCompletionInfo?
+        for try await generation in session.streamDetails(
+            to: "hello",
+            role: .user,
+            images: [] as [UserInput.Image],
+            videos: [] as [UserInput.Video]
+        ) {
+            if let generationInfo = generation.info {
+                info = generationInfo
+            }
+        }
+
+        let completionInfo = try XCTUnwrap(info)
+        XCTAssertNil(completionInfo.speculativeDecodingTelemetry)
+    }
+
+    func testDeferredSpeculativeDecodingMemoryPolicyFailDoesNotLoadDraftModel() async throws {
+        let session = ChatSession(
+            model(),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModelBytes: 1,
+                numDraftTokens: 2,
+                memoryPolicy: SpeculativeDecodingMemoryPolicy(
+                    limitBytes: 0,
+                    action: .fail
+                )
+            ) {
+                throw UnexpectedDraftModelLoadError()
+            },
+            generateParameters: GenerateParameters(maxTokens: 4, temperature: 0.0)
+        )
+
+        do {
+            for try await _ in session.streamDetails(
+                to: "hello",
+                role: .user,
+                images: [] as [UserInput.Image],
+                videos: [] as [UserInput.Video]
+            ) {}
+            XCTFail("expected SpeculativeDecodingMemoryError")
+        } catch is UnexpectedDraftModelLoadError {
+            XCTFail("draft model loader should not be called")
+        } catch let error as SpeculativeDecodingMemoryError {
+            XCTAssertFalse(error.evaluation.isWithinBudget)
+            XCTAssertFalse(error.evaluation.shouldUseSpeculativeDecoding)
+        } catch {
+            XCTFail("expected SpeculativeDecodingMemoryError, got \(error)")
+        }
+    }
+
+    func testDeferredSpeculativeDecodingLoadsDraftModelOnceAcrossTurns() async throws {
+        let loadCounter = DraftModelLoadCounter()
+        let session = ChatSession(
+            model(),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModelBytes: 0,
+                numDraftTokens: 2
+            ) {
+                await loadCounter.increment()
+                return ModelContainer(context: Self.makeModel())
+            },
+            generateParameters: GenerateParameters(maxTokens: 4, temperature: 0.0)
+        )
+
+        _ = try await session.respond(to: "hello")
+        _ = try await session.respond(to: "again")
+
+        let loadCount = await loadCounter.value
+        XCTAssertEqual(loadCount, 1)
     }
 
     // MARK: - KV Cache

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -232,6 +232,14 @@ func testMTPSpeculateRoundSmokeWithSynthetics() throws {
     // proposedCount = numDraft = 3; accepted = 3.
     #expect(iter.proposedCount == 3)
     #expect(iter.acceptedCount == 3)
+    let telemetry = try #require(iter.speculativeDecodingTelemetry)
+    #expect(telemetry.roundCount == 1)
+    #expect(telemetry.draftTokenCount == 3)
+    #expect(telemetry.acceptedDraftTokenCount == 3)
+    #expect(telemetry.targetModelCallCount == 1)
+    #expect(telemetry.draftModelCallCount == 1)
+    #expect(telemetry.targetVerifiedTokenCount == 4)
+    #expect(telemetry.emittedTokenCount == iter.tokenCount)
     // Verify the main model received emit=true on every call after prefill.
     #expect(main.lastIncomingEmitFlag == true)
 }

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -134,11 +134,15 @@ struct SpeculativeDecodingTests {
         )
 
         var speculativeTokens: [Int] = []
+        var telemetry: SpeculativeDecodingTelemetry?
         for await generation in try generateTokens(
             input: modelInput, parameters: parameters, context: mainContext,
             draftModel: draftContext.model, numDraftTokens: numDraftTokens
         ) {
             if let token = generation.token { speculativeTokens.append(token) }
+            if let info = generation.info {
+                telemetry = info.speculativeDecodingTelemetry
+            }
         }
 
         // Real MLX model kernels may choose different argmaxes for batched
@@ -146,6 +150,69 @@ struct SpeculativeDecodingTests {
         // Keep this as model-path coverage; exact equality belongs to the
         // stable-logit contract test above.
         #expect(speculativeTokens.count == maxTokens)
+
+        let speculativeTelemetry = try #require(telemetry)
+        #expect(speculativeTelemetry.roundCount > 0)
+        #expect(speculativeTelemetry.draftTokenCount > 0)
+        #expect(speculativeTelemetry.targetModelCallCount == speculativeTelemetry.roundCount)
+        #expect(speculativeTelemetry.draftModelCallCount == speculativeTelemetry.draftTokenCount)
+        #expect(speculativeTelemetry.acceptanceRate >= 0)
+        #expect(speculativeTelemetry.acceptanceRate <= 1)
+    }
+
+    @Test func `Speculative telemetry emitted count matches generated tokens`() async throws {
+        let input = UserInput(prompt: "Input text")
+        let modelInput = try await processor.prepare(input: input)
+        let parameters = GenerateParameters(
+            maxTokens: 1,
+            temperature: 0.0
+        )
+
+        var tokenCount = 0
+        var info: GenerateCompletionInfo?
+        for await generation in try generateTokens(
+            input: modelInput, parameters: parameters, context: mainContext,
+            draftModel: draftContext.model, numDraftTokens: 8
+        ) {
+            if generation.token != nil {
+                tokenCount += 1
+            }
+            if let generationInfo = generation.info {
+                info = generationInfo
+            }
+        }
+
+        let completionInfo = try #require(info)
+        let telemetry = try #require(completionInfo.speculativeDecodingTelemetry)
+        #expect(completionInfo.generationTokenCount == tokenCount)
+        #expect(telemetry.emittedTokenCount == tokenCount)
+        #expect(telemetry.emittedTokenCount == completionInfo.generationTokenCount)
+    }
+
+    @Test func `Speculative telemetry emitted count works with direct iterator`() async throws {
+        let input = UserInput(prompt: "Input text")
+        let modelInput = try await processor.prepare(input: input)
+        let parameters = GenerateParameters(
+            maxTokens: 3,
+            temperature: 0.0
+        )
+
+        var iterator = try SpeculativeTokenIterator(
+            input: modelInput,
+            mainModel: mainContext.model,
+            draftModel: draftContext.model,
+            parameters: parameters,
+            numDraftTokens: 8
+        )
+
+        var tokenCount = 0
+        while iterator.next() != nil {
+            tokenCount += 1
+        }
+
+        let telemetry = try #require(iterator.speculativeDecodingTelemetry)
+        #expect(tokenCount == 3)
+        #expect(telemetry.emittedTokenCount == tokenCount)
     }
 }
 

--- a/Tests/MLXLMTests/WiredMemoryPolicyTests.swift
+++ b/Tests/MLXLMTests/WiredMemoryPolicyTests.swift
@@ -44,4 +44,30 @@ final class WiredMemoryPolicyTests: XCTestCase {
         XCTAssertTrue(first.canAdmit(baseline: 50, activeSizes: [75], newSize: 75))
         XCTAssertFalse(first.canAdmit(baseline: 50, activeSizes: [75], newSize: 76))
     }
+
+    func testSpeculativeDecodingMemoryPolicyEvaluatesCombinedModelBudget() {
+        let policy = SpeculativeDecodingMemoryPolicy(
+            limitBytes: 1_000,
+            additionalBytes: 100,
+            action: .fallbackToDefault
+        )
+
+        let admitted = policy.evaluate(mainModelBytes: 600, draftModelBytes: 250)
+        XCTAssertEqual(admitted.estimatedBytes, 950)
+        XCTAssertTrue(admitted.isWithinBudget)
+        XCTAssertTrue(admitted.shouldUseSpeculativeDecoding)
+
+        let denied = policy.evaluate(mainModelBytes: 600, draftModelBytes: 350)
+        XCTAssertEqual(denied.estimatedBytes, 1_050)
+        XCTAssertFalse(denied.isWithinBudget)
+        XCTAssertFalse(denied.shouldUseSpeculativeDecoding)
+    }
+
+    func testSpeculativeDecodingMemoryPolicyAllowOverridesBudget() {
+        let policy = SpeculativeDecodingMemoryPolicy(limitBytes: 100, action: .allow)
+        let evaluation = policy.evaluate(mainModelBytes: 100, draftModelBytes: 1)
+
+        XCTAssertFalse(evaluation.isWithinBudget)
+        XCTAssertTrue(evaluation.shouldUseSpeculativeDecoding)
+    }
 }


### PR DESCRIPTION
## Proposed changes

Speculative decoding is workload and hardware-sensitive. A draft model can look good in theory but fail to pay off if acceptance is low or if the extra model pressure is too high.

The change set prepares the project for edge-aware speculative decoding by adding the two missing foundations:

1. observe speculative decoding quality/performance
2. avoid applying auxiliary-model speculation when memory pressure makes it likely to hurt

### Telemetry
It exposes whether speculative decoding is actually helping at runtime. Callers can now inspect acceptance rate, draft tokens, target verification calls, emitted tokens, and average emitted tokens per target call through GenerateCompletionInfo.speculativeDecodingTelemetry.


### Memory-Aware Gating
ChatSession now defaults speculative decoding to a memory policy based on GPU.maxRecommendedWorkingSetBytes(). Before this, enabling speculative decoding meant loading/running the main model plus draft model whenever requested. On memory-constrained systems, that can make things slower or less stable.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
