### PR TITLE
Fix KV cache quantization: cache updates lost due to value-type propagation

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -533,11 +533,12 @@ public struct TokenIterator: TokenIteratorProtocol {
     var state: LMOutput.State?
 
     var y: LMInput.Text
-    var cache: [KVCache]
+    var cacheContainer: KVCacheContainer
+    var cache: [KVCache] { cacheContainer.cache }
     var processor: LogitProcessor?
     let sampler: LogitSampler
 
-    public var tokenCount = 0
+    private(set) public var tokenCount = 0
     public let maxTokens: Int?
 
     // Cache quantization parameters
@@ -561,12 +562,30 @@ public struct TokenIterator: TokenIteratorProtocol {
         prompt: MLXArray, model: any LanguageModel, cache: [KVCache]? = nil,
         parameters: GenerateParameters
     ) throws {
-        self.model = model
-        self.y = .init(tokens: prompt)
-        self.cache = cache ?? model.newCache(parameters: parameters)
+        let input = LMInput(tokens: prompt)
+        try self.init(input: input, model: model, cache: cache, parameters: parameters)
+    }
 
-        self.processor = parameters.processor()
-        self.sampler = parameters.sampler()
+    /// Initialize a `TokenIterator` with the given input.
+    ///
+    /// - Parameters:
+    ///   - input: language model input
+    ///   - model: the ``LanguageModel``
+    ///   - cacheContainer: ``KVCacheContainer``
+    ///   - parameters: the generation parameters
+    ///   - processor: the logit processor override
+    ///   - sampler: the logit sampler override
+    public init(
+        input: LMInput, model: any LanguageModel, cacheContainer: KVCacheContainer,
+        parameters: GenerateParameters, processor: LogitProcessor? = nil,
+        sampler: LogitSampler? = nil
+    ) throws {
+        self.model = model
+        self.y = input.text
+        self.cacheContainer = cacheContainer
+
+        self.processor = processor ?? parameters.processor()
+        self.sampler = sampler ?? parameters.sampler()
         self.maxTokens = parameters.maxTokens
 
         self.kvBits = parameters.kvBits
@@ -574,7 +593,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.quantizedKVStart = parameters.quantizedKVStart
 
         self.promptPrefillTime = try measure {
-            try prepare(input: .init(text: y), windowSize: parameters.prefillStepSize)
+            try prepare(input: input, windowSize: parameters.prefillStepSize)
         }
     }
 
@@ -590,25 +609,22 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///   - model: the ``LanguageModel``
     ///   - cache: optional ``KVCache``
     ///   - parameters: the generation parameters
+    ///   - processor: the logit processor override
+    ///   - sampler: the logit sampler override
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
-        parameters: GenerateParameters
+        parameters: GenerateParameters, processor: LogitProcessor? = nil,
+        sampler: LogitSampler? = nil
     ) throws {
-        self.model = model
-        self.y = input.text
-        self.cache = cache ?? model.newCache(parameters: parameters)
+        let container = KVCacheContainer(cache: cache, model: model, parameters: parameters)
 
-        self.processor = parameters.processor()
-        self.sampler = parameters.sampler()
-        self.maxTokens = parameters.maxTokens
-
-        self.kvBits = parameters.kvBits
-        self.kvGroupSize = parameters.kvGroupSize
-        self.quantizedKVStart = parameters.quantizedKVStart
-
-        self.promptPrefillTime = try measure {
-            try prepare(input: input, windowSize: parameters.prefillStepSize)
-        }
+        try self.init(
+            input: input,
+            model: model,
+            cacheContainer: container,
+            parameters: parameters,
+            processor: processor,
+            sampler: sampler)
     }
 
     /// Initialize a `TokenIterator` with the given input and logit handling.
