### PR TITLE
Avoid replaying static chat prompt state

### DIFF
--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -113,9 +113,25 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         tools: [[String: any Sendable]]?,
                         additionalContext: [String: any Sendable]?
                     ) throws -> [Int] {
+                        try applyChatTemplate(
+                            messages: messages,
+                            tools: tools,
+                            additionalContext: additionalContext,
+                            addGenerationPrompt: true)
+                    }
+
+                    func applyChatTemplate(
+                        messages: [[String: any Sendable]],
+                        tools: [[String: any Sendable]]?,
+                        additionalContext: [String: any Sendable]?,
+                        addGenerationPrompt: Bool
+                    ) throws -> [Int] {
                         do {
                             return try upstream.applyChatTemplate(
-                                messages: messages, tools: tools, additionalContext: additionalContext)
+                                messages: messages,
+                                addGenerationPrompt: addGenerationPrompt,
+                                tools: tools,
+                                additionalContext: additionalContext)
                         } catch Tokenizers.TokenizerError.missingChatTemplate {
                             throw MLXLMCommon.TokenizerError.missingChatTemplate
                         }

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -448,7 +448,7 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
 @available(*, deprecated, renamed: "LLMRegistry", message: "Please use LLMRegistry directly.")
 public typealias ModelRegistry = LLMRegistry
 
