### PR TITLE
Fix iOS build: replace homeDirectoryForCurrentUser with shared HF cache helper

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/Gemma4AssistantDraftModelIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/Gemma4AssistantDraftModelIntegrationTests.swift
@@ -27,18 +27,6 @@ private func drafterForwardFixturesOrSkip(name: String) async -> URL? {
     }
 }
 
-private func hfSnapshotDir(modelId: String) -> URL? {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let hub = home.appendingPathComponent(".cache/huggingface/hub")
-    let folderName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
-    let snapshots = hub.appendingPathComponent(folderName).appendingPathComponent("snapshots")
-    guard
-        let entries = try? FileManager.default.contentsOfDirectory(
-            at: snapshots, includingPropertiesForKeys: nil)
-    else { return nil }
-    return entries.first
-}
-
 // MARK: - Gemma4 assistant integration tests
 //
 // Wrapped in `@Suite(.serialized)` so the three tests below (which each load

--- a/IntegrationTesting/IntegrationTestingTests/MTPAcceptanceRateTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPAcceptanceRateTests.swift
@@ -1,24 +1,11 @@
 // Copyright © 2026 Apple Inc.
 
 import Foundation
+import IntegrationTestHelpers
 import MLX
 import MLXLMCommon
 import MLXVLM
 import Testing
-
-// MARK: - Helpers
-
-private func hfSnapshotDir(modelId: String) -> URL? {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let hub = home.appendingPathComponent(".cache/huggingface/hub")
-    let folderName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
-    let snapshots = hub.appendingPathComponent(folderName).appendingPathComponent("snapshots")
-    guard
-        let entries = try? FileManager.default.contentsOfDirectory(
-            at: snapshots, includingPropertiesForKeys: nil)
-    else { return nil }
-    return entries.first
-}
 
 // MARK: - Acceptance-rate floor
 

--- a/IntegrationTesting/IntegrationTestingTests/MTPDrafterModelFactoryIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPDrafterModelFactoryIntegrationTests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
 import Foundation
+import IntegrationTestHelpers
 import MLXLMCommon
 import MLXVLM
 import Testing
