### PR TITLE
Fix consistent float32 dtype for gated delta SSM operations in Qwen3.5 models

### DIFF
--- a/Libraries/MLXLMCommon/GatedDelta.swift
+++ b/Libraries/MLXLMCommon/GatedDelta.swift
@@ -13,7 +13,7 @@ import MLXNN
 
 func computeGatedDeltaG(_ aLog: MLXArray, _ a: MLXArray, _ dtBias: MLXArray) -> MLXArray {
     let decay = exp(-exp(aLog.asType(.float32)) * softplus(a + dtBias))
-    return decay.asType(a.dtype)
+    return decay
 }
 
 // MARK: - Metal Kernel
@@ -75,6 +75,8 @@ private func makeGatedDeltaKernel(hasMask: Bool) -> MLXFast.MLXFastKernel? {
                 if (thread_index_in_simdgroup == 0) {
                   y[dv_idx] = static_cast<InT>(out);
                 }
+              } else {
+                y[dv_idx] = static_cast<InT>(0);
               }
               // Increment data pointers to next time step
               q_ += Hk * Dk;
@@ -210,7 +212,7 @@ private func gatedDeltaStepOps(
         state = MLX.where(expandedMask, state, oldState)
     }
 
-    return (y, state)
+    return (y.asType(q.dtype), state)
 }
 
 func gatedDeltaOps(
@@ -238,7 +240,7 @@ func gatedDeltaOps(
         k = repeated(k, count: repeatFactor, axis: -2)
     }
 
-    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: q.dtype)
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
 
     var ys = [MLXArray]()
     ys.reserveCapacity(T)
@@ -281,7 +283,7 @@ public func gatedDeltaUpdate(
     state: MLXArray? = nil,
     mask: MLXArray? = nil
 ) -> (MLXArray, MLXArray) {
-    let beta = sigmoid(b)
+    let beta = sigmoid(b).asType(.float32)
     let g = computeGatedDeltaG(aLog, a, dtBias)
 
     let B = q.dim(0)


### PR DESCRIPTION
In `gatedDeltaUpdate`, which is used by `Qwen35GatedDeltaNet`, `g` and `beta` inherited their dtype from the input tensor (`bfloat16`), while the SSM state is correctly maintained in `float32`. Additionally, `computeGatedDeltaG` computed in `float32` for precision but immediately downcasted back to input dtype, discarding that precision.

This dtype inconsistency caused MLX to compile the `gated_delta_step` Metal kernel with `bfloat16` for `g` and `beta` on the first generation turn. On subsequent turns where the computation graph differed (e.g. when reusing a `QuantizedKVCache` across turns), the correct `float32` dtype was used, causing a kernel source mismatch. MLX's `clear_library` would evict the old compiled pipeline while an `asyncEval` command buffer was still using it, triggering a Metal API validation crash.

**Changes**

Cast `beta` to `float32` explicitly in `gatedDeltaUpdate`, and return `float32` directly from `computeGatedDeltaG` rather than downcasting back to input dtype. I believe this matches the Python mlx-lm reference implementation, which uses `StT` (float32) consistently for all SSM computations.

Also reconciled recent changes from the Python counterpart (`gated_delta.py`): [#997](https://github.com/ml-explore/mlx-lm/pull/997) and [#1072](https://github.com/ml-explore/mlx-lm/pull/1072).

Note: discovered this issue while attempting various solutions for #312 This fix is a pre-requisite.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
