### PR TITLE
Fix LFM2-MoE sigmoid routing and expert-bias selection

### DIFF
--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -12,6 +12,12 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
+private let compiledLFM2MoESiluProduct: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
+    shapeless: true
+) { gate, up in
+    MLXNN.silu(gate) * up
+}
+
 public struct LFM2MoEConfiguration: Codable, Sendable {
     public let modelType: String
     public let vocabularySize: Int
@@ -255,7 +261,7 @@ class LFM2MoEMLP: Module, UnaryLayer {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        downProj(silu(gateProj(x)) * upProj(x))
+        downProj(compiledLFM2MoESiluProduct(gateProj(x), upProj(x)))
     }
 }
 

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -31,6 +31,7 @@ public struct LFM2MoEConfiguration: Codable, Sendable {
     public let convBias: Bool
     public let convLCache: Int
     public let ropeTheta: Float
+    public let routedScalingFactor: Float
 
     private let _fullAttnIdxs: [Int]?
     private let layerTypes: [String]?
@@ -67,6 +68,7 @@ public struct LFM2MoEConfiguration: Codable, Sendable {
         case convBias = "conv_bias"
         case convLCache = "conv_L_cache"
         case ropeTheta = "rope_theta"
+        case routedScalingFactor = "routed_scaling_factor"
         case ropeParameters = "rope_parameters"
         case _fullAttnIdxs = "full_attn_idxs"
         case layerTypes = "layer_types"
@@ -92,6 +94,8 @@ public struct LFM2MoEConfiguration: Codable, Sendable {
         self.normEps = try container.decode(Float.self, forKey: .normEps)
         self.convBias = try container.decode(Bool.self, forKey: .convBias)
         self.convLCache = try container.decode(Int.self, forKey: .convLCache)
+        self.routedScalingFactor =
+            try container.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1.0
         self.ropeParameters = try container.decodeIfPresent(
             [String: StringOrNumber].self, forKey: .ropeParameters)
 
@@ -286,25 +290,32 @@ class Lfm2MoeSparseMoeBlock: Module, UnaryLayer {
         }
     }
 
-    func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var gates = gate(x).asType(.float32)
-        gates = MLX.softmax(gates, axis: -1)
-
-        if useExpertBias, let expertBias {
-            gates = gates + expertBias
-        }
+    /// Returns top-k experts and unbiased sigmoid routing weights.
+    /// `expert_bias` affects selection only.
+    func route(_ x: MLXArray) -> (indices: MLXArray, weights: MLXArray) {
+        let routingWeights = MLX.sigmoid(gate(x).asType(.float32))
 
         let k = topK
-        let indices = argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k]
-        var scores = takeAlong(gates, indices, axis: -1)
-        if normTopKProb {
-            let denom = scores.sum(axis: -1, keepDims: true) + 1e-20
-            scores = scores / denom
+        let indices: MLXArray
+        if useExpertBias, let expertBias {
+            let selection = routingWeights + expertBias.asType(.float32)
+            indices = argPartition(-selection, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+        } else {
+            indices = argPartition(-routingWeights, kth: k - 1, axis: -1)[.ellipsis, ..<k]
         }
-        scores = scores.asType(x.dtype)
 
+        var weights = takeAlong(routingWeights, indices, axis: -1)
+        if normTopKProb {
+            weights = weights / (weights.sum(axis: -1, keepDims: true) + 1e-6)
+        }
+        weights = weights * args.routedScalingFactor
+        return (indices, weights)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (indices, weights) = route(x)
         let expertOutputs = switchMLP(x, indices)
-        return weightedExpertSum(expertOutputs, scores)
+        return weightedExpertSum(expertOutputs, weights.asType(x.dtype))
     }
 }
 

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -12,12 +12,6 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
-private let compiledLFM2MoESiluProduct: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
-    shapeless: true
-) { gate, up in
-    MLXNN.silu(gate) * up
-}
-
 public struct LFM2MoEConfiguration: Codable, Sendable {
     public let modelType: String
     public let vocabularySize: Int
@@ -261,7 +255,7 @@ class LFM2MoEMLP: Module, UnaryLayer {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        downProj(compiledLFM2MoESiluProduct(gateProj(x), upProj(x)))
+        downProj(compiledSiluProduct(gateProj(x), upProj(x)))
     }
 }
 

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -4,7 +4,7 @@ import MLXNN
 
 // Port of https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/switch_layers.py
 
-private let compiledSiluProduct: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
+public let compiledSiluProduct: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
     shapeless: true
 ) { gate, up in
     MLXNN.silu(gate) * up

--- a/Tests/MLXLMTests/LFM2MoeRoutingTests.swift
+++ b/Tests/MLXLMTests/LFM2MoeRoutingTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+
+final class LFM2MoeRoutingTests: XCTestCase {
+
+    private func makeConfig(useExpertBias: Bool, normTopkProb: Bool = false) throws
+        -> LFM2MoEConfiguration
+    {
+        let json = """
+            {
+                "model_type": "lfm2_moe",
+                "vocab_size": 32,
+                "hidden_size": 4,
+                "intermediate_size": 8,
+                "moe_intermediate_size": 8,
+                "num_hidden_layers": 1,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "norm_topk_prob": \(normTopkProb),
+                "num_attention_heads": 1,
+                "num_key_value_heads": 1,
+                "max_position_embeddings": 128,
+                "use_expert_bias": \(useExpertBias),
+                "num_dense_layers": 0,
+                "norm_eps": 1e-5,
+                "conv_bias": false,
+                "conv_L_cache": 3
+            }
+            """
+        return try JSONDecoder().decode(LFM2MoEConfiguration.self, from: Data(json.utf8))
+    }
+
+    private func makeBlock(
+        useExpertBias: Bool, expertBias: [Float]? = nil,
+        normTopkProb: Bool = false
+    ) throws -> Lfm2MoeSparseMoeBlock {
+        let block = Lfm2MoeSparseMoeBlock(
+            try makeConfig(useExpertBias: useExpertBias, normTopkProb: normTopkProb))
+        var params: [String: MLXArray] = ["gate.weight": MLX.eye(4)]
+        if let expertBias {
+            params["expert_bias"] = MLXArray(expertBias)
+        }
+        try block.update(parameters: ModuleParameters.unflattened(params), verify: [])
+        eval(block)
+        return block
+    }
+
+    private let logits: [Float] = [2, 1, 0, -1]
+    private func x() -> MLXArray { MLXArray(logits).reshaped(1, 1, 4) }
+    private func sig(_ v: Float) -> Float { 1 / (1 + expf(-v)) }
+
+    private func routed(_ block: Lfm2MoeSparseMoeBlock) -> [Int: Float] {
+        let r = block.route(x())
+        let idx = r.indices.reshaped(-1).asArray(Int32.self).map(Int.init)
+        let w = r.weights.reshaped(-1).asArray(Float.self)
+        return Dictionary(uniqueKeysWithValues: zip(idx, w))
+    }
+
+    func testExpertBiasSteersSelectionOnly() throws {
+        let block = try makeBlock(useExpertBias: true, expertBias: [0, 0, 1, 0])
+        let m = routed(block)
+
+        XCTAssertEqual(Set(m.keys), [0, 2], "expert_bias must move expert 2 into the top-k")
+        XCTAssertEqual(m[2] ?? .nan, sig(0), accuracy: 1e-4)
+        XCTAssertEqual(m[0] ?? .nan, sig(2), accuracy: 1e-4)
+    }
+
+    func testGateIsSigmoidNotSoftmax() throws {
+        let block = try makeBlock(useExpertBias: false)
+        let m = routed(block)
+
+        XCTAssertEqual(Set(m.keys), [0, 1])
+        XCTAssertEqual(m[0] ?? .nan, sig(2), accuracy: 1e-4)
+        XCTAssertEqual(m[1] ?? .nan, sig(1), accuracy: 1e-4)
+    }
+
+    func testNormTopKProbRenormalizesUnbiasedWeights() throws {
+        let block = try makeBlock(useExpertBias: false, normTopkProb: true)
+        let m = routed(block)
+
+        XCTAssertEqual(Set(m.keys), [0, 1])
+        let denom = sig(2) + sig(1)
+        XCTAssertEqual(m[0] ?? .nan, sig(2) / denom, accuracy: 1e-4)
+        XCTAssertEqual(m[1] ?? .nan, sig(1) / denom, accuracy: 1e-4)
+        XCTAssertEqual((m[0] ?? 0) + (m[1] ?? 0), 1, accuracy: 1e-4)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fix LFM2-MoE routing to match the sigmoid-gated behavior used by LFM2.5 checkpoints.

The current Swift path applies softmax to router logits and folds `expert_bias` into the combination weights. LFM2-MoE uses per-expert sigmoid scores: `expert_bias` should affect top-k selection only, while the returned weights stay gathered from the unbiased sigmoid scores, optionally normalized by `norm_topk_prob`, then scaled by `routed_scaling_factor`.

This mirrors the same routing fix in ml-explore/mlx-lm#1354.

This also adds focused routing regression tests for the sigmoid gate, expert-bias selection-only behavior, and top-k normalization.

The dense LFM2-MoE MLP path now compiles the SwiGLU activation product, matching the existing compiled SwitchGLU path used by the MoE experts.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
