### PR TITLE
Add Swift model conversion API

### DIFF
--- a/Libraries/MLXLLM/ModelConversion.swift
+++ b/Libraries/MLXLLM/ModelConversion.swift
@@ -1,0 +1,132 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+extension LLMModelFactory {
+
+    /// Download, quantize, and save a safetensors-backed LLM.
+    ///
+    /// This is the Swift equivalent of the common `mlx_lm.convert` workflow for models that
+    /// are available as compatible safetensors. PyTorch `.bin` conversion is intentionally out
+    /// of scope.
+    public func convert(
+        from downloader: any Downloader,
+        configuration: ModelConfiguration,
+        to outputDirectory: URL,
+        options: ModelConversionOptions = .init(),
+        useLatest: Bool = false,
+        downloadProgressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+        progressHandler: @Sendable @escaping (ModelConversionProgress) -> Void = { _ in }
+    ) async throws -> ModelConversionResult {
+        let resolved = try await resolveForModelConversion(
+            configuration: configuration,
+            from: downloader,
+            useLatest: useLatest,
+            progressHandler: { progress in
+                downloadProgressHandler(progress)
+                progressHandler(
+                    .init(
+                        stage: .downloading,
+                        fractionCompleted: progress.fractionCompleted,
+                        message: progress.localizedDescription))
+            })
+
+        return try await convert(
+            configuration: resolved,
+            to: outputDirectory,
+            options: options,
+            progressHandler: progressHandler)
+    }
+
+    /// Download, quantize, and save a safetensors-backed LLM.
+    public func convert(
+        from downloader: any Downloader,
+        configuration: ModelConfiguration,
+        to outputDirectory: URL,
+        bits: Int? = nil,
+        groupSize: Int? = nil,
+        mode: QuantizationMode = .affine,
+        useLatest: Bool = false,
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    ) async throws -> ModelConversionResult {
+        try await convert(
+            from: downloader,
+            configuration: configuration,
+            to: outputDirectory,
+            options: .init(bits: bits, groupSize: groupSize, mode: mode),
+            useLatest: useLatest,
+            downloadProgressHandler: progressHandler)
+    }
+
+    /// Quantize and save a local safetensors-backed LLM.
+    public func convert(
+        from directory: URL,
+        tokenizerDirectory: URL? = nil,
+        to outputDirectory: URL,
+        options: ModelConversionOptions = .init(),
+        progressHandler: @Sendable @escaping (ModelConversionProgress) -> Void = { _ in }
+    ) async throws -> ModelConversionResult {
+        try await convert(
+            configuration: .init(
+                modelDirectory: directory,
+                tokenizerDirectory: tokenizerDirectory ?? directory,
+                name: directory.deletingLastPathComponent().lastPathComponent + "/"
+                    + directory.lastPathComponent,
+                defaultPrompt: "",
+                extraEOSTokens: [],
+                eosTokenIds: [],
+                toolCallFormat: nil),
+            to: outputDirectory,
+            options: options,
+            progressHandler: progressHandler)
+    }
+
+    /// Quantize and save a resolved local safetensors-backed LLM.
+    public func convert(
+        configuration: ResolvedModelConfiguration,
+        to outputDirectory: URL,
+        options: ModelConversionOptions = .init(),
+        progressHandler: @Sendable @escaping (ModelConversionProgress) -> Void = { _ in }
+    ) async throws -> ModelConversionResult {
+        let modelDirectory = configuration.modelDirectory
+        let configurationURL = modelDirectory.appendingPathComponent("config.json")
+
+        let configData: Data
+        do {
+            configData = try Data(contentsOf: configurationURL)
+        } catch {
+            throw ModelFactoryError.configurationFileError(
+                configurationURL.lastPathComponent, configuration.name, error)
+        }
+        if sourceConfigurationIsQuantized(configData) {
+            throw ModelConversionError.sourceAlreadyQuantized(modelDirectory)
+        }
+
+        let baseConfig: BaseConfiguration
+        do {
+            baseConfig = try JSONDecoder.json5().decode(BaseConfiguration.self, from: configData)
+        } catch let error as DecodingError {
+            throw ModelFactoryError.configurationDecodingError(
+                configurationURL.lastPathComponent, configuration.name, error)
+        }
+
+        let model: LanguageModel
+        do {
+            model = try await typeRegistry.createModel(
+                configuration: configData, modelType: baseConfig.modelType)
+        } catch let error as DecodingError {
+            throw ModelFactoryError.configurationDecodingError(
+                configurationURL.lastPathComponent, configuration.name, error)
+        }
+
+        return try MLXLMCommon.convert(
+            modelDirectory: modelDirectory,
+            tokenizerDirectory: configuration.tokenizerDirectory,
+            model: model,
+            to: outputDirectory,
+            options: options,
+            progressHandler: progressHandler)
+    }
+}

