### PR TITLE
Moe refactoring -> reduces repeated small graph construction overhead

### DIFF
--- a/Libraries/MLXLLM/Models/AfMoE.swift
+++ b/Libraries/MLXLLM/Models/AfMoE.swift
@@ -338,7 +338,7 @@ class AfMoEMoE: Module, UnaryLayer {
 
         // Apply experts
         var y = experts(x, inds)
-        y = (y * selectedScores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = weightedExpertSum(y, selectedScores).asType(y.dtype)
 
         // Add shared expert output
         if let sharedExperts = sharedExperts {

--- a/Libraries/MLXLLM/Models/BailingMoe.swift
+++ b/Libraries/MLXLLM/Models/BailingMoe.swift
@@ -263,7 +263,7 @@ class BailingMoeSparseMoeBlock: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, weights) = gate.groupSelect(x)
         var out = switchMLP(x, inds)
-        out = (out * weights[.ellipsis, .newAxis]).sum(axis: -2)
+        out = weightedExpertSum(out, weights)
         if let shared = sharedExperts {
             out = out + shared(x)
         }

--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -330,7 +330,7 @@ class DeepseekV3MoE: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (indices, scores) = gate(x)
         var y = switchMLP(x, indices)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        y = weightedExpertSum(y, scores)
 
         if let shared = sharedExperts {
             y = y + shared(x)

--- a/Libraries/MLXLLM/Models/GLM4MOE.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOE.swift
@@ -214,7 +214,7 @@ class GLM4MoE: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = weightedExpertSum(y, scores).asType(y.dtype)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }

--- a/Libraries/MLXLLM/Models/GLM4MOELite.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOELite.swift
@@ -409,7 +409,7 @@ class GLM4MoELiteMoE: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = weightedExpertSum(y, scores).asType(y.dtype)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -315,7 +315,7 @@ class GraniteMoeHybridMoE: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (indices, gates) = router(x)
         let expertOutputs = switchMLP(x, indices)
-        return (expertOutputs * gates[.ellipsis, .newAxis]).sum(axis: -2)
+        return weightedExpertSum(expertOutputs, gates)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -359,7 +359,7 @@ class JambaSparseMoeBlock: Module {
         scores = MLX.softmax(scores, axis: -1, precise: true)
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return weightedExpertSum(y, scores)
     }
 }
 

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -304,8 +304,7 @@ class Lfm2MoeSparseMoeBlock: Module, UnaryLayer {
         scores = scores.asType(x.dtype)
 
         let expertOutputs = switchMLP(x, indices)
-        let weighted = expertOutputs * scores[.ellipsis, .newAxis]
-        return weighted.sum(axis: -2)
+        return weightedExpertSum(expertOutputs, scores)
     }
 }
 

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -302,7 +302,7 @@ class MiMoV2FlashMoE: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = weightedExpertSum(y, scores).asType(y.dtype)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }

--- a/Libraries/MLXLLM/Models/MiniMax.swift
+++ b/Libraries/MLXLLM/Models/MiniMax.swift
@@ -130,7 +130,7 @@ class MiniMaxSparseMoeBlock: Module {
         scores = scores.asType(x.dtype)
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return weightedExpertSum(y, scores)
     }
 }
 

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -527,7 +527,7 @@ private class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = weightedExpertSum(y, scores).asType(y.dtype)
 
         if let sharedExperts {
             y = y + sharedExperts(x)

--- a/Libraries/MLXLLM/Models/OlmoE.swift
+++ b/Libraries/MLXLLM/Models/OlmoE.swift
@@ -121,7 +121,7 @@ class OlmoeSparseMoeBlock: Module, UnaryLayer {
         }
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return weightedExpertSum(y, scores)
     }
 }
 

--- a/Libraries/MLXLLM/Models/PhiMoE.swift
+++ b/Libraries/MLXLLM/Models/PhiMoE.swift
@@ -143,7 +143,7 @@ class PhiMoESparseMoeBlock: Module {
         let scores = MLX.softmax(MLX.takeAlong(gates, inds, axis: -1), axis: -1, precise: true)
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return weightedExpertSum(y, scores)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -423,7 +423,7 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         }
 
         let y = switchMLP(x, inds)
