### PR TITLE
Fix Gemma 4 cross-layer KV sharing in no-cache forward pass

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1039,9 +1039,9 @@ private final class Gemma4TextBackbone: Module {
                 mask: layerMask,
                 cache: layerCache,
                 perLayerInput: layerInput,
-                sharedKV: hasExplicitCache && idx >= firstKVSharedLayerIdx
+                sharedKV: idx >= firstKVSharedLayerIdx
                     ? intermediates[sourceIdx].kv : nil,
-                offset: hasExplicitCache && idx >= firstKVSharedLayerIdx
+                offset: idx >= firstKVSharedLayerIdx
                     ? intermediates[sourceIdx].offset : nil
             )
             h = output


### PR DESCRIPTION
- Drop `hasExplicitCache &&` from the `sharedKV` and `offset` ternaries in `Gemma4TextBackbone`; the condition should only check `idx >= firstKVSharedLayerIdx`.
- Without the fix, any no-cache forward (embedding extraction, ColBERT-style retrieval, batched evaluation) re-projects K/V on the shared-KV layers and silently violates Gemma 4's invariant.
- Cached generation is unaffected: `hasExplicitCache` was always true on that path, so the same branch is taken.
- Verified against HF transformers: per-layer cosine restored to
  >= 0.999 across all 35 layers (pre-fix: 0.85 at L15, 0.03 at L34);
  final post-norm cosine 0.9995 (pre-fix: 0.10).

## Proposed changes

### Summary
Gemma 4's later transformer layers (`idx >= firstKVSharedLayerIdx`, layer 20+ on the E2B/E4B configs) reuse the K/V projections produced by an earlier "donor" layer rather than computing their own. The call site in `Gemma4TextBackbone` gates that handoff on `hasExplicitCache`:

```swift
sharedKV: hasExplicitCache && idx >= firstKVSharedLayerIdx
    ? intermediates[sourceIdx].kv : nil,
offset: hasExplicitCache && idx >= firstKVSharedLayerIdx
    ? intermediates[sourceIdx].offset : nil
```

When `cache == nil` (any forward pass without an external KV cache which is typical for embedding extraction, ColBERT-style retrieval heads, batched evaluation, anything that isn't an incremental generation loop) `hasExplicitCache` is `false`, so `sharedKV` collapses to `nil`. The shared-KV layers then fall through to the `computeQKV(...)` path that **re-projects K and V from their own hidden state**, silently violating Gemma 4's architectural invariant.

In an incremental generation loop `cache` is always provided, so the guard is a no-op, which is why the bug hasn't surfaced in the generation-focused parts of MLXVLM. It surfaces immediately for any downstream consumer that runs Gemma 4's text backbone without a cache.

### Fix

Drop the `hasExplicitCache &&` prefix on both ternaries. The condition we actually want is just "is this a shared-KV layer?", which the second clause already expresses:

```diff
-                sharedKV: hasExplicitCache && idx >= firstKVSharedLayerIdx
+                sharedKV: idx >= firstKVSharedLayerIdx
                     ? intermediates[sourceIdx].kv : nil,
-                offset: hasExplicitCache && idx >= firstKVSharedLayerIdx
+                offset: idx >= firstKVSharedLayerIdx
                     ? intermediates[sourceIdx].offset : nil
```

### Why this is safe for the cached generation path

When `cache != nil`, `hasExplicitCache == true`, so the guard was always a no-op there, the same `intermediates[sourceIdx].kv` was passed through. Behavior is unchanged for any existing generation call site.

### Evidence (HF transformers fp16 reference vs mlx-swift-lm bf16)

Captured against `google/gemma-4-E2B-it` (35 layers, shared-KV layers start at layer 15 in this config):
| Layer            | Pre-fix cosine vs HF       | Post-fix cosine vs HF |
|------------------|----------------------------|-----------------------|
| 0 – 14           | >= 0.9999                  | >= 0.9999             |
| 15 (1st shared)  | 0.85                       | >= 0.999              |
| 34               | 0.03 (norm ratio 0.24x)    | >= 0.999              |
| final post-norm  | 0.10 (norm ratio 2.08x)    | >= 0.9995             |

Sub-layer bisection on layer 15 isolates the divergence to the self-attention block (cos 0.79, norm 2.4x at attn output) while the layer's input hidden matches HF at cos 1.0 — ruling out residual / norm / MLP drift and pointing squarely at the K/V re-projection.

### Note on #327
PR #327 ("Add Gemma 4 12B unified") introduces a second `Gemma4TextBackbone` copy that carries the same `hasExplicitCache && idx >= firstKVSharedLayerIdx` guard verbatim. Whichever of our PRs lands second will need the same 2-token deletion applied to the 12B copy too, happy to take that follow-up either way.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Notes:
- **Tests**: not added in this PR. Covering this requires loading actual Gemma 4 weights, which `CONTRIBUTING.md` excludes from unit tests. Happy to follow up with an `IntegrationTesting` case that loads `mlx-community/gemma-4-e2b-it-bf16`, runs a no-cache forward on a short prompt, and asserts per-layer hidden cosine >= 0.999 against a recorded HF reference as part of this PR or a separate follow-up, whichever maintainers prefer.
- **Docs**: no public API change; no doc surface to update.