### PR TITLE
Gemma 4: skip vision_embedder weights in Gemma4Model.sanitize

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -71,7 +71,7 @@ public class Gemma4Model: Module, LLMModel, KVCacheDimensionProvider {
             // Skip vision/audio weights
             if k.hasPrefix("vision_tower") || k.hasPrefix("multi_modal_projector")
                 || k.hasPrefix("audio_tower") || k.hasPrefix("embed_audio")
-                || k.hasPrefix("embed_vision")
+                || k.hasPrefix("embed_vision") || k.hasPrefix("vision_embedder")
             {
                 continue
             }


### PR DESCRIPTION
## Summary

   The gemma4_unified 12B safetensors include a top-level vision_embedder

   submodule alongside the existing embed_vision / vision_tower keys. The

   dense Gemma4Model.sanitize skip list does not cover vision_embedder, so

   loading 12B unified weights through the LLM (text-only) path aborts with:

Unhandled keys ["vision_embedder"] in Gemma4Model

This one-line change adds vision_embedder to the prefix filter so

   language-only loading of mlx-community/gemma-4-12B-it-* builds succeeds.

   ## Test plan

   - [x] LLMTypeRegistry already maps gemma4_unified → Gemma4Model (#327).

   - [x] Built MLXLLM against mlx-community/gemma-4-12B-it-4bit (6.3 GB).

         Without this patch: load fails with the error above.

         With this patch: loadContainer succeeds and generation runs end-to-end.

   - [x] No behavioral change for dense E4B or text-only Gemma 4 paths — the

         new prefix only adds a skip; matching keys never existed in those models.

   ## Related

   Builds on #327 ("Add Gemma 4 12B unified").