### PR TITLE
Improve Qwen3.5 recurrent cache handling

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -24,20 +24,22 @@ extension LLMModel {
         let prefillStepSize = windowSize ?? 512
         var y = input.text
 
-        // Prepare the prompt in chunks if larger than the prefill size.
-        // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
-        // chunk N.
-        var state: LMOutput.State?
-        while y.tokens.size > prefillStepSize {
-            let input = y[.newAxis, ..<prefillStepSize]
-            let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
-            state = output.state
-            asyncEval(cache)
-            y = y[prefillStepSize...]
-        }
+        withPreparedCache(cache, lengths: y.sequenceLengths) {
+            // Prepare the prompt in chunks if larger than the prefill size.
+            // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
+            // chunk N.
+            var state: LMOutput.State?
+            while y.tokens.size > prefillStepSize {
+                let input = y[.newAxis, ..<prefillStepSize]
+                let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
+                state = output.state
+                asyncEval(cache)
+                y = y[prefillStepSize...]
+            }
 
-        // Single sync after the loop to flush any remaining async work.
-        eval(cache)
+            // Single sync after the loop to flush any remaining async work.
+            eval(cache)
+        }
 
         return .tokens(y)
     }

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -434,9 +434,9 @@ class FalconH1Mixer: Module {
                 let t = paddedInput.dim(1)
                 let ends = clip(lengths, min: 0, max: t - nKeep)
                 let positions = (ends[0..., .newAxis] + MLXArray(0 ..< nKeep))[.ellipsis, .newAxis]
-                cache[0] = MLX.takeAlong(paddedInput, positions, axis: 1)
+                cache[0] = contiguous(MLX.takeAlong(paddedInput, positions, axis: 1))
             } else {
-                cache[0] = paddedInput[0..., (-nKeep)...]
+                cache[0] = contiguous(paddedInput[0..., (-nKeep)..., 0...])
             }
         }
 

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -124,7 +124,7 @@ class GraniteMoeHybridMamba2Mixer: Module {
         if let cache {
             let end = padded.dim(1)
             let start = max(0, end - (convKernelSize - 1))
-            cache[0] = padded[0..., start ..< end, 0...]
+            cache[0] = contiguous(padded[0..., start ..< end, 0...])
         }
 
         let convOutput = conv1d(padded)
@@ -181,6 +181,7 @@ class GraniteMoeHybridMamba2Mixer: Module {
 
         if let cache {
             cache[1] = nextState
+            cache.advance(hiddenStates.dim(1))
         }
 
         let flattenedY = y.flattened(start: 2)

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -325,8 +325,9 @@ class JambaMambaMixer: Module {
             x, convState: convState, ssmState: ssmState)
 
         if let cache = cache {
-            cache[0] = newConvState
+            cache[0] = contiguous(newConvState)
             cache[1] = newSsmState
+            cache.advance(x.dim(1))
         }
 
         return output

--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -222,7 +222,8 @@ class LFM2ShortConv: Module {
 
         Bx = concatenated([state!, Bx], axis: -2)
         if let cache {
-            cache[0] = Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...]
+            cache[0] = contiguous(Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...])
+            cache.advance(x.dim(1))
         }
 
         let convOut = conv(Bx)

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -231,7 +231,8 @@ class LFM2MoEShortConv: Module {
         Bx = concatenated([state!, Bx], axis: -2)
         if let cache {
             let start = Bx.dim(1) - (lCache - 1)
-            cache[0] = Bx[0..., start..., 0...]
+            cache[0] = contiguous(Bx[0..., start..., 0...])
+            cache.advance(x.dim(1))
         }
 
         let convOut = conv(Bx)

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -180,7 +180,7 @@ private class NemotronHMamba2Mixer: Module, NemotronHMixer {
         if let cache {
             let end = padded.dim(1)
             let start = max(0, end - (convKernelSize - 1))
-            cache[0] = padded[0..., start ..< end, 0...]
+            cache[0] = contiguous(padded[0..., start ..< end, 0...])
         }
 
         let convOutput = conv1d(padded)
@@ -232,6 +232,7 @@ private class NemotronHMamba2Mixer: Module, NemotronHMixer {
 
         if let cache {
             cache[1] = nextState
+            cache.advance(hiddenStates.dim(1))
         }
 
         let flattenedY = y.flattened(start: 2)

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -24,7 +24,7 @@ class Qwen3Attention: Module {
     @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
     @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
 
-    let rope: RoPE
+    let rope: RoPELayer
 
     public init(_ args: Qwen3Configuration) {
         self.args = args
@@ -44,22 +44,13 @@ class Qwen3Attention: Module {
         _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
         _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: args.rmsNormEps)
 
-        let ropeScale: Float
-        if let ropeScaling = args.ropeScaling, ropeScaling["type"] == .string("linear"),
-            let factor = ropeScaling["factor"]
-        {
-            if let v = factor.asFloat() {
-                ropeScale = 1 / v
-            } else {
-                fatalError("ropeScaling.factor must be a float")
-            }
-        } else {
-            ropeScale = 1
-        }
-
-        self.rope = RoPE(
-            dimensions: headDim, traditional: false, base: args.ropeTheta,
-            scale: ropeScale)
+        self.rope = initializeRope(
+            dims: headDim,
+            base: args.ropeTheta,
+            traditional: false,
+            scalingConfig: args.ropeScaling,
+            maxPositionEmbeddings: args.maxPositionEmbeddings
+        )
     }
 
     public func callAsFunction(

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -251,7 +251,7 @@ final class Qwen35GatedDeltaNet: Module {
 
         let convInput = concatenated([convState, qkv], axis: 1)
         if let cache {
-            cache[0] = convInput[0..., (-(convKernelSize - 1))...]
+            cache[0] = contiguous(convInput[0..., (-(convKernelSize - 1))..., 0...])
         }
 
         let convOut = silu(conv1d(convInput))
@@ -287,6 +287,7 @@ final class Qwen35GatedDeltaNet: Module {
 
         if let cache {
             cache[1] = state
+            cache.advance(S)
         }
 
         out = norm(out, gate: z)

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -16,6 +16,10 @@ func sigmoidMultiply(_ x: MLXArray, _ gate: MLXArray) -> MLXArray {
     x * sigmoid(gate)
 }
 
+private func preciseSwiGLU(_ hiddenStates: MLXArray, gate: MLXArray, x: MLXArray) -> MLXArray {
+    (silu(gate.asType(.float32)) * x.asType(.float32)).asType(hiddenStates.dtype)
+}
+
 // MARK: - Model Components
 
 final class Qwen3NextRMSNormGated: Module {
@@ -31,7 +35,7 @@ final class Qwen3NextRMSNormGated: Module {
     func callAsFunction(_ hiddenStates: MLXArray, gate: MLXArray? = nil) -> MLXArray {
         var x = MLXFast.rmsNorm(hiddenStates, weight: weight, eps: eps)
         if let gate {
-            x = x * silu(gate)
+            x = preciseSwiGLU(hiddenStates, gate: gate, x: x)
         }
         return x
     }
@@ -258,7 +262,7 @@ public final class Qwen3NextGatedDeltaNet: Module {
 
         let convInput = concatenated([convState, mixedQKV], axis: 1)
         if let cache {
-            cache[0] = convInput[0..., (1 - convKernelSize)..., 0...]
+            cache[0] = contiguous(convInput[0..., (1 - convKernelSize)..., 0...])
         }
 
         let convOut = silu(conv1d(convInput))
@@ -290,6 +294,7 @@ public final class Qwen3NextGatedDeltaNet: Module {
 
         if let cache {
             cache[1] = newState
+            cache.advance(S)
         }
 
         let normalized = norm(out, gate: z)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -377,14 +377,14 @@ public struct RepetitionContext: LogitProcessor {
 
     public func process(logits: MLXArray) -> MLXArray {
         guard let indices = ring.validTokens?.asType(.uint32) else { return logits }
-        var selectedLogits = logits[0..., indices]
+        let broadcastIndices = indices[.newAxis, 0...]
+        var selectedLogits = takeAlong(logits, broadcastIndices, axis: -1)
 
         selectedLogits = MLX.where(
             selectedLogits .< 0, selectedLogits * repetitionPenalty,
             selectedLogits / repetitionPenalty)
 
-        logits[0..., indices] = selectedLogits
-        return logits
+        return putAlong(logits, broadcastIndices, values: selectedLogits, axis: -1)
     }
 
     mutating public func didSample(token: MLXArray) {
@@ -411,8 +411,9 @@ public struct PresencePenaltyContext: LogitProcessor {
 
     public func process(logits: MLXArray) -> MLXArray {
         guard let indices = ring.validTokens?.asType(.uint32) else { return logits }
-        logits[0..., indices] = logits[0..., indices] - presencePenalty
-        return logits
+        let broadcastIndices = indices[.newAxis, 0...]
+        let selectedLogits = takeAlong(logits, broadcastIndices, axis: -1) - presencePenalty
+        return putAlong(logits, broadcastIndices, values: selectedLogits, axis: -1)
     }
 
     mutating public func didSample(token: MLXArray) {
@@ -671,8 +672,9 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     /// Evaluate the next token and return the new token (y), updating cache state
     mutating func step(previous: LMInput.Text) -> MLXArray {
-        let result = model(
-            previous[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: state)
+        let result = withPreparedCache(cache, lengths: previous.sequenceLengths) {
+            model(previous[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: state)
+        }
         self.state = result.state
 
         // Apply dynamic cache quantization after each step

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -85,12 +85,46 @@ public protocol KVCache: Evaluatable {
 
     /// Create an independent deep copy of this cache.
     func copy() -> any KVCache
+
+    /// Prepare cache metadata for a batched sequence.
+    func prepare(lengths: [Int]?)
+
+    /// Prepare cache metadata for a batched sequence.
+    func prepare(lengths: MLXArray?)
+
+    /// Clear transient cache metadata after generation.
+    func finalize()
 }
 
 extension KVCache {
     public var ropeOffset: RoPEOffset {
         .scalar(offset)
     }
+
+    public func prepare(lengths: [Int]?) {}
+
+    public func prepare(lengths: MLXArray?) {}
+
+    public func finalize() {}
+}
+
+public func withPreparedCache<Result>(
+    _ cache: [any KVCache],
+    lengths: [Int]?,
+    _ body: () throws -> Result
+) rethrows -> Result {
+    guard let lengths else {
+        return try body()
+    }
+    for cache in cache {
+        cache.prepare(lengths: lengths)
+    }
+    defer {
+        for cache in cache {
+            cache.finalize()
+        }
+    }
+    return try body()
 }
 
 /// Protocol for caches that support efficient quantized operations
@@ -172,6 +206,12 @@ open class BaseKVCache: KVCache {
     open func copy() -> any KVCache {
         fatalError("copy() must be implemented by subclass")
     }
+
+    open func prepare(lengths: [Int]?) {}
+
+    open func prepare(lengths: MLXArray?) {}
+
+    open func finalize() {}
 
     /// Default implementation for caches without special mask requirements
     open func makeMask(
@@ -1163,7 +1203,7 @@ public class ChunkedKVCache: KVCacheSimple {
 
 /// Base cache for array-based state storage
 public class ArraysCache: BaseKVCache {
-    private var cache: [MLXArray?]
+    fileprivate var cache: [MLXArray?]
     internal var leftPadding: MLXArray?
     internal var lengths: MLXArray?
 
@@ -1198,10 +1238,7 @@ public class ArraysCache: BaseKVCache {
     }
 
     internal func copyContents(to new: ArraysCache) {
-        let s = self.state
-        if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
-        }
+        new.cache = cache.map { $0?[.ellipsis] }
         new.offset = self.offset
         new.leftPadding = self.leftPadding
         new.lengths = self.lengths
@@ -1244,15 +1281,15 @@ public class ArraysCache: BaseKVCache {
         lengths = concatenate(lengths, other.lengths)
     }
 
-    public func prepare(lengths: [Int]?) {
+    public override func prepare(lengths: [Int]?) {
         self.lengths = lengths.map { MLXArray($0) }
     }
 
-    public func prepare(lengths: MLXArray?) {
+    public override func prepare(lengths: MLXArray?) {
         self.lengths = lengths
     }
 
-    public func finalize() {
+    public override func finalize() {
         lengths = nil
         leftPadding = nil
     }
@@ -1273,6 +1310,11 @@ public class ArraysCache: BaseKVCache {
     internal var leftPaddingValues: [Int]? {
         guard let leftPadding else { return nil }
         return leftPadding.asArray(Int.self)
+    }
+
+    internal var lengthsValues: [Int]? {
+        guard let lengths else { return nil }
+        return lengths.asArray(Int.self)
     }
 
     internal var presentSlotIndices: [Int] {
@@ -1412,26 +1454,16 @@ public class CacheList: BaseKVCache {
         return new
     }
 
-    public func prepare(lengths: [Int]?) {
-        forEachArraysCache { $0.prepare(lengths: lengths) }
+    public override func prepare(lengths: [Int]?) {
+        caches.forEach { $0.prepare(lengths: lengths) }
     }
 
-    public func prepare(lengths: MLXArray?) {
-        forEachArraysCache { $0.prepare(lengths: lengths) }
+    public override func prepare(lengths: MLXArray?) {
+        caches.forEach { $0.prepare(lengths: lengths) }
     }
 
-    public func finalize() {
-        forEachArraysCache { $0.finalize() }
-    }
-
-    private func forEachArraysCache(_ body: (ArraysCache) -> Void) {
-        for cache in caches {
-            if let arrays = cache as? ArraysCache {
-                body(arrays)
-            } else if let list = cache as? CacheList {
-                list.forEachArraysCache(body)
-            }
-        }
+    public override func finalize() {
+        caches.forEach { $0.finalize() }
     }
 
     public override var isTrimmable: Bool {

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -88,6 +88,15 @@ public struct LMInput {
         ) -> Text {
             Text(tokens: tokens[indices, stream: stream], mask: mask)
         }
+
+        /// Per-batch sequence lengths derived from the optional attention mask.
+        public var sequenceLengths: [Int]? {
+            if let mask {
+                return mask.asType(.int32).sum(axis: -1).asArray(Int.self)
+            }
+            guard tokens.ndim == 2 else { return nil }
+            return Array(repeating: tokens.dim(1), count: tokens.dim(0))
+        }
     }
 
     /// Representation of prepared input image(s).

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -205,10 +205,25 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     mutating func speculateRound() {
         guard !passthrough else { return }
 
-        // Cap drafting by maxTokens.
-        let remaining = maxTokens.map { $0 - tokenCount } ?? (blockSize - 1)
-        let numDraft = Swift.min(remaining, blockSize - 1)
-        guard numDraft > 0 else { return }
+        // A speculative round can emit up to `numDraft + 1` tokens: the
+        // accepted draft prefix plus the verifier's correction/bonus token.
+        // Keep the whole pending buffer within the remaining output budget.
+        let numDraft: Int
+        if let maxTokens {
+            let remaining = maxTokens - tokenCount
+            guard remaining > 0 else { return }
+
+            let draftBudget = Swift.min(remaining - 1, blockSize - 1)
+            guard draftBudget > 0 else {
+                if let token = passthroughStep() {
+                    pendingTokens.append(token)
+                }
+                return
+            }
+            numDraft = draftBudget
+        } else {
+            numDraft = blockSize - 1
+        }
 
         guard
             let state = mainState,

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -408,7 +408,8 @@ private enum Language {
 
             Bx = concatenated([state!, Bx], axis: -2)
             if let cache {
-                cache[0] = Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...]
+                cache[0] = contiguous(Bx[0..., (Bx.dim(1) - (lCache - 1))..., 0...])
+                cache.advance(x.dim(1))
             }
 
             let convOut = conv(Bx)
@@ -1033,7 +1034,9 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
             pixelAttentionMask: pixelAttentionMask
         )
 
-        let result = languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings)
+        let result = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
+            languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings)
+        }
 
         return .logits(result)
     }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -538,7 +538,7 @@ enum Qwen35Language {
 
             let convInput = concatenated([convState, mixedQKV], axis: 1)
             if let cache, convKernelSize > 1 {
-                cache[0] = convInput[0..., (-(convKernelSize - 1))...]
+                cache[0] = contiguous(convInput[0..., (-(convKernelSize - 1))..., 0...])
             }
 
             let convOut = silu(conv1d(convInput))
@@ -572,6 +572,7 @@ enum Qwen35Language {
 
             if let cache {
                 cache[1] = state
+                cache.advance(S)
             }
 
             out = norm(out, gate: z)
@@ -1025,17 +1026,19 @@ public class Qwen35: Module, VLMModel {
         }
 
         let typedCache = castCache(cache)
-        let output = languageModel(
-            inputIds,
-            inputsEmbeds: inputEmbeddings,
-            cache: typedCache,
-            state: nil,
-            mask: input.text.mask,
-            positionIds: nil,
-            pixelValues: pixelValues,
-            imageGridTHW: imageFrames,
-            videoGridTHW: videoFrames
-        )
+        let output = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
+            languageModel(
+                inputIds,
+                inputsEmbeds: inputEmbeddings,
+                cache: typedCache,
+                state: nil,
+                mask: input.text.mask,
+                positionIds: nil,
+                pixelValues: pixelValues,
+                imageGridTHW: imageFrames,
+                videoGridTHW: videoFrames
+            )
+        }
 
         return .logits(output)
     }

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -31,6 +31,26 @@ private func assertArraysClose(_ lhs: [MLXArray], _ rhs: [MLXArray], label: Stri
     }
 }
 
+private final class LifecycleRecordingCache: BaseKVCache {
+    private(set) var preparedLengths: [Int]?
+    private(set) var finalizeCallCount = 0
+
+    override func prepare(lengths: [Int]?) {
+        preparedLengths = lengths
+    }
+
+    override func finalize() {
+        finalizeCallCount += 1
+    }
+
+    override func copy() -> any KVCache {
+        let new = LifecycleRecordingCache()
+        new.preparedLengths = preparedLengths
+        new.finalizeCallCount = finalizeCallCount
+        return new
+    }
+}
+
 // MARK: - Original parameterized test (updated with value assertions)
 
 @Test(
@@ -168,6 +188,88 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     assertArraysClose(restored.state, cache.state)
 }
 
+@Test func testArraysCacheMaskUsesLeftPaddingAfterStateUpdate() throws {
+    let cache = ArraysCache(size: 2, leftPadding: [1, 3])
+    cache[0] = MLXArray.ones([2, 4], dtype: .float32)
+
+    let mask = try #require(cache.makeMask(N: 4))
+    #expect(
+        mask.asArray(Bool.self) == [
+            false, true, true, true,
+            false, false, false, true,
+        ])
+}
+
+@Test func testArraysCacheAdvanceUpdatesSequenceMetadataOnly() throws {
+    let cache = ArraysCache(size: 2, leftPadding: [3, 5])
+    cache.offset = 7
+    cache.prepare(lengths: [4, 6])
+
+    cache.advance(2)
+
+    #expect(cache.offset == 7)
+    #expect(cache.leftPaddingValues == [1, 3])
+    #expect(cache.lengthsValues == [2, 4])
+}
+
+@Test func testArraysCacheMaskUsesLengthsWhenLeftPaddingIsAbsent() throws {
+    let cache = ArraysCache(size: 2)
+    cache.prepare(lengths: [1, 3])
+
+    let mask = try #require(cache.makeMask(N: 4))
+    #expect(
+        mask.asArray(Bool.self) == [
+            true, false, false, false,
+            true, true, true, false,
+        ])
+}
+
+@Test func testTextSequenceLengthsComeFromAttentionMask() throws {
+    let tokens = MLXArray(0 ..< 8).reshaped(2, 4)
+    let mask = MLXArray([1, 1, 0, 0, 1, 1, 1, 0]).reshaped(2, 4)
+    let text = LMInput.Text(tokens: tokens, mask: mask)
+
+    #expect(text.sequenceLengths == [2, 3])
+}
+
+@Test func testTextSequenceLengthsInferUniformBatches() throws {
+    let text = LMInput.Text(tokens: MLXArray(0 ..< 8).reshaped(2, 4))
+
+    #expect(text.sequenceLengths == [4, 4])
+}
+
+@Test func testCacheListForwardsPrepareAndFinalize() throws {
+    let arrays = ArraysCache(size: 2)
+    let cache = CacheList(arrays, KVCacheSimple())
+
+    cache.prepare(lengths: [2, 4])
+    #expect(arrays.lengthsValues == [2, 4])
+
+    cache.finalize()
+    #expect(arrays.lengthsValues == nil)
+}
+
+@Test func testCacheListForwardsLifecycleThroughKVCacheProtocol() throws {
+    let lifecycle = LifecycleRecordingCache()
+    let cache = CacheList(KVCacheSimple(), lifecycle)
+
+    cache.prepare(lengths: [2, 4])
+    #expect(lifecycle.preparedLengths == [2, 4])
+
+    cache.finalize()
+    #expect(lifecycle.finalizeCallCount == 1)
+}
+
+@Test func testWithPreparedCacheScopesSequenceMetadata() throws {
+    let cache = ArraysCache(size: 2)
+
+    withPreparedCache([cache], lengths: [2, 4]) {
+        #expect(cache.lengthsValues == [2, 4])
+    }
+
+    #expect(cache.lengthsValues == nil)
+}
+
 @Test func testArraysCacheLengthsRoundTrip() throws {
     let cache = ArraysCache(size: 2)
     cache.prepare(lengths: [4, 2])
@@ -179,6 +281,7 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
 
     let restored = try #require(loaded[0] as? ArraysCache)
     #expect(restored.currentLengths?.asArray(Int.self) == [4, 2])
+    #expect(restored.lengthsValues == [4, 2])
     assertArraysClose(restored.state, cache.state)
 }
 
@@ -307,6 +410,48 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     #expect(copied.currentLengths?.asArray(Int.self) == [5, 3])
     #expect(copied[0]?.shape == [2, 3, 4])
     #expect(copied[1]?.shape == [2, 1, 4, 4])
+}
+
+@Test func testArraysCacheFilterKeepsSequenceMetadata() throws {
+    let cache = ArraysCache(size: 2, leftPadding: [1, 3])
+    cache.prepare(lengths: [2, 4])
+    cache[0] = MLXArray.ones([2, 4], dtype: .float32)
+
+    cache.filter(batchIndices: MLXArray([1]))
+
+    #expect(cache.leftPaddingValues == [3])
+    #expect(cache.lengthsValues == [4])
+}
+
+@Test func testArraysCacheExtendPadsMissingSlotsAndMetadata() throws {
+    let first = ArraysCache(size: 2, leftPadding: [1, 3])
+    first.prepare(lengths: [2, 4])
+    first[0] = MLXArray.ones([2, 4], dtype: .float32)
+
+    let second = ArraysCache(size: 2)
+    second[1] = MLXArray.ones([1, 4], dtype: .float32) * 2
+
+    first.extend(other: second)
+
+    #expect(first[0]?.shape == [3, 4])
+    #expect(first[1]?.shape == [3, 4])
+    #expect(first.leftPaddingValues == [1, 3, 0])
+    #expect(first.lengthsValues == [2, 4, 0])
+}
+
+@Test func testArraysCacheCopyPreservesSparseSlotsAndMetadata() throws {
+    let cache = ArraysCache(size: 3, leftPadding: [2])
+    cache.prepare(lengths: [5])
+    cache[2] = MLXArray.ones([1, 4], dtype: .float32)
+
+    let copied = try #require(cache.copy() as? ArraysCache)
+
+    #expect(copied.slotCount == 3)
+    #expect(copied[0] == nil)
+    #expect(copied[1] == nil)
+    #expect(copied[2] != nil)
+    #expect(copied.leftPaddingValues == [2])
+    #expect(copied.lengthsValues == [5])
 }
 
 // MARK: - MambaCache type preservation

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -313,6 +313,38 @@ func testMTPIteratorPendingBufferDrainOrder() throws {
     #expect(iter.acceptedCount == 2)
 }
 
+@Test
+func testMTPIteratorUsesSingleStepWhenOnlyOneTokenRemains() throws {
+    // With maxTokens=2, the prepare-time bonus consumes the first output slot.
+    // Only one slot remains, so a speculative round would be unable to emit
+    // both an accepted draft and the verifier's correction/bonus token. The
+    // iterator must take one normal main-model step instead.
+    let mainLogitTokens: [Int32] = [
+        0, 0, 5,  // prefill follow-up picks bonus 5
+        11,  // single-token tail step
+    ]
+    let main = MockMainModel(nextLogitTokens: mainLogitTokens)
+    let drafter = MockDrafter(draftedTokenValue: 11)
+    let input = LMInput(tokens: MLXArray([Int32(1), 2, 3]))
+    let cache = CountingKVCache()
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: input, mainModel: main, drafter: drafter, mainCache: [cache],
+        parameters: GenerateParameters(maxTokens: 2), blockSize: 4
+    )
+
+    let tokens = [iter.next(), iter.next(), iter.next()]
+
+    #expect(tokens[0] == 5)
+    #expect(tokens[1] == 11)
+    #expect(tokens[2] == nil)
+    #expect(iter.tokenCount == 2)
+    #expect(drafter.draftBlockCallCount == 0)
+    #expect(iter.proposedCount == 0)
+    #expect(iter.acceptedCount == 0)
+    #expect(cache.offset == 4)
+}
+
 // MARK: - LogitProcessor emit-only invariant
 
 /// Records `didSample(token:)` calls so a test can verify which tokens the

--- a/Tests/MLXLMTests/SampleTests.swift
+++ b/Tests/MLXLMTests/SampleTests.swift
@@ -168,6 +168,29 @@ public class SampleTests: XCTestCase {
         XCTAssertEqual(values[3], 0.0, accuracy: 1e-6)
     }
 
+    func testPresencePenaltyDoesNotMutateLogitsViewSource() {
+        var processor = PresencePenaltyContext(presencePenalty: 0.5, presenceContextSize: 20)
+        processor.prompt(MLXArray([1, 3]))
+
+        let source = MLXArray([
+            0.0 as Float, 1.0 as Float, 2.0 as Float, 3.0 as Float,
+            10.0 as Float, 11.0 as Float, 12.0 as Float, 13.0 as Float,
+        ]).reshaped(1, 2, 4)
+        let logitsView = source[0..., 1, 0...]
+
+        let processed = processor.process(logits: logitsView)
+
+        zip(processed[0].asArray(Float.self), [10.0, 10.5, 12.0, 12.5]).forEach {
+            XCTAssertEqual($0, $1, accuracy: 1e-6)
+        }
+        zip(
+            source.asArray(Float.self),
+            [0.0, 1.0, 2.0, 3.0, 10.0, 11.0, 12.0, 13.0]
+        ).forEach {
+            XCTAssertEqual($0, $1, accuracy: 1e-6)
+        }
+    }
+
     func testFrequencyPenaltyContextPenalizesByTokenCount() {
         var processor = FrequencyPenaltyContext(frequencyPenalty: 0.5, frequencyContextSize: 5)
         processor.prompt(MLXArray([0, 0, 0, 1, 1]))

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -6,6 +6,7 @@ import MLXLLM
 import MLXLMCommon
 import Testing
 
+@Suite(.serialized)
 struct SpeculativeDecodingTests {
 
     let processor: any UserInputProcessor


### PR DESCRIPTION
## Proposed changes

Qwen3.6 models using `model_type: qwen3_5` rely heavily on hybrid linear-attention / GatedDelta layers. Keeping the convolution state contiguous avoids carrying strided slices through decode steps, which should reduce per-token cache overhead and better match upstream MLX Python behavior.

Advancing array-cache metadata and preserving left-padding masks also improves stability for padded or batched generation paths.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
