### PR TITLE
Fix build on Xcode 16.3 / SDK < 26

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -18,10 +18,10 @@ public struct ProcessedFrames {
 // scan accumulates thousands of cached intermediate surfaces and hits the
 // per-process IOSurface limit of 16384, crashing the render pipeline.
 // Batch-processing never re-renders the same frame twice, so the cache buys nothing.
-#if compiler(>=6.2)     // proxy check for macOS 26 SDK, where CIContext is Sendable
-private let context = CIContext(options: [.cacheIntermediates: false])
+#if compiler(>=6.2)  // proxy check for macOS 26 SDK, where CIContext is Sendable
+    private let context = CIContext(options: [.cacheIntermediates: false])
 #else
-nonisolated(unsafe) private let context = CIContext(options: [.cacheIntermediates: false])
+    nonisolated(unsafe) private let context = CIContext(options: [.cacheIntermediates: false])
 #endif
 
 /// Collection of methods for processing media (images, video, etc.).

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -18,7 +18,11 @@ public struct ProcessedFrames {
 // scan accumulates thousands of cached intermediate surfaces and hits the
 // per-process IOSurface limit of 16384, crashing the render pipeline.
 // Batch-processing never re-renders the same frame twice, so the cache buys nothing.
+#if compiler(>=6.2)     // proxy check for macOS 26 SDK, where CIContext is Sendable
 private let context = CIContext(options: [.cacheIntermediates: false])
+#else
+nonisolated(unsafe) private let context = CIContext(options: [.cacheIntermediates: false])
+#endif
 
 /// Collection of methods for processing media (images, video, etc.).
 ///


### PR DESCRIPTION
Building MLXVLM on Xcode 16.3 (SDK < 26) fails under Swift strict concurrency because `CIContext` is not Sendable. The annotation was added to the macOS 26 SDK. We [found this out](https://github.com/huggingface/AnyLanguageModel/actions/runs/27836815102/job/82386648527) when [bumping mlx-swift-lm to the latest 3.x version](https://github.com/huggingface/AnyLanguageModel/pull/162) in AnyLanguageModel.

## Proposed changes

Declare the `CIContext` var as `nonisolated(unsafe)`. `CIContext` rendering ops are actually thread-safe. macOS SDK v6 added an `@unchecked Sendable` annotation that is not present in previous SDKs.

[We prepared a test repo that uses GitHub CI](https://github.com/pcuenca/mlx-cicontext-fix-tests) to show how builds work with this PR and the official repo, for both Xcode 16.3 and Xcode 26.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works ([in a separate repo](https://github.com/pcuenca/mlx-cicontext-fix-tests))
- [ ] I have updated the necessary documentation (if needed)
