### PR TITLE
Expose ModelTypeRegistry.contains(_:) for pre-load support checks

### DIFF
--- a/Libraries/MLXLMCommon/Registries/ModelTypeRegistry.swift
+++ b/Libraries/MLXLMCommon/Registries/ModelTypeRegistry.swift
@@ -31,4 +31,12 @@ public actor ModelTypeRegistry<T> {
         return try creator(configuration)
     }
 
+    /// Whether a creator is registered for `modelType` — i.e. this registry can
+    /// instantiate that architecture. Lets a caller check support without
+    /// attempting a (throwing, allocating) `createModel`, e.g. to decide before
+    /// a multi-GB download whether a Hub repo's `model_type` is runnable.
+    public func contains(_ modelType: String) -> Bool {
+        creators[modelType] != nil
+    }
+
 }


### PR DESCRIPTION
`ModelTypeRegistry` can instantiate a model type via `createModel`, but there is
no way to ask whether a creator is registered for a given `model_type` without
attempting that throwing, allocating call. The `creators` dictionary is private,
so the check has to live on the type.

This adds a cheap `contains(_:)` so a caller can, for example, decide before a
multi-GB download whether a Hub repo's `model_type` is runnable by the factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)