### PR TITLE
Raise swift-syntax floor to 602.0.0 for prebuilt artifact resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.4")),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "604.0.0"),
+        // 602.0.0 floor: swift.org publishes signed prebuilt swift-syntax artifacts only for
+        // >= 602 tags on current toolchains; a 600.x/601.x resolution falls back to the full
+        // source compile of swift-syntax.
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "602.0.0" ..< "604.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Narrowed from the original proposal. This PR is now only the swift-syntax floor bump, flagged as useful
  
Why: swift.org publishes signed prebuilt swift-syntax artifacts only for >= 602 tags on current toolchains. A 600.x/601.x resolution silently falls back to compiling swift-syntax from source. Measured on Swift 6.3.2 / Xcode 26.5: forcing source compile adds ~46 Swift-compile tasks / ~29s of compile CPU per cold build (SwiftCompile 24.1s → 53.2s) that the prebuilt skips entirely. 