### PR TITLE
Align Falcon H1 with upstream MLX inference

### DIFF
--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -291,7 +291,11 @@ class FalconH1Attention: Module {
             maxPositionEmbeddings: args.maxPositionEmbeddings)
     }
 
-    func callAsFunction(_ x: MLXArray, mask: MLXArray? = nil, cache: KVCache? = nil) -> MLXArray {
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode = .none,
+        cache: KVCache? = nil
+    ) -> MLXArray {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x)
@@ -306,14 +310,11 @@ class FalconH1Attention: Module {
         queries = applyRotaryPosition(rope, to: queries, offset: offset)
         keys = applyRotaryPosition(rope, to: keys, offset: offset)
 
-        if let cache {
-            (keys, values) = cache.update(keys: keys, values: values)
-        }
-
-        var output = MLXFast.scaledDotProductAttention(
+        var output = attentionWithCacheUpdate(
             queries: queries,
             keys: keys,
             values: values,
+            cache: cache,
             scale: scale,
             mask: mask
         )
@@ -428,7 +429,15 @@ class FalconH1Mixer: Module {
         let paddedInput = concatenated([convState, convInput], axis: 1)
 
         if let cache = cache {
-            cache[0] = paddedInput[0..., (-(convKernelSize - 1))...]
+            let nKeep = convKernelSize - 1
+            if let lengths = cache.currentLengths {
+                let t = paddedInput.dim(1)
+                let ends = clip(lengths, min: 0, max: t - nKeep)
+                let positions = (ends[0..., .newAxis] + MLXArray(0 ..< nKeep))[.ellipsis, .newAxis]
+                cache[0] = MLX.takeAlong(paddedInput, positions, axis: 1)
+            } else {
+                cache[0] = paddedInput[0..., (-nKeep)...]
+            }
         }
 
         let convOutput = conv1d(paddedInput)
@@ -441,7 +450,8 @@ class FalconH1Mixer: Module {
         C: MLXArray,
         dt: MLXArray,
         state: MLXArray? = nil,
-        mask: MLXArray? = nil
+        mask: MLXArray? = nil,
+        lengths: MLXArray? = nil
     ) -> (MLXArray, MLXArray) {
         let (batchSize, seqLen, _) = (hiddenStates.dim(0), hiddenStates.dim(1), hiddenStates.dim(2))
 
@@ -459,7 +469,8 @@ class FalconH1Mixer: Module {
             dtBias: dtBias,
             state: state,
             timeStepLimit: timeStepLimit,
-            mask: mask
+            mask: mask,
+            lengths: lengths
         )
 
         return (y.reshaped(batchSize, seqLen, intermediateSize), newState)
@@ -504,10 +515,13 @@ class FalconH1Mixer: Module {
             C: C,
             dt: dt,
             state: state,
-            mask: mask
+            mask: mask,
+            lengths: cache?.currentLengths
         )
         if let cache = cache {
             cache[1] = state
+            cache.advance(y.dim(1))
+            cache.offset += y.dim(1)
         }
 
         if let norm = norm {
@@ -577,7 +591,7 @@ class FalconH1DecoderLayer: Module {
     func callAsFunction(
         _ h: MLXArray,
         cache: CacheList?,
-        attnMask: MLXArray?,
+        attnMask: MLXFast.ScaledDotProductAttentionMaskMode,
         mambaMask: MLXArray?
     ) -> MLXArray {
         var residual = h
@@ -598,26 +612,6 @@ class FalconH1DecoderLayer: Module {
         h = feedForward(h)
         return residual + h
     }
-}
-
-// MARK: - Helper Functions
-
-private func createSSMMask(h: MLXArray, cache: ArraysCache?) -> MLXArray? {
-    if let cache = cache {
-        return cache.makeMask(N: h.dim(1))
-    }
-    return nil
-}
-
-private func createAttentionMask(h: MLXArray, cache: [KVCache]?) -> MLXArray? {
-    let N = h.dim(1)
-    // If cache exists and can make masks, use it
-    // Otherwise for single token, no mask needed
-    // For multi-token, SDPA will handle causal mask internally when nil
-    if N == 1 {
-        return nil
-    }
-    return nil  // Will be handled by SDPA internally when nil
 }
 
 // MARK: - Model
@@ -656,8 +650,7 @@ public class FalconH1ModelInner: Module {
         let cache: [CacheList?] = cache ?? Array(repeating: nil, count: layers.count)
 
         let mambaMask = createSSMMask(h: h, cache: cache[0]?[0] as? MambaCache)
-        let attnMask: MLXArray? = createAttentionMask(
-            h: h, cache: cache[0]?[1] != nil ? [cache[0]![1]] : nil)
+        let attnMask = createAttentionMask(h: h, cache: cache[0]?[1])
 
         for (layer, c) in zip(layers, cache) {
             h = layer(
@@ -679,20 +672,26 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
     public let model: FalconH1ModelInner
     let configuration: FalconH1Configuration
 
-    @ModuleInfo(key: "lm_head") var lmHead: Linear
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
     public init(_ args: FalconH1Configuration) {
         self.configuration = args
         self.vocabularySize = args.vocabSize
-        self.kvHeads = (0 ..< args.numKeyValueHeads).map { _ in args.numHiddenLayers }
+        self.kvHeads = (0 ..< args.numHiddenLayers).map { _ in args.numKeyValueHeads }
         self.model = FalconH1ModelInner(args)
 
-        _lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabSize, bias: false)
+        if !args.tieWordEmbeddings {
+            _lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabSize, bias: false)
+        }
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         let out = model(inputs, cache: cache as? [CacheList])
-        return lmHead(out)
+        if let lmHead {
+            return lmHead(out)
+        }
+        return model.embedTokens.asLinear(out)
+            * (configuration.lmHeadMultiplier / configuration.embeddingMultiplier)
     }
 
     public func makeCache() -> [CacheList] {

--- a/Libraries/MLXLLM/Models/SSM.swift
+++ b/Libraries/MLXLLM/Models/SSM.swift
@@ -14,7 +14,7 @@ import MLXNN
 public func computeDt(_ dt: MLXArray, _ dtBias: MLXArray, _ timeStepLimit: (Float, Float))
     -> MLXArray
 {
-    let dt = softplus(dt + dtBias)
+    let dt = softplus(dt.asType(.float32) + dtBias)
     return MLX.clip(dt, min: timeStepLimit.0, max: timeStepLimit.1)
 }
 
@@ -50,7 +50,7 @@ private func makeSSMKernel() -> MLXFast.MLXFastKernel? {
                 auto idx = d_idx * Ds + s_idx;
                 auto dB_by_x = x_ * dt_ * static_cast<float>(B_[s_idx]);
                 auto state = dA * i_state[idx] + dB_by_x;
-                o_state[idx] = static_cast<T>(state);
+                o_state[idx] = static_cast<U>(state);
                 acc += state * C_[s_idx];
             }
             acc = simd_sum(acc);
@@ -90,6 +90,7 @@ func ssmUpdateKernel(
 ) -> (MLXArray, MLXArray) {
     let (n, _, h, d) = hiddenStates.shape4
     let inputType = hiddenStates.dtype
+    let stateType = state.dtype
     let (hb, ds) = (B.dim(-2), B.dim(-1))
 
     let dt = computeDt(dt, dtBias, timeStepLimit)
@@ -102,6 +103,7 @@ func ssmUpdateKernel(
         [hiddenStates, ALog, B, C, D, dt, state],
         template: [
             ("T", inputType),
+            ("U", stateType),
             ("Dh", d),
             ("Ds", ds),
             ("H", h),
@@ -110,7 +112,7 @@ func ssmUpdateKernel(
         grid: (32, d, h * n),
         threadGroup: (32, 8, 1),
         outputShapes: [[n, 1, h, d], state.shape],
-        outputDTypes: [inputType, inputType]
+        outputDTypes: [inputType, stateType]
     )
 
     return (outputs[0], outputs[1])
@@ -150,47 +152,104 @@ public func ssmAttn(
     dtBias: MLXArray,
     state: MLXArray? = nil,
     timeStepLimit: (Float, Float) = (0.001, 100.0),
-    mask: MLXArray? = nil
+    mask: MLXArray? = nil,
+    lengths: MLXArray? = nil,
+    step: Int = 256
 ) -> (MLXArray, MLXArray) {
     let (b, l, h, dh) = x.shape4
     let (_, _, g, d) = B.shape4
 
     let dt = computeDt(dt, dtBias, timeStepLimit)
     let repeats = h / g
-    let A = -MLX.exp(ALog)
-    var B = MLX.transposed(B, axes: [0, 2, 3, 1])
-
-    // A * s + B * C
-    var CB = MLX.swappedAxes(C, 1, 2).matmul(B)
-    CB = MLX.repeated(CB, count: repeats, axis: 1)
-
+    let A = -MLX.exp(ALog).asType(dt.dtype)
     let dtA = dt * A.reshaped(1, 1, -1)
-    var decay = MLX.exp(segsum(dtA.swappedAxes(1, 2), mask: mask))
-
-    let surrogateAttentionMatrix = MLX.tril(CB * decay, k: 0)
-
     let dtx = dt.reshaped(b, l, h, 1) * x
-    var y = surrogateAttentionMatrix.matmul(dtx.swappedAxes(1, 2))
-    y = MLX.swappedAxes(y, 1, 2)
+    let stateType = state?.dtype ?? x.dtype
 
-    decay = decay[0..., 0..., (-1)..., 0...].transposed(0, 3, 1, 2)
-    B = MLX.repeated(B, count: h / g, axis: 1).swappedAxes(2, 3)
-    var dtxdecay = dtx * decay
-    dtxdecay = dtxdecay.swappedAxes(1, 2).swappedAxes(2, 3)
+    func stepForward(
+        dtx: MLXArray,
+        dtA: MLXArray,
+        B: MLXArray,
+        C: MLXArray,
+        state: MLXArray?,
+        mask: MLXArray?,
+        lengths: MLXArray?
+    ) -> (MLXArray, MLXArray) {
+        let s = dtx.dim(1)
+        var B = MLX.transposed(B, axes: [0, 2, 3, 1])
 
-    var nextState = dtxdecay.matmul(B)
+        var CB = MLX.swappedAxes(C, 1, 2).matmul(B)
+        CB = MLX.repeated(CB, count: repeats, axis: 1)
 
-    if var state = state {
-        let expDtACumsum = MLX.exp(MLX.cumsum(dtA, axis: -2))
-        nextState = nextState + expDtACumsum[0..., -1, 0..., .newAxis, .newAxis] * state
-        state = state.reshaped(b, 1, g, repeats, dh, d)
-        let C = C.reshaped(b, l, g, 1, d, 1)
-        let yPrev = (state.matmul(C)).squeezed(axis: -1).flattened(start: 2, end: 3)
-        y = y + expDtACumsum[.ellipsis, .newAxis] * yPrev
+        var decay = MLX.exp(segsum(dtA.swappedAxes(1, 2), mask: mask))
+
+        let surrogateAttentionMatrix = MLX.tril(CB * decay, k: 0)
+
+        var y = surrogateAttentionMatrix.matmul(dtx.swappedAxes(1, 2))
+        y = MLX.swappedAxes(y, 1, 2)
+
+        if let lengths {
+            var pos = MLX.minimum(lengths, MLXArray(step)) - 1
+            pos = MLX.maximum(pos, MLXArray(0))
+            pos = expandedDimensions(pos, axes: [1, 2, 3])
+            decay = MLX.takeAlong(decay, pos, axis: 2)
+        } else {
+            decay = decay[0..., 0..., (-1)..., 0...]
+        }
+        decay = decay.transposed(0, 3, 1, 2)
+        B = MLX.repeated(B, count: h / g, axis: 1).swappedAxes(2, 3)
+        var dtxdecay = dtx * decay
+        dtxdecay = dtxdecay.swappedAxes(1, 2).swappedAxes(2, 3)
+
+        var nextState = dtxdecay.matmul(B)
+
+        if var state {
+            let expDtACumsum = MLX.exp(MLX.cumsum(dtA, axis: -2))
+            nextState = nextState + expDtACumsum[0..., -1, 0..., .newAxis, .newAxis] * state
+            state = state.reshaped(b, 1, g, repeats, dh, d)
+            let C = C.reshaped(b, s, g, 1, d, 1)
+            let yPrev = (state.matmul(C)).squeezed(axis: -1).flattened(start: 2, end: 3)
+            y = y + expDtACumsum[.ellipsis, .newAxis] * yPrev
+        }
+        if let state, let lengths {
+            nextState = MLX.where(
+                expandedDimensions(lengths .< 0, axes: [1, 2, 3]), state, nextState)
+        }
+
+        return (y.asType(x.dtype), nextState.asType(stateType))
     }
 
-    y = y + x * D.reshaped(1, 1, h, 1)
-    return (y, nextState)
+    var ys = [MLXArray]()
+    ys.reserveCapacity((l + step - 1) / step)
+
+    var state = state
+    var lengths = lengths
+    for i in stride(from: 0, to: l, by: step) {
+        let end = min(i + step, l)
+        let maskChunk = mask == nil ? nil : mask![0..., i ..< end]
+        let (y, nextState) = stepForward(
+            dtx: dtx[0..., i ..< end],
+            dtA: dtA[0..., i ..< end],
+            B: B[0..., i ..< end],
+            C: C[0..., i ..< end],
+            state: state,
+            mask: maskChunk,
+            lengths: lengths
+        )
+        ys.append(y)
+        state = nextState
+        asyncEval(y, nextState)
+        if let currentLengths = lengths {
+            lengths = currentLengths - step
+        }
+    }
+
+    let y = MLX.concatenated(ys, axis: 1) + x * D.reshaped(1, 1, h, 1)
+    guard let state else {
+        fatalError("SSM update did not produce a state")
+    }
+    eval(y, state)
+    return (y, state)
 }
 
 public func ssmUpdate(
@@ -203,7 +262,8 @@ public func ssmUpdate(
     dtBias: MLXArray,
     state: MLXArray? = nil,
     timeStepLimit: (Float, Float) = (0.001, 100.0),
-    mask: MLXArray? = nil
+    mask: MLXArray? = nil,
+    lengths: MLXArray? = nil
 ) -> (MLXArray, MLXArray) {
     let seqLen = hiddenStates.dim(1)
 
@@ -233,7 +293,8 @@ public func ssmUpdate(
             dtBias: dtBias,
             state: state,
             timeStepLimit: timeStepLimit,
-            mask: mask
+            mask: mask,
+            lengths: lengths
         )
     }
 }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1165,6 +1165,7 @@ public class ChunkedKVCache: KVCacheSimple {
 public class ArraysCache: BaseKVCache {
     private var cache: [MLXArray?]
     internal var leftPadding: MLXArray?
+    internal var lengths: MLXArray?
 
     public init(size: Int, leftPadding: [Int]? = nil) {
         self.cache = Array(repeating: nil, count: size)
@@ -1192,13 +1193,22 @@ public class ArraysCache: BaseKVCache {
 
     public override func copy() -> any KVCache {
         let new = ArraysCache(size: cache.count)
+        copyContents(to: new)
+        return new
+    }
+
+    internal func copyContents(to new: ArraysCache) {
         let s = self.state
         if !s.isEmpty {
             new.state = s.map { $0[.ellipsis] }
         }
         new.offset = self.offset
         new.leftPadding = self.leftPadding
-        return new
+        new.lengths = self.lengths
+    }
+
+    internal var batchSize: Int {
+        cache.lazy.compactMap { $0?.dim(0) }.first ?? leftPadding?.size ?? lengths?.size ?? 1
     }
 
     /// In-place filter to keep just the given indices in the cache
@@ -1206,24 +1216,78 @@ public class ArraysCache: BaseKVCache {
         cache = cache.map { c in
             c?[batchIndices]
         }
-        leftPadding = nil
+        leftPadding = leftPadding?[batchIndices]
+        lengths = lengths?[batchIndices]
     }
 
     /// In-place extend this cache with the other cache
     public func extend(other: ArraysCache) {
-        cache = zip(cache, other.cache).map { (c, o) in
-            if let c = c, let o = o {
-                return MLX.concatenated([c, o])
+        let aBatch = batchSize
+        let bBatch = other.batchSize
+
+        func concatenate(_ a: MLXArray?, _ b: MLXArray?) -> MLXArray? {
+            guard let example = a ?? b else {
+                return nil
             }
-            return c ?? o
+
+            let suffixShape = Array(example.shape.dropFirst())
+            let dtype = example.dtype
+            let lhs = a ?? MLXArray.zeros([aBatch] + suffixShape, dtype: dtype)
+            let rhs = b ?? MLXArray.zeros([bBatch] + suffixShape, dtype: dtype)
+            return MLX.concatenated([lhs, rhs])
         }
+
+        cache = zip(cache, other.cache).map { c, o in
+            concatenate(c, o)
+        }
+        leftPadding = concatenate(leftPadding, other.leftPadding)
+        lengths = concatenate(lengths, other.lengths)
+    }
+
+    public func prepare(lengths: [Int]?) {
+        self.lengths = lengths.map { MLXArray($0) }
+    }
+
+    public func prepare(lengths: MLXArray?) {
+        self.lengths = lengths
+    }
+
+    public func finalize() {
+        lengths = nil
         leftPadding = nil
     }
 
-    /// Create attention mask based on left padding
+    public func advance(_ N: Int) {
+        if let currentLengths = lengths {
+            lengths = currentLengths - N
+        }
+        if let currentLeftPadding = leftPadding {
+            leftPadding = currentLeftPadding - N
+        }
+    }
+
+    public var currentLengths: MLXArray? {
+        lengths
+    }
+
+    internal var leftPaddingValues: [Int]? {
+        guard let leftPadding else { return nil }
+        return leftPadding.asArray(Int.self)
+    }
+
+    internal var presentSlotIndices: [Int] {
+        cache.enumerated().compactMap { (i, v) in v != nil ? i : nil }
+    }
+
+    internal var slotCount: Int { cache.count }
+
+    /// Create attention mask based on left padding or prepared sequence lengths
     public func makeMask(N: Int) -> MLXArray? {
-        if cache[0] == nil, let leftPadding = leftPadding {
-            return MLXArray(0 ..< N) .>= leftPadding[0..., .newAxis]
+        let positions = MLXArray(0 ..< N)
+        if let leftPadding {
+            return positions .>= leftPadding[0..., .newAxis]
+        } else if let lengths {
+            return positions .< lengths[0..., .newAxis]
         } else {
             return nil
         }
@@ -1231,16 +1295,23 @@ public class ArraysCache: BaseKVCache {
 
     // MARK: - Serialization
 
-    /// metaState format: [slotCount, presentSlots (comma-separated), leftPadding (comma-separated, optional)]
+    /// metaState format: [slotCount, presentSlots, leftPadding?, lengths?]
     /// Legacy format (BaseKVCache default): [""]
     public override var metaState: [String] {
         get {
+            let leftPaddingState = Self.serializeMetadata(leftPadding)
+            let lengthsState = Self.serializeMetadata(lengths)
             var result = [
                 "\(cache.count)",
                 presentSlotIndices.map(String.init).joined(separator: ","),
             ]
-            if let lp = leftPaddingValues {
-                result.append(lp.map(String.init).joined(separator: ","))
+            if let leftPaddingState {
+                result.append(leftPaddingState)
+            } else if lengthsState != nil {
+                result.append("")
+            }
+            if let lengthsState {
+                result.append(lengthsState)
             }
             return result
         }
@@ -1258,34 +1329,27 @@ public class ArraysCache: BaseKVCache {
             let presentSlots =
                 savedMetaState[1].isEmpty
                 ? [] : savedMetaState[1].split(separator: ",").compactMap { Int($0) }
-            let lp: [Int]? =
-                savedMetaState.count >= 3
-                ? savedMetaState[2].split(separator: ",").compactMap({ Int($0) }) : nil
 
             self.cache = Array(repeating: nil, count: slotCount)
             for (arrayIdx, slotIdx) in presentSlots.enumerated()
             where slotIdx < slotCount && arrayIdx < state.count {
                 self.cache[slotIdx] = state[arrayIdx]
             }
-            self.leftPadding = lp.map { MLXArray($0) }
+            self.leftPadding = Self.metadataArray(savedMetaState, at: 2)
+            self.lengths = Self.metadataArray(savedMetaState, at: 3)
         } else {
             // Legacy: best-effort, state is compacted
             self.cache = state.map { $0 as MLXArray? }
         }
     }
 
-    /// Total number of slots (including nil)
-    internal var slotCount: Int { cache.count }
-
-    /// Indices of non-nil slots
-    internal var presentSlotIndices: [Int] {
-        cache.enumerated().compactMap { (i, v) in v != nil ? i : nil }
+    private static func serializeMetadata(_ array: MLXArray?) -> String? {
+        array?.asArray(Int.self).map(String.init).joined(separator: ",")
     }
 
-    /// Left padding values as Int array, or nil
-    internal var leftPaddingValues: [Int]? {
-        guard let lp = leftPadding else { return nil }
-        return lp.asArray(Int.self)
+    private static func metadataArray(_ state: [String], at index: Int) -> MLXArray? {
+        guard state.indices.contains(index), !state[index].isEmpty else { return nil }
+        return MLXArray(state[index].split(separator: ",").compactMap { Int($0) })
     }
 }
 
@@ -1297,12 +1361,7 @@ public class MambaCache: ArraysCache {
 
     public override func copy() -> any KVCache {
         let new = MambaCache()
-        let s = self.state
-        if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
-        }
-        new.offset = self.offset
-        new.leftPadding = self.leftPadding
+        copyContents(to: new)
         return new
     }
 }
@@ -1351,6 +1410,28 @@ public class CacheList: BaseKVCache {
         let copiedCaches = caches.map { $0.copy() }
         let new = CacheList(caches: copiedCaches)
         return new
+    }
+
+    public func prepare(lengths: [Int]?) {
+        forEachArraysCache { $0.prepare(lengths: lengths) }
+    }
+
+    public func prepare(lengths: MLXArray?) {
+        forEachArraysCache { $0.prepare(lengths: lengths) }
+    }
+
+    public func finalize() {
+        forEachArraysCache { $0.finalize() }
+    }
+
+    private func forEachArraysCache(_ body: (ArraysCache) -> Void) {
+        for cache in caches {
+            if let arrays = cache as? ArraysCache {
+                body(arrays)
+            } else if let list = cache as? CacheList {
+                list.forEachArraysCache(body)
+            }
+        }
     }
 
     public override var isTrimmable: Bool {

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -168,6 +168,147 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     assertArraysClose(restored.state, cache.state)
 }
 
+@Test func testArraysCacheLengthsRoundTrip() throws {
+    let cache = ArraysCache(size: 2)
+    cache.prepare(lengths: [4, 2])
+    cache[0] = MLXArray.ones([2, 4], dtype: .float32)
+
+    let url = tempURL()
+    try savePromptCache(url: url, cache: [cache], metadata: [:])
+    let (loaded, _) = try loadPromptCache(url: url)
+
+    let restored = try #require(loaded[0] as? ArraysCache)
+    #expect(restored.currentLengths?.asArray(Int.self) == [4, 2])
+    assertArraysClose(restored.state, cache.state)
+}
+
+@Test func testArraysCacheAdvanceUpdatesLengthsAndLeftPaddingMasks() throws {
+    let cache = ArraysCache(size: 2, leftPadding: [1, 3])
+    cache.prepare(lengths: [4, 2])
+    cache.advance(2)
+
+    #expect(cache.leftPaddingValues == [-1, 1])
+    #expect(cache.currentLengths?.asArray(Int.self) == [2, 0])
+
+    let mask = try #require(cache.makeMask(N: 3))
+    #expect(mask.asArray(Bool.self) == [true, true, true, false, true, true])
+
+    let lengthOnly = ArraysCache(size: 1)
+    lengthOnly.prepare(lengths: [2, 0])
+    let lengthMask = try #require(lengthOnly.makeMask(N: 3))
+    #expect(lengthMask.asArray(Bool.self) == [true, true, false, false, false, false])
+
+    cache.finalize()
+    #expect(cache.leftPaddingValues == nil)
+    #expect(cache.currentLengths == nil)
+}
+
+@Test func testArraysCacheFilterAndExtendPreserveBatchMetadata() throws {
+    let first = ArraysCache(size: 1, leftPadding: [0, 2])
+    first.prepare(lengths: [5, 3])
+    first[0] = MLXArray.ones([2, 2], dtype: .float32)
+
+    first.filter(batchIndices: MLXArray([1]))
+    #expect(first.leftPaddingValues == [2])
+    #expect(first.currentLengths?.asArray(Int.self) == [3])
+    #expect(first[0]?.shape == [1, 2])
+
+    let second = ArraysCache(size: 1, leftPadding: [1, 4])
+    second.prepare(lengths: [6, 2])
+    second[0] = MLXArray.ones([2, 2], dtype: .float32) * 2
+
+    first.extend(other: second)
+    #expect(first.leftPaddingValues == [2, 1, 4])
+    #expect(first.currentLengths?.asArray(Int.self) == [3, 6, 2])
+    #expect(first[0]?.shape == [3, 2])
+}
+
+@Test func testAttentionMaskUsesSharedCausalCachePath() throws {
+    let cache = KVCacheSimple()
+    let prefillInput = MLXArray.ones([1, 3, 8], dtype: .float32)
+
+    let prefillMask = createAttentionMask(h: prefillInput, cache: cache)
+    if case .causal = prefillMask {
+        // Expected for multi-token prefill: Falcon H1 uses the shared symbolic causal mask path.
+    } else {
+        Issue.record("Expected symbolic causal attention mask for prefill")
+    }
+
+    let tokenInput = MLXArray.ones([1, 1, 8], dtype: .float32)
+    let tokenMask = createAttentionMask(h: tokenInput, cache: cache)
+    if case .none = tokenMask {
+        // Expected for one-token decode: no materialized mask is needed.
+    } else {
+        Issue.record("Expected no attention mask for one-token decode")
+    }
+
+    cache.offset = 2
+    let forcedMask = createAttentionMask(h: prefillInput, cache: cache, returnArray: true)
+    guard case .array(let mask) = forcedMask else {
+        Issue.record("Expected forced attention mask array")
+        return
+    }
+    #expect(mask.shape == [3, 5])
+    #expect(
+        mask.asArray(Bool.self) == [
+            true, true, true, false, false,
+            true, true, true, true, false,
+            true, true, true, true, true,
+        ])
+}
+
+@Test func testSSMMaskUsesSharedMambaMetadataPath() throws {
+    let leftPadded = MambaCache(leftPadding: [1, 3])
+    let input = MLXArray.ones([2, 4, 8], dtype: .float32)
+
+    let leftPaddingMask = try #require(createSSMMask(h: input, cache: leftPadded))
+    #expect(
+        leftPaddingMask.asArray(Bool.self) == [
+            false, true, true, true,
+            false, false, false, true,
+        ])
+
+    let lengthMasked = MambaCache()
+    lengthMasked.prepare(lengths: [3, 1])
+    let lengthsMask = try #require(createSSMMask(h: input, cache: lengthMasked))
+    #expect(
+        lengthsMask.asArray(Bool.self) == [
+            true, true, true, false,
+            true, false, false, false,
+        ])
+}
+
+@Test func testCacheListPrepareFinalizePropagatesThroughNestedHybridCaches() throws {
+    let mamba = MambaCache(leftPadding: [0, 2])
+    let arrays = ArraysCache(size: 1)
+    let nested = CacheList(CacheList(mamba), arrays)
+
+    nested.prepare(lengths: [4, 1])
+
+    #expect(mamba.currentLengths?.asArray(Int.self) == [4, 1])
+    #expect(arrays.currentLengths?.asArray(Int.self) == [4, 1])
+
+    nested.finalize()
+
+    #expect(mamba.currentLengths == nil)
+    #expect(mamba.leftPaddingValues == nil)
+    #expect(arrays.currentLengths == nil)
+}
+
+@Test func testMambaCacheCopyPreservesBatchMaskMetadata() throws {
+    let cache = MambaCache(leftPadding: [2, 0])
+    cache.prepare(lengths: [5, 3])
+    cache[0] = MLXArray.ones([2, 3, 4], dtype: .float32)
+    cache[1] = MLXArray.ones([2, 1, 4, 4], dtype: .float32)
+
+    let copied = try #require(cache.copy() as? MambaCache)
+
+    #expect(copied.leftPaddingValues == [2, 0])
+    #expect(copied.currentLengths?.asArray(Int.self) == [5, 3])
+    #expect(copied[0]?.shape == [2, 3, 4])
+    #expect(copied[1]?.shape == [2, 1, 4, 4])
+}
+
 // MARK: - MambaCache type preservation
 
 @Test func testMambaCacheRoundTrip() throws {

--- a/Tests/MLXLMTests/SSMTests.swift
+++ b/Tests/MLXLMTests/SSMTests.swift
@@ -1,0 +1,57 @@
+// Copyright © 2026 Apple Inc.
+
+import MLX
+import MLXLLM
+import Testing
+
+@Test func testSSMAttnPreservesRecurrentStateDTypeAcrossChunks() throws {
+    MLXRandom.seed(7)
+
+    let dtype = DType.bfloat16
+    let batch = 1
+    let sequence = 5
+    let heads = 4
+    let headDim = 3
+    let groups = 2
+    let stateDim = 8
+
+    let x = MLXRandom.normal([batch, sequence, heads, headDim]).asType(dtype)
+    let aLog = MLXRandom.normal([heads]).asType(dtype)
+    let B = MLXRandom.normal([batch, sequence, groups, stateDim]).asType(dtype)
+    let C = MLXRandom.normal([batch, sequence, groups, stateDim]).asType(dtype)
+    let D = MLXRandom.normal([heads]).asType(dtype)
+    let dt = MLXRandom.normal([batch, sequence, heads]).asType(dtype)
+    let dtBias = MLXRandom.normal([heads]).asType(dtype)
+
+    let (freshY, freshState) = ssmAttn(
+        x: x,
+        ALog: aLog,
+        B: B,
+        C: C,
+        D: D,
+        dt: dt,
+        dtBias: dtBias,
+        step: 2
+    )
+    eval(freshY, freshState)
+
+    #expect(freshY.dtype == dtype)
+    #expect(freshState.dtype == dtype)
+
+    let previousState = MLXRandom.normal([batch, heads, headDim, stateDim]).asType(dtype)
+    let (continuedY, continuedState) = ssmAttn(
+        x: x,
+        ALog: aLog,
+        B: B,
+        C: C,
+        D: D,
+        dt: dt,
+        dtBias: dtBias,
+        state: previousState,
+        step: 2
+    )
+    eval(continuedY, continuedState)
+
+    #expect(continuedY.dtype == dtype)
+    #expect(continuedState.dtype == previousState.dtype)
+}


### PR DESCRIPTION
## Proposed changes

Update Falcon H1/H1R inference behavior to match current mlx-lm more closely.

This fixes tied embedding output projection and scaling, routes attention through the common cache-aware causal path, advances Mamba cache metadata during generation, reports per-layer KV head counts correctly, and chunks SSM prefill to reduce long-prompt memory and latency.

Also mirror upstream ArraysCache length handling for hybrid and batched paths: preserve left padding and lengths through filter, extend, copy, and serialization; forward length preparation through CacheList; and use per-row lengths in Falcon H1 convolution plus chunked SSM state updates.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
