### PR TITLE
Falcon-H1R: correctness, cache, and preset fixes

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -118,6 +118,11 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         defaultPrompt: "Is 9.9 greater or 9.11?"
     )
 
+    static public let falconH1R7B = ModelConfiguration(
+        id: "tiiuae/Falcon-H1R-7B",
+        defaultPrompt: "If the product of two numbers is 360 and their GCD is 6, what is their LCM?"
+    )
+
     static public let phi4bit = ModelConfiguration(
         id: "mlx-community/phi-2-hf-4bit-mlx",
         // https://www.promptingguide.ai/models/phi-2
@@ -388,6 +393,7 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         [
             codeLlama13b4bit,
             deepSeekR1_7B_4bit,
+            falconH1R7B,
             gemma2bQuantized,
             gemma_2_2b_it_4bit,
             gemma_2_9b_it_4bit,

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -711,7 +711,7 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
     ///   - inputs: token ids, shape `[batch, sequence]`
     ///   - cache: optional per-layer cache
     ///   - logitsToKeep: number of trailing positions for which to compute logits.
-    ///     `nil` falls back to ``FalconH1Configuration/numLogitsToKeep``. A non-positive
+    ///     `nil` falls back to the `num_logits_to_keep` configuration value. A non-positive
     ///     value keeps all positions (useful for perplexity / training evaluation).
     public func callAsFunction(
         _ inputs: MLXArray,

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -258,6 +258,7 @@ class FalconH1Attention: Module {
     let numKVHeads: Int
     let headDim: Int
     let scale: Float
+    let keyMultiplier: Float
 
     @ModuleInfo(key: "q_proj") var qProj: Linear
     @ModuleInfo(key: "k_proj") var kProj: Linear
@@ -272,6 +273,7 @@ class FalconH1Attention: Module {
         self.numKVHeads = args.numKeyValueHeads
         self.headDim = args.headDim
         self.scale = pow(Float(headDim), -0.5)
+        self.keyMultiplier = args.keyMultiplier
 
         _qProj.wrappedValue = Linear(hiddenSize, numHeads * headDim, bias: args.attentionBias)
         _kProj.wrappedValue = Linear(hiddenSize, numKVHeads * headDim, bias: args.attentionBias)
@@ -299,7 +301,7 @@ class FalconH1Attention: Module {
         let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
 
         var queries = qProj(x)
-        var keys = kProj(x)
+        var keys = kProj(x) * keyMultiplier
         var values = vProj(x)
 
         queries = queries.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
@@ -470,7 +472,8 @@ class FalconH1Mixer: Module {
             state: state,
             timeStepLimit: timeStepLimit,
             mask: mask,
-            lengths: lengths
+            lengths: lengths,
+            step: chunkSize
         )
 
         return (y.reshaped(batchSize, seqLen, intermediateSize), newState)
@@ -666,6 +669,9 @@ public class FalconH1ModelInner: Module {
 }
 
 public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
+    private static let scalingMetadataKey = "mlx_swift_lm.falcon_h1.scaling"
+    private static let scalingMetadataValue = "attention_qkv_runtime_key_v1"
+
     public let vocabularySize: Int
     public let kvHeads: [Int]
 
@@ -686,11 +692,47 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+        callAsFunction(inputs, cache: cache, logitsToKeep: 0)
+    }
+
+    public func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+    {
+        let logits = callAsFunction(
+            input.tokens,
+            cache: cache,
+            logitsToKeep: configuration.numLogitsToKeep)
+        return .init(logits: logits)
+    }
+
+    /// Compute logits for the input tokens.
+    ///
+    /// - Parameters:
+    ///   - inputs: token ids, shape `[batch, sequence]`
+    ///   - cache: optional per-layer cache
+    ///   - logitsToKeep: number of trailing positions for which to compute logits.
+    ///     `nil` falls back to ``FalconH1Configuration/numLogitsToKeep``. A non-positive
+    ///     value keeps all positions (useful for perplexity / training evaluation).
+    public func callAsFunction(
+        _ inputs: MLXArray,
+        cache: [KVCache]? = nil,
+        logitsToKeep: Int?
+    ) -> MLXArray {
         let out = model(inputs, cache: cache as? [CacheList])
-        if let lmHead {
-            return lmHead(out)
+
+        let keep = logitsToKeep ?? configuration.numLogitsToKeep
+        let hidden: MLXArray
+        if keep > 0 {
+            let start = max(0, out.dim(1) - keep)
+            hidden = out[0..., start..., 0...]
+        } else {
+            hidden = out
         }
-        return model.embedTokens.asLinear(out)
+
+        if let lmHead {
+            return lmHead(hidden)
+        }
+        return model.embedTokens.asLinear(hidden)
             * (configuration.lmHeadMultiplier / configuration.embeddingMultiplier)
     }
 
@@ -698,6 +740,15 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
         return (0 ..< configuration.numHiddenLayers).map { _ in
             CacheList(MambaCache(), KVCacheSimple())
         }
+    }
+
+    public func sanitize(weights: [String: MLXArray], metadata: [String: String]) -> [String:
+        MLXArray]
+    {
+        if metadata[Self.scalingMetadataKey] == Self.scalingMetadataValue {
+            return weights
+        }
+        return sanitize(weights: weights)
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
@@ -714,10 +765,15 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
                 param = param * args.embeddingMultiplier
             } else if name.hasSuffix("lm_head.weight") {
                 param = param * args.lmHeadMultiplier
-            } else if name.hasSuffix("q_proj.weight") || name.hasSuffix("k_proj.weight") {
+            } else if name.hasSuffix("q_proj.weight")
+                || name.hasSuffix("k_proj.weight")
+                || name.hasSuffix("v_proj.weight")
+            {
+                // The reference applies attention_in_multiplier to the hidden state before
+                // Q/K/V. Folding it into all three projection weights is equivalent.
+                // The key_multiplier is applied at runtime so that legacy MLX conversions
+                // that did not fold it into the weights are still reference-correct.
                 param = param * args.attentionInMultiplier
-            } else if name.hasSuffix("key_proj.weight") {
-                param = param * args.attentionInMultiplier * args.keyMultiplier
             } else if name.hasSuffix("o_proj.weight") {
                 param = param * args.attentionOutMultiplier
             } else if name.hasSuffix("out_proj.weight") {
@@ -741,7 +797,49 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        model.layers.map { _ in CacheList(MambaCache(), KVCacheSimple()) }
+        let attentionCache = makeAttentionCache(parameters: parameters)
+        return model.layers.map { _ in CacheList(MambaCache(), attentionCache.copy()) }
+    }
+
+    /// Build the attention cache for a single layer, honoring ``GenerateParameters``
+    /// memory controls while leaving the Mamba recurrent cache untouched.
+    private func makeAttentionCache(parameters: GenerateParameters?) -> any KVCache {
+        // Sliding-window attention: only the KV attention cache is bounded. The Mamba
+        // recurrent state retains its full history because it cannot be safely windowed.
+        if let maxKVSize = parameters?.maxKVSize {
+            return RotatingKVCache(maxSize: maxKVSize, keep: 4)
+        }
+
+        // Quantized attention cache. We create it eagerly when quantization starts at
+        // token 0; otherwise a plain KVCacheSimple is allocated and the dynamic
+        // quantizer converts it once `quantizedKVStart` is reached.
+        if let (bits, groupSize) = resolveKVQuantizationParameters(parameters),
+            parameters?.quantizedKVStart == 0
+        {
+            return QuantizedKVCache(groupSize: groupSize, bits: bits)
+        }
+
+        return KVCacheSimple()
+    }
+
+    private func resolveKVQuantizationParameters(_ parameters: GenerateParameters?)
+        -> (bits: Int, groupSize: Int)?
+    {
+        if let scheme = parameters?.kvScheme, let resolved = resolveAffineScheme(scheme) {
+            return resolved
+        }
+        if let bits = parameters?.kvBits {
+            return (bits, parameters?.kvGroupSize ?? 64)
+        }
+        return nil
+    }
+}
+
+extension FalconH1Model: ModelConversionMetadataProvider {
+    public var modelConversionMetadata: [String: String] {
+        [
+            Self.scalingMetadataKey: Self.scalingMetadataValue
+        ]
     }
 }
 

--- a/Libraries/MLXLLM/Models/SSM.swift
+++ b/Libraries/MLXLLM/Models/SSM.swift
@@ -263,7 +263,8 @@ public func ssmUpdate(
     state: MLXArray? = nil,
     timeStepLimit: (Float, Float) = (0.001, 100.0),
     mask: MLXArray? = nil,
-    lengths: MLXArray? = nil
+    lengths: MLXArray? = nil,
+    step: Int = 256
 ) -> (MLXArray, MLXArray) {
     let seqLen = hiddenStates.dim(1)
 
@@ -294,7 +295,8 @@ public func ssmUpdate(
             state: state,
             timeStepLimit: timeStepLimit,
             mask: mask,
-            lengths: lengths
+            lengths: lengths,
+            step: step
         )
     }
 }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1454,6 +1454,22 @@ public class CacheList: BaseKVCache {
         return new
     }
 
+    /// Recursively apply a transformation to every non-composite child cache.
+    ///
+    /// `CacheList` children are descended into; any other cache is passed to
+    /// `transform` and replaced by the returned value. This is the primitive
+    /// used by dynamic cache quantization and other cache-wide rewrites for
+    /// models with hybrid attention/recurrent caches (e.g. Falcon-H1).
+    public func mapChildren(_ transform: (KVCache) -> KVCache) {
+        caches = caches.map { child in
+            if let list = child as? CacheList {
+                list.mapChildren(transform)
+                return list
+            }
+            return transform(child)
+        }
+    }
+
     public override func prepare(lengths: [Int]?) {
         caches.forEach { $0.prepare(lengths: lengths) }
     }
@@ -2002,31 +2018,50 @@ public func maybeQuantizeKVCache(
         return
     }
 
-    // Find the first quantizable (non-Mamba, non-already-quantized) cache entry
-    guard let firstQuantizable = cache.first(where: { $0 is KVCacheSimple }),
-        !(firstQuantizable is QuantizedKVCache),
-        firstQuantizable.offset > quantizedKVStart
-    else {
+    /// Recursively decide whether a cache (or any of its children) is eligible for
+    /// quantization: it must be a plain ``KVCacheSimple`` that is not already
+    /// quantized and whose offset has crossed the requested start threshold.
+    func isQuantizable(_ cache: KVCache) -> Bool {
+        if let list = cache as? CacheList {
+            return list.children.contains(where: isQuantizable)
+        }
+        return cache is KVCacheSimple
+            && !(cache is QuantizedKVCache)
+            && cache.offset > quantizedKVStart
+    }
+
+    guard cache.contains(where: isQuantizable) else {
         return
     }
 
-    for i in 0 ..< cache.count {
-        if let simpleCache = cache[i] as? KVCacheSimple {
-            let state = simpleCache.state
-            if state.count == 2 {
-                let keyHeadDim = state[0].dim(3)
-                let valueHeadDim = state[1].dim(3)
-                guard
-                    resolvedKVQuantizationGroupSize(
-                        requested: effectiveGroupSize,
-                        keyHeadDim: keyHeadDim,
-                        valueHeadDim: valueHeadDim
-                    ) != nil
-                else {
-                    continue
-                }
+    /// Attempt to convert a single cache to its quantized form. Returns the
+    /// original cache if conversion is not possible for this entry.
+    func quantize(_ cache: KVCacheSimple) -> KVCache {
+        let state = cache.state
+        if state.count == 2 {
+            let keyHeadDim = state[0].dim(3)
+            let valueHeadDim = state[1].dim(3)
+            guard
+                resolvedKVQuantizationGroupSize(
+                    requested: effectiveGroupSize,
+                    keyHeadDim: keyHeadDim,
+                    valueHeadDim: valueHeadDim
+                ) != nil
+            else {
+                return cache
             }
-            cache[i] = simpleCache.toQuantized(groupSize: effectiveGroupSize, bits: effectiveBits)
+        }
+        return cache.toQuantized(groupSize: effectiveGroupSize, bits: effectiveBits)
+    }
+
+    for i in 0 ..< cache.count {
+        if let list = cache[i] as? CacheList {
+            list.mapChildren { child in
+                guard let simpleCache = child as? KVCacheSimple else { return child }
+                return quantize(simpleCache)
+            }
+        } else if let simpleCache = cache[i] as? KVCacheSimple {
+            cache[i] = quantize(simpleCache)
         }
         // TODO: RotatingKVCache.toQuantized() is not implemented yet, like in Python.
     }

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -17,6 +17,14 @@ public protocol BaseLanguageModel: Module {
     func sanitize(weights: [String: MLXArray], metadata: [String: String]) -> [String: MLXArray]
 }
 
+/// Optional metadata a model wants written into converted safetensors.
+///
+/// Model-specific metadata lets future loaders distinguish transformed MLX-native
+/// checkpoints from original upstream checkpoints without relying only on tensor shapes.
+public protocol ModelConversionMetadataProvider {
+    var modelConversionMetadata: [String: String] { get }
+}
+
 extension BaseLanguageModel {
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         weights

--- a/Libraries/MLXLMCommon/ModelConversion.swift
+++ b/Libraries/MLXLMCommon/ModelConversion.swift
@@ -219,7 +219,8 @@ public func convert(
     let weightsURLs = try saveModelConversionWeights(
         model.parameters().flattened(),
         to: outputDirectory,
-        maxShardSize: options.maxShardSize)
+        maxShardSize: options.maxShardSize,
+        metadata: modelConversionSafetensorsMetadata(for: model))
 
     progressHandler(.init(stage: .updatingConfiguration))
     try updateModelConfigWithQuantization(
@@ -785,7 +786,8 @@ package func makeModelConversionShards(
 package func saveModelConversionWeights(
     _ weights: [(String, MLXArray)],
     to outputDirectory: URL,
-    maxShardSize: Int64
+    maxShardSize: Int64,
+    metadata: [String: String] = [:]
 ) throws -> [URL] {
     let shards = try makeModelConversionShards(weights, maxShardSize: maxShardSize)
     let totalShards = shards.count
@@ -801,7 +803,7 @@ package func saveModelConversionWeights(
         let url = outputDirectory.appendingPathComponent(filename)
         let arrays = Dictionary(uniqueKeysWithValues: shard)
         eval(Array(arrays.values))
-        try save(arrays: arrays, metadata: ["format": "mlx"], url: url)
+        try save(arrays: arrays, metadata: modelConversionSafetensorsMetadata(metadata), url: url)
 
         for (key, _) in shard {
             weightMap[key] = filename
@@ -811,6 +813,19 @@ package func saveModelConversionWeights(
 
     try saveModelConversionIndex(weightMap: weightMap, totalSize: totalSize, to: outputDirectory)
     return weightsURLs
+}
+
+package func modelConversionSafetensorsMetadata(for model: BaseLanguageModel) -> [String: String] {
+    if let provider = model as? ModelConversionMetadataProvider {
+        return modelConversionSafetensorsMetadata(provider.modelConversionMetadata)
+    }
+    return modelConversionSafetensorsMetadata([:])
+}
+
+package func modelConversionSafetensorsMetadata(_ metadata: [String: String]) -> [String: String] {
+    var result = metadata
+    result["format"] = "mlx"
+    return result
 }
 
 package func saveModelConversionIndex(

--- a/Tests/MLXLMTests/FalconH1Tests.swift
+++ b/Tests/MLXLMTests/FalconH1Tests.swift
@@ -1,0 +1,176 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import XCTest
+
+final class FalconH1Tests: XCTestCase {
+
+    private func tinyConfiguration(numLogitsToKeep: Int = 1) throws -> FalconH1Configuration {
+        let json = """
+            {
+                "model_type": "falcon_h1",
+                "hidden_size": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "vocab_size": 100,
+                "mamba_d_ssm": 16,
+                "mamba_d_state": 8,
+                "mamba_d_head": 8,
+                "mamba_n_heads": 2,
+                "mamba_n_groups": 1,
+                "mamba_d_conv": 4,
+                "mamba_chunk_size": 64,
+                "attention_in_multiplier": 2.0,
+                "key_multiplier": 0.5,
+                "num_logits_to_keep": \(numLogitsToKeep)
+            }
+            """.data(using: .utf8)!
+        return try JSONDecoder.json5().decode(FalconH1Configuration.self, from: json)
+    }
+
+    // MARK: - Key scaling
+
+    func testSanitizeScalesQKVEquivalently() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+
+        // The sanitizer needs the conv1d weight of the first layer to decide whether
+        // the checkpoint is in the original (transposed) layout.
+        let convShape: [Int] = [32, 4, 32]
+        let weights: [String: MLXArray] = [
+            "model.layers.0.mamba.conv1d.weight": MLXArray.ones(convShape, dtype: .float32),
+            "model.layers.0.self_attn.q_proj.weight": MLXArray.ones([32, 32], dtype: .float32),
+            "model.layers.0.self_attn.k_proj.weight": MLXArray.ones([16, 32], dtype: .float32),
+            "model.layers.0.self_attn.v_proj.weight": MLXArray.ones([16, 32], dtype: .float32),
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        // The dead `key_proj.weight` branch must no longer exist, so `k_proj` is
+        // scaled exactly like `q_proj` and `v_proj`. The H1R-specific `key_multiplier`
+        // is applied at runtime in `FalconH1Attention`.
+        XCTAssertEqual(
+            sanitized["model.layers.0.self_attn.q_proj.weight"]!.mean().item(Float.self), 2.0,
+            accuracy: 1e-5)
+        XCTAssertEqual(
+            sanitized["model.layers.0.self_attn.k_proj.weight"]!.mean().item(Float.self), 2.0,
+            accuracy: 1e-5)
+        XCTAssertEqual(
+            sanitized["model.layers.0.self_attn.v_proj.weight"]!.mean().item(Float.self), 2.0,
+            accuracy: 1e-5)
+    }
+
+    // MARK: - Logits-to-keep
+
+    func testDirectCallKeepsAllLogits() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+
+        let inputs = MLXArray([0, 1, 2, 3, 4]).reshaped(1, 5)
+        let logits = model(inputs)
+
+        // Direct model calls are used by training/evaluation code and keep the
+        // standard full-sequence logits contract shared by other LLM models.
+        XCTAssertEqual(logits.shape, [1, 5, 100])
+    }
+
+    func testGenerationCallUsesConfiguredLogitsToKeep() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+
+        let inputs = MLXArray([0, 1, 2, 3, 4]).reshaped(1, 5)
+        let output = model(LMInput.Text(tokens: inputs), cache: nil, state: nil)
+        let logits = output.logits
+
+        // Generation follows H1R's `num_logits_to_keep` default and avoids the
+        // full vocabulary projection for prompt positions that will be discarded.
+        XCTAssertEqual(logits.shape, [1, 1, 100])
+    }
+
+    func testExplicitLogitsToKeep() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+
+        let inputs = MLXArray([0, 1, 2, 3, 4]).reshaped(1, 5)
+        let logits = model(inputs, cache: nil, logitsToKeep: 3)
+
+        XCTAssertEqual(logits.shape, [1, 3, 100])
+    }
+
+    // MARK: - Cache construction
+
+    func testNewCacheHonorsMaxKVSize() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+        let params = GenerateParameters(maxKVSize: 8)
+
+        let cache = model.newCache(parameters: params)
+        XCTAssertEqual(cache.count, 2)
+
+        for entry in cache {
+            let list = try XCTUnwrap(entry as? CacheList)
+            XCTAssertTrue(list[1] is RotatingKVCache, "attention cache should rotate")
+            XCTAssertTrue(list[0] is MambaCache, "mamba cache should remain unbounded")
+        }
+    }
+
+    func testNewCacheCreatesQuantizedAttentionCache() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+        let params = GenerateParameters(kvBits: 4, kvGroupSize: 32, quantizedKVStart: 0)
+
+        let cache = model.newCache(parameters: params)
+        XCTAssertEqual(cache.count, 2)
+
+        for entry in cache {
+            let list = try XCTUnwrap(entry as? CacheList)
+            XCTAssertTrue(list[1] is QuantizedKVCache, "attention cache should be quantized")
+            XCTAssertTrue(list[0] is MambaCache, "mamba cache should never be quantized")
+        }
+    }
+
+    func testDynamicQuantizerRecursesIntoCacheList() throws {
+        let simple = KVCacheSimple()
+        _ = simple.update(
+            keys: MLXArray.ones([1, 2, 8, 64], dtype: .float32),
+            values: MLXArray.ones([1, 2, 8, 64], dtype: .float32)
+        )
+        var cache: [any KVCache] = [CacheList(MambaCache(), simple)]
+
+        maybeQuantizeKVCache(
+            cache: &cache,
+            kvBits: 4,
+            kvGroupSize: 64,
+            quantizedKVStart: 0
+        )
+
+        let list = try XCTUnwrap(cache.first as? CacheList)
+        XCTAssertTrue(list[1] is QuantizedKVCache)
+        XCTAssertTrue(list[0] is MambaCache)
+    }
+
+    // MARK: - Conversion metadata
+
+    func testConversionMetadataSkipsResanitizingConvertedWeights() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+
+        let weights: [String: MLXArray] = [
+            "model.layers.0.mamba.conv1d.weight": MLXArray.ones([32, 4, 32], dtype: .float32),
+            "model.layers.0.self_attn.q_proj.weight": MLXArray.ones([32, 32], dtype: .float32),
+        ]
+
+        let metadata = model.modelConversionMetadata
+        let sanitized = model.sanitize(weights: weights, metadata: metadata)
+
+        XCTAssertEqual(
+            sanitized["model.layers.0.self_attn.q_proj.weight"]!.mean().item(Float.self), 1.0,
+            accuracy: 1e-5)
+        XCTAssertEqual(sanitized["model.layers.0.mamba.conv1d.weight"]!.shape, [32, 4, 32])
+    }
+}

--- a/Tests/MLXLMTests/LLMRegistryTests.swift
+++ b/Tests/MLXLMTests/LLMRegistryTests.swift
@@ -1,0 +1,14 @@
+// Copyright © 2026 Apple Inc.
+
+import MLXLLM
+import XCTest
+
+final class LLMRegistryTests: XCTestCase {
+
+    func testFalconH1RModelConfigurationIsRegistered() {
+        XCTAssertTrue(LLMRegistry.shared.contains(id: "tiiuae/Falcon-H1R-7B"))
+
+        let configuration = LLMRegistry.falconH1R7B
+        XCTAssertEqual(configuration.name, "tiiuae/Falcon-H1R-7B")
+    }
+}

--- a/Tests/MLXLMTests/ModelConversionTests.swift
+++ b/Tests/MLXLMTests/ModelConversionTests.swift
@@ -378,6 +378,22 @@ final class ModelConversionTests: XCTestCase {
         XCTAssertEqual(weightMap["a.weight"], "model-00002-of-00002.safetensors")
     }
 
+    func testSaveModelConversionWeightsWritesModelMetadata() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let weightsURL = try saveModelConversionWeights(
+            [("model.weight", MLXArray.ones([2, 2], dtype: .float32))],
+            to: directory,
+            maxShardSize: 1024,
+            metadata: ["mlx_swift_lm.test.scaling": "v1"]
+        )[0]
+
+        let (_, metadata) = try loadArraysAndMetadata(url: weightsURL)
+        XCTAssertEqual(metadata["format"], "mlx")
+        XCTAssertEqual(metadata["mlx_swift_lm.test.scaling"], "v1")
+    }
+
     func testUpdateConfigWritesQuantizationAndQuantizationConfig() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Proposed changes

- Correct Falcon-H1R attention key multiplier handling.
- Correct Q/K/V sanitizer scaling for attention_in_multiplier.
- Preserve full logits for direct model calls, while generation uses num_logits_to_keep.
- Propagate Falcon mamba_chunk_size into SSM update.
- Make Falcon hybrid cache respect attention-only KV limits and KV quantization.
- Add recursive cache quantization for CacheList without touching Mamba state.
- Add conversion metadata so converted Falcon checkpoints are not re-sanitized.
- Add tiiuae/Falcon-H1R-7B to LLMRegistry in the same style as other models.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
