### PR TITLE
fix MLXVLM prepare(): honor windowSize for chunked prefill (FastVLM / Gemma3 / Qwen2VL / LFM2VL / Pixtral / Mistral3)

### DIFF
--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1135,7 +1135,18 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: input.image?.pixels,
             mask: input.text.mask
         )
-        let result = languageModel(nil, cache: cache, inputEmbedding: embeddings)
+        let prefillStepSize = windowSize ?? 512
+        let totalPositions = embeddings.dim(1)
+        var processed = 0
+        while totalPositions - processed > 1 {
+            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+            let range = processed ..< (processed + chunkLength)
+            _ = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., range, 0...])
+            asyncEval(cache)
+            processed += chunkLength
+        }
+        eval(cache)
+        let result = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., processed..., 0...])
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1146,7 +1146,8 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             processed += chunkLength
         }
         eval(cache)
-        let result = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., processed..., 0...])
+        let result = languageModel(
+            nil, cache: cache, inputEmbedding: embeddings[0..., processed..., 0...])
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -985,11 +985,25 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
+        let prefillStepSize = windowSize ?? 512
+        let convertedCache = cache.compactMap { $0 as KVCache }
+
         guard let imagePixels = input.image?.pixels else {
-            // Text-only input
-            let convertedCache = cache.compactMap { $0 as KVCache }
+            var tokens = input.text.tokens
+            if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
+            let totalPositions = tokens.dim(1)
+            var processed = 0
+            while totalPositions - processed > 1 {
+                let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+                _ = languageModel(
+                    tokens[0..., processed ..< (processed + chunkLength)],
+                    cache: convertedCache, inputEmbedding: nil, mask: nil)
+                asyncEval(cache)
+                processed += chunkLength
+            }
+            eval(cache)
             let result = languageModel(
-                input.text.tokens, cache: convertedCache, inputEmbedding: nil, mask: nil)
+                tokens[0..., processed...], cache: convertedCache, inputEmbedding: nil, mask: nil)
             return .logits(result)
         }
 
@@ -999,17 +1013,22 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
             mask: input.text.mask
         )
 
-        let convertedCache = cache.compactMap { $0 as KVCache }
-        // Use causal masking for text generation
         let maskMode: MLXFast.ScaledDotProductAttentionMaskMode = .causal
-
+        let totalPositions = inputEmbeddings.dim(1)
+        var processed = 0
+        while totalPositions - processed > 1 {
+            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+            let range = processed ..< (processed + chunkLength)
+            _ = languageModel(
+                nil, cache: convertedCache,
+                inputEmbedding: inputEmbeddings[0..., range, 0...], mask: maskMode)
+            asyncEval(cache)
+            processed += chunkLength
+        }
+        eval(cache)
         let result = languageModel(
-            nil,  // Pass nil for tokens when using embeddings
-            cache: convertedCache,
-            inputEmbedding: inputEmbeddings,
-            mask: maskMode
-        )
-
+            nil, cache: convertedCache,
+            inputEmbedding: inputEmbeddings[0..., processed..., 0...], mask: maskMode)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -1041,13 +1041,15 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
             while totalPositions - processed > 1 {
                 let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
                 let range = processed ..< (processed + chunkLength)
-                _ = languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
+                _ = languageModel(
+                    nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
                 asyncEval(cache)
                 processed += chunkLength
             }
             eval(cache)
-            
-            let result = languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., processed..., 0...])
+
+            let result = languageModel(
+                nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., processed..., 0...])
             return result
         }
 

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -1035,7 +1035,20 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
         )
 
         let result = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
-            languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings)
+            let prefillStepSize = windowSize ?? 512
+            let totalPositions = inputEmbeddings.dim(1)
+            var processed = 0
+            while totalPositions - processed > 1 {
+                let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+                let range = processed ..< (processed + chunkLength)
+                _ = languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
+                asyncEval(cache)
+                processed += chunkLength
+            }
+            eval(cache)
+            
+            let result = languageModel(nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., processed..., 0...])
+            return result
         }
 
         return .logits(result)

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -743,7 +743,24 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
             imageSizes: imageSizes
         )
 