@@ -626,22 +642,20 @@ public struct TokenIterator: TokenIteratorProtocol {
         processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int = 512,
         maxTokens: Int? = nil
     ) throws {
-        self.model = model
-        self.y = input.text
-        self.cache = cache ?? model.newCache(parameters: nil)
+        let parameters = GenerateParameters(
+            maxTokens: maxTokens,
+            kvBits: nil,
+            kvGroupSize: 64,
+            quantizedKVStart: 0,
+            prefillStepSize: prefillStepSize)
 
-        self.processor = processor
-        self.sampler = sampler
-        self.maxTokens = maxTokens
-
-        // No cache quantization for this direct initialization
-        self.kvBits = nil
-        self.kvGroupSize = 64
-        self.quantizedKVStart = 0
-
-        self.promptPrefillTime = try measure {
-            try prepare(input: input, windowSize: prefillStepSize)
-        }
+        try self.init(
+            input: input,
+            model: model,
+            cache: cache,
+            parameters: parameters,
+            processor: processor,
+            sampler: sampler)
     }
 
     mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
@@ -684,13 +698,9 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
         self.state = result.state
 
-        // Apply dynamic cache quantization after each step
-        maybeQuantizeKVCache(
-            cache: &cache,
-            kvBits: kvBits,
-            kvGroupSize: kvGroupSize,
-            quantizedKVStart: quantizedKVStart
-        )
+        // Attempt dynamic cache quantization after each step if needed
+        cacheContainer.maybeQuantize(
+            kvBits: kvBits, kvGroupSize: kvGroupSize, quantizedKVStart: quantizedKVStart)
 
         return convertToToken(logits: result.logits)
     }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -106,6 +106,52 @@ extension KVCache {
     public func prepare(lengths: MLXArray?) {}
 
     public func finalize() {}
+
+    func asQuantizableWithGroupSize(_ groupSize: Int) -> QuantizableKVCache? {
+        switch self {
+        case let simple as KVCacheSimple:
+            return simple
+        // TODO: RotatingKVCache.toQuantized() is not implemented yet, like in Python.
+        // When implemented, add: case let rotating as RotatingKVCache...
+        default:
+            return nil
+        }
+    }
+
+    func canQuantize(at quantizedKVStart: Int, groupSize: Int) -> Bool {
+        guard let quantizable = asQuantizableWithGroupSize(groupSize) else { return false }
+
+        return quantizable.offset >= quantizedKVStart
+    }
+
+    func isValidQuantizedGroupSize(_ groupSize: Int) -> Bool {
+        guard state.count == 2 else { return false }
+        let keyHeadDim = state[0].dim(3)
+        let valueHeadDim = state[1].dim(3)
+
+        return [32, 64, 128].contains {
+            keyHeadDim.isMultiple(of: $0) && valueHeadDim.isMultiple(of: $0)
+        }
+    }
+
+    func resolvedKVQuantizationGroupSize(_ groupSize: Int, keyHeadDim: Int, valueHeadDim: Int)
+        -> Int?
+    {
+        let compatible = [32, 64, 128].filter {
+            keyHeadDim.isMultiple(of: $0) && valueHeadDim.isMultiple(of: $0)
+        }
+        guard !compatible.isEmpty else { return nil }
+        let requested = max(1, groupSize)
+
+        return compatible.min { lhs, rhs in
+            let lhsDistance = abs(lhs - requested)
+            let rhsDistance = abs(rhs - requested)
+            if lhsDistance == rhsDistance {
+                return lhs < rhs
+            }
+            return lhsDistance < rhsDistance
+        }
+    }
 }
 
 public func withPreparedCache<Result>(
@@ -125,6 +171,11 @@ public func withPreparedCache<Result>(
         }
     }
     return try body()
+}
+
+/// Protocol for caches that support conversion to quantized cache
+public protocol QuantizableKVCache: KVCache {
+    func toQuantized(groupSize: Int, bits: Int) -> QuantizedKVCache
 }
 
 /// Protocol for caches that support efficient quantized operations
