### PR TITLE
Make MLXLLM compilable on Linux

### DIFF
--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -10,7 +10,7 @@ import MLXLMCommon
 import MLXVLM
 
 #if canImport(CoreImage)
-    import CoreImage
+import CoreImage
 #endif
 
 // Both MLXLMCommon and MLXEmbedders define ModelContainer.
@@ -180,21 +180,21 @@ public enum ChatSessionTests {
 
     public static func visionModel(container: LLModelContainer) async throws {
         #if canImport(CoreImage)
-            let session = ChatSession(container, generateParameters: generateParameters)
-            let redImage = CIImage(color: .red).cropped(
-                to: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let session = ChatSession(container, generateParameters: generateParameters)
+        let redImage = CIImage(color: .red).cropped(
+            to: CGRect(x: 0, y: 0, width: 100, height: 100))
 
-            let result = try await streamAndCollect(
-                session.streamResponse(
-                    to: "What color is this image? Reply with just the color name.",
-                    image: .ciImage(redImage)), label: "Vision")
-            try check(
-                result.lowercased().contains("red"),
-                "Expected 'red' in response, got: \(result)"
-            )
+        let result = try await streamAndCollect(
+            session.streamResponse(
+                to: "What color is this image? Reply with just the color name.",
+                image: .ciImage(redImage)), label: "Vision")
+        try check(
+            result.lowercased().contains("red"),
+            "Expected 'red' in response, got: \(result)"
+        )
         #else
-            fatalError(
-                "Vision model test requires CoreImage, which is not available on this platform.")
+        fatalError(
+            "Vision model test requires CoreImage, which is not available on this platform.")
         #endif
     }
 

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -2,13 +2,16 @@
 // Integration packages inject their own Downloader and TokenizerLoader, then call
 // these functions which run the test and throw on failure.
 
-import CoreImage
 import Foundation
 import MLX
 import MLXEmbedders
 import MLXLLM
 import MLXLMCommon
 import MLXVLM
+
+#if canImport(CoreImage)
+    import CoreImage
+#endif
 
 // Both MLXLMCommon and MLXEmbedders define ModelContainer.
 public typealias LLModelContainer = MLXLMCommon.ModelContainer
@@ -176,18 +179,23 @@ public enum ChatSessionTests {
     }
 
     public static func visionModel(container: LLModelContainer) async throws {
-        let session = ChatSession(container, generateParameters: generateParameters)
-        let redImage = CIImage(color: .red).cropped(
-            to: CGRect(x: 0, y: 0, width: 100, height: 100))
+        #if canImport(CoreImage)
+            let session = ChatSession(container, generateParameters: generateParameters)
+            let redImage = CIImage(color: .red).cropped(
+                to: CGRect(x: 0, y: 0, width: 100, height: 100))
 
-        let result = try await streamAndCollect(
-            session.streamResponse(
-                to: "What color is this image? Reply with just the color name.",
-                image: .ciImage(redImage)), label: "Vision")
-        try check(
-            result.lowercased().contains("red"),
-            "Expected 'red' in response, got: \(result)"
-        )
+            let result = try await streamAndCollect(
+                session.streamResponse(
+                    to: "What color is this image? Reply with just the color name.",
+                    image: .ciImage(redImage)), label: "Vision")
+            try check(
+                result.lowercased().contains("red"),
+                "Expected 'red' in response, got: \(result)"
+            )
+        #else
+            fatalError(
+                "Vision model test requires CoreImage, which is not available on this platform.")
+        #endif
     }
 
     public static func streamDetailsWithTools(container: LLModelContainer) async throws {

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -1,8 +1,11 @@
 // Copyright © 2025 Apple Inc.
 
-import CoreGraphics
 import Foundation
 import MLX
+
+#if canImport(CoreGraphics)
+    import CoreGraphics
+#endif
 
 /// Configuration for speculative decoding in a `ChatSession`.
 ///

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -4,7 +4,7 @@ import Foundation
 import MLX
 
 #if canImport(CoreGraphics)
-    import CoreGraphics
+import CoreGraphics
 #endif
 
 /// Configuration for speculative decoding in a `ChatSession`.

--- a/Libraries/MLXLMCommon/Linux/CoreGraphics.swift
+++ b/Libraries/MLXLMCommon/Linux/CoreGraphics.swift
@@ -1,0 +1,22 @@
+// Copyright © 2026 Apple Inc.
+
+#if !canImport(CoreGraphics)
+
+    public typealias CGFloat = Double
+
+    public struct CGSize: Sendable {
+        public var width: CGFloat
+        public var height: CGFloat
+
+        public init(width: CGFloat, height: CGFloat) {
+            self.width = width
+            self.height = height
+        }
+
+        public init(width: Int, height: Int) {
+            self.width = CGFloat(width)
+            self.height = CGFloat(height)
+        }
+    }
+
+#endif

--- a/Libraries/MLXLMCommon/Linux/CoreGraphics.swift
+++ b/Libraries/MLXLMCommon/Linux/CoreGraphics.swift
@@ -2,21 +2,21 @@
 
 #if !canImport(CoreGraphics)
 
-    public typealias CGFloat = Double
+public typealias CGFloat = Double
 
-    public struct CGSize: Sendable {
-        public var width: CGFloat
-        public var height: CGFloat
+public struct CGSize: Sendable {
+    public var width: CGFloat
+    public var height: CGFloat
 
-        public init(width: CGFloat, height: CGFloat) {
-            self.width = width
-            self.height = height
-        }
-
-        public init(width: Int, height: Int) {
-            self.width = CGFloat(width)
-            self.height = CGFloat(height)
-        }
+    public init(width: CGFloat, height: CGFloat) {
+        self.width = width
+        self.height = height
     }
+
+    public init(width: Int, height: Int) {
+        self.width = CGFloat(width)
+        self.height = CGFloat(height)
+    }
+}
 
 #endif

--- a/Libraries/MLXLMCommon/Linux/CoreMedia.swift
+++ b/Libraries/MLXLMCommon/Linux/CoreMedia.swift
@@ -2,9 +2,9 @@
 
 #if !canImport(CoreMedia)
 
-    public struct CMTime {
-        public var value: Int64
-        public var timescale: Int32
-    }
+public struct CMTime {
+    public var value: Int64
+    public var timescale: Int32
+}
 
 #endif

--- a/Libraries/MLXLMCommon/Linux/CoreMedia.swift
+++ b/Libraries/MLXLMCommon/Linux/CoreMedia.swift
@@ -1,0 +1,10 @@
+// Copyright © 2026 Apple Inc.
+
+#if !canImport(CoreMedia)
+
+    public struct CMTime {
+        public var value: Int64
+        public var timescale: Int32
+    }
+
+#endif

--- a/Libraries/MLXLMCommon/Linux/Logger.swift
+++ b/Libraries/MLXLMCommon/Linux/Logger.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 Apple Inc.
+
+#if canImport(os)
+
+    import os
+
+    typealias Logger = os.Logger
+
+#else
+
+    final class Logger: Sendable {
+        private let subsystem: String
+        private let category: String
+
+        init(subsystem: String, category: String) {
+            self.subsystem = subsystem
+            self.category = category
+        }
+
+        func info(_ message: String) {
+            print("[INFO] [\(subsystem).\(category)] \(message)")
+        }
+
+        func error(_ message: String) {
+            print("[ERROR] [\(subsystem).\(category)] \(message)")
+        }
+    }
+
+#endif

--- a/Libraries/MLXLMCommon/Linux/Logger.swift
+++ b/Libraries/MLXLMCommon/Linux/Logger.swift
@@ -2,28 +2,28 @@
 
 #if canImport(os)
 
-    import os
+import os
 
-    typealias Logger = os.Logger
+typealias Logger = os.Logger
 
 #else
 
-    final class Logger: Sendable {
-        private let subsystem: String
-        private let category: String
+final class Logger: Sendable {
+    private let subsystem: String
+    private let category: String
 
-        init(subsystem: String, category: String) {
-            self.subsystem = subsystem
-            self.category = category
-        }
-
-        func info(_ message: String) {
-            print("[INFO] [\(subsystem).\(category)] \(message)")
-        }
-
-        func error(_ message: String) {
-            print("[ERROR] [\(subsystem).\(category)] \(message)")
-        }
+    init(subsystem: String, category: String) {
+        self.subsystem = subsystem
+        self.category = category
     }
+
+    func info(_ message: String) {
+        print("[INFO] [\(subsystem).\(category)] \(message)")
+    }
+
+    func error(_ message: String) {
+        print("[ERROR] [\(subsystem).\(category)] \(message)")
+    }
+}
 
 #endif

--- a/Libraries/MLXLMCommon/Linux/String+Linux.swift
+++ b/Libraries/MLXLMCommon/Linux/String+Linux.swift
@@ -1,0 +1,13 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+#if os(Linux)
+
+    extension String {
+        public init(localized resource: String) {
+            self = resource
+        }
+    }
+
+#endif

--- a/Libraries/MLXLMCommon/Linux/String+Linux.swift
+++ b/Libraries/MLXLMCommon/Linux/String+Linux.swift
@@ -4,10 +4,10 @@ import Foundation
 
 #if os(Linux)
 
-    extension String {
-        public init(localized resource: String) {
-            self = resource
-        }
+extension String {
+    public init(localized resource: String) {
+        self = resource
     }
+}
 
 #endif

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -1,7 +1,6 @@
 import Foundation
 import MLX
 import MLXNN
-import os
 
 private let logger = Logger(subsystem: "mlx-swift-lm", category: "paroquant")
 

--- a/Libraries/MLXLMCommon/UserInput+Audio.swift
+++ b/Libraries/MLXLMCommon/UserInput+Audio.swift
@@ -1,8 +1,22 @@
 // Copyright © 2026 Apple Inc.
 
-@preconcurrency import AVFoundation
 import Foundation
 import MLX
+
+#if canImport(AVFoundation)
+@preconcurrency import AVFoundation
+#endif
+
+#if canImport(AVFoundation)
+extension UserInput.AudioFormat {
+    public var asAudioFormatID: AudioFormatID {
+        switch self {
+        case .linearPCM:
+            return kAudioFormatLinearPCM
+        }
+    }
+}
+#endif
 
 extension UserInput.Audio {
 
@@ -10,6 +24,7 @@ extension UserInput.Audio {
     {
         switch self {
         case .url(let url):
+            #if canImport(AVFoundation)
             let asset = AVURLAsset(url: url)
 
             guard let track = try await asset.loadTracks(withMediaType: .audio).first else {
@@ -17,7 +32,7 @@ extension UserInput.Audio {
             }
 
             let settings: [String: Any] = [
-                AVFormatIDKey: processing.audioFormat,
+                AVFormatIDKey: processing.audioFormat.asAudioFormatID,
                 AVSampleRateKey: processing.sampleRate,
                 AVNumberOfChannelsKey: processing.channels,
                 AVLinearPCMBitDepthKey: 32,
@@ -47,7 +62,9 @@ extension UserInput.Audio {
             }
 
             return MLXArray(samples)
-
+            #else
+            fatalError("Audio processing is not supported on this platform.")
+            #endif
         case .array(let array):
             return array
         }

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -4,10 +4,10 @@ import Foundation
 import MLX
 
 #if canImport(AVFoundation)
-    @preconcurrency import AVFoundation
+@preconcurrency import AVFoundation
 #endif
 #if canImport(CoreImage)
-    import CoreImage
+import CoreImage
 #endif
 
 public typealias Message = [String: any Sendable]
@@ -55,22 +55,22 @@ public struct UserInput {
 
         #if canImport(CoreImage)
 
-            @available(
-                *, deprecated,
-                message: "Use init(image:, timeStamp:) instead"
-            )
-            public init(frame: CIImage, timeStamp: CMTime) {
-                self.image = .ciImage(frame)
-                self.timeStamp = timeStamp
-            }
+        @available(
+            *, deprecated,
+            message: "Use init(image:, timeStamp:) instead"
+        )
+        public init(frame: CIImage, timeStamp: CMTime) {
+            self.image = .ciImage(frame)
+            self.timeStamp = timeStamp
+        }
 
-            @available(
-                *, deprecated,
-                message: "Use image.asCIImage()"
-            )
-            public var frame: CIImage {
-                return try! image.asCIImage()
-            }
+        @available(
+            *, deprecated,
+            message: "Use image.asCIImage()"
+        )
+        public var frame: CIImage {
+            return try! image.asCIImage()
+        }
 
         #endif
     }
@@ -78,97 +78,97 @@ public struct UserInput {
     /// Representation of a video resource.
     public enum Video {
         #if canImport(AVFoundation)
-            case avAsset(AVAsset)
+        case avAsset(AVAsset)
         #endif
         case url(URL)
         /// Useful for decoded frames held in memory
         case frames([VideoFrame])
 
         #if canImport(AVFoundation)
-            @available(
-                *, deprecated,
-                message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
-            )
-            public func asAVAsset() -> AVAsset {
-                switch self {
-                case .avAsset(let asset):
-                    return asset
-                case .url(let url):
-                    return AVAsset(url: url)
-                case .frames:
-                    fatalError(
-                        "calling asAVAsset() on Video Input with VideoFames provided is unsupported and deprecated - please use MediaProcessing.asProcessedSequence() instead"
-                    )
-                }
+        @available(
+            *, deprecated,
+            message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
+        )
+        public func asAVAsset() -> AVAsset {
+            switch self {
+            case .avAsset(let asset):
+                return asset
+            case .url(let url):
+                return AVAsset(url: url)
+            case .frames:
+                fatalError(
+                    "calling asAVAsset() on Video Input with VideoFames provided is unsupported and deprecated - please use MediaProcessing.asProcessedSequence() instead"
+                )
             }
+        }
         #endif
     }
 
     /// Representation of an image resource.
     public enum Image {
         #if canImport(CoreImage)
-            case ciImage(CIImage)
+        case ciImage(CIImage)
         #endif
         case url(URL)
         case array(MLXArray)
 
         #if canImport(CoreImage)
-            public func asCIImage() throws -> CIImage {
-                switch self {
-                case .ciImage(let image):
+        public func asCIImage() throws -> CIImage {
+            switch self {
+            case .ciImage(let image):
+                return image
+
+            case .url(let url):
+                if let image = CIImage(contentsOf: url) {
                     return image
-
-                case .url(let url):
-                    if let image = CIImage(contentsOf: url) {
-                        return image
-                    }
-                    throw UserInputError.unableToLoad(url)
-
-                case .array(let array):
-                    guard array.ndim == 3 else {
-                        throw UserInputError.arrayError(
-                            "array must have 3 dimensions: \(array.ndim)")
-                    }
-
-                    var array = array
-
-                    // convert to 0 .. 255
-                    if array.max().item(Float.self) <= 1.0 {
-                        array = array * 255
-                    }
-
-                    // planar -> pixels
-                    switch array.dim(0) {
-                    case 3, 4:
-                        // channels first (planar)
-                        array = array.transposed(1, 2, 0)
-                    default:
-                        break
-                    }
-
-                    // 4 components per pixel
-                    switch array.dim(-1) {
-                    case 3:
-                        // pad to 4 bytes per pixel
-                        array = padded(array, widths: [0, 0, [0, 1]], value: MLXArray(255))
-                    case 4:
-                        // good
-                        break
-                    default:
-                        throw UserInputError.arrayError(
-                            "channel dimension must be last and 3/4: \(array.shape)")
-                    }
-
-                    let arrayData = array.asData()
-                    let (H, W, _) = array.shape3
-                    let cs = CGColorSpace(name: CGColorSpace.sRGB)!
-
-                    return CIImage(
-                        bitmapData: arrayData.data, bytesPerRow: W * 4,
-                        size: .init(width: W, height: H),
-                        format: .RGBA8, colorSpace: cs)
                 }
+                throw UserInputError.unableToLoad(url)
+
+            case .array(let array):
+                guard array.ndim == 3 else {
+                    throw UserInputError.arrayError(
+                        "array must have 3 dimensions: \(array.ndim)")
+                }
+
+                var array = array
+
+                // convert to 0 .. 255
+                if array.max().item(Float.self) <= 1.0 {
+                    array = array * 255
+                }
+
+                // planar -> pixels
+                switch array.dim(0) {
+                case 3, 4:
+                    // channels first (planar)
+                    array = array.transposed(1, 2, 0)
+                default:
+                    break
+                }
+
+                // 4 components per pixel
+                switch array.dim(-1) {
+                case 3:
+                    // pad to 4 bytes per pixel
+                    array = padded(array, widths: [0, 0, [0, 1]], value: MLXArray(255))
+                case 4:
+                    // good
+                    break
+                default:
+                    throw UserInputError.arrayError(
+                        "channel dimension must be last and 3/4: \(array.shape)")
+                }
+
+                let arrayData = array.asData()
+                let (H, W, _) = array.shape3
+                let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+
+                return CIImage(
+                    bitmapData: arrayData.data, bytesPerRow: W * 4,
+                    size: .init(width: W, height: H),
+                    format: .RGBA8, colorSpace: cs)
             }
+        }
         #endif
     }
 

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -180,6 +180,11 @@ public struct UserInput {
         // See also UserInput+Audio
     }
 
+    /// Representation of the audio format.
+    public enum AudioFormat: Sendable {
+        case linearPCM
+    }
+
     /// Representation of processing to apply to media.
     public struct Processing: Sendable {
         public var resize: CGSize?
@@ -209,8 +214,8 @@ public struct UserInput {
         /// Number of channels of audio.  If 1, convert to mono
         public var channels = 1
 
-        /// audio format
-        public var audioFormat: AudioFormatID = kAudioFormatLinearPCM
+        /// Audio format
+        public var audioFormat: AudioFormat = .linearPCM
 
         public init() {
         }

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -1,9 +1,14 @@
 // Copyright © 2024 Apple Inc.
 
-@preconcurrency import AVFoundation
-import CoreImage
 import Foundation
 import MLX
+
+#if canImport(AVFoundation)
+    @preconcurrency import AVFoundation
+#endif
+#if canImport(CoreImage)
+    import CoreImage
+#endif
 
 public typealias Message = [String: any Sendable]
 
@@ -40,10 +45,10 @@ public struct UserInput {
     }
 
     public struct VideoFrame {
-        public let frame: CIImage
+        public let frame: Image
         public let timeStamp: CMTime
 
-        public init(frame: CIImage, timeStamp: CMTime) {
+        public init(frame: Image, timeStamp: CMTime) {
             self.frame = frame
             self.timeStamp = timeStamp
         }
@@ -51,90 +56,99 @@ public struct UserInput {
 
     /// Representation of a video resource.
     public enum Video {
-        case avAsset(AVAsset)
+        #if canImport(AVFoundation)
+            case avAsset(AVAsset)
+        #endif
         case url(URL)
         /// Useful for decoded frames held in memory
         case frames([VideoFrame])
 
-        @available(
-            *, deprecated,
-            message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
-        )
-        public func asAVAsset() -> AVAsset {
-            switch self {
-            case .avAsset(let asset):
-                return asset
-            case .url(let url):
-                return AVAsset(url: url)
-            case .frames:
-                fatalError(
-                    "calling asAVAsset() on Video Input with VideoFames provided is unsupported and deprecated - please use MediaProcessing.asProcessedSequence() instead"
-                )
+        #if canImport(AVFoundation)
+            @available(
+                *, deprecated,
+                message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
+            )
+            public func asAVAsset() -> AVAsset {
+                switch self {
+                case .avAsset(let asset):
+                    return asset
+                case .url(let url):
+                    return AVAsset(url: url)
+                case .frames:
+                    fatalError(
+                        "calling asAVAsset() on Video Input with VideoFames provided is unsupported and deprecated - please use MediaProcessing.asProcessedSequence() instead"
+                    )
+                }
             }
-        }
+        #endif
     }
 
     /// Representation of an image resource.
     public enum Image {
-        case ciImage(CIImage)
+        #if canImport(CoreImage)
+            case ciImage(CIImage)
+        #endif
         case url(URL)
         case array(MLXArray)
 
-        public func asCIImage() throws -> CIImage {
-            switch self {
-            case .ciImage(let image):
-                return image
-
-            case .url(let url):
-                if let image = CIImage(contentsOf: url) {
+        #if canImport(CoreImage)
+            public func asCIImage() throws -> CIImage {
+                switch self {
+                case .ciImage(let image):
                     return image
+
+                case .url(let url):
+                    if let image = CIImage(contentsOf: url) {
+                        return image
+                    }
+                    throw UserInputError.unableToLoad(url)
+
+                case .array(let array):
+                    guard array.ndim == 3 else {
+                        throw UserInputError.arrayError(
+                            "array must have 3 dimensions: \(array.ndim)")
+                    }
+
+                    var array = array
+
+                    // convert to 0 .. 255
+                    if array.max().item(Float.self) <= 1.0 {
+                        array = array * 255
+                    }
+
+                    // planar -> pixels
+                    switch array.dim(0) {
+                    case 3, 4:
+                        // channels first (planar)
+                        array = array.transposed(1, 2, 0)
+                    default:
+                        break
+                    }
+
+                    // 4 components per pixel
+                    switch array.dim(-1) {
+                    case 3:
+                        // pad to 4 bytes per pixel
+                        array = padded(array, widths: [0, 0, [0, 1]], value: MLXArray(255))
+                    case 4:
+                        // good
+                        break
+                    default:
+                        throw UserInputError.arrayError(
+                            "channel dimension must be last and 3/4: \(array.shape)")
+                    }
+
+                    let arrayData = array.asData()
+                    let (H, W, _) = array.shape3
+                    let cs = CGColorSpace(name: CGColorSpace.sRGB)!
+
+                    return CIImage(
+                        bitmapData: arrayData.data, bytesPerRow: W * 4,
+                        size: .init(width: W, height: H),
+                        format: .RGBA8, colorSpace: cs)
                 }
-                throw UserInputError.unableToLoad(url)
-
-            case .array(let array):
-                guard array.ndim == 3 else {
-                    throw UserInputError.arrayError("array must have 3 dimensions: \(array.ndim)")
-                }
-
-                var array = array
-
-                // convert to 0 .. 255
-                if array.max().item(Float.self) <= 1.0 {
-                    array = array * 255
-                }
-
-                // planar -> pixels
-                switch array.dim(0) {
-                case 3, 4:
-                    // channels first (planar)
-                    array = array.transposed(1, 2, 0)
-                default:
-                    break
-                }
-
-                // 4 components per pixel
-                switch array.dim(-1) {
-                case 3:
-                    // pad to 4 bytes per pixel
-                    array = padded(array, widths: [0, 0, [0, 1]], value: MLXArray(255))
-                case 4:
-                    // good
-                    break
-                default:
-                    throw UserInputError.arrayError(
-                        "channel dimension must be last and 3/4: \(array.shape)")
-                }
-
-                let arrayData = array.asData()
-                let (H, W, _) = array.shape3
-                let cs = CGColorSpace(name: CGColorSpace.sRGB)!
-
-                return CIImage(
-                    bitmapData: arrayData.data, bytesPerRow: W * 4,
-                    size: .init(width: W, height: H),
-                    format: .RGBA8, colorSpace: cs)
             }
-        }
+        #endif
     }
 
     /// Representation of processing to apply to media.

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -45,13 +45,34 @@ public struct UserInput {
     }
 
     public struct VideoFrame {
-        public let frame: Image
+        public let image: Image
         public let timeStamp: CMTime
 
-        public init(frame: Image, timeStamp: CMTime) {
-            self.frame = frame
+        public init(image: Image, timeStamp: CMTime) {
+            self.image = image
             self.timeStamp = timeStamp
         }
+
+        #if canImport(CoreImage)
+
+            @available(
+                *, deprecated,
+                message: "Use init(image:, timeStamp:) instead"
+            )
+            public init(frame: CIImage, timeStamp: CMTime) {
+                self.image = .ciImage(frame)
+                self.timeStamp = timeStamp
+            }
+
+            @available(
+                *, deprecated,
+                message: "Use image.asCIImage()"
+            )
+            public var frame: CIImage {
+                return try! image.asCIImage()
+            }
+
+        #endif
     }
 
     /// Representation of a video resource.

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -443,8 +443,8 @@ public enum MediaProcessing {
             case .success(requestedTime: _, let image, actualTime: let actual):
                 let ciImage = CIImage(
                     cgImage: image, options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
-                let frame = try frameProcessing(.init(frame: ciImage, timeStamp: actual))
-                ciImages.append(frame.frame)
+                let frame = try frameProcessing(.init(frame: .ciImage(ciImage), timeStamp: actual))
+                ciImages.append(try frame.frame.asCIImage())
                 timestamps.append(frame.timeStamp)
             case .failure(requestedTime: _, _):
                 break
@@ -512,7 +512,7 @@ public enum MediaProcessing {
                 let videoFrame = videoFrames[targetIndex]
                 let frame = try frameProcessing(
                     .init(frame: videoFrame.frame, timeStamp: videoFrame.timeStamp))
-                ciImages.append(frame.frame)
+                ciImages.append(try frame.frame.asCIImage())
                 timestamps.append(frame.timeStamp)
             }
         }

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -443,8 +443,8 @@ public enum MediaProcessing {
             case .success(requestedTime: _, let image, actualTime: let actual):
                 let ciImage = CIImage(
                     cgImage: image, options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
-                let frame = try frameProcessing(.init(frame: .ciImage(ciImage), timeStamp: actual))
-                ciImages.append(try frame.frame.asCIImage())
+                let frame = try frameProcessing(.init(image: .ciImage(ciImage), timeStamp: actual))
+                ciImages.append(try frame.image.asCIImage())
                 timestamps.append(frame.timeStamp)
             case .failure(requestedTime: _, _):
                 break
@@ -511,8 +511,8 @@ public enum MediaProcessing {
             if let targetIndex {
                 let videoFrame = videoFrames[targetIndex]
                 let frame = try frameProcessing(
-                    .init(frame: videoFrame.frame, timeStamp: videoFrame.timeStamp))
-                ciImages.append(try frame.frame.asCIImage())
+                    .init(image: videoFrame.image, timeStamp: videoFrame.timeStamp))
+                ciImages.append(try frame.image.asCIImage())
                 timestamps.append(frame.timeStamp)
             }
         }

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -760,7 +760,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                 ) { frame in
                     // first apply the user requested resizing, etc. if any
                     let resizedImage = MediaProcessing.apply(
-                        try frame.frame.asCIImage(), processing: input.processing)
+                        try frame.image.asCIImage(), processing: input.processing)
                     if resizedSize == .zero {
                         let size = resizedImage.extent.size
                         let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
@@ -770,7 +770,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                         resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
                     }
                     let processedImage = preprocess(image: resizedImage, resizedSize: resizedSize)
-                    return VideoFrame(frame: .ciImage(processedImage), timeStamp: frame.timeStamp)
+                    return VideoFrame(image: .ciImage(processedImage), timeStamp: frame.timeStamp)
                 }
 
                 videosAsImageSequences.append(imageSequence.frames)

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -877,7 +877,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                     }
                     let processedImage = preprocessVideoFrame(
                         image: resizedImage, resizedSize: resizedSize)
-                    return VideoFrame(frame: processedImage, timeStamp: frame.timeStamp)
+                    return VideoFrame(image: .ciImage(processedImage), timeStamp: frame.timeStamp)
                 }
 
                 videosAsImageSequences.append(imageSequence.frames)

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -760,7 +760,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                 ) { frame in
                     // first apply the user requested resizing, etc. if any
                     let resizedImage = MediaProcessing.apply(
-                        frame.frame, processing: input.processing)
+                        try frame.frame.asCIImage(), processing: input.processing)
                     if resizedSize == .zero {
                         let size = resizedImage.extent.size
                         let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
@@ -770,7 +770,7 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                         resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
                     }
                     let processedImage = preprocess(image: resizedImage, resizedSize: resizedSize)
-                    return VideoFrame(frame: processedImage, timeStamp: frame.timeStamp)
+                    return VideoFrame(frame: .ciImage(processedImage), timeStamp: frame.timeStamp)
                 }
 
                 videosAsImageSequences.append(imageSequence.frames)

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -599,7 +599,7 @@ public struct Qwen2VLProcessor: UserInputProcessor {
                 ) { frame in
                     // first apply the user requested resizing, etc. if any
                     let resizedImage = MediaProcessing.apply(
-                        try frame.frame.asCIImage(), processing: input.processing)
+                        try frame.image.asCIImage(), processing: input.processing)
                     if resizedSize == .zero {
                         let size = resizedImage.extent.size
                         let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
@@ -609,7 +609,7 @@ public struct Qwen2VLProcessor: UserInputProcessor {
                         resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
                     }
                     let processedImage = preprocess(image: resizedImage, resizedSize: resizedSize)
-                    return VideoFrame(frame: .ciImage(processedImage), timeStamp: frame.timeStamp)
+                    return VideoFrame(image: .ciImage(processedImage), timeStamp: frame.timeStamp)
                 }
 
                 videosAsImageSequences.append(imageSequence.frames)

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -599,7 +599,7 @@ public struct Qwen2VLProcessor: UserInputProcessor {
                 ) { frame in
                     // first apply the user requested resizing, etc. if any
                     let resizedImage = MediaProcessing.apply(
-                        frame.frame, processing: input.processing)
+                        try frame.frame.asCIImage(), processing: input.processing)
                     if resizedSize == .zero {
                         let size = resizedImage.extent.size
                         let (resizedHeight, resizedWidth) = try QwenVL.targetSize(
@@ -609,7 +609,7 @@ public struct Qwen2VLProcessor: UserInputProcessor {
                         resizedSize = CGSize(width: resizedWidth, height: resizedHeight)
                     }
                     let processedImage = preprocess(image: resizedImage, resizedSize: resizedSize)
-                    return VideoFrame(frame: processedImage, timeStamp: frame.timeStamp)
+                    return VideoFrame(frame: .ciImage(processedImage), timeStamp: frame.timeStamp)
                 }
 
                 videosAsImageSequences.append(imageSequence.frames)

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -112,7 +112,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
                 let sequence = try await MediaProcessing.asProcessedSequence(
                     video, targetFPS: { _ in Double(2) }
                 ) { frame in
-                    let processed = MediaProcessing.apply(frame.frame, processing: input.processing)
+                    let processed = MediaProcessing.apply(
+                        try frame.frame.asCIImage(), processing: input.processing)
                     if resizedSize == .zero {
                         let size = processed.extent.size
                         let (height, width) = try QwenVL.targetSize(
@@ -124,7 +125,7 @@ public struct Qwen3VLProcessor: UserInputProcessor {
                         resizedSize = CGSize(width: width, height: height)
                     }
                     let finalImage = preprocess(image: processed, resizedSize: resizedSize)
-                    return VideoFrame(frame: finalImage, timeStamp: frame.timeStamp)
+                    return VideoFrame(frame: .ciImage(finalImage), timeStamp: frame.timeStamp)
                 }
                 accumulatedFrames.append(sequence.frames)
             }

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -113,7 +113,7 @@ public struct Qwen3VLProcessor: UserInputProcessor {
                     video, targetFPS: { _ in Double(2) }
                 ) { frame in
                     let processed = MediaProcessing.apply(
-                        try frame.frame.asCIImage(), processing: input.processing)
+                        try frame.image.asCIImage(), processing: input.processing)
                     if resizedSize == .zero {
                         let size = processed.extent.size
                         let (height, width) = try QwenVL.targetSize(
@@ -125,7 +125,7 @@ public struct Qwen3VLProcessor: UserInputProcessor {
                         resizedSize = CGSize(width: width, height: height)
                     }
                     let finalImage = preprocess(image: processed, resizedSize: resizedSize)
-                    return VideoFrame(frame: .ciImage(finalImage), timeStamp: frame.timeStamp)
+                    return VideoFrame(image: .ciImage(finalImage), timeStamp: frame.timeStamp)
                 }
                 accumulatedFrames.append(sequence.frames)
             }

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -320,14 +320,15 @@ public struct SmolVLMProcessor: UserInputProcessor {
                 }
             ) { frame in
 
-                let processedFrame = frame.frame
+                let processedFrame = try frame.frame
+                    .asCIImage()
                     .toSRGB()
                     .resampled(
                         to: CGSize(width: fixedImageSize, height: fixedImageSize),
                         method: CIImage.ResamplingMethod.lanczos
                     )
                     .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
-                return VideoFrame(frame: processedFrame, timeStamp: frame.timeStamp)
+                return VideoFrame(frame: .ciImage(processedFrame), timeStamp: frame.timeStamp)
             }
 
             let thwFrames = (0 ..< processedFrames.frames.count).map {

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -320,7 +320,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
                 }
             ) { frame in
 
-                let processedFrame = try frame.frame
+                let processedFrame = try frame.image
                     .asCIImage()
                     .toSRGB()
                     .resampled(
@@ -328,7 +328,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
                         method: CIImage.ResamplingMethod.lanczos
                     )
                     .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
-                return VideoFrame(frame: .ciImage(processedFrame), timeStamp: frame.timeStamp)
+                return VideoFrame(image: .ciImage(processedFrame), timeStamp: frame.timeStamp)
             }
 
             let thwFrames = (0 ..< processedFrames.frames.count).map {

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 import MLX
-@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
+
+@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 

--- a/Tests/MLXLMTests/MediaProcessingTests.swift
+++ b/Tests/MLXLMTests/MediaProcessingTests.swift
@@ -72,7 +72,8 @@ public class MediaProcesingTests: XCTestCase {
         // We know video is exactly 5 seconds long, expect 10 samples
         let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
             frame in
-            let image = preprocess(image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
+            let image = preprocess(
+                image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
 
             return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
         }
@@ -117,7 +118,8 @@ public class MediaProcesingTests: XCTestCase {
         // We know video is exactly 5 seconds long, expect 10 samples
         let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
             frame in
-            let image = preprocess(image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
+            let image = preprocess(
+                image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
 
             return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
         }

--- a/Tests/MLXLMTests/MediaProcessingTests.swift
+++ b/Tests/MLXLMTests/MediaProcessingTests.swift
@@ -72,9 +72,9 @@ public class MediaProcesingTests: XCTestCase {
         // We know video is exactly 5 seconds long, expect 10 samples
         let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
             frame in
-            let image = preprocess(image: frame.frame, resizedSize: .init(width: 224, height: 224))
+            let image = preprocess(image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
 
-            return VideoFrame.init(frame: image, timeStamp: frame.timeStamp)
+            return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
         }
 
         XCTAssert(frames.frames.count == 10)
@@ -101,7 +101,7 @@ public class MediaProcesingTests: XCTestCase {
         for i in 0 ..< (seconds * framerate) {
             let image = imageWithColor(colors.randomElement()!)
             let timeStamp: CMTime = .init(value: Int64(i), timescale: Int32(framerate))
-            rawFrames.append(VideoFrame(frame: image, timeStamp: timeStamp))
+            rawFrames.append(VideoFrame(image: .ciImage(image), timeStamp: timeStamp))
         }
 
         // Bogus preprocessing values
@@ -117,9 +117,9 @@ public class MediaProcesingTests: XCTestCase {
         // We know video is exactly 5 seconds long, expect 10 samples
         let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
             frame in
-            let image = preprocess(image: frame.frame, resizedSize: .init(width: 224, height: 224))
+            let image = preprocess(image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
 
-            return VideoFrame.init(frame: image, timeStamp: frame.timeStamp)
+            return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
         }
 
         XCTAssert(frames.frames.count == 10)


### PR DESCRIPTION
## Proposed changes

Make this package compilable on Linux.

Not all modules (targets) can be compiled on Linux. MLXVLM, for instance, has no Linux implementation yet.

Please note that, from a multi-platform perspective, `UserInput.Image` and `UserInput.Video` are very good. However, `UserInput.VideoFrame` is not suitable for a multi-platform environment. Therefore, I'm proposing to deprecate the `UserInput.VideoFrame.frame` property and replace it by `UserInput.VideoFrame.image`.

This will allow, in the future, to create a MediaProcessor which uses UserInput.Image instead of CIImage, making abstraction of the native API being used.
  
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
