### PR TITLE
Fix speculative decoding test oracle

### DIFF
--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXNN
 import Testing
 
 @Suite(.serialized)
@@ -68,12 +69,26 @@ struct SpeculativeDecodingTests {
     }
 
     @Test(arguments: [2, 8, 48], [false, true])
-    func `Speculative decoding matches default token generation`(
+    func `Speculative decoding matches default token generation for stable logits`(
         numDraftTokens: Int,
         withLogitProcessor: Bool
     ) async throws {
-        let input = UserInput(prompt: "Input text")
-        let modelInput = try await processor.prepare(input: input)
+        let vocabularySize = 100
+        let tokenizer = TestTokenizer(vocabularySize: vocabularySize)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "stable-transition-test"),
+            messageGenerator: DefaultMessageGenerator()
+        )
+        let model = StableTransitionLanguageModel(vocabularySize: vocabularySize)
+        let draftModel = StableTransitionLanguageModel(vocabularySize: vocabularySize)
+        let context = ModelContext(
+            configuration: processor.configuration,
+            model: model,
+            processor: processor,
+            tokenizer: processor.tokenizer
+        )
+        let input = LMInput(tokens: MLXArray([92, 85, 2, 95, 55, 7, 94, 42]))
         let parameters = GenerateParameters(
             maxTokens: 32,
             temperature: 0.0,  // Use greedy decoding for deterministic output
@@ -84,10 +99,39 @@ struct SpeculativeDecodingTests {
 
         var normalTokens: [Int] = []
         for await generation in try generateTokens(
-            input: modelInput, parameters: parameters, context: mainContext
+            input: input, parameters: parameters, context: context
         ) {
             if let token = generation.token { normalTokens.append(token) }
         }
+
+        var speculativeTokens: [Int] = []
+        for await generation in try generateTokens(
+            input: input, parameters: parameters, context: context,
+            draftModel: draftModel, numDraftTokens: numDraftTokens
+        ) {
+            if let token = generation.token { speculativeTokens.append(token) }
+        }
+
+        #expect(!normalTokens.isEmpty)
+        #expect(!speculativeTokens.isEmpty)
+        #expect(normalTokens == speculativeTokens)
+    }
+
+    @Test(arguments: [2, 8, 48], [false, true])
+    func `Speculative decoding Gemma3 smoke test`(
+        numDraftTokens: Int,
+        withLogitProcessor: Bool
+    ) async throws {
+        let input = UserInput(prompt: "Input text")
+        let modelInput = try await processor.prepare(input: input)
+        let maxTokens = 32
+        let parameters = GenerateParameters(
+            maxTokens: maxTokens,
+            temperature: 0.0,
+            repetitionPenalty: withLogitProcessor ? 1.5 : nil,
+            presencePenalty: withLogitProcessor ? 0.5 : nil,
+            frequencyPenalty: withLogitProcessor ? 0.2 : nil,
+        )
 
         var speculativeTokens: [Int] = []
         for await generation in try generateTokens(
@@ -97,8 +141,48 @@ struct SpeculativeDecodingTests {
             if let token = generation.token { speculativeTokens.append(token) }
         }
 
-        #expect(!normalTokens.isEmpty)
-        #expect(!speculativeTokens.isEmpty)
-        #expect(normalTokens == speculativeTokens)
+        // Real MLX model kernels may choose different argmaxes for batched
+        // verification and token-by-token decoding when logits are close.
+        // Keep this as model-path coverage; exact equality belongs to the
+        // stable-logit contract test above.
+        #expect(speculativeTokens.count == maxTokens)
+    }
+}
+
+/// Deterministic causal model for speculative decoding contract tests.
+///
+/// Each logit row predicts a high-margin transition from the token at the
+/// same position. Batched verification and token-by-token decoding therefore
+/// execute the same mathematical function, so equality failures point at the
+/// speculative iterator rather than at hardware-dependent MLX kernel drift.
+private final class StableTransitionLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let vocabularySize: Int
+    var kvHeads: [Int] { [] }
+
+    init(vocabularySize: Int) {
+        self.vocabularySize = vocabularySize
+        super.init()
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenIds = inputs.asArray(Int.self)
+        var logits = Array(
+            repeating: Float(-100),
+            count: tokenIds.count * vocabularySize
+        )
+
+        for (position, token) in tokenIds.enumerated() {
+            logits[position * vocabularySize + nextToken(after: token)] = 100
+        }
+
+        return MLXArray(logits, [1, tokenIds.count, vocabularySize])
+    }
+
+    private func nextToken(after token: Int) -> Int {
+        (token * 31 + 7) % vocabularySize
     }
 }


### PR DESCRIPTION
Use a deterministic high-margin transition model for exact speculative-vs-greedy equality coverage. Keep Gemma3 in the suite as a smoke test because real MLX batched verification and token-by-token decoding can choose different argmaxes when logits are close.

## Proposed changes

Fix https://github.com/ml-explore/mlx-swift-lm/issues/353 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