@@ -369,7 +420,7 @@ public func createSSMMask(h: MLXArray, cache: MambaCache?) -> MLXArray? {
 
 /// Standard KV cache implementation based on Python's KVCache
 /// See https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/base.py#L11
-public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
+public class KVCacheSimple: BaseKVCache, QuantizableKVCache, CustomDebugStringConvertible {
     internal var keys: MLXArray?
     internal var values: MLXArray?
     public var step = 256
@@ -468,7 +519,7 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
             let currentValues = values[.ellipsis, ..<offset, 0...]
             guard
                 let effectiveGroupSize = resolvedKVQuantizationGroupSize(
-                    requested: groupSize,
+                    groupSize,
                     keyHeadDim: currentKeys.dim(3),
                     valueHeadDim: currentValues.dim(3)
                 )
@@ -797,26 +848,6 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 }
 
-private func resolvedKVQuantizationGroupSize(
-    requested: Int,
-    keyHeadDim: Int,
-    valueHeadDim: Int
-) -> Int? {
-    let requested = max(1, requested)
-    let compatible = [32, 64, 128].filter {
-        keyHeadDim.isMultiple(of: $0) && valueHeadDim.isMultiple(of: $0)
-    }
-    guard !compatible.isEmpty else { return nil }
-    return compatible.min { lhs, rhs in
-        let lhsDistance = abs(lhs - requested)
-        let rhsDistance = abs(rhs - requested)
-        if lhsDistance == rhsDistance {
-            return lhs < rhs
-        }
-        return lhsDistance < rhsDistance
-    }
-}
-
 /// Quantized KV cache for memory efficiency using MLX quantization
 public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     private var keys: (MLXArray, MLXArray, MLXArray?)?
@@ -916,7 +947,7 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
         let vHeadDim = values.dim(3)
         let prev = offset
         let effectiveGroupSize = resolvedKVQuantizationGroupSize(
-            requested: groupSize,
+            groupSize,
             keyHeadDim: kHeadDim,
             valueHeadDim: vHeadDim
         )
@@ -1545,6 +1576,31 @@ public class CacheList: BaseKVCache {
     }
 }
 
