### PR TITLE
Fix Gemma4 QAT (E-series) load: KV-shared layers have no k_proj/v_proj/k_norm

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1428,11 +1428,30 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
     }
 
     func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        let firstKVSharedLayer = config.hiddenLayers - config.numKVSharedLayers
         var sanitized: [String: MLXArray] = [:]
         sanitized.reserveCapacity(weights.count + 1)
 
         for (key, value) in weights {
             if key.contains("rotary_emb") {
+                continue
+            }
+            // Drop redundant k_proj/v_proj/k_norm for KV-shared layers: they reuse an
+            // earlier layer's K/V and own no K projection or K norm, so the module tree
+            // has none. QAT checkpoints already omit these; some (PTQ) checkpoints still
+            // ship them, and keeping them would be an unexpected weight.
+            // Scope: text backbone only — the vision/audio towers share the
+            // `layers.N.self_attn.{k,v}_proj` naming, so without these guards the drop
+            // would amputate tower layers >= firstKVSharedLayer.
+            if firstKVSharedLayer > 0,
+                !key.contains("vision_tower"),
+                !key.contains("audio_tower"),
+                key.contains("self_attn.k_proj")
+                    || key.contains("self_attn.v_proj")
+                    || key.contains("self_attn.k_norm"),
+                let layerIdx = Self.decoderLayerIndex(in: key),
+                layerIdx >= firstKVSharedLayer
+            {
                 continue
             }
 
@@ -1486,6 +1505,13 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
         }
 
         return sanitized
+    }
+
+    /// Extract `N` from a weight key shaped like `…layers.N.…`, else nil.
+    private static func decoderLayerIndex(in key: String) -> Int? {
+        guard let range = key.range(of: "layers.") else { return nil }
+        let digits = key[range.upperBound...].prefix { $0.isNumber }
+        return Int(digits)
     }
 }
 


### PR DESCRIPTION
## What

Gemma 4 E-series (E2B/E4B) shares K/V across the last `num_kv_shared_layers` layers.
Those layers reuse the K/V of an earlier layer of the same attention type — they still
compute their own queries (`q_proj`/`q_norm`) but own **no** `k_proj`, `v_proj` or
`k_norm`. `Gemma4TextModelInner` already routes their KV via `previousKvs`/`sharedKV`,
and the forward path never touches `kProj`/`kNorm`/`vProj` for them.

But `Gemma4Attention` declared `k_proj`/`k_norm` as non-optional and created
`k_proj`/`v_proj`/`k_norm` **unconditionally** for every layer, so the loader demanded
`layers.N.self_attn.{k_proj,v_proj,k_norm}` for the KV-shared layers too.

Full-precision / PTQ checkpoints still carry those (now-redundant) tensors, so they
happened to load. **Quantization-aware (QAT)** checkpoints prune them, so e.g.
`mlx-community/gemma-4-E2B-it-qat-4bit` fails at layer 15 (the first shared layer):

```
keyNotFound layers.15.self_attn.v_proj.weight    (then k_norm.weight)
```

Confirmed against the checkpoint's `model.safetensors.index.json`: an owner layer (14)
ships `q/k/v_proj`, `q_norm`, `k_norm`, `o_proj`; a shared layer (15) ships only
`q_proj`, `q_norm`, `o_proj`. `v_norm` is `RMSNormNoScale` (parameter-free) so it never
appears in any checkpoint and needs no change.

## Change (`Gemma4Text.swift`)

- Make `kProj` and `kNorm` optional (`vProj` was already optional).
- Create `k_proj`/`v_proj`/`k_norm` only for the KV-**owning** layers, using the same
  `layerIdx >= numHiddenLayers - numKvSharedLayers` predicate already used for the
  double-wide-MLP gate.
- Guard the compute path (only KV-owning layers reach it; KV-shared layers always
  receive `sharedKV`).
- In `sanitize`, drop any redundant `k_proj`/`v_proj`/`k_norm` of KV-shared layers, so
  PTQ checkpoints that still ship them keep loading against the now-smaller module tree.

Net change is +50/−7 in one file; the forward/inference logic is untouched (it already
handled sharing correctly — only the module declarations over-claimed weights).

## Relationship to #320

This builds on top of @nyteshade's #320 (*make `per_layer_model_projection`
quantizable*) — that commit is **included here to preserve attribution**. #320 fixes the
**first** QAT load error (the PLE projection); this fixes the **second** (KV sharing).
Both are required for the QAT E-series checkpoints to load. Happy to rebase onto `main`
once #320 merges (then this becomes a single-commit follow-up).

## Verification

macOS (Apple Silicon), `mlx-community/gemma-4-E2B-it-qat-4bit`:

- **Before:** hard `keyNotFound` at layer 15 during load.
- **After:** loads and generates. Sample (text-only prompt through a tool-enabled
  session):

  > `[mood: thinking] I can check your sleep, steps, and heart rate for you. I'll start
  > with your health context.`

PTQ checkpoints (`mlx-community/gemma-4-e2b-it-4bit`) continue to load unchanged (the
`sanitize` drop handles the redundant tensors they still carry).
