### PR TITLE
Gemma 3: chunked prompt prefill, skip lm_head on prompt positions

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -430,8 +430,23 @@ public class Gemma3TextModel: Module, LLMModel {
             return .tokens(.init(tokens: emptyToken))
         }
 
-        return .tokens(input.text)
+        // Prefill through the inner model (no lm_head) to fill the KV cache, handing only
+        // the last token to the TokenIterator — skipping the 262k-vocab lm_head over every
+        // prompt position is the speedup. Chunk = explicit windowSize, else a tuned 128.
+        let prefillStepSize = Swift.min(
+            windowSize ?? Self.defaultPrefillChunkSize, config.slidingWindow)
+        var y = input.text
+        while y.tokens.size > 1 {
+            let n = Swift.min(prefillStepSize, y.tokens.size - 1)
+            _ = model(y[.newAxis, ..<n].tokens, mask: nil, cache: cache)
+            asyncEval(cache)
+            y = y[n...]
+        }
+        return .tokens(y)
     }
+
+    /// Prefill chunk size when the caller sets none, tuned for this path on Apple Silicon.
+    private static let defaultPrefillChunkSize = 128
 }
 
 extension Gemma3TextModel: LoRAModel {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -53,8 +53,9 @@ public protocol LogitProcessor {
 /// for the `TokenIterator`.
 public struct GenerateParameters: Sendable {
 
-    /// Step size for processing the prompt
-    public var prefillStepSize: Int
+    /// Step size for processing the prompt. `nil` lets each model pick its own prefill
+    /// chunk (the Gemma 3 text path uses a smaller chunk than the generic 512 default).
+    public var prefillStepSize: Int?
 
     /// Maximum tokens to generate
     public var maxTokens: Int?
@@ -118,7 +119,7 @@ public struct GenerateParameters: Sendable {
         presenceContextSize: Int = 20,
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
-        prefillStepSize: Int = 512
+        prefillStepSize: Int? = nil
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -615,7 +616,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///   - maxTokens: maximum number of tokens to generate
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
-        processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int = 512,
+        processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int? = nil,
         maxTokens: Int? = nil
     ) throws {
         self.model = model

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -170,7 +170,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: tokenCount,
-            prefillStepSize: parameters.prefillStepSize
+            prefillStepSize: parameters.prefillStepSize ?? 512
         )
     }
 
@@ -214,7 +214,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: input.text.tokens.size,
-            prefillStepSize: parameters.prefillStepSize
+            prefillStepSize: parameters.prefillStepSize ?? 512
         )
     }
 


### PR DESCRIPTION
## What

Speeds up **prompt prefill (time-to-first-token)** for all Gemma 3 text models by skipping the large `lm_head` on prompt positions and chunking the prefill for better CPU/GPU overlap.

## Why

`Gemma3TextModel.prepare` returned the whole prompt to the `TokenIterator`, which then ran the **262k-vocabulary** `lm_head` over **every** prompt position just to produce the first token. For Gemma 3's unusually large vocab this is a real TTFT tax that grows with prompt length, plus a large transient-logits memory spike.

## How

- Prefill all-but-the-last token through the **inner** `Gemma3Model` (no `lm_head`), updating only the KV cache; the discarded hidden states are never evaluated thanks to lazy eval. Only the final token goes through the full model to prime the iterator.
- Chunk the prefill with `asyncEval` per chunk so chunk *N+1*'s graph builds while the GPU evaluates chunk *N*. Chunk size honours an explicit `GenerateParameters.prefillStepSize` and otherwise defaults to **128**, empirically tuned for this path on Apple Silicon. To make that default reachable, `prefillStepSize` becomes optional (`nil` = let the model choose); **other models keep their 512 default** via `windowSize ?? 512` — no behaviour change for them.

## Results

`mlx-community/translategemma-4b-it-4bit` (Gemma 3 text), Apple Silicon, 577-token prompt, greedy, median of 3:

| | prompt tok/s | prefill time |
|--|--|--|
| before | 177 | 3253 ms |
| after | **463** | **1246 ms** |

**2.6× faster prefill.** Greedy output is byte-identical to before, including prompts longer than the 1024 sliding window where the rotating KV cache rotates.

## Tuning (chunk-size sweep)

| chunk | tok/s |
|--|--|
| 1024 (= sliding window) | 288 |
| 256 | 384 |
| **128 (default)** | **463** |
| 64 | 185 |

128 wins: larger chunks lose `asyncEval` pipelining; smaller ones drown in per-launch overhead.

## Scope / risk

- Behaviour change limited to the Gemma 3 text path; other models unaffected.
- Public API: `GenerateParameters.prefillStepSize` changes `Int` → `Int?` (constructing with an explicit value is unchanged; only the default becomes "model decides").