### PR TITLE
MLXLLM Gemma4Text: add MoE block (router + experts) for the text path

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -65,6 +65,11 @@ public struct Gemma4TextConfiguration: Codable, Sendable {
     var attentionKeqV: Bool = false
     var finalLogitSoftcapping: Float = 30.0
     var useDoubleWideMlp: Bool = true
+    // MoE block (E-series: enable_moe_block=true)
+    var enableMoEBlock: Bool = false
+    var numExperts: Int?
+    var topKExperts: Int?
+    var moeIntermediateSize: Int?
     var layerTypes: [String] = []
     var tieWordEmbeddings: Bool = true
 
@@ -98,6 +103,10 @@ public struct Gemma4TextConfiguration: Codable, Sendable {
         case attentionKeqV = "attention_k_eq_v"
         case finalLogitSoftcapping = "final_logit_softcapping"
         case useDoubleWideMlp = "use_double_wide_mlp"
+        case enableMoEBlock = "enable_moe_block"
+        case numExperts = "num_experts"
+        case topKExperts = "top_k_experts"
+        case moeIntermediateSize = "moe_intermediate_size"
         case layerTypes = "layer_types"
         case tieWordEmbeddings = "tie_word_embeddings"
         case ropeParameters = "rope_parameters"
@@ -142,6 +151,12 @@ public struct Gemma4TextConfiguration: Codable, Sendable {
             try container.decodeIfPresent(Float.self, forKey: .finalLogitSoftcapping) ?? 30.0
         self.useDoubleWideMlp =
             try container.decodeIfPresent(Bool.self, forKey: .useDoubleWideMlp) ?? true
+        self.enableMoEBlock =
+            try container.decodeIfPresent(Bool.self, forKey: .enableMoEBlock) ?? false
+        self.numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts)
+        self.topKExperts = try container.decodeIfPresent(Int.self, forKey: .topKExperts)
+        self.moeIntermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .moeIntermediateSize)
         if let decoded = try container.decodeIfPresent([String].self, forKey: .layerTypes) {
             self.layerTypes = decoded
         } else {
@@ -412,6 +427,85 @@ private class Gemma4MLP: Module {
     }
 }
 
+// MARK: - MoE Router + Experts (E-series)
+
+// MoE block ported from MLXVLM/Models/Gemma4.swift (ml-explore PRs #180, #228). yooz-engine.
+
+private class Gemma4TextRouter: Module {
+    let topKExperts: Int
+    let hiddenSize: Int
+    let rmsNormEps: Float
+    private let rootSize: Float
+
+    @ModuleInfo(key: "proj") var proj: Linear
+    @ParameterInfo(key: "scale") var scale: MLXArray
+    @ParameterInfo(key: "per_expert_scale") var perExpertScale: MLXArray
+
+    init(_ config: Gemma4TextConfiguration) {
+        guard let numExperts = config.numExperts, let topKExperts = config.topKExperts else {
+            fatalError("Gemma4 MoE router requires numExperts and topKExperts in config")
+        }
+        self.topKExperts = topKExperts
+        self.hiddenSize = config.hiddenSize
+        self.rmsNormEps = config.rmsNormEps
+        self.rootSize = pow(Float(config.hiddenSize), -0.5)
+
+        self._proj.wrappedValue = Linear(config.hiddenSize, numExperts, bias: false)
+        self._scale.wrappedValue = MLXArray.ones([config.hiddenSize])
+        self._perExpertScale.wrappedValue = MLXArray.ones([numExperts])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        let normed = MLXFast.rmsNorm(
+            x, weight: (scale * rootSize).asType(x.dtype), eps: rmsNormEps)
+        let scores = proj(normed)
+        let topKIndices = MLX.argPartition(scores, kth: -topKExperts, axis: -1)[
+            .ellipsis, (-topKExperts)...,
+        ]
+        var topKWeights = MLX.takeAlong(scores, topKIndices, axis: -1)
+        topKWeights = MLX.softmax(topKWeights, axis: -1)
+        topKWeights = topKWeights * perExpertScale[topKIndices].asType(topKWeights.dtype)
+        return (topKIndices, topKWeights)
+    }
+}
+
+private class Gemma4TextExperts: Module {
+    @ModuleInfo(key: "switch_glu") var switchGLU: SwitchGLU
+
+    init(_ config: Gemma4TextConfiguration) {
+        guard let numExperts = config.numExperts,
+            let moeIntermediateSize = config.moeIntermediateSize
+        else {
+            fatalError("Gemma4 MoE experts require numExperts and moeIntermediateSize in config")
+        }
+        self._switchGLU.wrappedValue = SwitchGLU(
+            inputDims: config.hiddenSize,
+            hiddenDims: moeIntermediateSize,
+            numExperts: numExperts,
+            activation: geluApproximate,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, topKIndices: MLXArray, topKWeights: MLXArray
+    ) -> MLXArray {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        let hidden = x.dim(2)
+        let topK = topKIndices.dim(-1)
+
+        let expertOutput = switchGLU(
+            x.reshaped(batch * length, hidden),
+            topKIndices.reshaped(batch * length, topK)
+        )
+        let weights = topKWeights.reshaped(batch * length, topK).asType(expertOutput.dtype)
+        return weightedExpertSum(expertOutput, weights).reshaped(batch, length, hidden)
+    }
+}
+
 // MARK: - Decoder Layer
 
 private class Gemma4DecoderLayer: Module {
@@ -419,6 +513,7 @@ private class Gemma4DecoderLayer: Module {
     let layerIdx: Int
     let layerType: String
     let hiddenSizePerLayerInput: Int
+    let enableMoE: Bool
 
     @ModuleInfo(key: "self_attn") var selfAttn: Gemma4Attention
     @ModuleInfo var mlp: Gemma4MLP
@@ -426,6 +521,13 @@ private class Gemma4DecoderLayer: Module {
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: RMSNorm
     @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: RMSNorm
     @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: RMSNorm
+
+    // MoE block (E-series): router, experts, and their extra norms
+    @ModuleInfo(key: "router") var router: Gemma4TextRouter?
+    @ModuleInfo(key: "experts") var experts: Gemma4TextExperts?
+    @ModuleInfo(key: "post_feedforward_layernorm_1") var postFeedforwardLayernorm1: RMSNorm?
+    @ModuleInfo(key: "post_feedforward_layernorm_2") var postFeedforwardLayernorm2: RMSNorm?
+    @ModuleInfo(key: "pre_feedforward_layernorm_2") var preFeedforwardLayernorm2: RMSNorm?
 
     // Per-layer input (PLE) gating
     @ModuleInfo(key: "per_layer_input_gate") var perLayerInputGate: Linear?
@@ -448,6 +550,7 @@ private class Gemma4DecoderLayer: Module {
         self.layerIdx = layerIdx
         self.layerType = config.layerTypes[layerIdx]
         self.hiddenSizePerLayerInput = config.hiddenSizePerLayerInput
+        self.enableMoE = config.enableMoEBlock
 
         self._selfAttn.wrappedValue = Gemma4Attention(config, layerIdx: layerIdx)
         self._mlp.wrappedValue = Gemma4MLP(config, layerIdx: layerIdx)
@@ -460,6 +563,17 @@ private class Gemma4DecoderLayer: Module {
             dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._postFeedforwardLayernorm.wrappedValue = RMSNorm(
             dimensions: config.hiddenSize, eps: config.rmsNormEps)
+
+        if config.enableMoEBlock {
+            self._router.wrappedValue = Gemma4TextRouter(config)
+            self._experts.wrappedValue = Gemma4TextExperts(config)
+            self._postFeedforwardLayernorm1.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.rmsNormEps)
+            self._postFeedforwardLayernorm2.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.rmsNormEps)
+            self._preFeedforwardLayernorm2.wrappedValue = RMSNorm(
+                dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        }
 
         if hiddenSizePerLayerInput > 0 {
             self._perLayerInputGate.wrappedValue = Linear(
@@ -492,10 +606,33 @@ private class Gemma4DecoderLayer: Module {
         var out = _addRMSNorm(residual, attnOut, postAttentionLayernorm.weight)
 
         let residual2 = out
-        out = preFeedforwardLayernorm(out)
-        out = mlp(out)
-        // Fused: residual + RMSNorm(out) * weight
-        out = _addRMSNorm(residual2, out, postFeedforwardLayernorm.weight)
+
+        if enableMoE,
+            let router,
+            let experts,
+            let pfln1 = postFeedforwardLayernorm1,
+            let pfln2 = postFeedforwardLayernorm2,
+            let pfln2pre = preFeedforwardLayernorm2
+        {
+            // Dense branch
+            var dense = preFeedforwardLayernorm(out)
+            dense = mlp(dense)
+            dense = pfln1(dense)
+
+            // Sparse branch
+            let (topKIndices, topKWeights) = router(out)
+            var sparse = pfln2pre(out)
+            sparse = experts(sparse, topKIndices: topKIndices, topKWeights: topKWeights)
+            sparse = pfln2(sparse)
+
+            // Combine then apply shared post-ff norm
+            out = _addRMSNorm(residual2, dense + sparse, postFeedforwardLayernorm.weight)
+        } else {
+            out = preFeedforwardLayernorm(out)
+            out = mlp(out)
+            // Fused: residual + RMSNorm(out) * weight
+            out = _addRMSNorm(residual2, out, postFeedforwardLayernorm.weight)
+        }
 
         // PLE gating
         if let gate = perLayerInputGate,
@@ -714,9 +851,13 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // MoE expert weight remapping ported from MLXVLM/Models/Gemma4.swift. yooz-engine.
+        // HuggingFace stores expert weights as fused gate_up_proj; SwitchGLU expects
+        // separate gate_proj and up_proj, each shaped [numExperts, hiddenDims, inputDims].
         let firstKvSharedLayerIdx = config.numHiddenLayers - config.numKvSharedLayers
         var sanitized = [String: MLXArray]()
-        for (k, v) in weights {
+        for (key, value) in weights {
+            let k = key
             // Skip vision/audio/rotary weights
             if k.contains("self_attn.rotary_emb")
                 || k.contains("input_max")
@@ -740,7 +881,37 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
             {
                 continue
             }
-            sanitized[k] = v
+
+            // Remap .experts.down_proj -> .experts.switch_glu.down_proj.weight
+            if k.hasSuffix(".experts.down_proj") {
+                sanitized[
+                    k.replacingOccurrences(
+                        of: ".experts.down_proj",
+                        with: ".experts.switch_glu.down_proj.weight"
+                    )
+                ] = value
+                continue
+            }
+
+            // Remap .experts.gate_up_proj -> split into gate_proj + up_proj
+            if k.hasSuffix(".experts.gate_up_proj") {
+                let mid = value.dim(-2) / 2
+                sanitized[
+                    k.replacingOccurrences(
+                        of: ".experts.gate_up_proj",
+                        with: ".experts.switch_glu.gate_proj.weight"
+                    )
+                ] = value[.ellipsis, ..<mid, 0...]
+                sanitized[
+                    k.replacingOccurrences(
+                        of: ".experts.gate_up_proj",
+                        with: ".experts.switch_glu.up_proj.weight"
+                    )
+                ] = value[.ellipsis, mid..., 0...]
+                continue
+            }
+
+            sanitized[k] = value
         }
         return sanitized
     }


### PR DESCRIPTION
The MLXLLM `Gemma4Text` text path can load dense and (since #342) KV-shared Gemma4 checkpoints, but not **MoE** ones (26B-A4B): loading fails with `Unhandled keys ["experts", "router", "post_feedforward_layernorm_1", "post_feedforward_layernorm_2", "pre_feedforward_layernorm_2"]`. The complete MoE implementation already exists in `MLXVLM/Models/Gemma4.swift` (#180, #228); this brings it to the LLM text path.

Adds: `Gemma4TextRouter`, `Gemma4TextExperts` (SwitchGLU), the `enable_moe_block` config + dense/sparse decoder branch, and the fused-expert weight remap in `sanitize` (`experts.gate_up_proj`/`down_proj` -> `switch_glu.*`). Pairs with the KV-sharing already merged in #342.

Verified by loading + generating `mlx-community/gemma-4-26b-a4b-it-4bit` through the LLM text path (correct output at native context). Ported from ml-explore's own MLXVLM implementation.