--- a/Libraries/MLXLMCommon/ModelConversion.swift
+++ b/Libraries/MLXLMCommon/ModelConversion.swift
@@ -1,0 +1,845 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+package let modelConversionSidecarPatterns = [
+    "*.json", "*.jsonl", "*.jinja", "*.txt", "*.model", "*.tiktoken", "*.py",
+]
+package let modelConversionDownloadPatterns = ["*.safetensors"] + modelConversionSidecarPatterns
+
+/// Quantization settings for one conversion pass or layer.
+public struct ModelConversionQuantization: Sendable, Equatable {
+    /// Quantization bit depth.
+    ///
+    /// `nil` lets MLX use the default for the selected quantization mode.
+    public var bits: Int?
+
+    /// Quantization group size.
+    ///
+    /// `nil` lets MLX use the default for the selected quantization mode.
+    public var groupSize: Int?
+
+    /// Quantization mode.
+    public var mode: QuantizationMode
+
+    public init(bits: Int? = nil, groupSize: Int? = nil, mode: QuantizationMode = .affine) {
+        self.bits = bits
+        self.groupSize = groupSize
+        self.mode = mode
+    }
+}
+
+/// Per-layer quantization decision.
+public enum ModelConversionQuantizationDecision: Sendable, Equatable {
+    /// Do not quantize this layer.
+    case skip
+
+    /// Quantize this layer, using the global conversion settings when the associated value is nil.
+    case quantize(ModelConversionQuantization? = nil)
+}
+
+/// Predicate used to customize layer quantization.
+public typealias ModelConversionQuantizationPredicate =
+    @Sendable (
+        _ path: String, _ module: Module
+    ) -> ModelConversionQuantizationDecision
+
+/// Options controlling model conversion.
+public struct ModelConversionOptions: Sendable {
+    /// Default quantization settings.
+    public var quantization: ModelConversionQuantization
+
+    /// Maximum safetensors shard size in bytes.
+    public var maxShardSize: Int64
+
+    /// Remove and recreate the output directory if it already exists.
+    public var overwriteExistingOutput: Bool
+
+    /// Optional per-layer quantization customization.
+    public var quantizationPredicate: ModelConversionQuantizationPredicate?
+
+    public var bits: Int? {
+        get { quantization.bits }
+        set { quantization.bits = newValue }
+    }
+
+    public var groupSize: Int? {
+        get { quantization.groupSize }
+        set { quantization.groupSize = newValue }
+    }
+
+    public var mode: QuantizationMode {
+        get { quantization.mode }
+        set { quantization.mode = newValue }
+    }
+
+    public init(
+        bits: Int? = nil,
+        groupSize: Int? = nil,
+        mode: QuantizationMode = .affine,
+        maxShardSize: Int64 = 5 * 1024 * 1024 * 1024,
+        overwriteExistingOutput: Bool = false,
+        quantizationPredicate: ModelConversionQuantizationPredicate? = nil
+    ) {
+        self.quantization = .init(bits: bits, groupSize: groupSize, mode: mode)
+        self.maxShardSize = maxShardSize
+        self.overwriteExistingOutput = overwriteExistingOutput
+        self.quantizationPredicate = quantizationPredicate
+    }
+}
+
+/// Coarse conversion stage for progress callbacks.
+public enum ModelConversionStage: String, Sendable {
+    case downloading
+    case copyingFiles
+    case loadingWeights
+    case quantizing
+    case savingWeights
+    case updatingConfiguration
+}
+
+/// Progress update emitted by the Swift conversion pipeline.
+///
+/// This intentionally stays coarse-grained so applications can map it onto their own UI without
+/// inheriting implementation details. Download progress is forwarded as a fractional value when
+/// the downloader provides one.
+public struct ModelConversionProgress: Sendable {
+    public let stage: ModelConversionStage
+    public let fractionCompleted: Double?
+    public let message: String?
+
+    public init(
+        stage: ModelConversionStage,
+        fractionCompleted: Double? = nil,
+        message: String? = nil
+    ) {
+        self.stage = stage
+        self.fractionCompleted = fractionCompleted
+        self.message = message
+    }
+}
+
+/// Result returned after converting and saving a model.
+public struct ModelConversionResult: Sendable {
+    /// Directory containing the converted model files.
+    public let outputDirectory: URL
+
+    /// URL of the first written safetensors weights file.
+    public let weightsURL: URL
+
+    /// URLs of the written safetensors shard files.
+    public let weightsURLs: [URL]
+
+    public init(outputDirectory: URL, weightsURL: URL) {
+        self.init(outputDirectory: outputDirectory, weightsURLs: [weightsURL])
+    }
+
+    public init(outputDirectory: URL, weightsURLs: [URL]) {
+        precondition(!weightsURLs.isEmpty)
+        self.outputDirectory = outputDirectory
+        self.weightsURL = weightsURLs[0]
+        self.weightsURLs = weightsURLs
+    }
+}
+
+/// Errors thrown by model conversion helpers.
+public enum ModelConversionError: LocalizedError, Equatable {
+    case outputDirectoryExists(URL)
+    case outputDirectoryMatchesSource(URL)
+    case noSafetensorsFiles(URL)
+    case unsupportedPyTorchWeights(URL)
+    case sourceAlreadyQuantized(URL)
+    case invalidShardSize(Int64)
+
+    public var errorDescription: String? {
+        switch self {
+        case .outputDirectoryExists(let directory):
+            "Cannot save to \(directory.path) because it already exists. Delete it, choose a new path, or set overwriteExistingOutput."
+        case .outputDirectoryMatchesSource(let directory):
+            "Cannot convert in place at \(directory.path). Choose an output directory separate from the source model and tokenizer directories."
+        case .noSafetensorsFiles(let directory):
+            "No safetensors weights were found in \(directory.path)."
+        case .unsupportedPyTorchWeights(let directory):
+            "PyTorch .bin weights in \(directory.path) are not supported. Use a safetensors model."
+        case .sourceAlreadyQuantized(let directory):
+            "The source model in \(directory.path) is already quantized. Re-quantizing is not supported by this conversion helper."
+        case .invalidShardSize(let shardSize):
+            "Shard size must be greater than zero, got \(shardSize)."
+        }
+    }
+}
+
+/// Quantize and save an already-instantiated model from a compatible safetensors directory.
+///
+/// The function loads safetensors weights, runs the model's sanitizer through
+/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:)``, applies quantization,
+/// writes safetensors shards and an index, copies tokenizer/config sidecar files, and updates
+/// `config.json` with the requested quantization block.
+public func convert(
+    modelDirectory: URL,
+    tokenizerDirectory: URL? = nil,
+    model: BaseLanguageModel,
+    to outputDirectory: URL,
+    options: ModelConversionOptions = .init(),
+    progressHandler: @Sendable (ModelConversionProgress) -> Void = { _ in },
+    perLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil
+) throws -> ModelConversionResult {
+    try validateConvertibleWeights(in: modelDirectory)
+    try validateSourceConfigurationForModelConversion(in: modelDirectory)
+    if perLayerQuantization != nil {
+        throw ModelConversionError.sourceAlreadyQuantized(modelDirectory)
+    }
+    try validateModelConversionOutputDirectory(
+        outputDirectory,
+        modelDirectory: modelDirectory,
+        tokenizerDirectory: tokenizerDirectory)
+
+    try prepareOutputDirectoryForModelConversion(
+        outputDirectory, overwriteExistingOutput: options.overwriteExistingOutput)
+
+    progressHandler(.init(stage: .copyingFiles))
+    try copyModelConversionFiles(
+        modelDirectory: modelDirectory,
+        tokenizerDirectory: tokenizerDirectory,
+        to: outputDirectory)
+
+    progressHandler(.init(stage: .loadingWeights))
+    try loadWeights(
+        modelDirectory: modelDirectory,
+        model: model,
+        perLayerQuantization: perLayerQuantization)
+
+    progressHandler(.init(stage: .quantizing))
+    let quantizationResult = quantizeForModelConversion(model: model, options: options)
+    eval(model)
+
+    progressHandler(.init(stage: .savingWeights))
+    let weightsURLs = try saveModelConversionWeights(
+        model.parameters().flattened(),
+        to: outputDirectory,
+        maxShardSize: options.maxShardSize)
+
+    progressHandler(.init(stage: .updatingConfiguration))
+    try updateModelConfigWithQuantization(
+        at: outputDirectory,
+        quantization: quantizationResult.defaultQuantization,
+        layerQuantization: quantizationResult.layerQuantization)
+
+    return ModelConversionResult(outputDirectory: outputDirectory, weightsURLs: weightsURLs)
+}
+
+package func prepareOutputDirectoryForModelConversion(
+    _ outputDirectory: URL,
+    overwriteExistingOutput: Bool
+) throws {
+    let fileManager = FileManager.default
+    if fileManager.fileExists(atPath: outputDirectory.path) {
+        guard overwriteExistingOutput else {
+            throw ModelConversionError.outputDirectoryExists(outputDirectory)
+        }
+        try fileManager.removeItem(at: outputDirectory)
+    }
+
+    try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+}
+
+package func validateModelConversionOutputDirectory(
+    _ outputDirectory: URL,
+    modelDirectory: URL,
+    tokenizerDirectory: URL?
+) throws {
+    let output = canonicalModelConversionDirectory(outputDirectory)
+    let model = canonicalModelConversionDirectory(modelDirectory)
+    if modelConversionDirectoriesOverlap(output, model) {
+        throw ModelConversionError.outputDirectoryMatchesSource(outputDirectory)
+    }
+
+    if let tokenizerDirectory {
+        let tokenizer = canonicalModelConversionDirectory(tokenizerDirectory)
+        if modelConversionDirectoriesOverlap(output, tokenizer) {
+            throw ModelConversionError.outputDirectoryMatchesSource(outputDirectory)
+        }
+    }
+}
+
+private func canonicalModelConversionDirectory(_ directory: URL) -> URL {
+    directory.resolvingSymlinksInPath().standardizedFileURL
+}
+
+private func modelConversionDirectoriesOverlap(_ first: URL, _ second: URL) -> Bool {
+    let firstComponents = first.pathComponents
+    let secondComponents = second.pathComponents
+
+    return firstComponents.starts(with: secondComponents)
+        || secondComponents.starts(with: firstComponents)
+}
+
+package func removeExistingModelWeights(in outputDirectory: URL) throws {
+    try removeModelConversionWeights(in: outputDirectory)
+}
+
+/// Quantize and save an already-instantiated model from a compatible safetensors directory.
+public func convert(
+    modelDirectory: URL,
+    tokenizerDirectory: URL? = nil,
+    model: BaseLanguageModel,
+    to outputDirectory: URL,
+    bits: Int? = nil,
+    groupSize: Int? = nil,
+    mode: QuantizationMode = .affine,
+    perLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil
+) throws -> ModelConversionResult {
+    try convert(
+        modelDirectory: modelDirectory,
+        tokenizerDirectory: tokenizerDirectory,
+        model: model,
+        to: outputDirectory,
+        options: .init(bits: bits, groupSize: groupSize, mode: mode),
+        perLayerQuantization: perLayerQuantization)
+}
+
+package func resolveForModelConversion(
+    configuration: ModelConfiguration,
+    from downloader: any Downloader,
+    useLatest: Bool,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+) async throws -> ResolvedModelConfiguration {
+    let modelDirectory: URL
+    switch configuration.id {
+    case .id(let id, let revision):
+        modelDirectory = try await downloader.download(
+            id: id,
+            revision: revision,
+            matching: modelConversionDownloadPatterns,
+            useLatest: useLatest,
+            progressHandler: progressHandler)
+    case .directory(let directory):
+        modelDirectory = directory
+    }
+
+    let tokenizerDirectory: URL
+    switch configuration.tokenizerSource {
+    case .id(let id, let revision):
+        tokenizerDirectory = try await downloader.download(
+            id: id,
+            revision: revision,
+            matching: modelConversionSidecarPatterns,
+            useLatest: useLatest,
+            progressHandler: { _ in })
+    case .directory(let directory):
+        tokenizerDirectory = directory
+    case nil:
+        tokenizerDirectory = modelDirectory
+    }
+
+    return configuration.resolved(
+        modelDirectory: modelDirectory,
+        tokenizerDirectory: tokenizerDirectory)
+}
+
+package func validateSourceConfigurationForModelConversion(in directory: URL) throws {
+    let configURL = directory.appendingPathComponent("config.json")
+    guard let data = try? Data(contentsOf: configURL) else {
+        return
+    }
+    if sourceConfigurationIsQuantized(data) {
+        throw ModelConversionError.sourceAlreadyQuantized(directory)
+    }
+}
+
+package func validateConvertibleWeights(in directory: URL) throws {
+    let fileManager = FileManager.default
+    let files = try fileManager.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles])
+
+    let safetensors = files.contains { $0.pathExtension == "safetensors" }
+    if safetensors {
+        if try safetensorsContainQuantizedWeights(files) {
+            throw ModelConversionError.sourceAlreadyQuantized(directory)
+        }
+        return
+    }
+
+    let pytorchWeights = files.contains { $0.pathExtension == "bin" }
+    if pytorchWeights {
+        throw ModelConversionError.unsupportedPyTorchWeights(directory)
+    }
+
+    throw ModelConversionError.noSafetensorsFiles(directory)
+}
+
+private func safetensorsContainQuantizedWeights(_ files: [URL]) throws -> Bool {
+    for file in files where file.pathExtension == "safetensors" {
+        if try safetensorsFileContainsQuantizedWeights(file) {
+            return true
+        }
+    }
+    return false
+}
+
+package func safetensorsFileContainsQuantizedWeights(_ url: URL) throws -> Bool {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+
+    guard let headerSizeData = try handle.read(upToCount: 8),
+        headerSizeData.count == 8
+    else {
+        return false
+    }
+
+    let headerSize = headerSizeData.enumerated().reduce(UInt64(0)) { result, byte in
+        result | (UInt64(byte.element) << UInt64(byte.offset * 8))
+    }
+    guard headerSize <= 100 * 1024 * 1024,
+        let headerData = try handle.read(upToCount: Int(headerSize)),
+        headerData.count == Int(headerSize),
+        let json = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+    else {
+        return false
+    }
+
+    return json.keys.contains { key in
+        key.hasSuffix(".scales")
+    }
+}
+
+package func copyModelConversionFiles(
+    modelDirectory: URL,
+    tokenizerDirectory: URL?,
+    to outputDirectory: URL
+) throws {
+    try copyModelConversionSidecars(from: modelDirectory, to: outputDirectory, copiesConfig: true)
+
+    if let tokenizerDirectory,
+        tokenizerDirectory.standardizedFileURL != modelDirectory.standardizedFileURL
+    {
+        try copyModelConversionSidecars(
+            from: tokenizerDirectory, to: outputDirectory, copiesConfig: false)
+    }
+}
+
+private func copyModelConversionSidecars(
+    from sourceDirectory: URL,
+    to outputDirectory: URL,
+    copiesConfig: Bool
+) throws {
+    let fileManager = FileManager.default
+    let resourceKeys: [URLResourceKey] = [.isDirectoryKey]
+    let files = try fileManager.contentsOfDirectory(
+        at: sourceDirectory,
+        includingPropertiesForKeys: resourceKeys,
+        options: [.skipsHiddenFiles])
+
+    let copiedExtensions: Set<String> = [
+        "json", "jsonl", "jinja", "txt", "model", "tiktoken", "py",
+    ]
+
+    for sourceURL in files {
+        let resourceValues = try sourceURL.resourceValues(forKeys: Set(resourceKeys))
+        if resourceValues.isDirectory == true {
+            continue
+        }
+
+        let filename = sourceURL.lastPathComponent
+        let lowercasedName = filename.lowercased()
+        if !copiesConfig && lowercasedName == "config.json" {
+            continue
+        }
+        if lowercasedName.hasSuffix(".safetensors.index.json") {
+            continue
+        }
+        if sourceURL.pathExtension == "safetensors" {
+            continue
+        }
+        if !copiedExtensions.contains(sourceURL.pathExtension.lowercased()) {
+            continue
+        }
+
+        let destinationURL = outputDirectory.appendingPathComponent(filename)
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+    }
+}
+
+package func updateModelConfigWithQuantization(
+    at outputDirectory: URL,
+    bits: Int?,
+    groupSize: Int?,
+    mode: QuantizationMode
+) throws {
+    try updateModelConfigWithQuantization(
+        at: outputDirectory,
+        quantization: .init(bits: bits, groupSize: groupSize, mode: mode),
+        layerQuantization: [:])
+}
+
+package func updateModelConfigWithQuantization(
+    at outputDirectory: URL,
+    quantization: ModelConversionQuantization,
+    layerQuantization: [String: ModelConversionQuantizationDecision]
+) throws {
+    let configURL = outputDirectory.appendingPathComponent("config.json")
+    guard FileManager.default.fileExists(atPath: configURL.path) else {
+        return
+    }
+
+    let data = try Data(contentsOf: configURL)
+    var json = try JSONDecoder.json5().decode([String: JSONValue].self, from: data)
+
+    let effectiveQuantization = effectiveModelConversionQuantization(quantization)
+    var quantizationJSON: [String: JSONValue] = [
+        "bits": .int(effectiveQuantization.bits),
+        "group_size": .int(effectiveQuantization.groupSize),
+        "mode": .string(quantizationModeName(quantization.mode)),
+    ]
+    for (path, decision) in layerQuantization.sorted(by: { $0.key < $1.key }) {
+        switch decision {
+        case .skip:
+            quantizationJSON[path] = .bool(false)
+        case .quantize(let value):
+            let value = value ?? quantization
+            let effectiveValue = effectiveModelConversionQuantization(value)
+            quantizationJSON[path] = .object([
+                "bits": .int(effectiveValue.bits),
+                "group_size": .int(effectiveValue.groupSize),
+                "mode": .string(quantizationModeName(value.mode)),
+            ])
+        }
+    }
+    let quantizationValue = JSONValue.object(quantizationJSON)
+    json["quantization"] = quantizationValue
+    json["quantization_config"] = quantizationValue
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let updatedData = try encoder.encode(json)
+    try updatedData.write(to: configURL)
+}
+
+package func sourceConfigurationIsQuantized(_ data: Data) -> Bool {
+    guard let json = try? JSONDecoder.json5().decode([String: JSONValue].self, from: data) else {
+        return false
+    }
+    return json["quantization"] != nil || json["quantization_config"] != nil
+}
+
+private func removeModelConversionWeights(in outputDirectory: URL) throws {
+    guard FileManager.default.fileExists(atPath: outputDirectory.path) else {
+        return
+    }
+
+    let files = try FileManager.default.contentsOfDirectory(
+        at: outputDirectory,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles])
+
+    for file in files {
+        let resourceValues = try file.resourceValues(forKeys: [.isDirectoryKey])
+        if resourceValues.isDirectory == true {
+            continue
+        }
+
+        if file.pathExtension == "safetensors"
+            || file.lastPathComponent.lowercased().hasSuffix(".safetensors.index.json")
+        {
+            try FileManager.default.removeItem(at: file)
+        }
+    }
+}
+
+private func quantizeForModelConversion(
+    model: BaseLanguageModel,
+    options: ModelConversionOptions
+) -> ModelConversionQuantizationResult {
+    var layerQuantization = [String: ModelConversionQuantizationDecision]()
+    let defaultQuantization = options.quantization
+    var effectiveDefaultQuantization = effectiveModelConversionQuantization(defaultQuantization)
+
+    let updates =
+        model
+        .leafModules()
+        .flattened()
+        .compactMap { path, module -> (String, Module)? in
+            let decision = options.quantizationPredicate?(path, module) ?? .quantize()
+            let quantization: ModelConversionQuantization
+            let usesDefaultQuantization: Bool
+            switch decision {
+            case .skip:
+                layerQuantization[path] = .skip
+                return nil
+            case .quantize(let override):
+                quantization = override ?? defaultQuantization
+                usesDefaultQuantization = override == nil
+            }
+
+            let effectiveQuantization = effectiveModelConversionQuantization(quantization)
+            guard
+                isConvertibleQuantizationTarget(
+                    module, groupSize: effectiveQuantization.groupSize)
+            else {
+                return nil
+            }
+
+            guard
+                let result = quantizeLayerForModelConversion(
+                    layer: module, quantization: quantization)
+            else {
+                return nil
+            }
+
+            if usesDefaultQuantization && defaultQuantization.hasUnresolvedDefaults {
+                effectiveDefaultQuantization = result.quantization
+            }
+            if result.quantization != effectiveDefaultQuantization {
+                layerQuantization[path] = .quantize(
+                    result.quantization.asModelConversionQuantization)
+            }
+            return (path, result.module)
+        }
+
+    model.update(modules: ModuleChildren.unflattened(updates))
+
+    return .init(
+        defaultQuantization: effectiveDefaultQuantization.asModelConversionQuantization,
+        layerQuantization: layerQuantization)
+}
+
+private func isConvertibleQuantizationTarget(_ module: Module, groupSize: Int) -> Bool {
+    if module is Quantized {
+        return false
+    }
+    if let linear = module as? Linear {
+        return linear.weight.dim(-1) % groupSize == 0
+    }
+    if let embedding = module as? Embedding {
+        return embedding.weight.dim(-1) % groupSize == 0
+    }
+    return module is Quantizable
+}
+
+private func quantizeLayerForModelConversion(
+    layer: Module,
+    quantization: ModelConversionQuantization
+) -> (module: Module, quantization: EffectiveModelConversionQuantization)? {
+    if layer is Quantized {
+        return nil
+    }
+
+    let effectiveQuantization = effectiveModelConversionQuantization(quantization)
+    let mode = quantization.mode
+
+    if let linear = layer as? Linear {
+        let (weight, scales, biases) = MLX.quantized(
+            linear.weight, groupSize: quantization.groupSize, bits: quantization.bits, mode: mode)
+        let actualQuantization =
+            inferModelConversionQuantization(
+                originalWeight: linear.weight,
+                quantizedWeight: weight,
+                scales: scales,
+                mode: mode) ?? effectiveQuantization
+        return (
+            QuantizedLinear(
+                weight: weight,
+                bias: linear.bias,
+                scales: scales,
+                biases: biases,
+                groupSize: actualQuantization.groupSize,
+                bits: actualQuantization.bits,
+                mode: mode),
+            actualQuantization
+        )
+    }
+
+    if let embedding = layer as? Embedding {
+        return (
+            QuantizedEmbedding(
+                weight: embedding.weight,
+                groupSize: effectiveQuantization.groupSize,
+                bits: effectiveQuantization.bits,
+                mode: mode),
+            effectiveQuantization
+        )
+    }
+
+    guard
+        let quantized = quantizeSingle(
+            layer: layer,
+            groupSize: effectiveQuantization.groupSize,
+            bits: effectiveQuantization.bits,
+            mode: mode)
+    else {
+        return nil
+    }
+    return (quantized, effectiveQuantization)
+}
+
+private struct EffectiveModelConversionQuantization: Equatable {
+    var bits: Int
+    var groupSize: Int
+    var mode: QuantizationMode
+
+    var asModelConversionQuantization: ModelConversionQuantization {
+        .init(bits: bits, groupSize: groupSize, mode: mode)
+    }
+}
+
+private struct ModelConversionQuantizationResult {
+    var defaultQuantization: ModelConversionQuantization
+    var layerQuantization: [String: ModelConversionQuantizationDecision]
+}
+
+extension ModelConversionQuantization {
+    fileprivate var hasUnresolvedDefaults: Bool {
+        bits == nil || groupSize == nil
+    }
+}
+
+private func effectiveModelConversionQuantization(
+    _ quantization: ModelConversionQuantization
+) -> EffectiveModelConversionQuantization {
+    .init(
+        bits: quantization.bits ?? defaultModelConversionBits(for: quantization.mode),
+        groupSize: quantization.groupSize
+            ?? defaultModelConversionGroupSize(for: quantization.mode),
+        mode: quantization.mode)
+}
+
+private func defaultModelConversionBits(for mode: QuantizationMode) -> Int {
+    switch mode {
+    case .mxfp8:
+        8
+    case .affine, .mxfp4, .nvfp4:
+        4
+    @unknown default:
+        4
+    }
+}
+
+private func defaultModelConversionGroupSize(for mode: QuantizationMode) -> Int {
+    switch mode {
+    case .mxfp4, .mxfp8, .nvfp4:
+        32
+    case .affine:
+        64
+    @unknown default:
+        64
+    }
+}
+
+private func inferModelConversionQuantization(
+    originalWeight: MLXArray,
+    quantizedWeight: MLXArray,
+    scales: MLXArray,
+    mode: QuantizationMode
+) -> EffectiveModelConversionQuantization? {
+    let inputDimensions = originalWeight.dim(-1)
+    let scaleGroups = scales.dim(-1)
+    guard inputDimensions > 0, scaleGroups > 0 else {
+        return nil
+    }
+
+    let quantizedInputDimensions = quantizedWeight.dim(-1)
+    let groupSize = inputDimensions / scaleGroups
+    let bits = quantizedInputDimensions * 32 / inputDimensions
+    guard groupSize > 0, bits > 0 else {
+        return nil
+    }
+
+    return .init(bits: bits, groupSize: groupSize, mode: mode)
+}
+
+package func makeModelConversionShards(
+    _ weights: [(String, MLXArray)],
+    maxShardSize: Int64
+) throws -> [[(String, MLXArray)]] {
+    guard maxShardSize > 0 else {
+        throw ModelConversionError.invalidShardSize(maxShardSize)
+    }
+
+    var shards = [[(String, MLXArray)]]()
+    var currentShard = [(String, MLXArray)]()
+    var currentShardSize: Int64 = 0
+
+    for weight in weights {
+        let itemSize = Int64(weight.1.nbytes)
+        if !currentShard.isEmpty && currentShardSize + itemSize > maxShardSize {
+            shards.append(currentShard)
+            currentShard = []
+            currentShardSize = 0
+        }
+        currentShard.append(weight)
+        currentShardSize += itemSize
+    }
+
+    if !currentShard.isEmpty {
+        shards.append(currentShard)
+    }
+
+    return shards
+}
+
+package func saveModelConversionWeights(
+    _ weights: [(String, MLXArray)],
+    to outputDirectory: URL,
+    maxShardSize: Int64
+) throws -> [URL] {
+    let shards = try makeModelConversionShards(weights, maxShardSize: maxShardSize)
+    let totalShards = shards.count
+    var weightMap = [String: String]()
+    let totalSize = weights.reduce(Int64(0)) { $0 + Int64($1.1.nbytes) }
+    var weightsURLs = [URL]()
+
+    for (index, shard) in shards.enumerated() {
+        let filename =
+            totalShards == 1
+            ? "model.safetensors"
+            : String(format: "model-%05d-of-%05d.safetensors", index + 1, totalShards)
+        let url = outputDirectory.appendingPathComponent(filename)
+        let arrays = Dictionary(uniqueKeysWithValues: shard)
+        eval(Array(arrays.values))
+        try save(arrays: arrays, metadata: ["format": "mlx"], url: url)
+
+        for (key, _) in shard {
+            weightMap[key] = filename
+        }
+        weightsURLs.append(url)
+    }
+
+    try saveModelConversionIndex(weightMap: weightMap, totalSize: totalSize, to: outputDirectory)
+    return weightsURLs
+}
+
+package func saveModelConversionIndex(
+    weightMap: [String: String],
+    totalSize: Int64,
+    to outputDirectory: URL
+) throws {
+    let sortedWeightMap = Dictionary(
+        uniqueKeysWithValues: weightMap.sorted(by: { $0.key < $1.key }))
+    let indexData: [String: Any] = [
+        "metadata": ["total_size": totalSize],
+        "weight_map": sortedWeightMap,
+    ]
+    let data = try JSONSerialization.data(
+        withJSONObject: indexData, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: outputDirectory.appendingPathComponent("model.safetensors.index.json"))
+}
+
+private func quantizationModeName(_ mode: QuantizationMode) -> String {
+    switch mode {
+    case .affine:
+        "affine"
+    case .mxfp4:
+        "mxfp4"
+    case .mxfp8:
+        "mxfp8"
+    case .nvfp4:
+        "nvfp4"
+    @unknown default:
+        String(describing: mode)
+    }
+}

