### PR TITLE
Lfm2.5 bidirectional embedders

### DIFF
--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -78,22 +78,22 @@ public class EmbedderRegistry: AbstractModelRegistry, @unchecked Sendable {
 
     /// LFM2.5 Embedding 350M — CLS-pooled 1024-d dense vectors (cosine).
     public static let lfm2_embedding_350m = ModelConfiguration(
-        id: "ronaldmannak/LFM2.5-Embedding-350M-bf16")
+        id: "mlx-community/LFM2.5-Embedding-350M-bf16")
     /// LFM2.5 Embedding 350M — 4-bit quantized.
     public static let lfm2_embedding_350m_4bit = ModelConfiguration(
-        id: "ronaldmannak/LFM2.5-Embedding-350M-4bit")
+        id: "mlx-community/LFM2.5-Embedding-350M-4bit")
     /// LFM2.5 Embedding 350M — 8-bit quantized.
     public static let lfm2_embedding_350m_8bit = ModelConfiguration(
-        id: "ronaldmannak/LFM2.5-Embedding-350M-8bit")
+        id: "mlx-community/LFM2.5-Embedding-350M-8bit")
     /// LFM2.5 ColBERT 350M — per-token 128-d multi-vectors (MaxSim late interaction).
     public static let lfm2_colbert_350m = ModelConfiguration(
-        id: "ronaldmannak/LFM2.5-ColBERT-350M-bf16")
+        id: "mlx-community/LFM2.5-ColBERT-350M-bf16")
     /// LFM2.5 ColBERT 350M — 4-bit quantized.
     public static let lfm2_colbert_350m_4bit = ModelConfiguration(
-        id: "ronaldmannak/LFM2.5-ColBERT-350M-4bit")
+        id: "mlx-community/LFM2.5-ColBERT-350M-4bit")
     /// LFM2.5 ColBERT 350M — 8-bit quantized.
     public static let lfm2_colbert_350m_8bit = ModelConfiguration(
-        id: "ronaldmannak/LFM2.5-ColBERT-350M-8bit")
+        id: "mlx-community/LFM2.5-ColBERT-350M-8bit")
 
     private static func all() -> [ModelConfiguration] {
         [

--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -25,6 +25,10 @@ public enum EmbedderTypeRegistry {
         "nomic_bert": create(NomicBertConfiguration.self) { NomicBertModel($0, pooler: false) },
         "qwen3": create(Qwen3Configuration.self) { Qwen3Model($0) },
 
+        // LFM2.5 bidirectional encoders (Embedding + ColBERT). Both share
+        // `model_type: "lfm2"`; the single model branches on the `"mlx"` head.
+        "lfm2": create(LFM2BidirectionalConfiguration.self) { LFM2BidirectionalModel($0) },
+
         "gemma3": create(Gemma3Configuration.self) { EmbeddingGemma($0) },
         "gemma3_text": create(Gemma3Configuration.self) { EmbeddingGemma($0) },
         "gemma3n": create(Gemma3Configuration.self) { EmbeddingGemma($0) },
@@ -72,6 +76,25 @@ public class EmbedderRegistry: AbstractModelRegistry, @unchecked Sendable {
     public static let qwen3_embedding = ModelConfiguration(
         id: "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ")
 
+    /// LFM2.5 Embedding 350M — CLS-pooled 1024-d dense vectors (cosine).
+    public static let lfm2_embedding_350m = ModelConfiguration(
+        id: "mlx-community/LFM2.5-Embedding-350M-bf16")
+    /// LFM2.5 Embedding 350M — 4-bit quantized.
+    public static let lfm2_embedding_350m_4bit = ModelConfiguration(
+        id: "mlx-community/LFM2.5-Embedding-350M-4bit")
+    /// LFM2.5 Embedding 350M — 8-bit quantized.
+    public static let lfm2_embedding_350m_8bit = ModelConfiguration(
+        id: "mlx-community/LFM2.5-Embedding-350M-8bit")
+    /// LFM2.5 ColBERT 350M — per-token 128-d multi-vectors (MaxSim late interaction).
+    public static let lfm2_colbert_350m = ModelConfiguration(
+        id: "mlx-community/LFM2.5-ColBERT-350M-bf16")
+    /// LFM2.5 ColBERT 350M — 4-bit quantized.
+    public static let lfm2_colbert_350m_4bit = ModelConfiguration(
+        id: "mlx-community/LFM2.5-ColBERT-350M-4bit")
+    /// LFM2.5 ColBERT 350M — 8-bit quantized.
+    public static let lfm2_colbert_350m_8bit = ModelConfiguration(
+        id: "mlx-community/LFM2.5-ColBERT-350M-8bit")
+
     private static func all() -> [ModelConfiguration] {
         [
             bge_micro,
@@ -89,6 +112,12 @@ public class EmbedderRegistry: AbstractModelRegistry, @unchecked Sendable {
             bge_m3,
             mixedbread_large,
             qwen3_embedding,
+            lfm2_embedding_350m,
+            lfm2_embedding_350m_4bit,
+            lfm2_embedding_350m_8bit,
+            lfm2_colbert_350m,
+            lfm2_colbert_350m_4bit,
+            lfm2_colbert_350m_8bit,
         ]
     }
 }

--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -78,22 +78,22 @@ public class EmbedderRegistry: AbstractModelRegistry, @unchecked Sendable {
 
     /// LFM2.5 Embedding 350M — CLS-pooled 1024-d dense vectors (cosine).
     public static let lfm2_embedding_350m = ModelConfiguration(
-        id: "mlx-community/LFM2.5-Embedding-350M-bf16")
+        id: "ronaldmannak/LFM2.5-Embedding-350M-bf16")
     /// LFM2.5 Embedding 350M — 4-bit quantized.
     public static let lfm2_embedding_350m_4bit = ModelConfiguration(
-        id: "mlx-community/LFM2.5-Embedding-350M-4bit")
+        id: "ronaldmannak/LFM2.5-Embedding-350M-4bit")
     /// LFM2.5 Embedding 350M — 8-bit quantized.
     public static let lfm2_embedding_350m_8bit = ModelConfiguration(
-        id: "mlx-community/LFM2.5-Embedding-350M-8bit")
+        id: "ronaldmannak/LFM2.5-Embedding-350M-8bit")
     /// LFM2.5 ColBERT 350M — per-token 128-d multi-vectors (MaxSim late interaction).
     public static let lfm2_colbert_350m = ModelConfiguration(
-        id: "mlx-community/LFM2.5-ColBERT-350M-bf16")
+        id: "ronaldmannak/LFM2.5-ColBERT-350M-bf16")
     /// LFM2.5 ColBERT 350M — 4-bit quantized.
     public static let lfm2_colbert_350m_4bit = ModelConfiguration(
-        id: "mlx-community/LFM2.5-ColBERT-350M-4bit")
+        id: "ronaldmannak/LFM2.5-ColBERT-350M-4bit")
     /// LFM2.5 ColBERT 350M — 8-bit quantized.
     public static let lfm2_colbert_350m_8bit = ModelConfiguration(
-        id: "mlx-community/LFM2.5-ColBERT-350M-8bit")
+        id: "ronaldmannak/LFM2.5-ColBERT-350M-8bit")
 
     private static func all() -> [ModelConfiguration] {
         [

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -133,7 +133,16 @@ public struct LFM2BidirectionalConfiguration: Decodable, Sendable {
         let ropeParameters = try c.decodeIfPresent(RopeParameters.self, forKey: .ropeParameters)
         ropeTheta = theta ?? ropeParameters?.ropeTheta ?? 1_000_000.0
 
-        mlx = try c.decode(MLXHead.self, forKey: .mlx)
+        // The custom `mlx` block is present on the converted checkpoints. If a config
+        // omits it (e.g. a raw SentenceTransformer LFM2.5 export), default to a
+        // CLS-pooled embedding head — a plain encoder with no projection — rather than
+        // throwing. ColBERT still requires the block, since the projection head can't
+        // be inferred from config.json alone.
+        mlx =
+            try c.decodeIfPresent(MLXHead.self, forKey: .mlx)
+            ?? MLXHead(
+                head: .embedding, pooling: "cls", prompts: nil, projDim: nil,
+                queryPrefix: nil, documentPrefix: nil, queryLength: nil, documentLength: nil)
     }
 }
 
@@ -372,7 +381,14 @@ public final class LFM2BidirectionalModel: Module, EmbeddingModel {
             return EmbeddingModelOutput(hiddenStates: lhs, pooledOutput: nil)
         case .colbert:
             // Per-token projection; caller pools .none + normalize (per-token L2), then MaxSim.
-            return EmbeddingModelOutput(hiddenStates: dense!(lhs), pooledOutput: nil)
+            var tok = dense!(lhs)
+            // Zero padded positions so they don't pollute MaxSim for batched callers
+            // (matches the reference's `tok * attention_mask`). `l2Normalized` keeps
+            // zeros as zeros, so a later `.none` + normalize remains correct.
+            if let mask {
+                tok = tok * mask.asType(tok.dtype).expandedDimensions(axis: -1)
+            }
+            return EmbeddingModelOutput(hiddenStates: tok, pooledOutput: nil)
         }
     }
 

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -120,7 +120,8 @@ public struct LFM2BidirectionalConfiguration: Decodable, Sendable {
         convLCache = try c.decodeIfPresent(Int.self, forKey: .convLCache) ?? 3
         blockFFDim =
             try c.decodeIfPresent(Int.self, forKey: .blockFFDim)
-            ?? c.decode(Int.self, forKey: .intermediateSize)
+            ?? c.decodeIfPresent(Int.self, forKey: .intermediateSize)
+            ?? hiddenSize
         blockMultipleOf = try c.decodeIfPresent(Int.self, forKey: .blockMultipleOf) ?? 256
         blockFFNDimMultiplier =
             try c.decodeIfPresent(Float.self, forKey: .blockFFNDimMultiplier) ?? 1.0
@@ -278,7 +279,17 @@ private final class LFM2BiDecoderLayer: Module {
     func callAsFunction(
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode
     ) -> MLXArray {
-        let r = isAttention ? attn!(operatorNorm(x), mask: mask) : conv!(operatorNorm(x))
+        let normalized = operatorNorm(x)
+        // Exactly one of `attn`/`conv` is set in `init` (per `isAttention`); bind
+        // explicitly so the invariant is visible rather than force-unwrapped.
+        let r: MLXArray
+        if let attn {
+            r = attn(normalized, mask: mask)
+        } else if let conv {
+            r = conv(normalized)
+        } else {
+            preconditionFailure("LFM2BiDecoderLayer must have either attention or conv")
+        }
         let h = x + r
         return h + feedForward(ffnNorm(h))
     }
@@ -386,7 +397,11 @@ public final class LFM2BidirectionalModel: Module, EmbeddingModel {
             // keeping query expansion and the document skiplist filter are the
             // retrieval layer's job. Callers pool `.none` + normalize (per-token L2),
             // then apply their own token masks before MaxSim.
-            return EmbeddingModelOutput(hiddenStates: dense!(lhs), pooledOutput: nil)
+            // `dense` is non-nil exactly when `head == .colbert` (set in `init`).
+            guard let dense else {
+                preconditionFailure("ColBERT head requires a dense projection layer")
+            }
+            return EmbeddingModelOutput(hiddenStates: dense(lhs), pooledOutput: nil)
         }
     }
 

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -358,7 +358,13 @@ public final class LFM2BidirectionalModel: Module, EmbeddingModel {
         if inp.ndim == 1 {
             inp = inp.reshaped(1, -1)
         }
-        let lhs = model(inp, attentionMask: attentionMask)  // (B, L, hidden)
+        // Reshape a 1-D mask to match the 1-D input reshape above, so the additive
+        // mask the backbone builds broadcasts cleanly over (B, heads, L, L) in SDPA.
+        var mask = attentionMask
+        if let m = mask, m.ndim == 1 {
+            mask = m.reshaped(1, -1)
+        }
+        let lhs = model(inp, attentionMask: mask)  // (B, L, hidden)
 
         switch head {
         case .embedding:

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -195,8 +195,9 @@ private final class LFM2BiAttention: Module {
     }
 }
 
-/// Non-causal gated short convolution (centered, symmetric padding). Padded
-/// positions are zeroed via the `keep` mask so they cannot leak through the kernel.
+/// Non-causal gated short convolution (centered, symmetric padding). The conv
+/// intentionally runs unmasked over the full sequence — see `callAsFunction` for why
+/// padded / ColBERT query-expansion positions are deliberately not zeroed.
 private final class LFM2BiShortConv: Module {
     @ModuleInfo(key: "conv") var conv: Conv1d
     @ModuleInfo(key: "in_proj") var inProj: Linear

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -215,12 +215,14 @@ private final class LFM2BiShortConv: Module {
         super.init()
     }
 
-    func callAsFunction(_ x: MLXArray, keep: MLXArray?) -> MLXArray {
+    // The conv runs over the full hidden states even for padded inputs. The
+    // checkpoints were trained WITHOUT zeroing the conv stream on the eager/sdpa
+    // path (only flash-attention-2 zeros it); zeroing padding / ColBERT
+    // query-expansion positions here shifts per-token embeddings and hurts MaxSim.
+    // Padding is handled only via the attention key-padding mask.
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
         let s = inProj(x).split(parts: 3, axis: -1)  // [B, C, x]
-        var Bx = s[0] * s[2]
-        if let keep {
-            Bx = Bx * keep.expandedDimensions(axis: -1)
-        }
+        let Bx = s[0] * s[2]
         var convOut = conv(Bx)
         if convOut.dim(1) != Bx.dim(1) {
             convOut = convOut[0..., 0 ..< Bx.dim(1), 0...]
@@ -276,10 +278,9 @@ private final class LFM2BiDecoderLayer: Module {
     }
 
     func callAsFunction(
-        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, keep: MLXArray?
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode
     ) -> MLXArray {
-        let r =
-            isAttention ? attn!(operatorNorm(x), mask: mask) : conv!(operatorNorm(x), keep: keep)
+        let r = isAttention ? attn!(operatorNorm(x), mask: mask) : conv!(operatorNorm(x))
         let h = x + r
         return h + feedForward(ffnNorm(h))
     }
@@ -288,9 +289,10 @@ private final class LFM2BiDecoderLayer: Module {
 // MARK: - Backbone
 
 /// Token ids `(B, L)` -> last hidden state `(B, L, hidden)` after `embedding_norm`.
-/// Builds the bidirectional additive pad mask and the conv keep-mask from
-/// `attentionMask` (1 = real token, 0 = padding); when `attentionMask` is nil the
-/// sequence is assumed unpadded (single-sequence encoding).
+/// Builds the bidirectional additive attention key-padding mask from `attentionMask`
+/// (1 = real token, 0 = padding). The short-conv is intentionally left unmasked to
+/// match the trained eager/sdpa behavior; `attentionMask == nil` means a single
+/// unpadded sequence.
 private final class LFM2BiBackbone: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
     @ModuleInfo(key: "embedding_norm") var embeddingNorm: RMSNorm
@@ -308,18 +310,16 @@ private final class LFM2BiBackbone: Module {
         var h = embedTokens(ids)
 
         var maskMode: MLXFast.ScaledDotProductAttentionMaskMode = .none
-        var keep: MLXArray? = nil
         if let attentionMask {
-            // conv keep-mask: (B, L) float, 1 = real, 0 = pad
-            keep = attentionMask.asType(h.dtype)
-            // additive attention mask: (B, 1, 1, L), 0 where real, -inf where pad.
-            // log(1) = 0, log(0) = -inf — matches the Bert idiom in this module.
+            // additive attention key-padding mask: (B, 1, 1, L), 0 where real, -inf
+            // where pad. log(1) = 0, log(0) = -inf — matches the Bert idiom here.
+            // Padding affects attention only; the short-conv sees the full stream.
             let additive = attentionMask.asType(h.dtype).expandedDimensions(axes: [1, 2]).log()
             maskMode = .array(additive)
         }
 
         for layer in layers {
-            h = layer(h, mask: maskMode, keep: keep)
+            h = layer(h, mask: maskMode)
         }
         return embeddingNorm(h)
     }

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -380,15 +380,15 @@ public final class LFM2BidirectionalModel: Module, EmbeddingModel {
             // CLS == BOS at position 0; caller pools .cls + normalize.
             return EmbeddingModelOutput(hiddenStates: lhs, pooledOutput: nil)
         case .colbert:
-            // Per-token projection; caller pools .none + normalize (per-token L2), then MaxSim.
-            var tok = dense!(lhs)
-            // Zero padded positions so they don't pollute MaxSim for batched callers
-            // (matches the reference's `tok * attention_mask`). `l2Normalized` keeps
-            // zeros as zeros, so a later `.none` + normalize remains correct.
-            if let mask {
-                tok = tok * mask.asType(tok.dtype).expandedDimensions(axis: -1)
-            }
-            return EmbeddingModelOutput(hiddenStates: tok, pooledOutput: nil)
+            // Per-token projection -> raw multi-vectors. The encoder does NOT mask or
+            // filter outputs: in ColBERT the attention mask serves double duty — for
+            // documents `0` is batch padding to drop, but for queries `0` marks
+            // expansion tokens that PyLate keeps and scores — so the model cannot
+            // decide which to zero. Matching the upstream model, dropping padding /
+            // keeping query expansion and the document skiplist filter are the
+            // retrieval layer's job. Callers pool `.none` + normalize (per-token L2),
+            // then apply their own token masks before MaxSim.
+            return EmbeddingModelOutput(hiddenStates: dense!(lhs), pooledOutput: nil)
         }
     }
 

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -1,0 +1,391 @@
+// Copyright © 2026 Apple Inc.
+
+// MLX Swift port of LiquidAI's LFM2.5 *bidirectional* (encoder) backbone + retrieval heads.
+//
+// Powers two on-device retrieval models that share the LFM2.5-350M hybrid backbone
+// (short-conv + GQA attention, SwiGLU MLP, RMSNorm):
+//   - LFM2.5-Embedding-350M  — CLS pooling -> 1024-d sentence vector (cosine).
+//   - LFM2.5-ColBERT-350M     — per-token Dense 1024->128 projection (MaxSim).
+//
+// Encoder patches relative to the *causal* generative `LFM2.swift` in MLXLLM:
+//   1. attention is bidirectional (additive pad-only mask, no causal mask),
+//   2. the short conv is non-causal / centered (symmetric padding = kernel/2),
+//   3. no LM head; a pooling/projection head is used instead.
+//
+// Both models share `model_type: "lfm2"` and differ only by the custom `"mlx"`
+// block in config.json (`head: "embedding"` vs `"colbert"`). A single model class
+// branches on that head. Ported from Models/mlx/lfm2_bidirectional.py and the
+// standalone Models/swift reference; kept self-contained to match this module's
+// convention (Qwen3/Gemma3 are reimplemented here rather than imported from MLXLLM).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct LFM2BidirectionalConfiguration: Decodable, Sendable {
+    public let vocabSize: Int
+    public let hiddenSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let normEps: Float
+    public let convBias: Bool
+    public let convLCache: Int
+    public let blockFFDim: Int
+    public let blockMultipleOf: Int
+    public let blockFFNDimMultiplier: Float
+    public let blockAutoAdjustFFDim: Bool
+    public let ropeTheta: Float
+    public let layerTypes: [String]
+    public let maxPositionEmbeddings: Int?
+    public let mlx: MLXHead
+
+    /// The custom `"mlx"` block that selects the retrieval head and carries the
+    /// prompt/prefix conventions used by callers (the library does not inject them).
+    public struct MLXHead: Codable, Sendable {
+        public enum Kind: String, Codable, Sendable {
+            case embedding
+            case colbert
+        }
+        public let head: Kind
+        // embedding
+        public let pooling: String?
+        public let prompts: [String: String]?
+        // colbert
+        public let projDim: Int?
+        public let queryPrefix: String?
+        public let documentPrefix: String?
+        public let queryLength: Int?
+        public let documentLength: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case head, pooling, prompts
+            case projDim = "proj_dim"
+            case queryPrefix = "query_prefix"
+            case documentPrefix = "document_prefix"
+            case queryLength = "query_length"
+            case documentLength = "document_length"
+        }
+    }
+
+    public var headDim: Int { hiddenSize / numAttentionHeads }
+
+    /// Indices of the `full_attention` layers (the rest are short-conv layers).
+    public var attnLayerIdxs: [Int] {
+        layerTypes.enumerated().compactMap { $0.element == "full_attention" ? $0.offset : nil }
+    }
+
+    private struct RopeParameters: Codable {
+        let ropeTheta: Float?
+        enum CodingKeys: String, CodingKey { case ropeTheta = "rope_theta" }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case normEps = "norm_eps"
+        case blockNormEps = "block_norm_eps"
+        case convBias = "conv_bias"
+        case convLCache = "conv_L_cache"
+        case blockFFDim = "block_ff_dim"
+        case intermediateSize = "intermediate_size"
+        case blockMultipleOf = "block_multiple_of"
+        case blockFFNDimMultiplier = "block_ffn_dim_multiplier"
+        case blockAutoAdjustFFDim = "block_auto_adjust_ff_dim"
+        case ropeTheta = "rope_theta"
+        case ropeParameters = "rope_parameters"
+        case layerTypes = "layer_types"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case mlx
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        vocabSize = try c.decode(Int.self, forKey: .vocabSize)
+        hiddenSize = try c.decode(Int.self, forKey: .hiddenSize)
+        numHiddenLayers = try c.decode(Int.self, forKey: .numHiddenLayers)
+        numAttentionHeads = try c.decode(Int.self, forKey: .numAttentionHeads)
+        numKeyValueHeads =
+            try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? numAttentionHeads
+        normEps =
+            try c.decodeIfPresent(Float.self, forKey: .normEps)
+            ?? c.decodeIfPresent(Float.self, forKey: .blockNormEps) ?? 1e-5
+        convBias = try c.decodeIfPresent(Bool.self, forKey: .convBias) ?? false
+        convLCache = try c.decodeIfPresent(Int.self, forKey: .convLCache) ?? 3
+        blockFFDim =
+            try c.decodeIfPresent(Int.self, forKey: .blockFFDim)
+            ?? c.decode(Int.self, forKey: .intermediateSize)
+        blockMultipleOf = try c.decodeIfPresent(Int.self, forKey: .blockMultipleOf) ?? 256
+        blockFFNDimMultiplier =
+            try c.decodeIfPresent(Float.self, forKey: .blockFFNDimMultiplier) ?? 1.0
+        blockAutoAdjustFFDim =
+            try c.decodeIfPresent(Bool.self, forKey: .blockAutoAdjustFFDim) ?? true
+        layerTypes = try c.decode([String].self, forKey: .layerTypes)
+        maxPositionEmbeddings = try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings)
+
+        let theta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta)
+        let ropeParameters = try c.decodeIfPresent(RopeParameters.self, forKey: .ropeParameters)
+        ropeTheta = theta ?? ropeParameters?.ropeTheta ?? 1_000_000.0
+
+        mlx = try c.decode(MLXHead.self, forKey: .mlx)
+    }
+}
+
+// MARK: - Blocks
+
+/// Grouped-query attention with per-head q/k RMSNorm and RoPE. Bidirectional
+/// (the only mask is an optional additive pad mask passed by the backbone).
+private final class LFM2BiAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+    @ModuleInfo(key: "q_layernorm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_layernorm") var kNorm: RMSNorm
+
+    let rope: RoPE
+    let nHeads: Int
+    let nKVHeads: Int
+    let scale: Float
+
+    init(_ c: LFM2BidirectionalConfiguration) {
+        let dim = c.hiddenSize
+        let hd = c.headDim
+        nHeads = c.numAttentionHeads
+        nKVHeads = c.numKeyValueHeads
+        scale = pow(Float(hd), -0.5)
+
+        _qProj.wrappedValue = Linear(dim, nHeads * hd, bias: false)
+        _kProj.wrappedValue = Linear(dim, nKVHeads * hd, bias: false)
+        _vProj.wrappedValue = Linear(dim, nKVHeads * hd, bias: false)
+        _outProj.wrappedValue = Linear(nHeads * hd, dim, bias: false)
+        _qNorm.wrappedValue = RMSNorm(dimensions: hd, eps: c.normEps)
+        _kNorm.wrappedValue = RMSNorm(dimensions: hd, eps: c.normEps)
+        rope = RoPE(dimensions: hd, traditional: false, base: c.ropeTheta)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode
+    ) -> MLXArray {
+        let (B, L) = (x.dim(0), x.dim(1))
+        var q = qNorm(qProj(x).reshaped(B, L, nHeads, -1)).transposed(0, 2, 1, 3)
+        var k = kNorm(kProj(x).reshaped(B, L, nKVHeads, -1)).transposed(0, 2, 1, 3)
+        let v = vProj(x).reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+        q = rope(q)
+        k = rope(k)
+        let o = MLXFast.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: scale, mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+        return outProj(o)
+    }
+}
+
+/// Non-causal gated short convolution (centered, symmetric padding). Padded
+/// positions are zeroed via the `keep` mask so they cannot leak through the kernel.
+private final class LFM2BiShortConv: Module {
+    @ModuleInfo(key: "conv") var conv: Conv1d
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    init(_ c: LFM2BidirectionalConfiguration) {
+        _conv.wrappedValue = Conv1d(
+            inputChannels: c.hiddenSize, outputChannels: c.hiddenSize,
+            kernelSize: c.convLCache, padding: c.convLCache / 2,
+            groups: c.hiddenSize, bias: c.convBias)
+        _inProj.wrappedValue = Linear(c.hiddenSize, 3 * c.hiddenSize, bias: c.convBias)
+        _outProj.wrappedValue = Linear(c.hiddenSize, c.hiddenSize, bias: c.convBias)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, keep: MLXArray?) -> MLXArray {
+        let s = inProj(x).split(parts: 3, axis: -1)  // [B, C, x]
+        var Bx = s[0] * s[2]
+        if let keep {
+            Bx = Bx * keep.expandedDimensions(axis: -1)
+        }
+        var convOut = conv(Bx)
+        if convOut.dim(1) != Bx.dim(1) {
+            convOut = convOut[0..., 0 ..< Bx.dim(1), 0...]
+        }
+        return outProj(s[1] * convOut)
+    }
+}
+
+/// SwiGLU MLP with the LFM2 `block_auto_adjust_ff_dim` width adjustment.
+private final class LFM2BiMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "w1") var w1: Linear
+    @ModuleInfo(key: "w2") var w2: Linear
+    @ModuleInfo(key: "w3") var w3: Linear
+
+    init(_ c: LFM2BidirectionalConfiguration) {
+        var ff = c.blockFFDim
+        if c.blockAutoAdjustFFDim {
+            ff = Int(Float(2 * ff) / 3.0)
+            ff = Int(c.blockFFNDimMultiplier * Float(ff))
+            let m = c.blockMultipleOf
+            ff = m * ((ff + m - 1) / m)
+        }
+        _w1.wrappedValue = Linear(c.hiddenSize, ff, bias: false)
+        _w2.wrappedValue = Linear(ff, c.hiddenSize, bias: false)
+        _w3.wrappedValue = Linear(c.hiddenSize, ff, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray { w2(silu(w1(x)) * w3(x)) }
+}
+
+/// One hybrid block: `operator_norm` -> (attention | short-conv) -> residual,
+/// then `ffn_norm` -> SwiGLU -> residual.
+private final class LFM2BiDecoderLayer: Module {
+    let isAttention: Bool
+    @ModuleInfo(key: "self_attn") var attn: LFM2BiAttention?
+    @ModuleInfo(key: "conv") var conv: LFM2BiShortConv?
+    @ModuleInfo(key: "feed_forward") var feedForward: LFM2BiMLP
+    @ModuleInfo(key: "operator_norm") var operatorNorm: RMSNorm
+    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+    init(_ c: LFM2BidirectionalConfiguration, idx: Int) {
+        isAttention = c.attnLayerIdxs.contains(idx)
+        if isAttention {
+            _attn.wrappedValue = LFM2BiAttention(c)
+        } else {
+            _conv.wrappedValue = LFM2BiShortConv(c)
+        }
+        _feedForward.wrappedValue = LFM2BiMLP(c)
+        _operatorNorm.wrappedValue = RMSNorm(dimensions: c.hiddenSize, eps: c.normEps)
+        _ffnNorm.wrappedValue = RMSNorm(dimensions: c.hiddenSize, eps: c.normEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, keep: MLXArray?
+    ) -> MLXArray {
+        let r =
+            isAttention ? attn!(operatorNorm(x), mask: mask) : conv!(operatorNorm(x), keep: keep)
+        let h = x + r
+        return h + feedForward(ffnNorm(h))
+    }
+}
+
+// MARK: - Backbone
+
+/// Token ids `(B, L)` -> last hidden state `(B, L, hidden)` after `embedding_norm`.
+/// Builds the bidirectional additive pad mask and the conv keep-mask from
+/// `attentionMask` (1 = real token, 0 = padding); when `attentionMask` is nil the
+/// sequence is assumed unpadded (single-sequence encoding).
+private final class LFM2BiBackbone: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "embedding_norm") var embeddingNorm: RMSNorm
+    fileprivate let layers: [LFM2BiDecoderLayer]
+
+    init(_ c: LFM2BidirectionalConfiguration) {
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: c.vocabSize, dimensions: c.hiddenSize)
+        _embeddingNorm.wrappedValue = RMSNorm(dimensions: c.hiddenSize, eps: c.normEps)
+        layers = (0 ..< c.numHiddenLayers).map { LFM2BiDecoderLayer(c, idx: $0) }
+        super.init()
+    }
+
+    func callAsFunction(_ ids: MLXArray, attentionMask: MLXArray?) -> MLXArray {
+        var h = embedTokens(ids)
+
+        var maskMode: MLXFast.ScaledDotProductAttentionMaskMode = .none
+        var keep: MLXArray? = nil
+        if let attentionMask {
+            // conv keep-mask: (B, L) float, 1 = real, 0 = pad
+            keep = attentionMask.asType(h.dtype)
+            // additive attention mask: (B, 1, 1, L), 0 where real, -inf where pad.
+            // log(1) = 0, log(0) = -inf — matches the Bert idiom in this module.
+            let additive = attentionMask.asType(h.dtype).expandedDimensions(axes: [1, 2]).log()
+            maskMode = .array(additive)
+        }
+
+        for layer in layers {
+            h = layer(h, mask: maskMode, keep: keep)
+        }
+        return embeddingNorm(h)
+    }
+}
+
+// MARK: - Model
+
+/// LFM2.5 bidirectional encoder for retrieval. One class serves both heads,
+/// selected by the `"mlx"` block in config.json:
+///
+/// - `embedding`: returns the backbone hidden states `(B, L, hidden)`; callers pool
+///   with `.cls` + `normalize` to get a 1024-d sentence vector (cosine similarity).
+/// - `colbert`: applies a per-token Dense projection -> `(B, L, projDim)`; callers
+///   pool with `.none` + `normalize` to get per-token multi-vectors (MaxSim).
+public final class LFM2BidirectionalModel: Module, EmbeddingModel {
+    @ModuleInfo(key: "model") private var model: LFM2BiBackbone
+    @ModuleInfo(key: "dense") private var dense: Linear?
+
+    public let configuration: LFM2BidirectionalConfiguration
+    private let head: LFM2BidirectionalConfiguration.MLXHead.Kind
+
+    public var vocabularySize: Int { configuration.vocabSize }
+
+    public var poolingStrategy: Pooling.Strategy? {
+        head == .colbert ? Pooling.Strategy.none : Pooling.Strategy.cls
+    }
+
+    public init(_ c: LFM2BidirectionalConfiguration) {
+        self.configuration = c
+        self.head = c.mlx.head
+        self._model.wrappedValue = LFM2BiBackbone(c)
+        if c.mlx.head == .colbert {
+            self._dense.wrappedValue = Linear(c.hiddenSize, c.mlx.projDim ?? 128, bias: false)
+        }
+        super.init()
+    }
+
+    public func callAsFunction(
+        _ inputs: MLXArray,
+        positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    ) -> EmbeddingModelOutput {
+        var inp = inputs
+        if inp.ndim == 1 {
+            inp = inp.reshaped(1, -1)
+        }
+        let lhs = model(inp, attentionMask: attentionMask)  // (B, L, hidden)
+
+        switch head {
+        case .embedding:
+            // CLS == BOS at position 0; caller pools .cls + normalize.
+            return EmbeddingModelOutput(hiddenStates: lhs, pooledOutput: nil)
+        case .colbert:
+            // Per-token projection; caller pools .none + normalize (per-token L2), then MaxSim.
+            return EmbeddingModelOutput(hiddenStates: dense!(lhs), pooledOutput: nil)
+        }
+    }
+
+    /// Weights from `convert.py` are already `model.`-prefixed (and the ColBERT head
+    /// is the bare key `dense.weight`), so this only applies the depthwise Conv1d
+    /// transpose guard — `(O, 1, K)` -> `(O, K, 1)` — for robustness against weights
+    /// re-converted straight from Hugging Face. It must NOT blanket-prepend `model.`
+    /// (that would corrupt `dense.weight`).
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var sanitized = [String: MLXArray]()
+        for (name, param) in weights {
+            var p = param
+            if name.contains("conv.weight") {
+                if param.shape[param.shape.count - 1] > param.dim(1) {
+                    p = param.transposed(0, 2, 1)
+                }
+            }
+            sanitized[name] = p
+        }
+        return sanitized
+    }
+}