@@ -11,15 +12,9 @@ import Testing
 func testMTPDrafterFactoryLoadFromDirectoryWhenCheckpointPresent() async throws {
     // Look for the 31B-assistant-bf16 checkpoint in the HF cache; skip
     // gracefully when absent.
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let hub = home.appendingPathComponent(".cache/huggingface/hub")
-    let folder = hub.appendingPathComponent(
-        "models--mlx-community--gemma-4-31B-it-assistant-bf16/snapshots"
-    )
     guard
-        let entries = try? FileManager.default.contentsOfDirectory(
-            at: folder, includingPropertiesForKeys: nil),
-        let snapshot = entries.first
+        let snapshot = hfSnapshotDir(
+            modelId: "mlx-community/gemma-4-31B-it-assistant-bf16")
     else {
         Issue.record("31B-assistant-bf16 checkpoint not in HF cache; skipping factory load test")
         return

--- a/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
@@ -28,18 +28,6 @@ import Tokenizers
 
 // MARK: - Helpers
 
-private func hfSnapshotDir(modelId: String) -> URL? {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let hub = home.appendingPathComponent(".cache/huggingface/hub")
-    let folderName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
-    let snapshots = hub.appendingPathComponent(folderName).appendingPathComponent("snapshots")
-    guard
-        let entries = try? FileManager.default.contentsOfDirectory(
-            at: snapshots, includingPropertiesForKeys: nil)
-    else { return nil }
-    return entries.first
-}
-
 private struct LoadedPair {
     let context: ModelContext
     let drafter: any MTPDrafterModel

--- a/IntegrationTesting/IntegrationTestingTests/MTPQuantizationOnsetTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPQuantizationOnsetTests.swift
@@ -1,24 +1,11 @@
 // Copyright © 2026 Apple Inc.
 
 import Foundation
+import IntegrationTestHelpers
 import MLX
 import MLXLMCommon
 import MLXVLM
 import Testing
-
-// MARK: - Helpers
-
-private func hfSnapshotDir(modelId: String) -> URL? {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let hub = home.appendingPathComponent(".cache/huggingface/hub")
-    let folderName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
-    let snapshots = hub.appendingPathComponent(folderName).appendingPathComponent("snapshots")
-    guard
-        let entries = try? FileManager.default.contentsOfDirectory(
-            at: snapshots, includingPropertiesForKeys: nil)
-    else { return nil }
-    return entries.first
-}
 
 // MARK: - R13 — mid-generation KV cache quantization onset
 

--- a/IntegrationTesting/IntegrationTestingTests/MTPRung4TokenParityTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPRung4TokenParityTests.swift
@@ -26,18 +26,6 @@ private func mtpFixturesDirOrSkip(name: String) async -> URL? {
     }
 }
 
-private func hfSnapshotDir(modelId: String) -> URL? {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let hub = home.appendingPathComponent(".cache/huggingface/hub")
-    let folderName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
-    let snapshots = hub.appendingPathComponent(folderName).appendingPathComponent("snapshots")
-    guard
-        let entries = try? FileManager.default.contentsOfDirectory(
-            at: snapshots, includingPropertiesForKeys: nil)
-    else { return nil }
-    return entries.first
-}
-
 // MARK: - Shared bound drafter
 //
 // Rung 4 requires the drafter to be paired with a real target so that the

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -864,6 +864,48 @@ private let timeToolSchema: ToolSpec = [
 
 private let multiToolSchemas: [ToolSpec] = [weatherToolSchema, timeToolSchema]
 
+// MARK: - Hugging Face cache locations
+
+/// Returns the root directory for Hugging Face caches (`~/.cache/huggingface`).
+///
+/// `FileManager.homeDirectoryForCurrentUser` is unavailable on iOS, so this helper
+/// falls back to `NSHomeDirectory()`. On macOS that resolves to the real user home
+/// (matching the `huggingface_hub` Python client's default cache layout); on iOS it
+/// resolves to the app sandbox home, where these integration tests do not normally run
+/// but where the path is at least addressable for callers that pre-populate caches.
+public func hfCacheDir() -> URL {
+    URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        .appendingPathComponent(".cache/huggingface", isDirectory: true)
+}
+
+/// Returns the local snapshot directory for `modelId` inside the Hugging Face hub cache,
+/// following the `models--{owner}--{name}/snapshots/{rev}` layout written by `huggingface_hub`.
+/// When `revision` is `nil` (the default) picks the first entry under `snapshots/` — sufficient
+/// for the usual single-revision case.
+/// When `revision` is non-nil, returns that specific snapshot directory if it exists.
+/// Returns `nil` when the model (or the requested revision) is not present in the cache.
+public func hfSnapshotDir(modelId: String, revision: String? = nil) -> URL? {
+    let folderName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
+    let snapshots = hfCacheDir()
+        .appendingPathComponent("hub", isDirectory: true)
+        .appendingPathComponent(folderName, isDirectory: true)
+        .appendingPathComponent("snapshots", isDirectory: true)
+    if let revision {
+        let pinned = snapshots.appendingPathComponent(revision, isDirectory: true)
+        var isDir: ObjCBool = false
+        guard
+            FileManager.default.fileExists(atPath: pinned.path, isDirectory: &isDir),
+            isDir.boolValue
+        else { return nil }
+        return pinned
+    }
+    guard
+        let entries = try? FileManager.default.contentsOfDirectory(
+            at: snapshots, includingPropertiesForKeys: nil)
+    else { return nil }
+    return entries.first
+}
+
 // MARK: - Dataset download
 
 public enum IntegrationTestDatasetError: LocalizedError {
@@ -905,9 +947,8 @@ public func downloadDataset(
     revision: String,
     matching patterns: [String] = []
 ) async throws -> URL {
-    let cacheRoot = FileManager.default
-        .homeDirectoryForCurrentUser
-        .appendingPathComponent(".cache/huggingface/integration-test-datasets", isDirectory: true)
+    let cacheRoot = hfCacheDir()
+        .appendingPathComponent("integration-test-datasets", isDirectory: true)
     let snapshotDir =
         cacheRoot
         .appendingPathComponent(repo, isDirectory: true)


### PR DESCRIPTION
homeDirectoryForCurrentUser is API_UNAVAILABLE on iOS, which broke the IntegrationTestHelpers SPM library on iOS. This change centralizes Hugging Face cache path resolution into two helper functions in IntegrationTestHelpers: hfCacheDir()
hfSnapshotDir(modelId:revision:)

## Proposed changes

Fix build failure:
mlx-swift-lm/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift:909:10: 'homeDirectoryForCurrentUser' is unavailable in iOS

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