--- a/Tests/MLXLMTests/ModelConversionTests.swift
+++ b/Tests/MLXLMTests/ModelConversionTests.swift
@@ -1,0 +1,482 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+
+final class ModelConversionTests: XCTestCase {
+
+    func testModelConversionOptionsDefaultsLeaveQuantizationDefaultsUnspecified() {
+        let options = ModelConversionOptions()
+
+        XCTAssertNil(options.bits)
+        XCTAssertNil(options.groupSize)
+        XCTAssertEqual(options.mode, .affine)
+        XCTAssertNil(options.quantization.bits)
+        XCTAssertNil(options.quantization.groupSize)
+    }
+
+    func testResolveForModelConversionDownloadsTokenizerSidecarPatterns() async throws {
+        let downloader = ConversionMockDownloader()
+        let configuration = ModelConfiguration(
+            id: "org/model",
+            revision: "abc123",
+            tokenizerSource: .id("org/tokenizer", revision: "tok456"))
+
+        let resolved = try await resolveForModelConversion(
+            configuration: configuration,
+            from: downloader,
+            useLatest: false,
+            progressHandler: { _ in })
+
+        let calls = downloader.calls.value
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls[0].id, "org/model")
+        XCTAssertEqual(calls[0].revision, "abc123")
+        XCTAssertTrue(calls[0].patterns.contains("*.safetensors"))
+        XCTAssertTrue(calls[0].patterns.contains("*.model"))
+        XCTAssertTrue(calls[0].patterns.contains("*.tiktoken"))
+
+        XCTAssertEqual(calls[1].id, "org/tokenizer")
+        XCTAssertEqual(calls[1].revision, "tok456")
+        XCTAssertFalse(calls[1].patterns.contains("*.safetensors"))
+        XCTAssertTrue(calls[1].patterns.contains("*.txt"))
+        XCTAssertTrue(calls[1].patterns.contains("*.model"))
+        XCTAssertNotEqual(resolved.modelDirectory, resolved.tokenizerDirectory)
+    }
+
+    func testConfigQuantizationUpdatePreservesExistingKeys() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent("config.json")
+        try """
+        {
+          "model_type": "llama",
+          "hidden_size": 128
+        }
+        """.data(using: .utf8)!.write(to: configURL)
+
+        try updateModelConfigWithQuantization(
+            at: directory, bits: 4, groupSize: 32, mode: .mxfp4)
+
+        let data = try Data(contentsOf: configURL)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["model_type"] as? String, "llama")
+        XCTAssertEqual(json["hidden_size"] as? Int, 128)
+
+        let quantization = try XCTUnwrap(json["quantization"] as? [String: Any])
+        XCTAssertEqual(quantization["bits"] as? Int, 4)
+        XCTAssertEqual(quantization["group_size"] as? Int, 32)
+        XCTAssertEqual(quantization["mode"] as? String, "mxfp4")
+    }
+
+    func testConfigQuantizationUpdateResolvesNilDefaults() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent("config.json")
+        try """
+        {
+          "model_type": "llama"
+        }
+        """.data(using: .utf8)!.write(to: configURL)
+
+        try updateModelConfigWithQuantization(
+            at: directory,
+            quantization: .init(mode: .affine),
+            layerQuantization: [
+                "model.layers.0.mlp.down_proj": .quantize(.init(mode: .mxfp8)),
+                "model.layers.0.self_attn.q_norm": .skip,
+            ])
+
+        let data = try Data(contentsOf: configURL)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let quantization = try XCTUnwrap(json["quantization"] as? [String: Any])
+        XCTAssertEqual(quantization["bits"] as? Int, 4)
+        XCTAssertEqual(quantization["group_size"] as? Int, 64)
+        XCTAssertEqual(quantization["mode"] as? String, "affine")
+
+        let layer = try XCTUnwrap(
+            quantization["model.layers.0.mlp.down_proj"] as? [String: Any])
+        XCTAssertEqual(layer["bits"] as? Int, 8)
+        XCTAssertEqual(layer["group_size"] as? Int, 32)
+        XCTAssertEqual(layer["mode"] as? String, "mxfp8")
+        XCTAssertEqual(quantization["model.layers.0.self_attn.q_norm"] as? Bool, false)
+    }
+
+    func testCopyModelConversionFilesCopiesSidecarsAndSkipsWeights() throws {
+        let modelDirectory = try makeTemporaryDirectory()
+        let tokenizerDirectory = try makeTemporaryDirectory()
+        let outputDirectory = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: modelDirectory)
+            try? FileManager.default.removeItem(at: tokenizerDirectory)
+            try? FileManager.default.removeItem(at: outputDirectory)
+        }
+
+        try write("{}", to: modelDirectory.appendingPathComponent("config.json"))
+        try write("{}", to: modelDirectory.appendingPathComponent("generation_config.json"))
+        try write("{}", to: modelDirectory.appendingPathComponent("tokenizer_config.json"))
+        try write("{}", to: modelDirectory.appendingPathComponent("tokenizer.jsonl"))
+        try write("print('custom')", to: modelDirectory.appendingPathComponent("tokenization.py"))
+        try write("weights", to: modelDirectory.appendingPathComponent("model.safetensors"))
+        try write(
+            "index", to: modelDirectory.appendingPathComponent("model.safetensors.index.json"))
+        try write("{}", to: tokenizerDirectory.appendingPathComponent("config.json"))
+        try write("{}", to: tokenizerDirectory.appendingPathComponent("tokenizer.json"))
+        try write("template", to: tokenizerDirectory.appendingPathComponent("chat_template.jinja"))
+
+        try copyModelConversionFiles(
+            modelDirectory: modelDirectory,
+            tokenizerDirectory: tokenizerDirectory,
+            to: outputDirectory)
+
+        XCTAssertTrue(fileExists("config.json", in: outputDirectory))
+        XCTAssertTrue(fileExists("generation_config.json", in: outputDirectory))
+        XCTAssertTrue(fileExists("tokenizer_config.json", in: outputDirectory))
+        XCTAssertTrue(fileExists("tokenizer.jsonl", in: outputDirectory))
+        XCTAssertTrue(fileExists("tokenization.py", in: outputDirectory))
+        XCTAssertTrue(fileExists("tokenizer.json", in: outputDirectory))
+        XCTAssertTrue(fileExists("chat_template.jinja", in: outputDirectory))
+        XCTAssertFalse(fileExists("model.safetensors", in: outputDirectory))
+        XCTAssertFalse(fileExists("model.safetensors.index.json", in: outputDirectory))
+    }
+
+    func testRemoveExistingModelWeightsClearsStaleOutputArtifacts() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try write("old", to: directory.appendingPathComponent("model.safetensors"))
+        try write("old", to: directory.appendingPathComponent("model-00001-of-00002.safetensors"))
+        try write("old", to: directory.appendingPathComponent("model.safetensors.index.json"))
+        try write("{}", to: directory.appendingPathComponent("config.json"))
+
+        try removeExistingModelWeights(in: directory)
+
+        XCTAssertFalse(fileExists("model.safetensors", in: directory))
+        XCTAssertFalse(fileExists("model-00001-of-00002.safetensors", in: directory))
+        XCTAssertFalse(fileExists("model.safetensors.index.json", in: directory))
+        XCTAssertTrue(fileExists("config.json", in: directory))
+    }
+
+    func testPrepareOutputDirectoryRejectsExistingPathByDefault() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        XCTAssertThrowsError(
+            try prepareOutputDirectoryForModelConversion(
+                directory, overwriteExistingOutput: false)
+        ) { error in
+            XCTAssertEqual(error as? ModelConversionError, .outputDirectoryExists(directory))
+        }
+    }
+
+    func testPrepareOutputDirectoryOverwriteRemovesStaleFiles() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try write("stale", to: directory.appendingPathComponent("tokenizer.model"))
+
+        try prepareOutputDirectoryForModelConversion(directory, overwriteExistingOutput: true)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        XCTAssertFalse(fileExists("tokenizer.model", in: directory))
+    }
+
+    func testValidateOutputDirectoryRejectsModelDirectory() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        XCTAssertThrowsError(
+            try validateModelConversionOutputDirectory(
+                directory, modelDirectory: directory, tokenizerDirectory: nil)
+        ) { error in
+            XCTAssertEqual(error as? ModelConversionError, .outputDirectoryMatchesSource(directory))
+        }
+    }
+
+    func testValidateOutputDirectoryRejectsModelDirectoryParent() throws {
+        let parentDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parentDirectory) }
+
+        let modelDirectory = parentDirectory.appendingPathComponent("model")
+        try FileManager.default.createDirectory(
+            at: modelDirectory, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(
+            try validateModelConversionOutputDirectory(
+                parentDirectory, modelDirectory: modelDirectory, tokenizerDirectory: nil)
+        ) { error in
+            XCTAssertEqual(
+                error as? ModelConversionError,
+                .outputDirectoryMatchesSource(parentDirectory))
+        }
+    }
+
+    func testValidateOutputDirectoryRejectsModelDirectoryChild() throws {
+        let modelDirectory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: modelDirectory) }
+
+        let outputDirectory = modelDirectory.appendingPathComponent("converted")
+
+        XCTAssertThrowsError(
+            try validateModelConversionOutputDirectory(
+                outputDirectory, modelDirectory: modelDirectory, tokenizerDirectory: nil)
+        ) { error in
+            XCTAssertEqual(
+                error as? ModelConversionError,
+                .outputDirectoryMatchesSource(outputDirectory))
+        }
+    }
+
+    func testValidateOutputDirectoryRejectsTokenizerDirectory() throws {
+        let modelDirectory = try makeTemporaryDirectory()
+        let tokenizerDirectory = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: modelDirectory)
+            try? FileManager.default.removeItem(at: tokenizerDirectory)
+        }
+
+        XCTAssertThrowsError(
+            try validateModelConversionOutputDirectory(
+                tokenizerDirectory,
+                modelDirectory: modelDirectory,
+                tokenizerDirectory: tokenizerDirectory)
+        ) { error in
+            XCTAssertEqual(
+                error as? ModelConversionError,
+                .outputDirectoryMatchesSource(tokenizerDirectory))
+        }
+    }
+
+    func testValidateConvertibleWeightsRejectsPyTorchOnlyDirectory() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try write("weights", to: directory.appendingPathComponent("pytorch_model.bin"))
+
+        XCTAssertThrowsError(try validateConvertibleWeights(in: directory)) { error in
+            XCTAssertEqual(
+                error as? ModelConversionError,
+                .unsupportedPyTorchWeights(directory))
+        }
+    }
+
+    func testValidateConvertibleWeightsRejectsQuantizedSafetensors() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try writeSafetensorsHeader(
+            [
+                "model.layers.0.self_attn.q_proj.weight": [
+                    "dtype": "F16", "shape": [1], "data_offsets": [0, 2],
+                ],
+                "model.layers.0.self_attn.q_proj.scales": [
+                    "dtype": "F16", "shape": [1], "data_offsets": [2, 4],
+                ],
+            ],
+            to: directory.appendingPathComponent("model.safetensors"))
+
+        XCTAssertThrowsError(try validateConvertibleWeights(in: directory)) { error in
+            XCTAssertEqual(error as? ModelConversionError, .sourceAlreadyQuantized(directory))
+        }
+    }
+
+    func testSourceConfigurationIsQuantizedDetectsBothConfigKeys() throws {
+        let quantization = try XCTUnwrap(
+            """
+            {
+              "model_type": "llama",
+              "quantization": { "bits": 4, "group_size": 64 }
+            }
+            """.data(using: .utf8))
+        let quantizationConfig = try XCTUnwrap(
+            """
+            {
+              "model_type": "llama",
+              "quantization_config": { "bits": 4, "group_size": 64 }
+            }
+            """.data(using: .utf8))
+        let plain = try XCTUnwrap(
+            """
+            {
+              "model_type": "llama"
+            }
+            """.data(using: .utf8))
+
+        XCTAssertTrue(sourceConfigurationIsQuantized(quantization))
+        XCTAssertTrue(sourceConfigurationIsQuantized(quantizationConfig))
+        XCTAssertFalse(sourceConfigurationIsQuantized(plain))
+    }
+
+    func testConfigQuantizationUpdateAcceptsJSON5Config() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent("config.json")
+        try """
+        {
+          // JSON5 comments are accepted by normal model loading.
+          "model_type": "llama",
+        }
+        """.data(using: .utf8)!.write(to: configURL)
+
+        try updateModelConfigWithQuantization(
+            at: directory, bits: 4, groupSize: 64, mode: .affine)
+
+        let data = try Data(contentsOf: configURL)
+        XCTAssertTrue(sourceConfigurationIsQuantized(data))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["model_type"] as? String, "llama")
+
+        let quantization = try XCTUnwrap(json["quantization"] as? [String: Any])
+        XCTAssertEqual(quantization["bits"] as? Int, 4)
+        XCTAssertEqual(quantization["group_size"] as? Int, 64)
+        XCTAssertEqual(quantization["mode"] as? String, "affine")
+    }
+
+    func testValidateSourceConfigurationRejectsQuantizedConfig() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try """
+        {
+          "model_type": "llama",
+          "quantization_config": { "bits": 4, "group_size": 64 }
+        }
+        """.data(using: .utf8)!.write(to: directory.appendingPathComponent("config.json"))
+
+        XCTAssertThrowsError(try validateSourceConfigurationForModelConversion(in: directory)) {
+            error in
+            XCTAssertEqual(error as? ModelConversionError, .sourceAlreadyQuantized(directory))
+        }
+    }
+
+    func testSaveModelConversionIndexWritesMetadataAndWeightMap() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try saveModelConversionIndex(
+            weightMap: [
+                "b.weight": "model-00001-of-00002.safetensors",
+                "a.weight": "model-00002-of-00002.safetensors",
+            ],
+            totalSize: 16,
+            to: directory)
+
+        let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
+        let data = try Data(contentsOf: indexURL)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let metadata = try XCTUnwrap(json["metadata"] as? [String: Any])
+        XCTAssertEqual(metadata["total_size"] as? Int, 16)
+
+        let weightMap = try XCTUnwrap(json["weight_map"] as? [String: String])
+        XCTAssertEqual(weightMap["b.weight"], "model-00001-of-00002.safetensors")
+        XCTAssertEqual(weightMap["a.weight"], "model-00002-of-00002.safetensors")
+    }
+
+    func testUpdateConfigWritesQuantizationAndQuantizationConfig() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent("config.json")
+        try """
+        {
+          "model_type": "llama"
+        }
+        """.data(using: .utf8)!.write(to: configURL)
+
+        try updateModelConfigWithQuantization(
+            at: directory,
+            quantization: .init(bits: 4, groupSize: 64, mode: .affine),
+            layerQuantization: [
+                "model.layers.0.mlp.down_proj": .quantize(
+                    .init(bits: 8, groupSize: 32, mode: .mxfp8))
+            ])
+
+        let data = try Data(contentsOf: configURL)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let quantization = try XCTUnwrap(json["quantization"] as? [String: Any])
+        let quantizationConfig = try XCTUnwrap(json["quantization_config"] as? [String: Any])
+        XCTAssertEqual(quantization["bits"] as? Int, 4)
+        XCTAssertEqual(quantization["group_size"] as? Int, 64)
+        XCTAssertEqual(quantization["mode"] as? String, "affine")
+        XCTAssertEqual(quantizationConfig["mode"] as? String, "affine")
+
+        let layer = try XCTUnwrap(
+            quantization["model.layers.0.mlp.down_proj"] as? [String: Any])
+        XCTAssertEqual(layer["bits"] as? Int, 8)
+        XCTAssertEqual(layer["group_size"] as? Int, 32)
+        XCTAssertEqual(layer["mode"] as? String, "mxfp8")
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelConversionTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try contents.data(using: .utf8)!.write(to: url)
+    }
+
+    private func writeSafetensorsHeader(_ header: [String: Any], to url: URL) throws {
+        let headerData = try JSONSerialization.data(withJSONObject: header, options: [.sortedKeys])
+        var data = Data()
+        var headerSize = UInt64(headerData.count).littleEndian
+        withUnsafeBytes(of: &headerSize) { data.append(contentsOf: $0) }
+        data.append(headerData)
+        try data.write(to: url)
+    }
+
+    private func fileExists(_ filename: String, in directory: URL) -> Bool {
+        FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(filename).path)
+    }
+}
+
+private struct ConversionMockDownloader: Downloader {
+    struct Call: Equatable, Sendable {
+        let id: String
+        let revision: String?
+        let patterns: [String]
+    }
+
+    let calls = ConversionLockIsolated<[Call]>([])
+
+    func download(
+        id: String,
+        revision: String?,
+        matching patterns: [String],
+        useLatest: Bool,
+        progressHandler: @Sendable @escaping (Progress) -> Void
+    ) async throws -> URL {
+        calls.withLock { $0.append(Call(id: id, revision: revision, patterns: patterns)) }
+        return URL(filePath: "/mock/\(id.replacingOccurrences(of: "/", with: "_"))")
+    }
+}
+
+private final class ConversionLockIsolated<Value: Sendable>: @unchecked Sendable {
+    private var storage: Value
+    private let lock = NSLock()
+
+    init(_ value: Value) {
+        storage = value
+    }
+
+    func withLock<R>(_ body: (inout Value) -> R) -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&storage)
+    }
+
+    var value: Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds a basic Swift model conversion API for quantizing safetensors-backed LLMs through MLXLMCommon and LLMModelFactory. Fix #266 .

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