-        let logits = languageModel(inputIds, cache: cache, inputsEmbeds: embeddings)
+        var tokens = inputIds
+        if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
+        let prefillStepSize = windowSize ?? 512
+        let totalPositions = embeddings.dim(1)
+        var processed = 0
+        while totalPositions - processed > 1 {
+            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+            let range = processed ..< (processed + chunkLength)
+            _ = languageModel(
+                tokens[0..., range], cache: cache,
+                inputsEmbeds: embeddings[0..., range, 0...])
+            asyncEval(cache)
+            processed += chunkLength
+        }
+        eval(cache)
+        let logits = languageModel(
+            tokens[0..., processed...], cache: cache,
+            inputsEmbeds: embeddings[0..., processed..., 0...])
         return .logits(.init(logits: logits))
     }
 

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -872,7 +872,8 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        let inputIds = input.text.tokens
+        var inputIds = input.text.tokens
+        if inputIds.ndim == 1 { inputIds = inputIds.expandedDimensions(axis: 0) }
         let pixelValues = input.image?.pixels
 
         let embeddings = getInputEmbeddings(
@@ -880,7 +881,22 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: pixelValues
         )
 
-        let logits = languageModel(inputIds, cache: cache, inputsEmbeds: embeddings)
+        let prefillStepSize = windowSize ?? 512
+        let totalPositions = embeddings.dim(1)
+        var processed = 0
+        while totalPositions - processed > 1 {
+            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+            let range = processed ..< (processed + chunkLength)
+            _ = languageModel(
+                inputIds[0..., range], cache: cache,
+                inputsEmbeds: embeddings[0..., range, 0...])
+            asyncEval(cache)
+            processed += chunkLength
+        }
+        eval(cache)
+        let logits = languageModel(
+            inputIds[0..., processed...], cache: cache,
+            inputsEmbeds: embeddings[0..., processed..., 0...])
         return .logits(.init(logits: logits))
     }
 

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -729,7 +729,8 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             processed += chunkLength
         }
         eval(cache)
-        let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings[0..., processed..., 0...])
+        let result = languageModel(
+            nil, cache: cache, inputEmbedding: inputEmbeddings[0..., processed..., 0...])
 
         return .logits(result)
     }

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -718,7 +718,18 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)
 
-        let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings)
+        let prefillStepSize = windowSize ?? 512
+        let totalPositions = inputEmbeddings.dim(1)
+        var processed = 0
+        while totalPositions - processed > 1 {
+            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+            let range = processed ..< (processed + chunkLength)
+            _ = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings[0..., range, 0...])
+            asyncEval(cache)
+            processed += chunkLength
+        }
+        eval(cache)
+        let result = languageModel(nil, cache: cache, inputEmbedding: inputEmbeddings[0..., processed..., 0...])
 
         return .logits(result)
     }

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -273,18 +273,32 @@ public class YourModel: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        // TODO prepare the cache and resulting logits based on the
-        // text prompt and any media assets
+        // Merge image and text embeddings, then prefill the KV cache in
+        // windowSize-sized chunks. Single-pass prefill allocates transient
+        // buffers proportional to prompt length and causes OOM on long prompts.
         guard let image = input.image else { throw VLMError.imageRequired }
         guard let mask = input.text.mask else { throw VLMError.maskRequired }
-        let inputIds = input.text.tokens
+        var inputIds = input.text.tokens
+        if inputIds.ndim == 1 { inputIds = inputIds.expandedDimensions(axis: 0) }
 
