### PR TITLE
Gemma4: drop gemma4_unified vision_embedder weights in sanitize

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -68,10 +68,13 @@ public class Gemma4Model: Module, LLMModel, KVCacheDimensionProvider {
             let startsWithModel = k.hasPrefix("model.")
             k = k.replacingOccurrences(of: "model.", with: "", options: .anchored)
 
-            // Skip vision/audio weights
+            // Skip vision/audio weights. `vision_embedder` is the gemma4_unified
+            // (12B) encoder-free vision module; without it, loading a multimodal
+            // gemma4_unified checkpoint (e.g. mlx-community/gemma-4-12B-it-4bit)
+            // through the text path fails with `Unhandled keys ["vision_embedder"]`.
             if k.hasPrefix("vision_tower") || k.hasPrefix("multi_modal_projector")
                 || k.hasPrefix("audio_tower") || k.hasPrefix("embed_audio")
-                || k.hasPrefix("embed_vision")
+                || k.hasPrefix("embed_vision") || k.hasPrefix("vision_embedder")
             {
                 continue
             }


### PR DESCRIPTION
The `gemma4_unified` (12B) family is multimodal: its checkpoints carry an encoder-free vision module under the `vision_embedder` prefix, alongside the already-skipped `embed_vision` / `embed_audio`. `gemma4_unified` is registered to the text `Gemma4Model` in `LLMModelFactory`, but `Gemma4Model.sanitize` does not drop `vision_embedder`, so loading a multimodal checkpoint (e.g. `mlx-community/gemma-4-12B-it-4bit`) through the text path fails with:

```
Unhandled keys ["vision_embedder"] in Gemma4Model
```

This adds the one missing prefix to the existing vision/audio skip list. Verified by loading + greedy-generating `mlx-community/gemma-4-12B-it-4bit` and matching mlx-vlm's text path token-for-token.