### PR TITLE
fix speculative decode tests

### DIFF
--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -28,7 +28,7 @@ struct SpeculativeDecodingTests {
         let mainModel = Gemma3TextModel(modelConfig)
 
         // on hardware with a NAX, float32 (the default dtype) runs
-        // in tf32 in bach mode and float32 in non-batch.  this
+        // in tf32 in batch mode and float32 in non-batch.  this
         // change in behavior can cause issues with prediction and
         // doesn't match real world behavior (where float32 is not used)
         mainModel.apply {

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -26,6 +26,18 @@ struct SpeculativeDecodingTests {
         )
 
         let mainModel = Gemma3TextModel(modelConfig)
+
+        // on hardware with a NAX, float32 (the default dtype) runs
+        // in tf32 in bach mode and float32 in non-batch.  this
+        // change in behavior can cause issues with prediction and
+        // doesn't match real world behavior (where float32 is not used)
+        mainModel.apply {
+            if $0.dtype == .float32 {
+                $0.asType(.float16)
+            } else {
+                $0
+            }
+        }
         let mainContext = ModelContext(
             configuration: processor.configuration,
             model: mainModel,
@@ -34,6 +46,13 @@ struct SpeculativeDecodingTests {
         )
 
         let draftModel = Gemma3TextModel(modelConfig)
+        draftModel.apply {
+            if $0.dtype == .float32 {
+                $0.asType(.float16)
+            } else {
+                $0
+            }
+        }
         let draftContext = ModelContext(
             configuration: processor.configuration,
             model: draftModel,


### PR DESCRIPTION
## Proposed changes

- fix #315
- run models in float16 (more typical) and avoid the float32/tf32 mismatch

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