--- a/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
+++ b/Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift
@@ -133,16 +133,13 @@ public struct LFM2BidirectionalConfiguration: Decodable, Sendable {
         let ropeParameters = try c.decodeIfPresent(RopeParameters.self, forKey: .ropeParameters)
         ropeTheta = theta ?? ropeParameters?.ropeTheta ?? 1_000_000.0
 
-        // The custom `mlx` block is present on the converted checkpoints. If a config
-        // omits it (e.g. a raw SentenceTransformer LFM2.5 export), default to a
-        // CLS-pooled embedding head — a plain encoder with no projection — rather than
-        // throwing. ColBERT still requires the block, since the projection head can't
-        // be inferred from config.json alone.
-        mlx =
-            try c.decodeIfPresent(MLXHead.self, forKey: .mlx)
-            ?? MLXHead(
-                head: .embedding, pooling: "cls", prompts: nil, projDim: nil,
-                queryPrefix: nil, documentPrefix: nil, queryLength: nil, documentLength: nil)
+        // The custom `mlx` block selects the retrieval head (embedding vs colbert)
+        // and carries the prompt/prefix conventions; it can't be inferred from
+        // config.json alone, so it is required. A config that omits it fails to decode
+        // rather than silently building the wrong model — matching how the library
+        // fails loud on architecture-selecting config (e.g. `ModelTypeRegistry` throws
+        // `unsupportedModelType` for an unknown `model_type`).
+        mlx = try c.decode(MLXHead.self, forKey: .mlx)
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -126,6 +126,7 @@ let package = Package(
                 "MLXLLM",
                 "MLXVLM",
                 "MLXEmbedders",
+                "IntegrationTestHelpers",
             ],
             path: "Tests/MLXLMTests",
             exclude: [

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,6 @@ let package = Package(
                 "MLXLLM",
                 "MLXVLM",
                 "MLXEmbedders",
-                "IntegrationTestHelpers",
             ],
             path: "Tests/MLXLMTests",
             exclude: [

--- a/Tests/MLXLMTests/LFM2BidirectionalTests.swift
+++ b/Tests/MLXLMTests/LFM2BidirectionalTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IntegrationTestHelpers
 import MLX
 import MLXLMCommon
 import MLXNN
@@ -11,17 +12,17 @@ import Testing
 // (identical math). The default device is a task-local, so each test scopes its
 // own work and they remain safe to run in parallel.
 
-// Real model dirs + HF float32 parity fixtures (exported by Models/mlx/export_swift_ref.py).
-// The parity test is skipped automatically when these aren't present (e.g. CI).
-private let lfm2EmbeddingDir = URL(
-    fileURLWithPath:
-        "/Users/ronaldmannak/Developer/Projects/Models/mlx-models/LFM2.5-Embedding-350M-bf16")
-private let lfm2ColbertDir = URL(
-    fileURLWithPath:
-        "/Users/ronaldmannak/Developer/Projects/Models/mlx-models/LFM2.5-ColBERT-350M-bf16")
+// Parity fixtures: the real bf16 models resolved from the default Hugging Face hub
+// cache (`~/.cache/huggingface`, via `hfSnapshotDir`), plus the HF float32 reference
+// exported by Models/mlx/export_swift_ref.py. The parity test is skipped automatically
+// when these aren't present locally (CI, or a machine that hasn't downloaded the models);
+// it never triggers a download.
+private let lfm2EmbeddingDir = hfSnapshotDir(modelId: "mlx-community/LFM2.5-Embedding-350M-bf16")
+private let lfm2ColbertDir = hfSnapshotDir(modelId: "mlx-community/LFM2.5-ColBERT-350M-bf16")
 private let lfm2RefURL = URL(fileURLWithPath: "/tmp/ref/swift_ref.safetensors")
 
 private let lfm2FixturesAvailable: Bool = {
+    guard let lfm2EmbeddingDir, let lfm2ColbertDir else { return false }
     let fm = FileManager.default
     return fm.fileExists(atPath: lfm2RefURL.path)
         && fm.fileExists(atPath: lfm2EmbeddingDir.appendingPathComponent("config.json").path)
@@ -228,7 +229,8 @@ struct LFM2BidirectionalTests {
             let ref = try loadArrays(url: lfm2RefURL)
 
             // Embedding: compare the raw CLS vector (cosine is scale-invariant).
-            let emb = try loadLFM2(lfm2EmbeddingDir)
+            // Force-unwrap is safe: `lfm2FixturesAvailable` already proved both dirs exist.
+            let emb = try loadLFM2(lfm2EmbeddingDir!)
             var worstEmb: Float = 1
             var i = 0
             while let idsArr = ref["emb_ids_\(i)"] {
@@ -241,7 +243,7 @@ struct LFM2BidirectionalTests {
             #expect(worstEmb > 0.999, "worst embedding cosine \(worstEmb)")
 
             // ColBERT: compare the per-token projection.
-            let col = try loadLFM2(lfm2ColbertDir)
+            let col = try loadLFM2(lfm2ColbertDir!)
             var worstCol: Float = 1
             i = 0
             while let idsArr = ref["col_ids_\(i)"] {

--- a/Tests/MLXLMTests/LFM2BidirectionalTests.swift
+++ b/Tests/MLXLMTests/LFM2BidirectionalTests.swift
@@ -1,8 +1,5 @@
 import Foundation
-import IntegrationTestHelpers
 import MLX
-import MLXLMCommon
-import MLXNN
 import Testing
 
 @testable import MLXEmbedders
@@ -11,23 +8,6 @@ import Testing
 // op below is scoped to the CPU backend via `Device.withDefaultDevice(.cpu)`
 // (identical math). The default device is a task-local, so each test scopes its
 // own work and they remain safe to run in parallel.
-
-// Parity fixtures: the real bf16 models resolved from the default Hugging Face hub
-// cache (`~/.cache/huggingface`, via `hfSnapshotDir`), plus the HF float32 reference
-// exported by Models/mlx/export_swift_ref.py. The parity test is skipped automatically
-// when these aren't present locally (CI, or a machine that hasn't downloaded the models);
-// it never triggers a download.
-private let lfm2EmbeddingDir = hfSnapshotDir(modelId: "mlx-community/LFM2.5-Embedding-350M-bf16")
-private let lfm2ColbertDir = hfSnapshotDir(modelId: "mlx-community/LFM2.5-ColBERT-350M-bf16")
-private let lfm2RefURL = URL(fileURLWithPath: "/tmp/ref/swift_ref.safetensors")
-
-private let lfm2FixturesAvailable: Bool = {
-    guard let lfm2EmbeddingDir, let lfm2ColbertDir else { return false }
-    let fm = FileManager.default
-    return fm.fileExists(atPath: lfm2RefURL.path)
-        && fm.fileExists(atPath: lfm2EmbeddingDir.appendingPathComponent("config.json").path)
-        && fm.fileExists(atPath: lfm2ColbertDir.appendingPathComponent("config.json").path)
-}()
 
 private let embeddingConfigJSON = """
     {
@@ -77,15 +57,6 @@ private let colbertConfigJSON = """
 
 private func decode(_ json: String) throws -> LFM2BidirectionalConfiguration {
     try JSONDecoder().decode(LFM2BidirectionalConfiguration.self, from: Data(json.utf8))
-}
-
-private func cosine(_ a: MLXArray, _ b: MLXArray) -> Float {
-    let af = a.asType(.float32).reshaped(-1)
-    let bf = b.asType(.float32).reshaped(-1)
-    let dot = (af * bf).sum()
-    let na = sqrt((af * af).sum())
-    let nb = sqrt((bf * bf).sum())
-    return (dot / (na * nb)).item(Float.self)
 }
 
 struct LFM2BidirectionalTests {
@@ -219,59 +190,5 @@ struct LFM2BidirectionalTests {
             #expect(maskedNorm > 0)
             #expect(realNorm > 0)
         }
-    }
-
-    // MARK: - Parity vs HF float32 reference (gated on local fixtures)
-
-    @Test(
-        "LFM2.5 outputs match the HF float32 reference",
-        .enabled(if: lfm2FixturesAvailable))
-    func testParityAgainstReference() throws {
-        try Device.withDefaultDevice(.cpu) {
-            let ref = try loadArrays(url: lfm2RefURL)
-
-            // Embedding: compare the raw CLS vector (cosine is scale-invariant).
-            // Force-unwrap is safe: `lfm2FixturesAvailable` already proved both dirs exist.
-            let emb = try loadLFM2(lfm2EmbeddingDir!)
-            var worstEmb: Float = 1
-            var i = 0
-            while let idsArr = ref["emb_ids_\(i)"] {
-                let ids = idsArr.asType(.int32).reshaped(1, -1)
-                let cls = emb(ids).hiddenStates![0..., 0, 0...]
-                worstEmb = min(worstEmb, cosine(cls, ref["emb_cls_\(i)"]!))
-                i += 1
-            }
-            #expect(i > 0)
-            #expect(worstEmb > 0.999, "worst embedding cosine \(worstEmb)")
-
-            // ColBERT: compare the per-token projection.
-            let col = try loadLFM2(lfm2ColbertDir!)
-            var worstCol: Float = 1
-            i = 0
-            while let idsArr = ref["col_ids_\(i)"] {
-                let ids = idsArr.asType(.int32).reshaped(1, -1)
-                let proj = col(ids).hiddenStates!
-                worstCol = min(worstCol, cosine(proj, ref["col_proj_\(i)"]!))
-                i += 1
-            }
-            #expect(i > 0)
-            #expect(worstCol > 0.999, "worst colbert cosine \(worstCol)")
-        }
-    }
-
-    /// Build the model from a local dir and load its weights as float32 (max precision
-    /// for the parity comparison), mirroring the factory's sanitize + load path.
-    private func loadLFM2(_ dir: URL) throws -> LFM2BidirectionalModel {
-        let configData = try Data(contentsOf: dir.appendingPathComponent("config.json"))
-        let config = try JSONDecoder.json5().decode(
-            LFM2BidirectionalConfiguration.self, from: configData)
-        let model = LFM2BidirectionalModel(config)
-
-        var weights = try loadArrays(url: dir.appendingPathComponent("model.safetensors"))
-        weights = model.sanitize(weights: weights)
-        weights = weights.mapValues { $0.asType(.float32) }
-        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
-        eval(model)
-        return model
     }
 }

--- a/Tests/MLXLMTests/LFM2BidirectionalTests.swift
+++ b/Tests/MLXLMTests/LFM2BidirectionalTests.swift
@@ -197,8 +197,8 @@ struct LFM2BidirectionalTests {
         }
     }
 
-    @Test("ColBERT zeroes padded positions when given an attention mask")
-    func testColbertZeroesPaddedPositions() throws {
+    @Test("ColBERT returns raw per-token vectors and does not erase masked positions")
+    func testColbertKeepsMaskedPositions() throws {
         let c = try decode(colbertConfigJSON)
         Device.withDefaultDevice(.cpu) {
             let model = LFM2BidirectionalModel(c)
@@ -208,10 +208,12 @@ struct LFM2BidirectionalTests {
             let out = model(ids, positionIds: nil, tokenTypeIds: nil, attentionMask: mask)
             let tok = out.hiddenStates!  // (1, 6, projDim)
             tok.eval()
-            // Padded positions (indices 4, 5) must be all-zero; real ones must not be.
-            let padNorm = sqrt((tok[0, 4] * tok[0, 4]).sum()).item(Float.self)
+            // Masked positions (4, 5) are NOT zeroed: the encoder returns raw vectors,
+            // so ColBERT query-expansion tokens survive for the retrieval layer to keep
+            // (documents drop padding + apply the skiplist outside the model).
+            let maskedNorm = sqrt((tok[0, 4] * tok[0, 4]).sum()).item(Float.self)
             let realNorm = sqrt((tok[0, 0] * tok[0, 0]).sum()).item(Float.self)
-            #expect(padNorm == 0)
+            #expect(maskedNorm > 0)
             #expect(realNorm > 0)
         }
     }

--- a/Tests/MLXLMTests/LFM2BidirectionalTests.swift
+++ b/Tests/MLXLMTests/LFM2BidirectionalTests.swift
@@ -178,6 +178,44 @@ struct LFM2BidirectionalTests {
         }
     }
 
+    @Test("A config without an mlx block defaults to a CLS embedding head")
+    func testConfigWithoutMLXBlockDefaultsToEmbedding() throws {
+        let json = """
+            {
+              "model_type": "lfm2", "vocab_size": 64, "hidden_size": 32,
+              "num_hidden_layers": 2, "num_attention_heads": 4, "num_key_value_heads": 2,
+              "norm_eps": 1e-5, "conv_L_cache": 3, "block_ff_dim": 64,
+              "block_multiple_of": 8, "block_ffn_dim_multiplier": 1.0,
+              "block_auto_adjust_ff_dim": true, "rope_theta": 1000000.0,
+              "layer_types": ["conv", "full_attention"]
+            }
+            """
+        let c = try decode(json)
+        #expect(c.mlx.head == .embedding)
+        Device.withDefaultDevice(.cpu) {
+            #expect(LFM2BidirectionalModel(c).poolingStrategy == .cls)
+        }
+    }
+
+    @Test("ColBERT zeroes padded positions when given an attention mask")
+    func testColbertZeroesPaddedPositions() throws {
+        let c = try decode(colbertConfigJSON)
+        Device.withDefaultDevice(.cpu) {
+            let model = LFM2BidirectionalModel(c)
+            let ids = MLXArray((0 ..< 6).map { Int32($0 % 64) }).reshaped(1, 6)
+            let mask = MLXArray([1, 1, 1, 1, 0, 0].map { Int32($0) }).reshaped(1, 6)
+
+            let out = model(ids, positionIds: nil, tokenTypeIds: nil, attentionMask: mask)
+            let tok = out.hiddenStates!  // (1, 6, projDim)
+            tok.eval()
+            // Padded positions (indices 4, 5) must be all-zero; real ones must not be.
+            let padNorm = sqrt((tok[0, 4] * tok[0, 4]).sum()).item(Float.self)
+            let realNorm = sqrt((tok[0, 0] * tok[0, 0]).sum()).item(Float.self)
+            #expect(padNorm == 0)
+            #expect(realNorm > 0)
+        }
+    }
+
     // MARK: - Parity vs HF float32 reference (gated on local fixtures)
 
     @Test(

--- a/Tests/MLXLMTests/LFM2BidirectionalTests.swift
+++ b/Tests/MLXLMTests/LFM2BidirectionalTests.swift
@@ -179,8 +179,8 @@ struct LFM2BidirectionalTests {
         }
     }
 
-    @Test("A config without an mlx block defaults to a CLS embedding head")
-    func testConfigWithoutMLXBlockDefaultsToEmbedding() throws {
+    @Test("A config without an mlx block fails to decode (the head can't be inferred)")
+    func testConfigWithoutMLXBlockThrows() {
         let json = """
             {
               "model_type": "lfm2", "vocab_size": 64, "hidden_size": 32,
@@ -191,10 +191,12 @@ struct LFM2BidirectionalTests {
               "layer_types": ["conv", "full_attention"]
             }
             """
-        let c = try decode(json)
-        #expect(c.mlx.head == .embedding)
-        Device.withDefaultDevice(.cpu) {
-            #expect(LFM2BidirectionalModel(c).poolingStrategy == .cls)
+        // The mlx block selects the retrieval head and can't be inferred from
+        // config.json, so a config that omits it must fail loudly rather than silently
+        // building an embedding model — matching the library's fail-loud handling of
+        // architecture-selecting config (e.g. ModelTypeRegistry's unsupportedModelType).
+        #expect(throws: DecodingError.self) {
+            _ = try decode(json)
         }
     }
 

--- a/Tests/MLXLMTests/LFM2BidirectionalTests.swift
+++ b/Tests/MLXLMTests/LFM2BidirectionalTests.swift
@@ -1,0 +1,233 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import MLXEmbedders
+
+// `swift test` from the CLI can't bundle mlx-swift's Metal library, so every MLX
+// op below is scoped to the CPU backend via `Device.withDefaultDevice(.cpu)`
+// (identical math). The default device is a task-local, so each test scopes its
+// own work and they remain safe to run in parallel.
+
+// Real model dirs + HF float32 parity fixtures (exported by Models/mlx/export_swift_ref.py).
+// The parity test is skipped automatically when these aren't present (e.g. CI).
+private let lfm2EmbeddingDir = URL(
+    fileURLWithPath:
+        "/Users/ronaldmannak/Developer/Projects/Models/mlx-models/LFM2.5-Embedding-350M-bf16")
+private let lfm2ColbertDir = URL(
+    fileURLWithPath:
+        "/Users/ronaldmannak/Developer/Projects/Models/mlx-models/LFM2.5-ColBERT-350M-bf16")
+private let lfm2RefURL = URL(fileURLWithPath: "/tmp/ref/swift_ref.safetensors")
+
+private let lfm2FixturesAvailable: Bool = {
+    let fm = FileManager.default
+    return fm.fileExists(atPath: lfm2RefURL.path)
+        && fm.fileExists(atPath: lfm2EmbeddingDir.appendingPathComponent("config.json").path)
+        && fm.fileExists(atPath: lfm2ColbertDir.appendingPathComponent("config.json").path)
+}()
+
+private let embeddingConfigJSON = """
+    {
+      "model_type": "lfm2",
+      "vocab_size": 64,
+      "hidden_size": 32,
+      "num_hidden_layers": 4,
+      "num_attention_heads": 4,
+      "num_key_value_heads": 2,
+      "norm_eps": 1e-5,
+      "conv_bias": false,
+      "conv_L_cache": 3,
+      "block_ff_dim": 64,
+      "block_multiple_of": 8,
+      "block_ffn_dim_multiplier": 1.0,
+      "block_auto_adjust_ff_dim": true,
+      "rope_theta": 1000000.0,
+      "layer_types": ["conv", "full_attention", "conv", "full_attention"],
+      "max_position_embeddings": 128000,
+      "mlx": { "head": "embedding", "pooling": "cls",
+               "prompts": { "query": "query: ", "document": "document: " } }
+    }
+    """
+
+private let colbertConfigJSON = """
+    {
+      "model_type": "lfm2",
+      "vocab_size": 64,
+      "hidden_size": 32,
+      "num_hidden_layers": 4,
+      "num_attention_heads": 4,
+      "num_key_value_heads": 2,
+      "norm_eps": 1e-5,
+      "conv_bias": false,
+      "conv_L_cache": 3,
+      "block_ff_dim": 64,
+      "block_multiple_of": 8,
+      "block_ffn_dim_multiplier": 1.0,
+      "block_auto_adjust_ff_dim": true,
+      "rope_theta": 1000000.0,
+      "layer_types": ["conv", "full_attention", "conv", "full_attention"],
+      "mlx": { "head": "colbert", "proj_dim": 16,
+               "query_prefix": "[Q] ", "document_prefix": "[D] ",
+               "query_length": 32, "document_length": 512 }
+    }
+    """
+
+private func decode(_ json: String) throws -> LFM2BidirectionalConfiguration {
+    try JSONDecoder().decode(LFM2BidirectionalConfiguration.self, from: Data(json.utf8))
+}
+
+private func cosine(_ a: MLXArray, _ b: MLXArray) -> Float {
+    let af = a.asType(.float32).reshaped(-1)
+    let bf = b.asType(.float32).reshaped(-1)
+    let dot = (af * bf).sum()
+    let na = sqrt((af * af).sum())
+    let nb = sqrt((bf * bf).sum())
+    return (dot / (na * nb)).item(Float.self)
+}
+
+struct LFM2BidirectionalTests {
+
+    // MARK: - Configuration
+
+    @Test("Embedding config decodes to a CLS-pooled head")
+    func testEmbeddingConfigDecode() throws {
+        let c = try decode(embeddingConfigJSON)
+        #expect(c.mlx.head == .embedding)
+        #expect(c.vocabSize == 64)
+        #expect(c.numKeyValueHeads == 2)
+        // full_attention at indices 1 and 3.
+        #expect(c.attnLayerIdxs == [1, 3])
+        Device.withDefaultDevice(.cpu) {
+            #expect(LFM2BidirectionalModel(c).poolingStrategy == .cls)
+        }
+    }
+
+    @Test("ColBERT config decodes to a none-pooled projection head")
+    func testColbertConfigDecode() throws {
+        let c = try decode(colbertConfigJSON)
+        #expect(c.mlx.head == .colbert)
+        #expect(c.mlx.projDim == 16)
+        #expect(c.mlx.queryLength == 32)
+        Device.withDefaultDevice(.cpu) {
+            #expect(LFM2BidirectionalModel(c).poolingStrategy == Pooling.Strategy.none)
+        }
+    }
+
+    @Test("Real configs decode with the expected attention layout")
+    func testRealConfigAttentionLayout() throws {
+        // The 350M models alternate conv/attention with full_attention at these indices.
+        let layerTypes = [
+            "conv", "conv", "full_attention", "conv", "conv", "full_attention",
+            "conv", "conv", "full_attention", "conv", "full_attention", "conv",
+            "full_attention", "conv", "full_attention", "conv",
+        ]
+        let json = """
+            {
+              "model_type": "lfm2", "vocab_size": 65536, "hidden_size": 1024,
+              "num_hidden_layers": 16, "num_attention_heads": 16, "num_key_value_heads": 8,
+              "norm_eps": 1e-5, "conv_L_cache": 3, "block_ff_dim": 6656,
+              "block_multiple_of": 256, "block_ffn_dim_multiplier": 1.0,
+              "block_auto_adjust_ff_dim": true, "rope_theta": 1000000.0,
+              "layer_types": \(layerTypes), "mlx": { "head": "embedding", "pooling": "cls" }
+            }
+            """
+        let c = try decode(json)
+        #expect(c.attnLayerIdxs == [2, 5, 8, 10, 12, 14])
+        #expect(c.headDim == 64)
+    }
+
+    // MARK: - Synthetic forward (shape + invariants, random weights)
+
+    @Test("Embedding head pools the CLS token to a normalized vector")
+    func testEmbeddingForwardShape() throws {
+        let c = try decode(embeddingConfigJSON)
+        Device.withDefaultDevice(.cpu) {
+            let model = LFM2BidirectionalModel(c)
+            let ids = MLXArray((0 ..< 10).map { Int32($0 % 64) }).reshaped(2, 5)
+
+            let out = model(ids)
+            out.hiddenStates!.eval()
+            #expect(out.hiddenStates!.shape == [2, 5, 32])
+
+            let pooled = Pooling(strategy: .cls)(out, normalize: true)
+            pooled.eval()
+            #expect(pooled.shape == [2, 32])
+            // L2-normalized rows -> unit norm.
+            let norms = sqrt((pooled * pooled).sum(axis: -1))
+            #expect(abs(norms[0].item(Float.self) - 1.0) < 1e-3)
+        }
+    }
+
+    @Test("ColBERT head projects every token to projDim multi-vectors")
+    func testColbertForwardShape() throws {
+        let c = try decode(colbertConfigJSON)
+        Device.withDefaultDevice(.cpu) {
+            let model = LFM2BidirectionalModel(c)
+            let ids = MLXArray((0 ..< 10).map { Int32($0 % 64) }).reshaped(2, 5)
+
+            let out = model(ids)
+            out.hiddenStates!.eval()
+            #expect(out.hiddenStates!.shape == [2, 5, 16])
+
+            // .none pooling returns the per-token multi-vectors unchanged.
+            let pooled = Pooling(strategy: .none)(out)
+            pooled.eval()
+            #expect(pooled.shape == [2, 5, 16])
+        }
+    }
+
+    // MARK: - Parity vs HF float32 reference (gated on local fixtures)
+
+    @Test(
+        "LFM2.5 outputs match the HF float32 reference",
+        .enabled(if: lfm2FixturesAvailable))
+    func testParityAgainstReference() throws {
+        try Device.withDefaultDevice(.cpu) {
+            let ref = try loadArrays(url: lfm2RefURL)
+
+            // Embedding: compare the raw CLS vector (cosine is scale-invariant).
+            let emb = try loadLFM2(lfm2EmbeddingDir)
+            var worstEmb: Float = 1
+            var i = 0
+            while let idsArr = ref["emb_ids_\(i)"] {
+                let ids = idsArr.asType(.int32).reshaped(1, -1)
+                let cls = emb(ids).hiddenStates![0..., 0, 0...]
+                worstEmb = min(worstEmb, cosine(cls, ref["emb_cls_\(i)"]!))
+                i += 1
+            }
+            #expect(i > 0)
+            #expect(worstEmb > 0.999, "worst embedding cosine \(worstEmb)")
+
+            // ColBERT: compare the per-token projection.
+            let col = try loadLFM2(lfm2ColbertDir)
+            var worstCol: Float = 1
+            i = 0
+            while let idsArr = ref["col_ids_\(i)"] {
+                let ids = idsArr.asType(.int32).reshaped(1, -1)
+                let proj = col(ids).hiddenStates!
+                worstCol = min(worstCol, cosine(proj, ref["col_proj_\(i)"]!))
+                i += 1
+            }
+            #expect(i > 0)
+            #expect(worstCol > 0.999, "worst colbert cosine \(worstCol)")
+        }
+    }
+
+    /// Build the model from a local dir and load its weights as float32 (max precision
+    /// for the parity comparison), mirroring the factory's sanitize + load path.
+    private func loadLFM2(_ dir: URL) throws -> LFM2BidirectionalModel {
+        let configData = try Data(contentsOf: dir.appendingPathComponent("config.json"))
+        let config = try JSONDecoder.json5().decode(
+            LFM2BidirectionalConfiguration.self, from: configData)
+        let model = LFM2BidirectionalModel(config)
+
+        var weights = try loadArrays(url: dir.appendingPathComponent("model.safetensors"))
+        weights = model.sanitize(weights: weights)
+        weights = weights.mapValues { $0.asType(.float32) }
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+        eval(model)
+        return model
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds support for LiquidAI's **LFM2.5 bidirectional encoders** to `MLXEmbedders`:

- **LFM2.5-Embedding-350M** — CLS-pooled 1024-d dense vector (cosine similarity).
- **LFM2.5-ColBERT-350M** — per-token `Dense(1024→128)` projection (MaxSim late interaction).

A single `LFM2BidirectionalModel: EmbeddingModel` branches on the config `mlx` head. Both models share `model_type: "lfm2"` and are registered in `EmbedderTypeRegistry` plus six `EmbedderRegistry` configurations (`mlx-community/LFM2.5-…-{bf16,4bit,8bit}`).

### Implementation notes
- The encoder differs from the causal generative `LFM2` in `MLXLLM`: **non-causal** GQA attention (additive pad-only mask, no causal mask), a **centered** depthwise short-conv, and a pooling/projection head (no LM head). The short-conv runs **unmasked** over the full sequence — the checkpoints were trained that way on the eager/SDPA path, and zeroing padded / ColBERT query-expansion positions would shift per-token embeddings and hurt MaxSim; padding is handled only by the attention key-padding mask. Kept self-contained in `MLXEmbedders` per the module's convention (Qwen3/Gemma3 are reimplemented there rather than imported from `MLXLLM`).
- The ColBERT head returns **raw per-token vectors**; pad-dropping, query-expansion, and the punctuation skiplist live in the retrieval layer (as in PyLate), not the model.
- `sanitize` applies only the depthwise-conv transpose guard — deliberately **not** a blanket `model.` prefix (that would corrupt the bare `dense.weight`).

### Files
- `Libraries/MLXEmbedders/Models/LFM2Bidirectional.swift` (new) — config, bidirectional backbone, model, `sanitize`.
- `Libraries/MLXEmbedders/ModelFactory.swift` — `"lfm2"` type creator + six model configurations.
- `Tests/MLXLMTests/LFM2BidirectionalTests.swift` (new) —  config-decode + forward-shape tests.

---

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
