### PR TITLE
fix Gemma4 prepare() to honor windowSize -- prompt prefill is never chunked

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1728,9 +1728,10 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             let (allEmbeds, allPerLayerInputs) = try getInputEmbeddings(
                 inputIds: input.text.tokens, pixelValues: imagePixels)
             // Prefill the merged image+text embeddings (and the aligned
-            // per-layer inputs) in windowSize-sized chunks, evaluating the
-            // KV cache between chunks; the final position yields the
-            // first-token logits. Matches LLMModel.prepare and #297.
+            // per-layer inputs) in windowSize-sized chunks; the final
+            // position yields the first-token logits. Matches
+            // LLMModel.prepare and #297. asyncEval lets the CPU build
+            // chunk N+1's graph while the GPU evaluates chunk N.
             let totalPositions = allEmbeds.dim(1)
             var processed = 0
             while totalPositions - processed > 1 {
@@ -1742,9 +1743,11 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
                     inputsEmbeds: allEmbeds[0..., range, 0...],
                     perLayerInputs: allPerLayerInputs.map { $0[0..., range, 0..., 0...] }
                 )
-                eval(cache)
+                asyncEval(cache)
                 processed += chunkLength
             }
+            // Single sync after the loop to flush any remaining async work.
+            eval(cache)
             let result = languageModel(
                 nil,
                 cache: convertedCache,
@@ -1767,9 +1770,11 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
                     tokens[0..., processed ..< (processed + chunkLength)],
                     cache: convertedCache
                 )
-                eval(cache)
+                asyncEval(cache)
                 processed += chunkLength
             }