+public class KVCacheContainer {
+    private(set) public var cache: [KVCache] = []
+    private var canQuantize: Bool
+
+    public init(cache: [KVCache]? = nil, model: any LanguageModel, parameters: GenerateParameters) {
+        let cache = cache ?? model.newCache(parameters: parameters)
+
+        self.cache = cache
+        self.canQuantize =
+            parameters.kvBits != nil
+            && cache.contains { $0.asQuantizableWithGroupSize(parameters.kvGroupSize) != nil }
+    }
+
+    public func maybeQuantize(kvBits: Int?, kvGroupSize: Int = 64, quantizedKVStart: Int = 0) {
+        guard canQuantize else { return }
+
+        if maybeQuantizeKVCache(
+            cache: &cache, kvBits: kvBits, kvGroupSize: kvGroupSize,
+            quantizedKVStart: quantizedKVStart)
+        {
+            canQuantize = false
+        }
+    }
+}
+
 // MARK: - Error Types
 
 struct KVCacheError: Error {
@@ -1969,43 +2025,24 @@ public func quantizedScaledDotProductAttention(
 ///   - kvBits: Number of bits for quantization (nil = no quantization)
 ///   - kvGroupSize: Group size for quantization
 ///   - quantizedKVStart: Token count threshold to begin quantizing
+/// - Returns: true if cache was quantized, otherwise false
+@discardableResult
 public func maybeQuantizeKVCache(
     cache: inout [KVCache],
     kvBits: Int?,
     kvGroupSize: Int = 64,
     quantizedKVStart: Int = 0
-) {
-    guard let kvBits = kvBits, !cache.isEmpty else { return }
+) -> Bool {
+    guard let kvBits = kvBits, !cache.isEmpty else { return false }
+    guard cache.contains(where: { $0.canQuantize(at: quantizedKVStart, groupSize: kvGroupSize) })
+    else { return false }
 
-    // Find the first quantizable (non-Mamba, non-already-quantized) cache entry
-    guard let firstQuantizable = cache.first(where: { $0 is KVCacheSimple }),
-        !(firstQuantizable is QuantizedKVCache),
-        firstQuantizable.offset > quantizedKVStart
-    else {
-        return
+    cache = cache.map {
+        guard let quantizableCache = $0.asQuantizableWithGroupSize(kvGroupSize) else { return $0 }
+        guard quantizableCache.isValidQuantizedGroupSize(kvGroupSize) else { return $0 }
+
+        return quantizableCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
     }
 
-    for i in 0 ..< cache.count {
-        // Handle cache types that support quantization
-        if let simpleCache = cache[i] as? KVCacheSimple {
-            let state = simpleCache.state
-            if state.count == 2 {
-                let keyHeadDim = state[0].dim(3)
-                let valueHeadDim = state[1].dim(3)
-                guard
-                    resolvedKVQuantizationGroupSize(
-                        requested: kvGroupSize,
-                        keyHeadDim: keyHeadDim,
-                        valueHeadDim: valueHeadDim
-                    ) != nil
-                else {
-                    continue
-                }
-            }
-            cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
-        }
-        // TODO: RotatingKVCache.toQuantized() is not implemented yet, like in Python.
-        // When implemented, add: else if let rotatingCache = cache[i] as? RotatingKVCache { ... }
-        // MambaCache and CacheList don't use traditional KV quantization
-    }
+    return true
 }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1220,7 +1220,6 @@ final class Gemma4TextBackbone: Module {
         }
         let finalPerLayerInputs = projectPerLayerInputs(h0, perLayerInputs: processedPerLayerInputs)
 
-        let hasExplicitCache = cache != nil
         let localCache =
             cache ?? Array(repeating: nil as KVCache?, count: max(firstKVSharedLayerIdx, 1))
         var fullMask: MLXFast.ScaledDotProductAttentionMaskMode

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -112,7 +112,7 @@ private enum Language {
             var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
             freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]
 
-            var freqsT = freqs[0]
+            let freqsT = freqs[0]
             var offset = mropeSectionRaw[0]
             for dim in 1 ..< mropeSectionRaw.count {
                 let length = mropeSectionRaw[dim]


### PR DESCRIPTION
**Background**

`maybeQuantizeKVCache` takes `cache: inout [KVCache]` and replaces array elements with new `QuantizedKVCache` instances when the quantization threshold is crossed. Because Swift arrays are value types, this replacement was only visible inside `TokenIterator`'s local copy — the caller's array continued holding the original `KVCacheSimple` references. The quantized caches were deallocated at the end of generation, silently discarding all context generated after the quantization threshold. See [issue #312](https://github.com/ml-explore/mlx-swift-lm/issues/312) for additional details and reproduction steps.

**What this PR does**

Introduces `KVCacheContainer`, a reference-type (`class`) wrapper that owns the `[KVCache]` array. `TokenIterator` now holds a `KVCacheContainer` rather than a bare array, so element replacements during quantization are visible to any holder of the same container. `KVCacheContainer.maybeQuantize` also uses the new `Bool` return value from `maybeQuantizeKVCache` to set a `canQuantize` flag to `false` after the first successful quantization pass, eliminating the redundant per-step scan of all cache layers that occurred in the original code.

The `QuantizableKVCache` protocol is introduced to formalize which cache types support conversion to quantized form. `KVCacheSimple` conforms to it. `RotatingKVCache` is not yet supported (matching the Python implementation) with a TODO stub in place. Several quantization helpers (`asQuantizableWithGroupSize`, `canQuantize(at:groupSize:)`, `isValidQuantizedGroupSize`, `resolvedKVQuantizationGroupSize`) are moved from a private free function into a `KVCache` extension, making them accessible for reuse and testing. The dead-code `!(firstQuantizable is QuantizedKVCache)` check noted in the original issue is removed.

`maybeQuantizeKVCache` gains `@discardableResult` and now returns `Bool` to indicate whether quantization occurred.

`TokenIterator`'s multiple `init` paths are consolidated to funnel through a single canonical initializer, reducing duplication. The previously-fixed inits also pick up optional `processor` and `sampler` override parameters for consistency. `tokenCount` is tightened to `private(set) public`.

**Out of scope**

This PR does not address the `ChatSession` side of cache ownership, `SpeculativeTokenIterator`, or `RotatingKVCache` quantization support. Those are candidates for follow-up work.

**Unrelated changes**

Two minor compiler warning fixes are included: removal of an unused `hasExplicitCache` variable in `Gemma4.swift`, and a `var` → `let` correction for `freqsT` in `Qwen25VL.swift`.

_PR description crafted with assist from Claude since I'm a bad explainer_

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
