### PR TITLE
Support correlated tool call transcripts

### DIFF
--- a/Libraries/MLXLMCommon/Chat.swift
+++ b/Libraries/MLXLMCommon/Chat.swift
@@ -17,17 +17,45 @@ public enum Chat {
         /// Array of audio data associated with the message.
         public var audios: [UserInput.Audio]
 
+        /// Tool-call metadata associated with this message.
+        public var tool: Tool?
+
+        public struct Tool: Sendable {
+            fileprivate enum Storage: Sendable {
+                case calls([ToolCall])
+                case result(id: String)
+            }
+
+            fileprivate let storage: Storage
+
+            private init(storage: Storage) {
+                self.storage = storage
+            }
+
+            /// Tool calls emitted by an assistant message.
+            public static func calls(_ calls: [ToolCall]) -> Self {
+                Self(storage: .calls(calls))
+            }
+
+            /// Id of the assistant tool call answered by a tool message.
+            public static func result(id: String) -> Self {
+                Self(storage: .result(id: id))
+            }
+        }
+
         public init(
             role: Role, content: String,
             images: [UserInput.Image] = [],
             videos: [UserInput.Video] = [],
-            audios: [UserInput.Audio] = []
+            audios: [UserInput.Audio] = [],
+            tool: Tool? = nil
         ) {
             self.role = role
             self.content = content
             self.images = images
             self.videos = videos
             self.audios = audios
+            self.tool = tool
         }
 
         public static func system(
@@ -37,9 +65,14 @@ public enum Chat {
         }
 
         public static func assistant(
-            _ content: String, images: [UserInput.Image] = [], videos: [UserInput.Video] = []
+            _ content: String,
+            images: [UserInput.Image] = [],
+            videos: [UserInput.Video] = [],
+            toolCalls: [ToolCall]? = nil
         ) -> Self {
-            Self(role: .assistant, content: content, images: images, videos: videos)
+            Self(
+                role: .assistant, content: content, images: images, videos: videos,
+                tool: toolCalls.map { .calls($0) })
         }
 
         public static func user(
@@ -51,8 +84,8 @@ public enum Chat {
             Self(role: .user, content: content, images: images, videos: videos, audios: audios)
         }
 
-        public static func tool(_ content: String) -> Self {
-            Self(role: .tool, content: content)
+        public static func tool(_ content: String, id: String? = nil) -> Self {
+            Self(role: .tool, content: content, tool: id.map { .result(id: $0) })
         }
 
         public enum Role: String, Sendable {
@@ -90,10 +123,38 @@ public protocol MessageGenerator: Sendable {
 extension MessageGenerator {
 
     public func generate(message: Chat.Message) -> Message {
-        [
+        var dictionary: Message = [
             "role": message.role.rawValue,
             "content": message.content,
         ]
+
+        addToolMetadata(to: &dictionary, for: message)
+
+        return dictionary
+    }
+
+    /// Adds tool-call metadata from a structured message to a raw message dictionary.
+    public func addToolMetadata(to dictionary: inout Message, for message: Chat.Message) {
+        switch message.tool?.storage {
+        case .calls(let calls):
+            dictionary["tool_calls"] = calls.map { toolCall -> [String: any Sendable] in
+                var entry: [String: any Sendable] = [
+                    "type": "function",
+                    "function": [
+                        "name": toolCall.function.name,
+                        "arguments": toolCall.function.argumentsObject,
+                    ] as [String: any Sendable],
+                ]
+                if let id = toolCall.id {
+                    entry["id"] = id
+                }
+                return entry
+            }
+        case .result(let id):
+            dictionary["tool_call_id"] = id
+        case nil:
+            break
+        }
     }
 
     public func generate(messages: [Chat.Message]) -> [Message] {
@@ -119,8 +180,8 @@ extension MessageGenerator {
     }
 }
 
-/// Default implementation of ``MessageGenerator`` that produces a
-/// `role` and `content`.
+/// Default implementation of ``MessageGenerator`` that produces `role` and
+/// `content`, plus `tool_call_id` and `tool_calls` when present.
 ///
 /// ```swift
 /// [
@@ -130,13 +191,6 @@ extension MessageGenerator {
 /// ```
 public struct DefaultMessageGenerator: MessageGenerator {
     public init() {}
-
-    public func generate(message: Chat.Message) -> Message {
-        [
-            "role": message.role.rawValue,
-            "content": message.content,
-        ]
-    }
 }
 
 /// Implementation of ``MessageGenerator`` that produces a

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -777,7 +777,7 @@ public final class ChatSession {
                         {
                             for toolCall in pendingToolCalls {
                                 let toolResult = try await toolDispatch(toolCall)
-                                messages.append(.tool(toolResult))
+                                messages.append(.tool(toolResult, id: toolCall.id))
                             }
                             continue restart
                         }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -31,8 +31,7 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
 
         guard
             let data = jsonStr.data(using: .utf8),
-            let normalizedData = normalizedToolCallData(from: data),
-            let function = try? JSONDecoder().decode(ToolCall.Function.self, from: normalizedData)
+            let toolCall = parseToolCall(from: data)
         else { return nil }
 
         // If tool schemas are provided, only accept calls to declared tools.
@@ -40,7 +39,7 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
             var isDeclaredTool = false
             for tool in tools {
                 let functionSpec = tool["function"] as? [String: any Sendable]
-                if functionSpec?["name"] as? String == function.name {
+                if functionSpec?["name"] as? String == toolCall.function.name {
                     isDeclaredTool = true
                     break
                 }
@@ -51,13 +50,19 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
             }
         }
 
-        return ToolCall(function: function)
+        return toolCall
     }
 
-    private func normalizedToolCallData(from data: Data) -> Data? {
+    private func parseToolCall(from data: Data) -> ToolCall? {
         guard var jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
             return nil
+        }
+
+        var id = jsonObject["id"] as? String
+        if let functionObject = jsonObject["function"] as? [String: Any] {
+            id = id ?? functionObject["id"] as? String
+            jsonObject = functionObject
         }
 
         if let stringifiedArguments = jsonObject["arguments"] as? String {
@@ -69,6 +74,11 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
             jsonObject["arguments"] = argumentsObject
         }
 
-        return try? JSONSerialization.data(withJSONObject: jsonObject)
+        guard
+            let normalizedData = try? JSONSerialization.data(withJSONObject: jsonObject),
+            let function = try? JSONDecoder().decode(ToolCall.Function.self, from: normalizedData)
+        else { return nil }
+
+        return ToolCall(function: function, id: id)
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/Llama3ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Llama3ToolCallParser.swift
@@ -12,6 +12,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
     public init() {}
 
     private struct LlamaFunction: Codable {
+        let id: String?
         let name: String
         let parameters: [String: JSONValue]?
         let arguments: [String: JSONValue]?
@@ -37,7 +38,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
                 name: llamaFunc.name,
                 arguments: args
             )
-            return ToolCall(function: function)
+            return ToolCall(function: function, id: llamaFunc.id)
         }
 
         // Fallback to Pythonic format
@@ -67,7 +68,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
                     name: llamaFunc.name,
                     arguments: args
                 )
-                return ToolCall(function: function)
+                return ToolCall(function: function, id: llamaFunc.id)
             }
         }
 
@@ -78,7 +79,7 @@ public struct Llama3ToolCallParser: ToolCallParser, Sendable {
                 name: llamaFunc.name,
                 arguments: args
             )
-            return [ToolCall(function: function)]
+            return [ToolCall(function: function, id: llamaFunc.id)]
         }
 
         // Try Pythonic list like [func1(args), func2(args)] or single func1(args)

--- a/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
@@ -42,9 +42,13 @@ public struct MistralToolCallParser: ToolCallParser, Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let argsPart = String(text[argsRange.upperBound...])
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        var callID: String?
 
         // Handle optional [CALL_ID] between name and [ARGS]
         if let callIdRange = namePart.range(of: "[CALL_ID]") {
+            let parsedCallID = String(namePart[callIdRange.upperBound...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            callID = parsedCallID.isEmpty ? nil : parsedCallID
             namePart = String(namePart[..<callIdRange.lowerBound])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
         }
@@ -57,7 +61,8 @@ public struct MistralToolCallParser: ToolCallParser, Sendable {
         }
 
         return ToolCall(
-            function: ToolCall.Function(name: namePart, arguments: argsDict)
+            function: ToolCall.Function(name: namePart, arguments: argsDict),
+            id: callID
         )
     }
 }

--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -20,13 +20,21 @@ public struct ToolCall: Hashable, Codable, Sendable {
             self.name = name
             self.arguments = arguments.mapValues { JSONValue.from($0) }
         }
+
+        var argumentsObject: [String: any Sendable] {
+            arguments.mapValues { $0.sendableValue }
+        }
     }
 
     /// The function to be called
     public let function: Function
 
-    public init(function: Function) {
+    /// Optional id used to correlate a tool call with its tool result.
+    public let id: String?
+
+    public init(function: Function, id: String? = nil) {
         self.function = function
+        self.id = id
     }
 }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -135,6 +135,18 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         }
     }
 
+    /// Generate an ID compatible with this tool-call syntax.
+    func generateToolCallID() -> String {
+        let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+
+        switch self {
+        case .mistral:
+            return String(uuid.prefix(9))
+        default:
+            return "call_" + uuid.lowercased()
+        }
+    }
+
     /// Infer the tool call format based on model type from config.json.
     ///
     /// This method maps known model types to their corresponding tool call formats,

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -26,6 +26,7 @@ public class ToolCallProcessor {
 
     // MARK: - Properties
 
+    private let format: ToolCallFormat
     private let parser: any ToolCallParser
     private let tools: [[String: any Sendable]]?
     private let supportsBareJSONFallback: Bool
@@ -33,6 +34,7 @@ public class ToolCallProcessor {
     private let jsonObjectScanner = JSONLeadingObjectScanner(startCharacter: "{")
     private var state = State.normal
     private var toolCallBuffer = ""
+    private var emittedToolCallIDs: Set<String> = []
 
     /// The tool calls extracted during processing.
     public var toolCalls: [ToolCall] = []
@@ -59,6 +61,7 @@ public class ToolCallProcessor {
     ///   - format: The tool call format to use (defaults to `.json` for standard JSON format)
     ///   - tools: Optional tool schemas for type-aware parsing
     public init(format: ToolCallFormat = .json, tools: [[String: any Sendable]]? = nil) {
+        self.format = format
         self.parser = format.createParser()
         self.tools = tools
         self.supportsBareJSONFallback = format == .json
@@ -134,7 +137,7 @@ public class ToolCallProcessor {
 
         let buffered = toolCallBuffer
         let parsedCalls = parser.parseEOS(buffered, tools: tools)
-        toolCalls.append(contentsOf: parsedCalls)
+        appendToolCalls(parsedCalls)
 
         toolCallBuffer = ""
         state = .normal
@@ -160,7 +163,7 @@ public class ToolCallProcessor {
                 state = .collectingToolCall
 
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                    toolCalls.append(toolCall)
+                    appendToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     return leading.isEmpty ? nil : leading
@@ -185,7 +188,7 @@ public class ToolCallProcessor {
             toolCallBuffer += chunk
 
             if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                toolCalls.append(toolCall)
+                appendToolCall(toolCall)
                 toolCallBuffer = ""
                 state = .normal
                 return nil
@@ -293,7 +296,7 @@ public class ToolCallProcessor {
 
                 // Parse the tool call using the parser.
                 if let toolCall = parser.parse(content: bufferedToolCall, tools: tools) {
-                    toolCalls.append(toolCall)
+                    appendToolCall(toolCall)
                     state = .normal
                     toolCallBuffer = ""
 
@@ -370,7 +373,7 @@ public class ToolCallProcessor {
         let trailingToken = split.trailing
 
         if let toolCall = parser.parse(content: jsonCandidate, tools: tools) {
-            toolCalls.append(toolCall)
+            appendToolCall(toolCall)
 
             state = .normal
             toolCallBuffer = ""
@@ -435,6 +438,33 @@ public class ToolCallProcessor {
     private func combine(_ first: String?, _ second: String?) -> String? {
         let merged = (first ?? "") + (second ?? "")
         return merged.isEmpty ? nil : merged
+    }
+
+    private func appendToolCalls(_ calls: [ToolCall]) {
+        for call in calls {
+            appendToolCall(call)
+        }
+    }
+
+    private func appendToolCall(_ call: ToolCall) {
+        toolCalls.append(normalizedToolCall(call))
+    }
+
+    private func normalizedToolCall(_ call: ToolCall) -> ToolCall {
+        if let id = call.id, !id.isEmpty, emittedToolCallIDs.insert(id).inserted {
+            return call
+        }
+
+        return ToolCall(function: call.function, id: generateToolCallID())
+    }
+
+    private func generateToolCallID() -> String {
+        while true {
+            let id = format.generateToolCallID()
+            if emittedToolCallIDs.insert(id).inserted {
+                return id
+            }
+        }
     }
 
     /// Separates a token from a string buffer based on a separator

--- a/Libraries/MLXLMCommon/Tool/Value.swift
+++ b/Libraries/MLXLMCommon/Tool/Value.swift
@@ -100,6 +100,25 @@ public enum JSONValue: Hashable, Codable, Sendable {
         }
     }
 
+    var sendableValue: any Sendable {
+        switch self {
+        case .null:
+            return NSNull()
+        case .bool(let value):
+            return value
+        case .int(let value):
+            return value
+        case .double(let value):
+            return value
+        case .string(let value):
+            return value
+        case .array(let value):
+            return value.map { $0.sendableValue }
+        case .object(let value):
+            return value.mapValues { $0.sendableValue }
+        }
+    }
+
     /// Convert to JSON Schema representation
     public var asSchema: [String: any Sendable] {
         switch self {

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1177,8 +1177,10 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
 /// - Image precedes text content
 /// - Empty system messages are removed - the chat template applies a default one in this case
 public struct FastVLMMessageGenerator: MessageGenerator {
+    public init() {}
+
     public func generate(message: Chat.Message) -> MLXLMCommon.Message {
-        [
+        var dictionary: MLXLMCommon.Message = [
             "role": message.role.rawValue,
             "content": []
                 + message.images.map { _ in
@@ -1186,6 +1188,8 @@ public struct FastVLMMessageGenerator: MessageGenerator {
                 }
                 + [["type": "text", "text": message.content]],
         ]
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
     }
 
     public func generate(messages: [Chat.Message]) -> [MLXLMCommon.Message] {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2558,13 +2558,14 @@ public struct Gemma4MessageGenerator: MessageGenerator {
     public init() {}
 
     public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        var dictionary: MLXLMCommon.Message
         if message.role == .system {
-            [
+            dictionary = [
                 "role": message.role.rawValue,
                 "content": message.content,
             ]
         } else {
-            [
+            dictionary = [
                 "role": message.role.rawValue,
                 "content": message.images.map { _ in
                     ["type": "image"]
@@ -2577,6 +2578,8 @@ public struct Gemma4MessageGenerator: MessageGenerator {
                     ],
             ]
         }
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
     }
 }
 

--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -1255,7 +1255,7 @@ public struct GlmOcrMessageGenerator: MessageGenerator {
     public init() {}
 
     public func generate(message: Chat.Message) -> MLXLMCommon.Message {
-        [
+        var dictionary: MLXLMCommon.Message = [
             "role": message.role.rawValue,
             "content": [
                 ["type": "text", "text": message.content]
@@ -1264,5 +1264,7 @@ public struct GlmOcrMessageGenerator: MessageGenerator {
                     ["type": "image"]
                 },
         ]
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
     }
 }

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -907,12 +907,14 @@ public struct Mistral3MessageGenerator: MessageGenerator {
 
     public func generate(message: Chat.Message) -> Message {
         // For Mistral3 VLM, images come before text in the content
-        [
+        var dictionary: Message = [
             "role": message.role.rawValue,
             "content": message.images.map { _ in
                 ["type": "image"]
             } + [["type": "text", "text": message.content]],
         ]
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
     }
 }
 

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -930,12 +930,14 @@ public struct Qwen2VLMessageGenerator: MessageGenerator {
         // <|vision_start|><|image_pad|><|vision_end|>{text}. Putting text first
         // shifts image-token positions and skews MROPE position IDs, producing
         // a deterministic ~9 px bbox offset vs the Python mlx-vlm reference.
-        [
+        var dictionary: MLXLMCommon.Message = [
             "role": message.role.rawValue,
             "content":
                 message.images.map { _ in ["type": "image"] }
                 + message.videos.map { _ in ["type": "video"] }
                 + [["type": "text", "text": message.content]],
         ]
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1769,9 +1769,11 @@ public struct Qwen3VLMessageGenerator: MessageGenerator {
             ["type": "video"]
         }
 
-        return [
+        var dictionary: MLXLMCommon.Message = [
             "role": message.role.rawValue,
             "content": imageContent + videoContent + textContent,
         ]
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
     }
 }

--- a/Tests/MLXLMTests/ToolCallIdTests.swift
+++ b/Tests/MLXLMTests/ToolCallIdTests.swift
@@ -1,0 +1,205 @@
+import MLXLMCommon
+import Testing
+
+struct ToolCallIdTests {
+    @Test("Assistant tool calls and tool results form a correlated transcript")
+    func assistantToolCallsAndToolResultsFormCorrelatedTranscript() throws {
+        let weatherCall = ToolCall(
+            function: .init(
+                name: "get_weather",
+                arguments: [
+                    "location": .string("Paris")
+                ]
+            ),
+            id: "call_123"
+        )
+        let timeCall = ToolCall(
+            function: .init(
+                name: "get_time",
+                arguments: [
+                    "timezone": .string("UTC")
+                ]
+            ),
+            id: "call_456"
+        )
+
+        let messages: [Chat.Message] = [
+            .assistant("", toolCalls: [weatherCall, timeCall]),
+            .tool(#"{"temperature":18}"#, id: "call_123"),
+            .tool(#"{"time":"12:00"}"#, id: "call_456"),
+        ]
+
+        let rawMessages = DefaultMessageGenerator().generate(messages: messages)
+        let assistant = rawMessages[0]
+        let calls = try #require(assistant["tool_calls"] as? [[String: any Sendable]])
+
+        #expect(assistant["role"] as? String == "assistant")
+        #expect(calls.count == 2)
+
+        let weather = calls[0]
+        #expect(weather["id"] as? String == "call_123")
+        #expect(weather["type"] as? String == "function")
+
+        let weatherFunction = try #require(weather["function"] as? [String: any Sendable])
+        #expect(weatherFunction["name"] as? String == "get_weather")
+
+        let weatherArguments = try #require(weatherFunction["arguments"] as? [String: any Sendable])
+        #expect(weatherArguments["location"] as? String == "Paris")
+
+        let time = calls[1]
+        #expect(time["id"] as? String == "call_456")
+        #expect(time["type"] as? String == "function")
+
+        let timeFunction = try #require(time["function"] as? [String: any Sendable])
+        #expect(timeFunction["name"] as? String == "get_time")
+        let timeArguments = try #require(timeFunction["arguments"] as? [String: any Sendable])
+        #expect(timeArguments["timezone"] as? String == "UTC")
+
+        let weatherResult = rawMessages[1]
+        #expect(weatherResult["role"] as? String == "tool")
+        #expect(weatherResult["content"] as? String == #"{"temperature":18}"#)
+        #expect(weatherResult["tool_call_id"] as? String == "call_123")
+
+        let timeResult = rawMessages[2]
+        #expect(timeResult["role"] as? String == "tool")
+        #expect(timeResult["content"] as? String == #"{"time":"12:00"}"#)
+        #expect(timeResult["tool_call_id"] as? String == "call_456")
+    }
+
+    @Test("Plain messages do not emit tool metadata")
+    func plainMessageDoesNotEmitToolMetadata() throws {
+        let dictionary = DefaultMessageGenerator().generate(message: .user("hi"))
+
+        #expect(dictionary["role"] as? String == "user")
+        #expect(dictionary["content"] as? String == "hi")
+        #expect(dictionary["tool_call_id"] == nil)
+        #expect(dictionary["tool_calls"] == nil)
+    }
+
+    @Test("ToolCall id defaults to nil for source compatibility")
+    func toolCallDefaultIdIsNil() {
+        let toolCall = ToolCall(function: .init(name: "noop", arguments: [:]))
+        #expect(toolCall.id == nil)
+    }
+
+    @Test("Parsed tool calls preserve supplied ids")
+    func parsedToolCallsPreserveSuppliedIDs() throws {
+        let processor = ToolCallProcessor()
+        let content =
+            #"<tool_call>{"id":"call_model","name":"get_weather","arguments":{"location":"Paris"}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.id == "call_model")
+        #expect(toolCall.function.name == "get_weather")
+    }
+
+    @Test("OpenAI style JSON tool calls preserve supplied ids")
+    func openAIStyleJSONToolCallsPreserveSuppliedIDs() throws {
+        let processor = ToolCallProcessor()
+        let content =
+            #"<tool_call>{"id":"call_openai","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.id == "call_openai")
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+    }
+
+    @Test("Nested OpenAI style JSON tool call ids are preserved")
+    func nestedOpenAIStyleJSONToolCallIDsArePreserved() throws {
+        let processor = ToolCallProcessor()
+        let content =
+            #"<tool_call>{"type":"function","function":{"id":"call_nested","name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.id == "call_nested")
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+    }
+
+    @Test("Parsed tool calls without ids receive generated ids")
+    func parsedToolCallsWithoutIDsReceiveGeneratedIDs() throws {
+        let processor = ToolCallProcessor()
+        let content =
+            #"<tool_call>{"name":"get_weather","arguments":{"location":"Paris"}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+
+        let toolCall = try #require(processor.toolCalls.first)
+        let id = try #require(toolCall.id)
+        #expect(id.hasPrefix("call_"))
+
+        let messages: [Chat.Message] = [
+            .assistant("", toolCalls: [toolCall]),
+            .tool(#"{"temperature":18}"#, id: id),
+        ]
+        let rawMessages = DefaultMessageGenerator().generate(messages: messages)
+        let calls = try #require(rawMessages[0]["tool_calls"] as? [[String: any Sendable]])
+        #expect(calls[0]["id"] as? String == id)
+        #expect(rawMessages[1]["tool_call_id"] as? String == id)
+    }
+
+    @Test("Mistral format generates Mistral-compatible tool call ids")
+    func mistralFormatGeneratesMistralCompatibleToolCallIDs() throws {
+        let processor = ToolCallProcessor(format: .mistral)
+        _ = processor.processChunk("[TOOL_CALLS]get_weather[ARGS]{\"location\":\"Paris\"}")
+        processor.processEOS()
+
+        let id = try #require(processor.toolCalls.first?.id)
+        #expect(id.count == 9)
+        #expect(
+            id.utf8.allSatisfy { byte in
+                (byte >= 48 && byte <= 57)
+                    || (byte >= 65 && byte <= 90)
+                    || (byte >= 97 && byte <= 122)
+            })
+    }
+
+    @Test("Generated tool call ids are distinct within one assistant turn")
+    func generatedToolCallIDsAreDistinctWithinOneAssistantTurn() throws {
+        let processor = ToolCallProcessor()
+        let content =
+            #"<tool_call>{"name":"first_call","arguments":{}}</tool_call><tool_call>{"name":"second_call","arguments":{}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+
+        #expect(processor.toolCalls.count == 2)
+        let firstID = try #require(processor.toolCalls[0].id)
+        let secondID = try #require(processor.toolCalls[1].id)
+        #expect(firstID != secondID)
+    }
+
+    @Test("Duplicate supplied tool call ids are normalized")
+    func duplicateSuppliedToolCallIDsAreNormalized() throws {
+        let processor = ToolCallProcessor()
+        let content =
+            #"<tool_call>{"id":"call_duplicate","name":"first_call","arguments":{}}</tool_call><tool_call>{"id":"call_duplicate","name":"second_call","arguments":{}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+
+        #expect(processor.toolCalls.count == 2)
+        #expect(processor.toolCalls[0].id == "call_duplicate")
+        let secondID = try #require(processor.toolCalls[1].id)
+        #expect(secondID != "call_duplicate")
+        #expect(secondID.hasPrefix("call_"))
+    }
+
+    @Test("Tool result continuations preserve explicit ids")
+    func toolResultContinuationsPreserveExplicitIDs() {
+        let messages: [Chat.Message] = [
+            .tool(#"{"temperature":18}"#, id: "call_123")
+        ]
+
+        let rawMessages = DefaultMessageGenerator().generate(messages: messages)
+        #expect(rawMessages[0]["role"] as? String == "tool")
+        #expect(rawMessages[0]["content"] as? String == #"{"temperature":18}"#)
+        #expect(rawMessages[0]["tool_call_id"] as? String == "call_123")
+    }
+
+}

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -1059,6 +1059,7 @@ struct ToolTests {
 
         let toolCall = try #require(parser.parse(content: content, tools: nil))
 
+        #expect(toolCall.id == "abc123xyz")
         #expect(toolCall.function.name == "get_weather")
         #expect(toolCall.function.arguments["location"] == .string("Paris"))
     }

--- a/Tests/MLXLMTests/UserInputTests.swift
+++ b/Tests/MLXLMTests/UserInputTests.swift
@@ -210,6 +210,51 @@ public class UserInputTests: XCTestCase {
         assertEqual(expected, messages)
     }
 
+    public func testCustomMessageGeneratorsPreserveToolMetadata() throws {
+        let toolCall = ToolCall(
+            function: .init(
+                name: "get_weather",
+                arguments: [
+                    "location": .string("Paris")
+                ]
+            ),
+            id: "call_custom_123"
+        )
+        let assistant = Chat.Message.assistant("Checking weather", toolCalls: [toolCall])
+        let toolResult = Chat.Message.tool(#"{"temperature":18}"#, id: "call_custom_123")
+
+        let generators: [(String, (Chat.Message) -> MLXLMCommon.Message)] = [
+            ("Qwen2VL", { Qwen2VLMessageGenerator().generate(message: $0) }),
+            ("Qwen3VL", { Qwen3VLMessageGenerator().generate(message: $0) }),
+            ("Gemma4", { Gemma4MessageGenerator().generate(message: $0) }),
+            ("FastVLM", { FastVLMMessageGenerator().generate(message: $0) }),
+            ("GlmOcr", { GlmOcrMessageGenerator().generate(message: $0) }),
+            ("Mistral3", { Mistral3MessageGenerator().generate(message: $0) }),
+        ]
+
+        for (name, generate) in generators {
+            let rawAssistant = generate(assistant)
+            XCTAssertEqual(rawAssistant["role"] as? String, "assistant", name)
+            XCTAssertNotNil(rawAssistant["content"], name)
+
+            let calls = try XCTUnwrap(
+                rawAssistant["tool_calls"] as? [[String: any Sendable]], name)
+            XCTAssertEqual(calls.count, 1, name)
+            XCTAssertEqual(calls[0]["id"] as? String, "call_custom_123", name)
+            XCTAssertEqual(calls[0]["type"] as? String, "function", name)
+
+            let function = try XCTUnwrap(calls[0]["function"] as? [String: any Sendable], name)
+            XCTAssertEqual(function["name"] as? String, "get_weather", name)
+            let arguments = try XCTUnwrap(function["arguments"] as? [String: any Sendable], name)
+            XCTAssertEqual(arguments["location"] as? String, "Paris", name)
+
+            let rawToolResult = generate(toolResult)
+            XCTAssertEqual(rawToolResult["role"] as? String, "tool", name)
+            XCTAssertNotNil(rawToolResult["content"], name)
+            XCTAssertEqual(rawToolResult["tool_call_id"] as? String, "call_custom_123", name)
+        }
+    }
+
     // MARK: - Qwen2 Message Generator Tests
 
     public func testQwen2ConversionImage() {


### PR DESCRIPTION
## Proposed changes

This PR adds the missing transcript representation and default message-generation support for correlated tool calls. Model-specific generators can build on this where needed.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
