### PR TITLE
Fix Gemma4 E-series load: make per_layer_model_projection quantizable

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -589,7 +589,14 @@ private class Gemma4TextModelInner: Module {
                 tokenPLE.dim(0), tokenPLE.dim(1),
                 config.numHiddenLayers, config.hiddenSizePerLayerInput)
 
-            // Model projection PLE
+            // Model projection PLE. The hidden_size**-0.5 scale (the reference
+            // impl's `per_layer_projection_scale`) is applied here, AFTER the
+            // projection, so the projection itself stays a plain Linear and
+            // quantizes like every other Linear in the model. The 8-bit E-series
+            // checkpoints ship per_layer_model_projection as a packed
+            // QuantizedLinear; a custom non-Linear module is invisible to
+            // quantize() and would mismatch those packed weights at load.
+            let perLayerProjectionScale = pow(Float(config.hiddenSize), -0.5)
             let modelPLE = (modelProj(h) * perLayerProjectionScale).reshaped(
                 h.dim(0), h.dim(1),
                 config.numHiddenLayers, config.hiddenSizePerLayerInput)


### PR DESCRIPTION
## Problem

Quantized Gemma 4 E-series (per-layer-embeddings) checkpoints — e.g. `gemma-4-E4B-it-MLX-8bit` — crash at load:

```
mismatchedSize(path: ["language_model","model","per_layer_model_projection","weight"],
  modules: [..., "ScaledLinear"],
  expectedShape: [10752, 2560], actualShape: [10752, 640])
```

`10752 = num_hidden_layers (42) × hidden_size_per_layer_input (256)`. The input dim is wrong: the model expects `2560` (= `hidden_size`, full precision) but the 8-bit checkpoint ships the packed `QuantizedLinear` weight `640 = 2560 / 4` (4 values per `uint32`), plus `.scales`/`.biases`.

## Cause

`per_layer_model_projection` is declared as a custom `ScaledLinear` — a plain `Module` that holds a raw `weight` and does `matmul(x, weight.T) * scalar`. `quantize()` only converts `Linear`/`Embedding`, so `ScaledLinear` is invisible to it: the projection stays full-precision while the checkpoint stores it quantized → shape mismatch at load. (Dense/bf16 E-series checkpoints load fine, which is why this went unnoticed.)

## Fix

Mirror the Python reference (`mlx_lm` `gemma3n`), where `per_layer_model_projection` is a plain `nn.Linear` and `per_layer_projection_scale = hidden_size**-0.5` is applied separately in the forward pass:

- Make `per_layer_model_projection` a plain `Linear` (so it quantizes like every other `Linear`).
- Apply the `hidden_size**-0.5` scale after the projection in `callAsFunction`.
- Remove the now-unused `ScaledLinear`.

Net: +14 / −22 lines.

## Verification

On macOS / Apple Silicon, `gemma-4-E4B-it-MLX-8bit` now loads and runs — prefill ~1670 t/s on a 35.7k-token prompt. Previously a hard crash at load. Full-precision E-series checkpoints continue to load (the projection is still a `Linear`; only its quantization visibility changed).