-        let inputEmbedding = inputEmbeddings(
+        let allEmbeds = inputEmbeddings(
             inputIds: inputIds, pixelValues: image.pixels, mask: mask)
 
+        let prefillStepSize = windowSize ?? 512
+        let totalPositions = allEmbeds.dim(1)
+        var processed = 0
+        while totalPositions - processed > 1 {
+            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
+            let range = processed ..< (processed + chunkLength)
+            _ = languageModel(inputIds[0..., range], cache: cache,
+                              inputEmbedding: allEmbeds[0..., range, 0...], mask: mask)
+            asyncEval(cache)
+            processed += chunkLength
+        }
+        eval(cache)
         let result = languageModel(
-            inputIds, cache: cache, inputEmbedding: inputEmbedding, mask: mask)
-
+            inputIds[0..., processed...], cache: cache,
+            inputEmbedding: allEmbeds[0..., processed..., 0...], mask: mask)
         return .logits(result)
     }
 


### PR DESCRIPTION
Fixes #336.

Idefics3 was fixed in #297, SmolVLM2 inherits via typealias, Gemma4 was fixed in #337. This PR extends the same chunked-prefill pattern to the 6 remaining models that still run the full prompt in a single forward pass.

## Problem

`GenerateParameters.prefillStepSize` flows through `TokenIterator` into `VLMModel.prepare(_:cache:windowSize:)`, but 6 of the MLXVLM implementations ignore `windowSize` and run the entire merged embedding in one shot. Single-pass prefill allocates transient buffers proportional to prompt length.

Measured by the issue reporter on Gemma4 E4B 4-bit (M3 Pro 18 GB, 8k-token prompt):

| prefill | peak MLX active |
|---------|----------------|
| single-pass (pre-fix) | ~17.7 GB |
| chunked, windowSize=512 (post-#337) | ~5.1 GB |

## Fix

All 6 models follow the Gemma4 / #337 loop structure:

```swift
let prefillStepSize = windowSize ?? 512
let totalPositions = allEmbeds.dim(1)
var processed = 0
while totalPositions - processed > 1 {
    let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
    let range = processed ..< (processed + chunkLength)
    _ = languageModel(nil, cache: cache, inputEmbedding: allEmbeds[0..., range, 0...])
    asyncEval(cache)
    processed += chunkLength
}
eval(cache)
let result = languageModel(nil, cache: cache, inputEmbedding: allEmbeds[0..., processed..., 0...])
```

`asyncEval(cache)` lets the CPU build chunk N+1's graph while the GPU evaluates chunk N. A single `eval(cache)` sync before the last position keeps the semantics identical to the single-pass path.

Models fixed and their call pattern:

| Model | call pattern |
|-------|-------------|
| FastVLM | `languageModel(nil, cache:, inputEmbedding:)` |
| Gemma3 | embed path + text-only token-chunk path |
| Qwen2VL | `languageModel(nil, cache:, inputEmbedding:)` |
| LFM2VL | `languageModel(nil, cache:, inputsEmbeds:)` |
| Pixtral | `languageModel(inputIds, cache:, inputsEmbeds:)` — slices inputIds + embeds |
| Mistral3 | same as Pixtral |

README porting template updated to show chunked `prepare()`.

## Models deferred (different architectures — separate follow-up)

- **Qwen25VL / GlmOcr**: MROPE `positionIds` tensor `[3, batch, seq_len]` requires an additional slice axis; fixing without regressions needs more care.
- **Qwen35 / Qwen35MoE / Qwen3VL**: `languageModel` receives raw `pixelValues` / `deepstackEmbeds` directly rather than a pre-merged embedding; the chunking hook is inside the backbone, not in `prepare()`.
- **Paligemma**: uses a full 4D bidirectional attention mask `[batch, heads, seq_len, seq_len]` that would need to be sliced in both query and key dimensions.

## Tests

```
xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS'
```

137/137 tests pass (including SpeculativeDecodingTests and Gemma4ChunkedPrefillTests added in #337).