+            // Single sync after the loop to flush any remaining async work.
+            eval(cache)
             let result = languageModel(tokens[0..., processed...], cache: convertedCache)
             return .logits(result)
         }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1723,18 +1723,54 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         -> PrepareResult
     {
         let convertedCache = cache.map { $0 }
+        let prefillStepSize = windowSize ?? 512
         if let imagePixels = input.image?.pixels {
-            let (inputsEmbeds, perLayerInputs) = try getInputEmbeddings(
+            let (allEmbeds, allPerLayerInputs) = try getInputEmbeddings(
                 inputIds: input.text.tokens, pixelValues: imagePixels)
+            // Prefill the merged image+text embeddings (and the aligned
+            // per-layer inputs) in windowSize-sized chunks, evaluating the
+            // KV cache between chunks; the final position yields the
+            // first-token logits. Matches LLMModel.prepare and #297.
+            let totalPositions = allEmbeds.dim(1)
+            var processed = 0
+            while totalPositions - processed > 1 {
+                let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+                let range = processed ..< (processed + chunkLength)
+                _ = languageModel(
+                    nil,
+                    cache: convertedCache,
+                    inputsEmbeds: allEmbeds[0..., range, 0...],
+                    perLayerInputs: allPerLayerInputs.map { $0[0..., range, 0..., 0...] }
+                )
+                eval(cache)
+                processed += chunkLength
+            }
             let result = languageModel(
                 nil,
                 cache: convertedCache,
-                inputsEmbeds: inputsEmbeds,
-                perLayerInputs: perLayerInputs
+                inputsEmbeds: allEmbeds[0..., processed..., 0...],
+                perLayerInputs: allPerLayerInputs.map { $0[0..., processed..., 0..., 0...] }
             )
             return .logits(result)
         } else {
-            let result = languageModel(input.text.tokens, cache: convertedCache)
+            // Text-only path: chunk raw tokens (per-layer inputs are derived
+            // from each chunk's tokens inside the backbone).
+            var tokens = input.text.tokens
+            if tokens.ndim == 1 {
+                tokens = tokens.expandedDimensions(axis: 0)
+            }
+            let totalPositions = tokens.dim(1)
+            var processed = 0
+            while totalPositions - processed > 1 {
+                let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+                _ = languageModel(
+                    tokens[0..., processed ..< (processed + chunkLength)],
+                    cache: convertedCache
+                )
+                eval(cache)
+                processed += chunkLength
+            }
+            let result = languageModel(tokens[0..., processed...], cache: convertedCache)
             return .logits(result)
         }
     }

--- a/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
@@ -1,0 +1,141 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXVLM
+
+/// Unit tests for `Gemma4.prepare(_:cache:windowSize:)` chunked prefill.
+///
+/// The core property under test is **chunk-size invariance**: prefilling the
+/// same prompt with a small `windowSize` (many chunks) and a `windowSize`
+/// larger than the prompt (single pass) must agree on the final logits and
+/// leave the KV caches at the same offsets. The synthetic config deliberately
+/// covers Gemma 4's tricky structures: sliding-window layers whose rotating
+/// caches wrap across chunk boundaries, a global-attention layer, KV-shared
+/// tail layers, and per-layer inputs.
+struct Gemma4ChunkedPrefillTests {
+
+    /// Tiny Gemma4 built from a sparse JSON config (all other fields take
+    /// the decoder defaults). 6 text layers with sliding_window_pattern 3
+    /// → [sliding, sliding, full, sliding, sliding, full]; the last 2 are
+    /// KV-shared, so 4 caches (3 rotating + 1 standard). sliding_window 8
+    /// is much smaller than the test prompt, forcing rotation.
+    private static func makeTinyModel() throws -> Gemma4 {
+        let json = """
+            {
+                "text_config": {
+                    "hidden_size": 64,
+                    "num_hidden_layers": 6,
+                    "intermediate_size": 128,
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "head_dim": 16,
+                    "global_head_dim": 32,
+                    "vocab_size": 200,
+                    "vocab_size_per_layer_input": 200,
+                    "num_kv_shared_layers": 2,
+                    "hidden_size_per_layer_input": 8,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 3,
+                    "max_position_embeddings": 4096
+                },
+                "vision_config": {
+                    "num_hidden_layers": 1,
+                    "hidden_size": 16,
+                    "intermediate_size": 32,
+                    "num_attention_heads": 2,
+                    "head_dim": 8,
+                    "position_embedding_size": 64
+                }
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Gemma4Configuration.self, from: Data(json.utf8))
+        return Gemma4(config)
+    }
+
+    /// Token ids well inside the tiny vocabulary.
+    private static func makePrompt(count: Int) -> [Int] {
+        (0 ..< count).map { ($0 * 7 + 3) % 199 }
+    }
+
+    private static func prefillLogits(
+        model: Gemma4, tokens: [Int], windowSize: Int
+    ) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
+        let cache = model.newCache(parameters: nil)
+        let input = LMInput(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
+        let result = try model.prepare(input, cache: cache, windowSize: windowSize)
+        guard case .logits(let output) = result else {
+            Issue.record("Expected .logits from Gemma4.prepare, got .tokens")
+            return (MLXArray(0), [])
+        }
+        // Final-position logits regardless of how many positions the last
+        // forward covered.
+        let logits = output.logits[0..., -1, 0...]
+        eval(logits)
+        return (logits, cache.map { $0.offset })
+    }
+
+    @Test(
+        "Chunked and single-pass prefill agree on logits and cache offsets",
+        arguments: [3, 5, 8, 16])
+    func chunkSizeInvariance(chunkSize: Int) throws {
+        let model = try Self.makeTinyModel()
+        let tokens = Self.makePrompt(count: 37)
+
+        let chunked = try Self.prefillLogits(
+            model: model, tokens: tokens, windowSize: chunkSize)
+        let singlePass = try Self.prefillLogits(
+            model: model, tokens: tokens, windowSize: 1024)
+
+        #expect(chunked.cacheOffsets == singlePass.cacheOffsets)
+        #expect(chunked.cacheOffsets.allSatisfy { $0 == tokens.count })
+
+        let close = allClose(
+            chunked.logits, singlePass.logits, rtol: 1e-4, atol: 1e-5
+        ).item(Bool.self)
+        #expect(
+            close,
+            """
+            Final-position logits differ between windowSize=\(chunkSize) and \
+            single-pass prefill — chunked prefill must be numerically \
+            equivalent under causal masking.
+            """)
+    }
+
+    @Test("Prompt shorter than windowSize takes the single-chunk path")
+    func shortPromptSingleChunk() throws {
+        let model = try Self.makeTinyModel()
+        let tokens = Self.makePrompt(count: 5)
+
+        let result = try Self.prefillLogits(model: model, tokens: tokens, windowSize: 512)
+        #expect(result.cacheOffsets.allSatisfy { $0 == tokens.count })
+        #expect(result.logits.shape == [1, 200])
+    }
+
+    @Test("Unbatched (1-D) token input is accepted on the text path")
+    func unbatchedTokensAccepted() throws {
+        let model = try Self.makeTinyModel()
+        let tokens = Self.makePrompt(count: 21)
+
+        let cache = model.newCache(parameters: nil)
+        let input = LMInput(tokens: MLXArray(tokens))  // 1-D, no batch axis
+        let result = try model.prepare(input, cache: cache, windowSize: 6)
+        guard case .logits(let output) = result else {
+            Issue.record("Expected .logits from Gemma4.prepare")
+            return
+        }
+        eval(output.logits)
+        #expect(cache.allSatisfy { $0.offset == tokens.count })
+
+        // And it matches the batched run.
+        let batched = try Self.prefillLogits(model: model, tokens: tokens, windowSize: 6)
+        let close = allClose(
+            output.logits[0..., -1, 0...], batched.logits, rtol: 1e-4, atol: 1e-5
+        ).item(Bool.self)
+        #expect(close, "1-D and [1, N] token inputs must produce identical logits.")
+    }
+}


### PR DESCRIPTION
## Proposed changes
Addresses the Gemma4 instance of #336 (MLXVLM models ignore `windowSize` — same fix shape as #297).

`Gemma4.prepare(_:cache:windowSize:)` accepts `windowSize` but never uses it: the whole prompt runs through the language model in one forward pass, so transient prefill memory scales with prompt length (~1.7 MB/token measured on E4B 4-bit — a 4k-token prompt peaks at 11.2 GB MLX active against 4.3 GiB of weights; 16k crashes an 18 GB machine).

This applies the same chunking #297 added for Idefics3, to both Gemma4 branches: the text path chunks raw tokens; the image path chunks the merged embeddings together with the aligned per-layer-input slices. The KV cache is evaluated between chunks; the final position returns the first-token logits.

Gemma4-specific notes: KV-shared layers read the source layer's cache-augmented keys/values, so per-chunk forwards still see full history; per-layer inputs are per-token; RoPE offsets and masks derive from `cache.offset`. 

## Verification (Gemma4 E4B 4-bit, M3 Pro 18 GB)

- **Memory** (5 iters/point, temp 0, medians): peak MLX active 11.2→5.0 GB at 4k, 17.7→5.1 GB at 8k; 16k was un-runnable before (~33 GB projected) and peaks at 5.2 GB after. TTFT improved 25.6→17.9 s (4k) and 70.5→47.1 s (8k).
- **Output equality:** greedy outputs byte-identical before/after at 34/492/573/733-token prompts (spanning the 512 chunk boundary). At 4k/8k, long free-form greedy generations are deterministic per build and can diverge at near-tie tokens (floating-point evaluation order — same class of variation as changing `prefillStepSize` on `LLMModel`); needle-recall scoring was 5/5 in both configurations at all lengths.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