-        let combined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        let combined = weightedExpertSum(y, scores)
 
         var sharedY = sharedExpert(x)
         sharedY = sigmoid(sharedExpertGate(x)) * sharedY

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -143,7 +143,7 @@ class Qwen3MoESparseMoeBlock: Module, UnaryLayer {
         }
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return weightedExpertSum(y, scores)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -340,7 +340,7 @@ final class Qwen3NextSparseMoeBlock: Module {
         }
 
         let y = switchMLP(x, inds)
-        let combined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        let combined = weightedExpertSum(y, scores)
 
         var sharedY = sharedExpert(x)
         sharedY = sigmoid(sharedExpertGate(x)) * sharedY

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -4,6 +4,18 @@ import MLXNN
 
 // Port of https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/switch_layers.py
 
+private let compiledSiluProduct: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { gate, up in
+    MLXNN.silu(gate) * up
+}
+
+public let weightedExpertSum: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { outputs, weights in
+    (outputs * MLX.expandedDimensions(weights, axis: -1)).sum(axis: -2)
+}
+
 public func gatherSort(x: MLXArray, indices: MLXArray) -> (MLXArray, MLXArray, MLXArray) {
     let m = indices.dim(-1)
     let indices = indices.flattened()
@@ -36,18 +48,42 @@ public class SwitchGLU: Module {
     let hiddenDims: Int
     let numExperts: Int
     let activation: (MLXArray) -> MLXArray
+    let activationProduct: (@Sendable (MLXArray, MLXArray) -> MLXArray)?
 
     public init(
         inputDims: Int,
         hiddenDims: Int,
         numExperts: Int,
-        activation: @escaping (MLXArray) -> MLXArray = MLXNN.silu,
+        bias: Bool = false
+    ) {
+        self.inputDims = inputDims
+        self.hiddenDims = hiddenDims
+        self.numExperts = numExperts
+        self.activation = MLXNN.silu
+        self.activationProduct = compiledSiluProduct
+
+        self._gateProj.wrappedValue = SwitchLinear(
+            inputDims: inputDims, outputDims: hiddenDims, numExperts: numExperts, bias: bias)
+        self._upProj.wrappedValue = SwitchLinear(
+            inputDims: inputDims, outputDims: hiddenDims, numExperts: numExperts, bias: bias)
+        self._downProj.wrappedValue = SwitchLinear(
+            inputDims: hiddenDims, outputDims: inputDims, numExperts: numExperts, bias: bias)
+
+        super.init()
+    }
+
+    public init(
+        inputDims: Int,
+        hiddenDims: Int,
+        numExperts: Int,
+        activation: @escaping (MLXArray) -> MLXArray,
         bias: Bool = false
     ) {
         self.inputDims = inputDims
         self.hiddenDims = hiddenDims
         self.numExperts = numExperts
         self.activation = activation
+        self.activationProduct = nil
 
         self._gateProj.wrappedValue = SwitchLinear(
             inputDims: inputDims, outputDims: hiddenDims, numExperts: numExperts, bias: bias)
@@ -73,8 +109,14 @@ public class SwitchGLU: Module {
 
         let xUp = upProj(x, idx, sortedIndices: doSort)
         let xGate = gateProj(x, idx, sortedIndices: doSort)
+        let activated =
+            if let activationProduct {
+                activationProduct(xGate, xUp)
+            } else {
+                activation(xGate) * xUp
+            }
         x = downProj(
-            activation(xGate) * xUp,
+            activated,
             idx,
             sortedIndices: doSort)
 
@@ -99,18 +141,40 @@ public class FusedGateUpSwitchGLU: Module {
     let hiddenDims: Int
     let numExperts: Int
     let activation: (MLXArray) -> MLXArray
+    let activationProduct: (@Sendable (MLXArray, MLXArray) -> MLXArray)?
 
     public init(
         inputDims: Int,
         hiddenDims: Int,
         numExperts: Int,
-        activation: @escaping (MLXArray) -> MLXArray = MLXNN.silu,
+        bias: Bool = false
+    ) {
+        self.inputDims = inputDims
+        self.hiddenDims = hiddenDims
+        self.numExperts = numExperts
+        self.activation = MLXNN.silu
+        self.activationProduct = compiledSiluProduct
+
+        self._gateUpProj.wrappedValue = SwitchLinear(
+            inputDims: inputDims, outputDims: 2 * hiddenDims, numExperts: numExperts, bias: bias)
+        self._downProj.wrappedValue = SwitchLinear(
+            inputDims: hiddenDims, outputDims: inputDims, numExperts: numExperts, bias: bias)
+
+        super.init()
+    }
+
+    public init(
+        inputDims: Int,
+        hiddenDims: Int,
+        numExperts: Int,
+        activation: @escaping (MLXArray) -> MLXArray,
         bias: Bool = false
     ) {
         self.inputDims = inputDims
         self.hiddenDims = hiddenDims
         self.numExperts = numExperts
         self.activation = activation
+        self.activationProduct = nil
 
         self._gateUpProj.wrappedValue = SwitchLinear(
             inputDims: inputDims, outputDims: 2 * hiddenDims, numExperts: numExperts, bias: bias)
@@ -134,8 +198,14 @@ public class FusedGateUpSwitchGLU: Module {
 
         let gateUp = gateUpProj(x, idx, sortedIndices: doSort)
         let parts = MLX.split(gateUp, parts: 2, axis: -1)
+        let activated =
+            if let activationProduct {
+                activationProduct(parts[0], parts[1])
+            } else {
+                activation(parts[0]) * parts[1]
+            }
         x = downProj(
-            activation(parts[0]) * parts[1],
+            activated,
             idx,
             sortedIndices: doSort)
 

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -587,8 +587,8 @@ private final class Gemma4TextExperts: Module {
             x.reshaped(batch * length, hidden),
             topKIndices.reshaped(batch * length, topK)
         )
-        let weights = topKWeights.reshaped(batch * length, topK, 1).asType(expertOutput.dtype)
-        return (expertOutput * weights).sum(axis: -2).reshaped(batch, length, hidden)
+        let weights = topKWeights.reshaped(batch * length, topK).asType(expertOutput.dtype)
+        return weightedExpertSum(expertOutput, weights).reshaped(batch, length, hidden)
     }
 }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -622,7 +622,7 @@ enum Qwen35Language {
             }
 
             let y = switchMLP(x, inds)
-            let combined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+            let combined = weightedExpertSum(y, scores)
 
             var sharedY = sharedExpert(x)
             sharedY = sigmoid(sharedExpertGate(x)) * sharedY

--- a/Tests/MLXLMTests/SwitchLayersTests.swift
+++ b/Tests/MLXLMTests/SwitchLayersTests.swift
@@ -1,0 +1,17 @@
+import MLX
+import MLXLMCommon
+import XCTest
+
+final class SwitchLayersTests: XCTestCase {
+    func testWeightedExpertSumMatchesGenericExpression() {
+        let outputs = MLXArray(0 ..< 24).asType(.float32).reshaped(2, 3, 4)
+        let weights = MLXArray([Float](arrayLiteral: 0.25, 0.75, 1.0, 0.0, 0.5, 0.5))
+            .reshaped(2, 3)
+
+        let expected = (outputs * weights[.ellipsis, .newAxis]).sum(axis: -2)
+        let actual = weightedExpertSum(outputs, weights)
+
+        eval(expected, actual)
+        XCTAssertTrue(allClose(actual, expected).item(Bool.self))
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR reduces repeated small graph construction overhead in shared MoE paths.

Many MoE models combine routed expert outputs with router scores using the same expression:

```swift
(outputs * weights[..., .newAxis]).sum(axis: -2)
```

This PR centralizes that pattern behind a shared compiled helper, `weightedExpertSum`, and updates MoE model implementations to use it. It also adds a compiled default-SiLU product path for `SwitchGLU` / `FusedGateUpSwitchGLU`, covering the common:

```swift
silu(gate) * up
```

case while preserving the existing generic path for custom activations.

The intent is to reduce Swift/MLX dispatch and graph setup overhead in MoE-heavy models without changing model math, weights, quantization, cache behavior, or dependency versions.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)