### PR TITLE
Fix Gemma 4 QAT load: KV-shared layers carry no k_proj/v_proj/k_norm

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -206,12 +206,15 @@ private class Gemma4Attention: Module {
     let scale: Float
 
     @ModuleInfo(key: "q_proj") var qProj: Linear
-    @ModuleInfo(key: "k_proj") var kProj: Linear
+    // Optional: KV-shared layers reuse an earlier layer's K/V and own no k_proj/v_proj.
+    @ModuleInfo(key: "k_proj") var kProj: Linear?
     @ModuleInfo(key: "v_proj") var vProj: Linear?
     @ModuleInfo(key: "o_proj") var oProj: Linear
 
     @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
-    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+    // Optional: KV-shared layers don't compute K, so they carry no k_norm weight.
+    // (v_norm is RMSNormNoScale — parameter-free — so it never appears in checkpoints.)
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm?
     @ModuleInfo(key: "v_norm") var vNorm: RMSNormNoScale
 
     @ModuleInfo var rope: RoPELayer
@@ -240,14 +243,26 @@ private class Gemma4Attention: Module {
         self.scale = 1.0
 
         self._qProj.wrappedValue = Linear(dim, nHeads * effectiveHeadDim, bias: false)
-        self._kProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
-        if !useKeqV {
-            self._vProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+        // KV-shared layers (the last `num_kv_shared_layers`) reuse the K/V of an earlier
+        // layer of the same attention type, so they own no k_proj/v_proj. Quantized
+        // (QAT) checkpoints prune those tensors; create them only for the KV-owning
+        // layers so the module tree matches the checkpoint. (Older/PTQ checkpoints that
+        // still ship the redundant tensors are dropped in `sanitize`.) Same predicate as
+        // the double-wide MLP gate.
+        let firstKvSharedLayerIdx = config.numHiddenLayers - config.numKvSharedLayers
+        let isKvSharedLayer = layerIdx >= firstKvSharedLayerIdx && firstKvSharedLayerIdx > 0
+        if !isKvSharedLayer {
+            self._kProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+            if !useKeqV {
+                self._vProj.wrappedValue = Linear(dim, nKvHeads * effectiveHeadDim, bias: false)
+            }
         }
         self._oProj.wrappedValue = Linear(nHeads * effectiveHeadDim, dim, bias: false)
 
         self._qNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
-        self._kNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
+        if !isKvSharedLayer {
+            self._kNorm.wrappedValue = RMSNorm(dimensions: effectiveHeadDim, eps: config.rmsNormEps)
+        }
         self._vNorm.wrappedValue = RMSNormNoScale(eps: config.rmsNormEps)
 
         // RoPE: sliding uses default, full uses proportional with partial rotation
@@ -287,6 +302,14 @@ private class Gemma4Attention: Module {
             // KV-shared layers use pre-computed KV from an earlier layer.
             kvState = sharedKV
         } else {
+            // Only KV-owning layers fall here (KV-shared layers always receive `sharedKV`),
+            // so k_proj and k_norm are guaranteed to exist.
+            guard let kProj, let kNorm else {
+                fatalError(
+                    "Gemma4Attention layer \(layerIdx) computed its own K/V but has no k_proj/k_norm; "
+                        + "KV-shared layers must be passed `sharedKV`.")
+            }
+            // Keep `kRaw` (pre-norm) — the no-vProj fallback below reuses it for `vNorm(kRaw)`.
             let kRaw = kProj(x).reshaped(B, L, nKvHeads, effectiveHeadDim)
             var k = kNorm(kRaw)
             k = k.transposed(0, 2, 1, 3)
@@ -691,6 +714,7 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        let firstKvSharedLayerIdx = config.numHiddenLayers - config.numKvSharedLayers
         var sanitized = [String: MLXArray]()
         for (k, v) in weights {
             // Skip vision/audio/rotary weights
@@ -702,9 +726,30 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
             {
                 continue
             }
+            // Drop redundant k_proj/v_proj/k_norm for KV-shared layers: they reuse an
+            // earlier layer's K/V and own no K projection or K norm, so the module tree
+            // has none. QAT checkpoints already omit these; some (PTQ) checkpoints still
+            // ship them, and keeping them would be an unexpected weight. Dropping here
+            // makes both load against the same tree. (v_norm is parameter-free.)
+            if firstKvSharedLayerIdx > 0,
+                k.contains("self_attn.k_proj")
+                    || k.contains("self_attn.v_proj")
+                    || k.contains("self_attn.k_norm"),
+                let layerIdx = Self.decoderLayerIndex(in: k),
+                layerIdx >= firstKvSharedLayerIdx
+            {
+                continue
+            }
             sanitized[k] = v
         }
         return sanitized
+    }
+
+    /// Extract `N` from a weight key shaped like `…layers.N.…`, else nil.
+    private static func decoderLayerIndex(in key: String) -> Int? {
+        guard let range = key.range(of: "layers.") else { return nil }
+        let digits = key[range.upperBound...].prefix { $0.isNumber }
+        return Int(digits)
     }
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] {


### PR DESCRIPTION
## Proposed changes

Gemma 4 E-series shares K/V across the last `num_kv_shared_layers` layers: those layers reuse the K/V of an earlier layer of the same attention type. They compute their own queries (`q_proj`/`q_norm`) but own **no `k_proj`, `v_proj` or `k_norm`** — only `o_proj`/`q_proj`/`q_norm`.

`Gemma4Attention` declared `k_proj`/`k_norm` as non-optional and created `k_proj`/`v_proj`/`k_norm` unconditionally, so the loader demanded `layers.N.self_attn.{k_proj,v_proj,k_norm}` for the shared layers too. Full-precision / PTQ checkpoints still carry those redundant tensors, so they loaded — but **quantization-aware (QAT) checkpoints prune them**, so loading `gemma-4-E2B-it-qat-4bit` failed at layer 15 (the first shared layer):

```
keyNotFound layers.15.self_attn.v_proj.weight   (then k_norm.weight)
```

Confirmed against the checkpoint index: a shared layer ships only `o_proj`/`q_proj`/`q_norm`; it lacks `k_proj.{weight,scales,biases}`, `v_proj.{weight,scales,biases}` and `k_norm.weight`. (`v_norm` is `RMSNormNoScale` — parameter-free — so it never appears in any checkpoint.)

This change:
- makes `k_proj`/`k_norm` optional and creates `k_proj`/`v_proj`/`k_norm` only for the KV-owning layers (same predicate as the existing double-wide-MLP gate);
- guards the compute path — KV-shared layers always receive `sharedKV`, so the K/V-owning branch is unreachable for them (with a clear `fatalError` if a misconfiguration ever sends one there);
- drops any redundant `k_proj`/`v_proj`/`k_norm` of KV-shared layers in `sanitize`, so PTQ checkpoints that still ship them keep loading against the now-smaller tree.

Together with the `per_layer_model_projection` fix (#320), this lets the QAT E-series checkpoints load and run. Verified on macOS: `gemma-4-E2B-it-qat-4bit` now loads and responds. The change has been running in a downstream app loading the Gemma 4 E2B/E4B QAT checkpoints on Apple Silicon.

A sibling fix exists for the VLM path (`MLXVLM/Models/Gemma4.swift`), which I'll send as a follow-up PR rebased on the recent KV-shared / drafter work in `main`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have run `pre-commit run --all-files` — authored in-tree through the fork's formatting; happy to address any `swift-format` nits
- [ ] I have added tests — this is a checkpoint-load-path fix, exercised via the integration model-loading tests rather than a unit test
- [ ] I have updated the necessary documentation (n/a)