-private struct LLMUserInputProcessor: UserInputProcessor {
+struct LLMUserInputProcessor: PrefixUserInputProcessor {
 
     let tokenizer: Tokenizer
     let configuration: ModelConfiguration
@@ -463,14 +463,20 @@ private struct LLMUserInputProcessor: UserInputProcessor {
         self.messageGenerator = messageGenerator
     }
 
-    func prepare(input: UserInput) throws -> LMInput {
+    private func promptTokens(from input: UserInput, addGenerationPrompt: Bool = true) throws
+        -> [Int]
+    {
         let messages = messageGenerator.generate(from: input)
         do {
-            let promptTokens = try tokenizer.applyChatTemplate(
-                messages: messages, tools: input.tools, additionalContext: input.additionalContext)
-
-            return LMInput(tokens: MLXArray(promptTokens))
+            return try tokenizer.applyChatTemplate(
+                messages: messages,
+                tools: input.tools,
+                additionalContext: input.additionalContext,
+                addGenerationPrompt: addGenerationPrompt)
         } catch TokenizerError.missingChatTemplate {
+            guard addGenerationPrompt else {
+                return []
+            }
             print(
                 "No chat template was included or provided, so converting messages to simple text format. This is not optimal for model performance, so applications should provide a chat template if none is included with the model."
             )
@@ -478,9 +484,56 @@ private struct LLMUserInputProcessor: UserInputProcessor {
                 messages
                 .compactMap { $0["content"] as? String }
                 .joined(separator: "\n\n")
-            let promptTokens = tokenizer.encode(text: prompt)
-            return LMInput(tokens: MLXArray(promptTokens))
+            return tokenizer.encode(text: prompt)
         }
+    }
+
+    func prepare(input: UserInput) throws -> LMInput {
+        LMInput(tokens: MLXArray(try promptTokens(from: input)))
+    }
+
+    func preparePrefix(
+        input: UserInput,
+        fullInput: LMInput
+    ) throws -> LMInput? {
+        guard case .chat(let messages) = input.prompt else {
+            return nil
+        }
+        let staticMessages = messages.prefix { $0.role == .system }
+        let hasPromptTools = !(input.tools?.isEmpty ?? true)
+        guard !staticMessages.isEmpty || hasPromptTools else {
+            return nil
+        }
+
+        let staticInput = UserInput(
+            chat: Array(staticMessages),
+            processing: input.processing,
+            tools: input.tools,
+            additionalContext: input.additionalContext)
+        let staticTokens = try promptTokens(from: staticInput, addGenerationPrompt: false)
+        guard !staticTokens.isEmpty else {
+            return nil
+        }
+
+        guard fullInput.text.tokens.ndim == 1, fullInput.text.mask == nil else {
+            return nil
+        }
+        let fullTokens = fullInput.text.tokens.asArray(Int.self)
+        guard fullTokens.starts(with: staticTokens) else {
+            return nil
+        }
+
+        if let firstTurnContent = messages.dropFirst(staticMessages.count).first?.content,
+            !firstTurnContent.isEmpty
+        {
+            let contentTokens = tokenizer.encode(text: firstTurnContent, addSpecialTokens: false)
+            let suffix = fullTokens.dropFirst(staticTokens.count)
+            if !contentTokens.isEmpty && suffix.starts(with: contentTokens) {
+                return nil
+            }
+        }
+
+        return LMInput(tokens: MLXArray(staticTokens))
     }
 }
 

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -118,6 +118,19 @@ public struct SpeculativeDecodingConfig: Sendable {
     }
 }
 
+/// Protocol for processors that can render a reusable static-only prompt prefix.
+///
+/// Do not conform a processor to this protocol unless ``preparePrefix`` produces
+/// a complete semantic prefix boundary for later full prompt renders.
+/// Generic ``UserInputProcessor`` implementations are not assumed to have that
+/// property.
+public protocol PrefixUserInputProcessor: UserInputProcessor {
+    func preparePrefix(
+        input: UserInput,
+        fullInput: LMInput
+    ) async throws -> LMInput?
+}
+
 /// Simplified API for multi-turn conversations with LLMs and VLMs.
 ///
 /// For example:
@@ -144,21 +157,85 @@ public struct SpeculativeDecodingConfig: Sendable {
 ///   model operations.
 public final class ChatSession {
 
-    enum Cache {
+    private enum Cache {
         case empty
-        case kvcache([KVCache], draftKVCache: [KVCache]?)
+        case kvcache([KVCache], draftKVCache: [KVCache]?, prompt: Prompt.State)
         case history([Chat.Message])
     }
 
+    /// Tool schemas used by a chat session.
+    public struct ToolConfiguration: Sendable {
+        /// Tool schemas rendered into the model prompt.
+        public var prompt: [ToolSpec]?
+        /// Tool schemas used for parsing generated tool calls.
+        public var parser: [ToolSpec]?
+
+        public init(prompt: [ToolSpec]? = nil, parser: [ToolSpec]? = nil) {
+            self.prompt = prompt
+            self.parser = parser
+        }
+
+        public init(_ tools: [ToolSpec]?) {
+            self.init(prompt: tools, parser: tools)
+        }
+    }
+
     private let model: ModelContainer
-    public var instructions: String?
+    /// System instructions rendered into the session prompt.
+    public var instructions: String? {
+        didSet {
+            promptConfigurationRevision += 1
+        }
+    }
     private let cache: SerialAccessContainer<Cache>
     private let loadedDraftModel: SerialAccessContainer<ModelContainer?>
     public var processing: UserInput.Processing
     public var generateParameters: GenerateParameters
-    public var additionalContext: [String: any Sendable]?
-    public var tools: [ToolSpec]?
+    public var additionalContext: [String: any Sendable]? {
+        didSet {
+            promptConfigurationRevision += 1
+        }
+    }
+    /// Tool schemas for prompt rendering and tool-call parsing.
+    public var toolConfiguration: ToolConfiguration {
+        didSet {
+            if !Self.toolSpecsEqual(oldValue.prompt, toolConfiguration.prompt) {
+                promptConfigurationRevision += 1
+            }
+        }
+    }
+    /// Tool schemas used both for prompt rendering and tool-call parsing.
+    ///
+    /// This property preserves the original ``ChatSession`` behavior for callers
+    /// that use a single tool schema list. Assigning it updates
+    /// ``toolConfiguration`` for both prompt rendering and parsing.
+    public var tools: [ToolSpec]? {
+        get { toolConfiguration.prompt }
+        set {
+            toolConfiguration = .init(newValue)
+        }
+    }
     public var toolDispatch: (@Sendable (ToolCall) async throws -> String)?
+    private var promptConfigurationRevision = 0
+
+    private static func toolSpecsEqual(_ lhs: [ToolSpec]?, _ rhs: [ToolSpec]?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case (let lhs?, let rhs?):
+            guard
+                let lhsData = try? JSONSerialization.data(
+                    withJSONObject: lhs, options: [.sortedKeys]),
+                let rhsData = try? JSONSerialization.data(
+                    withJSONObject: rhs, options: [.sortedKeys])
+            else {
+                return false
+            }
+            return lhsData == rhsData
+        default:
+            return false
+        }
+    }
 
     /// Speculative decoding configuration, nil if disabled.
     public let speculativeDecoding: SpeculativeDecodingConfig?
@@ -190,7 +267,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -223,7 +300,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -260,7 +337,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -297,7 +374,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -310,13 +387,13 @@ public final class ChatSession {
     /// across multiple sessions to avoid re-prefilling the same tokens each time.
     ///
     /// > Important: If the cache was built from a session that already included system
-    /// > instructions, do not pass the same `instructions` here — they would be
-    /// > re-tokenized on each call to ``respond(to:role:images:videos:audios:)`` without matching
-    /// > KV state, producing incoherent output.
+    /// > instructions or prompt-rendered tools, do not pass the same values here; they
+    /// > would be re-tokenized on each call to ``respond(to:role:images:videos:audios:)``
+    /// > without matching KV state, producing incoherent output.
     ///
     /// - Parameters:
     ///   - model: the ``ModelContainer``
-    ///   - instructions: optional system instructions for the session — leave `nil` if the
+    ///   - instructions: optional system instructions for the session; leave `nil` if the
     ///     cache already encodes a system prompt
     ///   - cache: a non-empty `[KVCache]` previously loaded with ``loadPromptCache(url:)``,
     ///     matching the given model
@@ -339,11 +416,11 @@ public final class ChatSession {
     ) {
         self.model = model
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.cache = .init(.kvcache(cache, draftKVCache: nil, prompt: .restored))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -356,13 +433,13 @@ public final class ChatSession {
     /// across multiple sessions to avoid re-prefilling the same tokens each time.
     ///
     /// > Important: If the cache was built from a session that already included system
-    /// > instructions, do not pass the same `instructions` here — they would be
-    /// > re-tokenized on each call to ``respond(to:role:images:videos:audios:)`` without matching
-    /// > KV state, producing incoherent output.
+    /// > instructions or prompt-rendered tools, do not pass the same values here; they
+    /// > would be re-tokenized on each call to ``respond(to:role:images:videos:audios:)``
+    /// > without matching KV state, producing incoherent output.
     ///
     /// - Parameters:
     ///   - model: the ``ModelContext``
-    ///   - instructions: optional system instructions for the session — leave `nil` if the
+    ///   - instructions: optional system instructions for the session; leave `nil` if the
     ///     cache already encodes a system prompt
     ///   - cache: a non-empty `[KVCache]` previously loaded with ``loadPromptCache(url:)``,
     ///     matching the given model
@@ -385,11 +462,11 @@ public final class ChatSession {
     ) {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.cache = .init(.kvcache(cache, draftKVCache: nil, prompt: .restored))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -539,6 +616,187 @@ public final class ChatSession {
         }
     }
 
+    /// Groups prompt rendering, exact-prefix validation, and prompt-cache state transitions.
+    ///
+    /// The canonical prompt is rendered each turn. When the processor and cache support
+    /// safe prefix reuse, an exact already-cached static prefix is sliced before model
+    /// prefill.
+    private enum Prompt {
+        enum State: Equatable, Sendable {
+            case pending
+            case applied(staticPrefix: [Int], promptConfigurationRevision: Int)
+            case restored
+        }
+
+        struct Configuration: Sendable {
+            var instructions: String?
+            var processing: UserInput.Processing
+            var toolConfiguration: ToolConfiguration
+            var additionalContext: [String: any Sendable]?
+            var revision: Int
+            var allowsPrefixReuse: Bool
+        }
+
+        struct PreparedInput {
+            var input: LMInput
+            var state: State
+        }
+
+        static func fullMessages(
+            turnMessages: [Chat.Message],
+            instructions: String?
+        ) -> [Chat.Message] {
+            guard let instructions else {
+                return turnMessages
+            }
+
+            return [.system(instructions)] + turnMessages
+        }
+
+        static func staticPrefixTokens(
+            staticInput: LMInput,
+            fullInput: LMInput
+        ) -> [Int]? {
+            guard staticInput.text.tokens.ndim == 1,
+                fullInput.text.tokens.ndim == 1,
+                staticInput.text.mask == nil,
+                fullInput.text.mask == nil
+            else {
+                return nil
+            }
+
+            let staticTokens = staticInput.text.tokens.asArray(Int.self)
+            guard !staticTokens.isEmpty else {
+                return nil
+            }
+
+            let fullTokens = fullInput.text.tokens.asArray(Int.self)
+            guard fullTokens.starts(with: staticTokens) else {
+                return nil
+            }
+
+            return staticTokens
+        }
+
+        static func suffixInput(fullInput: LMInput, dropping prefixTokens: [Int]) -> LMInput? {
+            guard fullInput.text.tokens.ndim == 1, fullInput.text.mask == nil else {
+                return nil
+            }
+
+            let fullTokens = fullInput.text.tokens.asArray(Int.self)
+            guard fullTokens.starts(with: prefixTokens) else {
+                return nil
+            }
+
+            return LMInput(
+                text: .init(tokens: fullInput.text.tokens[prefixTokens.count...]),
+                image: fullInput.image,
+                video: fullInput.video,
+                audio: fullInput.audio)
+        }
+
+        static func prepareInput(
+            processor: any UserInputProcessor,
+            turnMessages: [Chat.Message],
+            kvCache: [KVCache],
+            promptState: State,
+            configuration: Configuration
+        ) async throws -> PreparedInput {
+            switch promptState {
+            case .restored:
+                let userInput = UserInput(
+                    chat: fullMessages(
+                        turnMessages: turnMessages,
+                        instructions: configuration.instructions),
+                    processing: configuration.processing,
+                    tools: configuration.toolConfiguration.prompt,
+                    additionalContext: configuration.additionalContext)
+                return PreparedInput(
+                    input: try await processor.prepare(input: userInput),
+                    state: promptState)
+
+            case .applied(_, let storedRevision) where storedRevision != configuration.revision:
+                throw ChatSessionError.promptCacheMismatch
+
+            case .pending, .applied:
+                if configuration.instructions == nil
+                    && configuration.toolConfiguration.prompt == nil
+                {
+                    let userInput = UserInput(
+                        chat: turnMessages,
+                        processing: configuration.processing,
+                        tools: nil,
+                        additionalContext: configuration.additionalContext)
+                    let preparedState =
+                        if promptState == .pending {
+                            State.applied(
+                                staticPrefix: [],
+                                promptConfigurationRevision: configuration.revision)
+                        } else {
+                            promptState
+                        }
+                    return PreparedInput(
+                        input: try await processor.prepare(input: userInput),
+                        state: preparedState)
+                }
+
+                let fullUserInput = UserInput(
+                    chat: fullMessages(
+                        turnMessages: turnMessages,
+                        instructions: configuration.instructions),
+                    processing: configuration.processing,
+                    tools: configuration.toolConfiguration.prompt,
+                    additionalContext: configuration.additionalContext)
+                let fullInput = try await processor.prepare(input: fullUserInput)
+                let prefixProcessor = processor as? any PrefixUserInputProcessor
+                let canReuseStaticPrefix =
+                    configuration.allowsPrefixReuse
+                    && prefixProcessor != nil
+                    && !kvCache.isEmpty
+                    && kvCache.allSatisfy(\.supportsStaticPrefixReuse)
+
+                switch promptState {
+                case .pending:
+                    let staticPrefix: [Int]?
+                    if canReuseStaticPrefix {
+                        let staticInput: LMInput?
+                        if let prefixProcessor {
+                            staticInput = try? await prefixProcessor.preparePrefix(
+                                input: fullUserInput,
+                                fullInput: fullInput)
+                        } else {
+                            staticInput = nil
+                        }
+                        staticPrefix = staticInput.flatMap {
+                            staticPrefixTokens(staticInput: $0, fullInput: fullInput)
+                        }
+                    } else {
+                        staticPrefix = nil
+                    }
+                    return PreparedInput(
+                        input: fullInput,
+                        state: .applied(
+                            staticPrefix: staticPrefix ?? [],
+                            promptConfigurationRevision: configuration.revision))
+
+                case .applied(let staticPrefix, _):
+                    guard canReuseStaticPrefix, !staticPrefix.isEmpty else {
+                        return PreparedInput(input: fullInput, state: promptState)
+                    }
+                    guard
+                        let suffixInput = suffixInput(fullInput: fullInput, dropping: staticPrefix)
+                    else {
+                        throw ChatSessionError.promptCacheMismatch
+                    }
+                    return PreparedInput(input: suffixInput, state: promptState)
+
+                case .restored:
+                    preconditionFailure("handled above")
+                }
+            }
+        }
+    }
+
     /// Produces a streaming response to a prompt by transforming the
     /// raw `Generation` values.
     ///
@@ -573,13 +831,25 @@ public final class ChatSession {
         // images and videos are not Sendable (MLXArray) but they are consumed
         // and are only being sent to the inner async
         let inputMessages = SendableBox<[Chat.Message]>(messages)
+        let model = self.model
+        let instructions = self.instructions
+        let processing = self.processing
+        let toolConfiguration = self.toolConfiguration
+        let toolDispatch = self.toolDispatch
+        let additionalContext = self.additionalContext
+        let promptInputConfiguration = Prompt.Configuration(
+            instructions: instructions,
+            processing: processing,
+            toolConfiguration: toolConfiguration,
+            additionalContext: additionalContext,
+            revision: self.promptConfigurationRevision,
+            allowsPrefixReuse: generateParameters.processor() == nil)
+        let cache = self.cache
+        let loadedDraftModel = self.loadedDraftModel
+        let generateParameters = self.generateParameters
+        let speculativeDecoding = self.speculativeDecoding
 
-        let task = Task {
-            [
-                model,
-                instructions, processing, tools, toolDispatch,
-                additionalContext, cache, loadedDraftModel, generateParameters, speculativeDecoding
-            ] in
+        let task = Task { @Sendable in
             do {
                 try await cache.update { cache in
 
@@ -589,9 +859,6 @@ public final class ChatSession {
                     let modelConfiguration = await model.configuration
 
                     var messages: [Chat.Message] = []
-                    if let instructions {
-                        messages.append(.system(instructions))
-                    }
 
                     // prepare the cache, if needed.  note:
                     // this is using the LanguageModel (not Sendable) outside
@@ -612,19 +879,23 @@ public final class ChatSession {
 
                     var kvCache: [KVCache]
                     var draftKVCache: [KVCache]?
+                    var promptState: Prompt.State
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil)
+                        promptState = .pending
+                        cache = .kvcache(kvCache, draftKVCache: nil, prompt: promptState)
 
-                    case .kvcache(let array, let storedDraftCache):
+                    case .kvcache(let array, let storedDraftCache, let storedPromptState):
                         kvCache = array
                         draftKVCache = storedDraftCache
+                        promptState = storedPromptState
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil)
+                        promptState = .pending
+                        cache = .kvcache(kvCache, draftKVCache: nil, prompt: promptState)
                         messages.append(contentsOf: history)
                     }
 
@@ -633,12 +904,17 @@ public final class ChatSession {
 
                     // loop can restart on tool calls
                     restart: while !messages.isEmpty {
-                        let userInput = UserInput(
-                            chat: messages,
-                            processing: processing,
-                            tools: tools, additionalContext: additionalContext)
-                        let input = try await processor.prepare(input: userInput)
+                        let turnMessages = messages
                         messages.removeAll()
+
+                        let preparedPrompt = try await Prompt.prepareInput(
+                            processor: processor,
+                            turnMessages: turnMessages,
+                            kvCache: kvCache,
+                            promptState: promptState,
+                            configuration: promptInputConfiguration)
+                        let input = preparedPrompt.input
+                        let preparedPromptState = preparedPrompt.state
 
                         // Select the token iterator based on speculative decoding configuration.
                         let (genStream, genTask): (AsyncStream<Generation>, Task<Void, Never>)
@@ -654,7 +930,7 @@ public final class ChatSession {
                                 modelConfiguration: modelConfiguration,
                                 tokenizer: tokenizer,
                                 iterator: iterator,
-                                tools: tools
+                                tools: toolConfiguration.parser
                             )
                         }
 
@@ -723,7 +999,10 @@ public final class ChatSession {
                                     if draftKVCache == nil {
                                         draftKVCache = draftModel.newCache(
                                             parameters: generateParameters)
-                                        cache = .kvcache(kvCache, draftKVCache: draftKVCache)
+                                        cache = .kvcache(
+                                            kvCache,
+                                            draftKVCache: draftKVCache,
+                                            prompt: promptState)
                                     }
                                     let draftCache = draftKVCache!
 
@@ -742,13 +1021,19 @@ public final class ChatSession {
                                         modelConfiguration: modelConfiguration,
                                         tokenizer: tokenizer,
                                         iterator: iterator,
-                                        tools: tools
+                                        tools: toolConfiguration.parser
                                     )
                                 }
                             }
                         } else {
                             // Standard path with no speculative decoding.
                             (genStream, genTask) = try defaultGeneration()
+                        }
+
+                        if preparedPromptState != promptState {
+                            promptState = preparedPromptState
+                            cache = .kvcache(
+                                kvCache, draftKVCache: draftKVCache, prompt: promptState)
                         }
 
                         var pendingToolCalls: [ToolCall] = []
@@ -842,7 +1127,7 @@ public final class ChatSession {
     {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _):
+            case .kvcache(let cache, _, _):
                 return try await body(cache)
             default:
                 return try await body(nil)
@@ -861,7 +1146,7 @@ public final class ChatSession {
     public func saveCache(to url: URL) async throws {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _):
+            case .kvcache(let cache, _, _):
                 try savePromptCache(url: url, cache: cache)
             default:
                 throw ChatSessionError.noCacheAvailable
@@ -874,8 +1159,15 @@ public final class ChatSession {
 public enum ChatSessionError: LocalizedError {
     /// ``ChatSession/saveCache(to:)`` was called before any generation occurred.
     case noCacheAvailable
+    /// The stored prompt prefix no longer matches the rendered prompt.
+    case promptCacheMismatch
 
     public var errorDescription: String? {
-        "No KV cache is available. Call respond() or streamResponse() before saveCache(to:)."
+        switch self {
+        case .noCacheAvailable:
+            "No KV cache is available. Call respond() or streamResponse() before saveCache(to:)."
+        case .promptCacheMismatch:
+            "The cached prompt prefix no longer matches the rendered prompt. Call clear() after changing instructions, tools, or additionalContext."
+        }
     }
 }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -53,6 +53,9 @@ public protocol KVCache: Evaluatable {
     /// get the maximum size (if any)
     var maxSize: Int? { get }
 
+    /// Whether this cache preserves its initial prefix for safe static prefix reuse.
+    var supportsStaticPrefixReuse: Bool { get }
+
     /// update the cache with new keys and values and return all keys/values
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray)
 
@@ -99,6 +102,10 @@ public protocol KVCache: Evaluatable {
 extension KVCache {
     public var ropeOffset: RoPEOffset {
         .scalar(offset)
+    }
+
+    public var supportsStaticPrefixReuse: Bool {
+        false
     }
 
     public func prepare(lengths: [Int]?) {}
@@ -173,6 +180,7 @@ public protocol QuantizedKVCacheProtocol: KVCache {
 open class BaseKVCache: KVCache {
     public var offset: Int = 0
     public var maxSize: Int? { nil }
+    open var supportsStaticPrefixReuse: Bool { false }
 
     public func innerState() -> [MLXArray] { [] }
 
@@ -373,6 +381,8 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     internal var keys: MLXArray?
     internal var values: MLXArray?
     public var step = 256
+
+    public override var supportsStaticPrefixReuse: Bool { true }
 
     public override init() {
         super.init()
@@ -826,6 +836,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     public private(set) var bits: Int
     public let mode: QuantizationMode
 
+    public override var supportsStaticPrefixReuse: Bool { true }
+
     public init(groupSize: Int = 64, bits: Int = 8, mode: QuantizationMode = .affine) {
         self.groupSize = groupSize
         self.bits = bits
@@ -1111,6 +1123,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
 public class ChunkedKVCache: KVCacheSimple {
     private var chunkSize: Int?
     private var startPosition: Int = 0
+
+    public override var supportsStaticPrefixReuse: Bool { chunkSize == nil }
 
     public init(chunkSize: Int? = nil) {
         self.chunkSize = chunkSize
@@ -1425,6 +1439,14 @@ public class CacheList: BaseKVCache {
 
     public override func innerState() -> [MLXArray] {
         caches.flatMap { $0.innerState() }
+    }
+
+    public override var maxSize: Int? {
+        caches.compactMap(\.maxSize).min()
+    }
+
+    public override var supportsStaticPrefixReuse: Bool {
+        caches.allSatisfy(\.supportsStaticPrefixReuse)
     }
 
     public subscript(index: Int) -> KVCache {

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -18,6 +18,13 @@ public protocol Tokenizer: Sendable {
         tools: [[String: any Sendable]]?,
         additionalContext: [String: any Sendable]?
     ) throws -> [Int]
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?,
+        addGenerationPrompt: Bool
+    ) throws -> [Int]
 }
 
 extension Tokenizer {
@@ -51,15 +58,31 @@ extension Tokenizer {
     ) throws -> [Int] {
         try applyChatTemplate(messages: messages, tools: tools, additionalContext: nil)
     }
+
+    public func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?,
+        addGenerationPrompt: Bool
+    ) throws -> [Int] {
+        guard addGenerationPrompt else {
+            throw TokenizerError.unsupportedChatTemplateOptions
+        }
+        return try applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: additionalContext)
+    }
 }
 
 public enum TokenizerError: LocalizedError {
     case missingChatTemplate
+    case unsupportedChatTemplateOptions
 
     public var errorDescription: String? {
         switch self {
         case .missingChatTemplate:
             "This tokenizer does not have a chat template."
+        case .unsupportedChatTemplateOptions:
+            "This tokenizer does not support the requested chat template options."
         }
     }
 }

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -2,11 +2,12 @@
 
 import Foundation
 import MLX
-import MLXLLM
 import MLXNN
 import MLXOptimizers
 import XCTest
+import os
 
+@testable import MLXLLM
 @testable import MLXLMCommon
 
 /// See also ChatSessionIntegrationTests
@@ -17,6 +18,58 @@ public class ChatSessionTests: XCTestCase {
         var content: String
     }
 
+    private struct RecordedTemplate: Equatable, Sendable {
+        var messages: [RecordedMessage]
+        var toolCount: Int?
+    }
+
+    private final class PreparedTokenRecorder: Sendable {
+        private let values = OSAllocatedUnfairLock(initialState: [[Int]]())
+        private let shapes = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        func append(_ value: [Int], shape: [Int]) {
+            values.withLock {
+                $0.append(value)
+            }
+            shapes.withLock {
+                $0.append(shape)
+            }
+        }
+
+        var snapshot: [[Int]] {
+            values.withLock { $0 }
+        }
+
+        var shapeSnapshot: [[Int]] {
+            shapes.withLock { $0 }
+        }
+    }
+
+    private final class RecordingLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
+        let recorder: PreparedTokenRecorder
+        let kvHeads: [Int]
+
+        init(recorder: PreparedTokenRecorder, kvHeadCount: Int = 1) {
+            self.recorder = recorder
+            self.kvHeads = Array(repeating: 1, count: kvHeadCount)
+            super.init()
+        }
+
+        func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+            -> PrepareResult
+        {
+            recorder.append(
+                input.text.tokens.asArray(Int.self),
+                shape: input.text.tokens.shape)
+            return .tokens(input.text)
+        }
+
+        func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+            let tokenCount = max(1, inputs.asArray(Int.self).count)
+            return MLXArray.zeros([1, tokenCount, 8])
+        }
+    }
+
     private struct RecordingMessageGenerator: MessageGenerator {
         let continuation: AsyncStream<[RecordedMessage]>.Continuation
 
@@ -24,6 +77,241 @@ public class ChatSessionTests: XCTestCase {
             continuation.yield(messages.map { .init(role: $0.role, content: $0.content) })
 
             return DefaultMessageGenerator().generate(messages: messages)
+        }
+    }
+
+    private struct RecordingTokenizer: Tokenizer {
+        let continuation: AsyncStream<RecordedTemplate>.Continuation
+        let base = TestTokenizer()
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            base.encode(text: text, addSpecialTokens: addSpecialTokens)
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            base.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            base.convertTokenToId(token)
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            base.convertIdToToken(id)
+        }
+
+        var bosToken: String? { base.bosToken }
+        var eosToken: String? { base.eosToken }
+        var unknownToken: String? { base.unknownToken }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            let recordedMessages = messages.map { message in
+                RecordedMessage(
+                    role: Chat.Message.Role(rawValue: message["role"] as? String ?? "")!,
+                    content: message["content"] as? String ?? "")
+            }
+            continuation.yield(.init(messages: recordedMessages, toolCount: tools?.count))
+            return base.encode(text: "")
+        }
+    }
+
+    private struct StaticPrefixTokenizer: Tokenizer {
+        let unsafeDynamicTemplate: Bool
+        var staticOnlyAssistantHeader = false
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            []
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: " ")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            String(id)
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            let dynamicTokens: [Int] = messages.flatMap { message -> [Int] in
+                switch message["content"] as? String {
+                case "first":
+                    return [101]
+                case "second":
+                    return [102]
+                case "tool result":
+                    return [103]
+                default:
+                    return []
+                }
+            }
+
+            let hasSystem = messages.contains { $0["role"] as? String == "system" }
+            if hasSystem || tools != nil {
+                let systemContent =
+                    messages.first { $0["role"] as? String == "system" }?[
+                        "content"] as? String
+                let staticTokens = systemContent == "Changed prefix." ? [21, 22] : [11, 12]
+                return staticTokens + dynamicTokens
+                    + (addGenerationPrompt && staticOnlyAssistantHeader ? [200] : [])
+            }
+
+            return (unsafeDynamicTemplate ? [99] : []) + dynamicTokens
+        }
+    }
+
+    private struct UserHeaderPrefixTokenizer: Tokenizer {
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            switch text {
+            case "first": [101]
+            case "second": [102]
+            default: []
+            }
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: " ")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            String(id)
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            let dynamicTokens = messages.flatMap { message -> [Int] in
+                switch message["content"] as? String {
+                case "first": [101]
+                case "second": [102]
+                default: []
+                }
+            }
+            let hasStaticPrompt =
+                messages.contains { $0["role"] as? String == "system" }
+                || tools != nil
+            let staticTokens = hasStaticPrompt ? [11, 12, 50] : []
+            return staticTokens + dynamicTokens + (addGenerationPrompt ? [200] : [])
+        }
+    }
+
+    private struct StaticPrefixInputProcessor: PrefixUserInputProcessor {
+        let tokenizer: Tokenizer
+        let configuration: ModelConfiguration
+        let messageGenerator: MessageGenerator
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = messageGenerator.generate(from: input)
+            let promptTokens = try tokenizer.applyChatTemplate(
+                messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+
+            return LMInput(tokens: MLXArray(promptTokens))
+        }
+
+        func preparePrefix(
+            input: UserInput,
+            fullInput: LMInput
+        ) throws -> LMInput? {
+            guard case .chat(let messages) = input.prompt else {
+                return nil
+            }
+            let chat = Array(messages.prefix { $0.role == .system })
+            let rawMessages = messageGenerator.generate(messages: chat)
+            let promptTokens = try tokenizer.applyChatTemplate(
+                messages: rawMessages,
+                tools: input.tools,
+                additionalContext: input.additionalContext,
+                addGenerationPrompt: false)
+
+            return LMInput(tokens: MLXArray(promptTokens))
+        }
+    }
+
+    private struct TwoDimensionalStaticPrefixProcessor: PrefixUserInputProcessor {
+        let configuration = ModelConfiguration(id: "test")
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = DefaultMessageGenerator().generate(from: input)
+            let dynamicTokens: [Int] = messages.flatMap { message -> [Int] in
+                switch message["content"] as? String {
+                case "first":
+                    return [101]
+                case "second":
+                    return [102]
+                default:
+                    return []
+                }
+            }
+            let hasSystem = messages.contains { $0["role"] as? String == "system" }
+            let tokens = (hasSystem || input.tools != nil ? [11, 12] : []) + dynamicTokens
+            return LMInput(tokens: MLXArray(tokens).reshaped(1, tokens.count))
+        }
+
+        func preparePrefix(
+            input: UserInput,
+            fullInput: LMInput
+        ) throws -> LMInput? {
+            guard case .chat(let messages) = input.prompt else {
+                return nil
+            }
+            let chat = Array(messages.prefix { $0.role == .system })
+            return try prepare(
+                input: UserInput(
+                    chat: chat,
+                    processing: input.processing,
+                    tools: input.tools,
+                    additionalContext: input.additionalContext))
         }
     }
 
@@ -70,6 +358,78 @@ public class ChatSessionTests: XCTestCase {
 
     private func model(processor: TestInputProcessor = TestInputProcessor()) -> ModelContext {
         Self.makeModel(processor: processor)
+    }
+
+    private func recordingModel(
+        tokenizer: Tokenizer,
+        recorder: PreparedTokenRecorder,
+        kvHeadCount: Int = 1
+    ) -> ModelContext {
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        return recordingModel(
+            processor: processor,
+            tokenizer: tokenizer,
+            recorder: recorder,
+            kvHeadCount: kvHeadCount)
+    }
+
+    private func recordingModel(
+        processor: any UserInputProcessor,
+        tokenizer: Tokenizer,
+        recorder: PreparedTokenRecorder,
+        kvHeadCount: Int = 1
+    ) -> ModelContext {
+        return .init(
+            configuration: ModelConfiguration(id: "test"),
+            model: RecordingLanguageModel(recorder: recorder, kvHeadCount: kvHeadCount),
+            processor: processor,
+            tokenizer: tokenizer)
+    }
+
+    private var lookupTools: [ToolSpec] {
+        [
+            [
+                "type": "function",
+                "function": [
+                    "name": "lookup",
+                    "description": "Look up a value",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+    }
+
+    private func staticPrefixSession(
+        recorder: PreparedTokenRecorder,
+        unsafeDynamicTemplate: Bool = false,
+        staticOnlyAssistantHeader: Bool = false,
+        maxKVSize: Int? = nil,
+        repetitionPenalty: Float? = nil
+    ) -> ChatSession {
+        let tokenizer = StaticPrefixTokenizer(
+            unsafeDynamicTemplate: unsafeDynamicTemplate,
+            staticOnlyAssistantHeader: staticOnlyAssistantHeader)
+        let processor = StaticPrefixInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        return ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(
+                maxTokens: 1,
+                maxKVSize: maxKVSize,
+                repetitionPenalty: repetitionPenalty),
+            tools: lookupTools)
     }
 
     private let generationParameters = GenerateParameters(maxTokens: 50)
@@ -170,6 +530,367 @@ public class ChatSessionTests: XCTestCase {
             $0 + history.count + $1 + 1
         }
         XCTAssertLessThan(actualPreparedMessageCount, replayedHistoryPreparedMessageCount)
+    }
+
+    func testStaticInstructionsAndPromptToolsUseExactCachedPrefix() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+        _ = try await session.respond(to: [.tool("tool result")])
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+                [103],
+            ])
+    }
+
+    func testGenericProcessorDoesNotInferReusableStaticPrefix() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ChatSession(
+            recordingModel(
+                tokenizer: StaticPrefixTokenizer(unsafeDynamicTemplate: false),
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testLLMProcessorEnablesStaticPrefixOptimizationForUsers() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = StaticPrefixTokenizer(unsafeDynamicTemplate: false)
+        let processor = LLMUserInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testLLMProcessorRendersReusablePrefixWithoutGenerationPrompt() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = StaticPrefixTokenizer(
+            unsafeDynamicTemplate: false,
+            staticOnlyAssistantHeader: true)
+        let processor = LLMUserInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101, 200],
+                [102, 200],
+            ])
+    }
+
+    func testLLMProcessorRejectsPrefixEndingWithUserTurnHeader() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = UserHeaderPrefixTokenizer()
+        let processor = LLMUserInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 50, 101, 200],
+                [11, 12, 50, 102, 200],
+            ])
+    }
+
+    func testStaticPrefixOptimizationDisabledForBoundedKVCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(recorder: recorder, maxKVSize: 2)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testStaticPrefixOptimizationDisabledForRepetitionPenalty() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(recorder: recorder, repetitionPenalty: 1.1)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testStaticPrefixOptimizationPreservesTwoDimensionalTokens() async throws {
+        let recorder = PreparedTokenRecorder()
+        let processor = TwoDimensionalStaticPrefixProcessor()
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: TestTokenizer(),
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+        XCTAssertEqual(recorder.shapeSnapshot, [[1, 3], [1, 3]])
+    }
+
+    func testStaticPrefixOptimizationUsesFullPromptSuffixNotDynamicTemplate() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(recorder: recorder, unsafeDynamicTemplate: true)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testParserOnlyToolConfigurationChangeDoesNotInvalidatePromptCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        session.toolConfiguration.parser = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "new_parser_only_tool",
+                    "description": "Used only for parsing",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testStaticPrefixMismatchThrowsInsteadOfCorruptingCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        session.instructions = "Changed prefix."
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101]])
+        }
+    }
+
+    func testPromptConfigurationChangeThrowsAfterReusableStaticPrefix() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = staticPrefixSession(
+            recorder: recorder,
+            staticOnlyAssistantHeader: true)
+
+        _ = try await session.respond(to: "first")
+        session.instructions = "Changed prefix."
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101, 200]])
+        }
+    }
+
+    func testRestoredCacheRendersConfiguredInstructionsAndPromptTools() async throws {
+        let (recordedTemplates, continuation) = AsyncStream<RecordedTemplate>.makeStream()
+        let tokenizer = RecordingTokenizer(continuation: continuation)
+        let recorder = PreparedTokenRecorder()
+        let restoredCache = KVCacheSimple()
+        let keys = MLXArray.zeros([1, 1, 1, 1])
+        let values = MLXArray.zeros([1, 1, 1, 1])
+        _ = restoredCache.update(keys: keys, values: values)
+        let session = ChatSession(
+            recordingModel(tokenizer: tokenizer, recorder: recorder),
+            instructions: "Restored instructions.",
+            cache: [restoredCache],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        continuation.finish()
+
+        var calls: [RecordedTemplate] = []
+        for await call in recordedTemplates {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(calls.map { $0.messages.map(\.role) }, [[.system, .user]])
+        XCTAssertEqual(calls.map(\.toolCount), [1])
+    }
+
+    func testClearRebuildsStaticInstructionsAndPromptTools() async throws {
+        let (recordedTemplates, continuation) = AsyncStream<RecordedTemplate>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: RecordingTokenizer(continuation: continuation),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let tools: [ToolSpec] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "lookup",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+        let session = ChatSession(
+            model(processor: processor),
+            instructions: "Static prefix.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: tools)
+
+        _ = try await session.respond(to: "first")
+        await session.clear()
+        _ = try await session.respond(to: "after clear")
+        continuation.finish()
+
+        var calls: [RecordedTemplate] = []
+        for await call in recordedTemplates {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(
+            calls.map { $0.messages.map(\.role) },
+            [
+                [.system, .user],
+                [.system, .user],
+            ])
+        XCTAssertEqual(calls.map(\.toolCount), [1, 1])
+    }
+
+    func testParserOnlyToolsAreNotRenderedIntoPrompt() async throws {
+        let (recordedTemplates, continuation) = AsyncStream<RecordedTemplate>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: RecordingTokenizer(continuation: continuation),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let tools: [ToolSpec] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "lookup",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 1))
+        session.toolConfiguration = .init(prompt: nil, parser: tools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+        continuation.finish()
+
+        var calls: [RecordedTemplate] = []
+        for await call in recordedTemplates {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(
+            calls.map { $0.messages.map(\.role) },
+            [
+                [.user],
+                [.user],
+            ])
+        XCTAssertEqual(calls.map(\.toolCount), [nil, nil])
     }
 
     func testChatSessionAsyncInterrupt() async throws {

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -260,6 +260,24 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     #expect(lifecycle.finalizeCallCount == 1)
 }
 
+@Test func testCacheListReportsBoundedChildMaxSize() throws {
+    #expect(CacheList(KVCacheSimple(), RotatingKVCache(maxSize: 32)).maxSize == 32)
+    #expect(
+        CacheList(KVCacheSimple(), CacheList(KVCacheSimple(), RotatingKVCache(maxSize: 16)))
+            .maxSize == 16)
+    #expect(CacheList(KVCacheSimple(), KVCacheSimple()).maxSize == nil)
+}
+
+@Test func testCachesReportStaticPrefixReuseSupport() throws {
+    #expect(KVCacheSimple().supportsStaticPrefixReuse)
+    #expect(QuantizedKVCache().supportsStaticPrefixReuse)
+    #expect(!RotatingKVCache(maxSize: 32).supportsStaticPrefixReuse)
+    #expect(ChunkedKVCache().supportsStaticPrefixReuse)
+    #expect(!ChunkedKVCache(chunkSize: 32).supportsStaticPrefixReuse)
+    #expect(CacheList(KVCacheSimple(), QuantizedKVCache()).supportsStaticPrefixReuse)
+    #expect(!CacheList(KVCacheSimple(), ChunkedKVCache(chunkSize: 32)).supportsStaticPrefixReuse)
+}
+
 @Test func testWithPreparedCacheScopesSequenceMetadata() throws {
     let cache = ArraysCache(size: 2)
 


### PR DESCRIPTION
## Proposed changes

Avoid replaying static prompt material in long-lived `ChatSession` instances.

`ChatSession` now renders session instructions and prompt tool schemas only when the KV cache is first built, or after `clear()`. Later turns append only incremental messages/tool results, while parser tool schemas remain available for tool-call parsing.

#### Why

For chatbots and agents, static instructions are already represented in the KV cache after the first turn. Re-rendering them on every response wastes context and prefill work. For agents, repeated tool schemas can be especially expensive.

The existing `tools:` API remains source-compatible. A grouped `ToolConfiguration` supports advanced prompt/parser schema separation without expanding every initializer.

#### Notes

`clear()` resets the session cache, so the next response rebuilds the static prefix. Apps that change instructions mid-session should call `clear()` or create a new session.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
