### PR TITLE
Reuse cached chat transcript prefixes

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -688,6 +688,12 @@ public final class ChatSession {
             return [.system(instructions)] + turnMessages
         }
 
+        static func containsMedia(_ messages: [Chat.Message]) -> Bool {
+            messages.contains {
+                !$0.images.isEmpty || !$0.videos.isEmpty || !$0.audios.isEmpty
+            }
+        }
+
         static func suffixInput(fullInput: LMInput, dropping prefixTokens: [Int]) -> LMInput? {
             guard fullInput.text.tokens.ndim == 1, fullInput.text.mask == nil else {
                 return nil
@@ -728,6 +734,9 @@ public final class ChatSession {
                 })
             else {
                 return .unavailable
+            }
+            guard !containsMedia(turnMessages) else {
+                return .invalid
             }
 
             let fullUserInput = UserInput(

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -786,7 +786,7 @@ public final class ChatSession {
                     additionalContext: configuration.additionalContext)
                 return PreparedInput(
                     input: try await processor.prepare(input: userInput),
-                    state: promptState)
+                    state: .applied(promptConfigurationRevision: configuration.revision))
 
             case .applied(let storedRevision) where storedRevision != configuration.revision:
                 throw ChatSessionError.promptCacheMismatch
@@ -1160,10 +1160,7 @@ public final class ChatSession {
                             }
 
                             ledger.append(contentsOf: turnMessages)
-                            let hasAssistantTurn =
-                                !contentTokens.isEmpty
-                                || (generationTrace.stopReason == .stop
-                                    && !generationTrace.committedTokens.isEmpty)
+                            let hasAssistantTurn = !generationTrace.committedTokens.isEmpty
                             if hasAssistantTurn {
                                 ledger.appendAssistant(assistantOutput)
                             }

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -148,18 +148,20 @@ public final class ChatSession {
         struct Message: Sendable {
             var role: Chat.Message.Role
             var content: String
+            var tool: Chat.Message.Tool?
 
-            init(role: Chat.Message.Role, content: String) {
+            init(role: Chat.Message.Role, content: String, tool: Chat.Message.Tool? = nil) {
                 self.role = role
                 self.content = content
+                self.tool = tool
             }
 
             init(_ message: Chat.Message) {
-                self.init(role: message.role, content: message.content)
+                self.init(role: message.role, content: message.content, tool: message.tool)
             }
 
             var chatMessage: Chat.Message {
-                .init(role: role, content: content)
+                .init(role: role, content: content, tool: tool)
             }
         }
 
@@ -176,8 +178,12 @@ public final class ChatSession {
             transcript.append(contentsOf: messages.map(Message.init))
         }
 
-        mutating func appendAssistant(_ content: String) {
-            transcript.append(.init(role: .assistant, content: content))
+        mutating func appendAssistant(_ content: String, toolCalls: [ToolCall]) {
+            transcript.append(
+                .init(
+                    role: .assistant,
+                    content: content,
+                    tool: toolCalls.isEmpty ? nil : .calls(toolCalls)))
         }
     }
 
@@ -1113,14 +1119,22 @@ public final class ChatSession {
                                 ledger: ledger)
                         }
 
+                        var generatedToolCalls: [ToolCall] = []
                         var pendingToolCalls: [ToolCall] = []
 
                         for await item in genStream {
                             // collect tool calls for dispatch; if no
                             // toolDispatch the caller handles them via
                             // the transform (streamDetails path)
-                            if let toolCall = item.toolCall, toolDispatch != nil {
-                                pendingToolCalls.append(toolCall)
+                            if let toolCall = item.toolCall {
+                                generatedToolCalls.append(toolCall)
+                                if toolDispatch != nil {
+                                    pendingToolCalls.append(toolCall)
+                                } else if let value = transform(item) {
+                                    if case .terminated = continuation.yield(value) {
+                                        break
+                                    }
+                                }
                             } else if let value = transform(item) {
                                 if case .terminated = continuation.yield(value) {
                                     break
@@ -1162,7 +1176,8 @@ public final class ChatSession {
                             ledger.append(contentsOf: turnMessages)
                             let hasAssistantTurn = !generationTrace.committedTokens.isEmpty
                             if hasAssistantTurn {
-                                ledger.appendAssistant(assistantOutput)
+                                ledger.appendAssistant(
+                                    assistantOutput, toolCalls: generatedToolCalls)
                             }
                             var committedLedgerTokens = ledger.tokens
                             committedLedgerTokens.reserveCapacity(committedLedgerTokenCount)

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -144,21 +144,124 @@ public struct SpeculativeDecodingConfig: Sendable {
 ///   model operations.
 public final class ChatSession {
 
-    enum Cache {
+    private struct PromptLedger: Sendable {
+        struct Message: Sendable {
+            var role: Chat.Message.Role
+            var content: String
+
+            init(role: Chat.Message.Role, content: String) {
+                self.role = role
+                self.content = content
+            }
+
+            init(_ message: Chat.Message) {
+                self.init(role: message.role, content: message.content)
+            }
+
+            var chatMessage: Chat.Message {
+                .init(role: role, content: content)
+            }
+        }
+
+        var transcript: [Message]
+        var tokens: [Int]
+
+        static let empty = PromptLedger(transcript: [], tokens: [])
+
+        var chatTranscript: [Chat.Message] {
+            transcript.map(\.chatMessage)
+        }
+
+        mutating func append(contentsOf messages: [Chat.Message]) {
+            transcript.append(contentsOf: messages.map(Message.init))
+        }
+
+        mutating func appendAssistant(_ content: String) {
+            transcript.append(.init(role: .assistant, content: content))
+        }
+    }
+
+    private enum Cache {
         case empty
-        case kvcache([KVCache], draftKVCache: [KVCache]?)
+        case kvcache(
+            [KVCache], draftKVCache: [KVCache]?, prompt: Prompt.State,
+            ledger: PromptLedger)
         case history([Chat.Message])
     }
 
+    /// Tool schemas used by a chat session.
+    public struct ToolConfiguration: Sendable {
+        /// Tool schemas rendered into the model prompt.
+        public var prompt: [ToolSpec]?
+        /// Tool schemas used for parsing generated tool calls.
+        public var parser: [ToolSpec]?
+
+        public init(prompt: [ToolSpec]? = nil, parser: [ToolSpec]? = nil) {
+            self.prompt = prompt
+            self.parser = parser
+        }
+
+        public init(_ tools: [ToolSpec]?) {
+            self.init(prompt: tools, parser: tools)
+        }
+    }
+
     private let model: ModelContainer
-    public var instructions: String?
+    /// System instructions rendered into the session prompt.
+    public var instructions: String? {
+        didSet {
+            promptConfigurationRevision += 1
+        }
+    }
     private let cache: SerialAccessContainer<Cache>
     private let loadedDraftModel: SerialAccessContainer<ModelContainer?>
     public var processing: UserInput.Processing
     public var generateParameters: GenerateParameters
-    public var additionalContext: [String: any Sendable]?
-    public var tools: [ToolSpec]?
+    public var additionalContext: [String: any Sendable]? {
+        didSet {
+            promptConfigurationRevision += 1
+        }
+    }
+    /// Tool schemas for prompt rendering and tool-call parsing.
+    public var toolConfiguration: ToolConfiguration {
+        didSet {
+            if !Self.toolSpecsEqual(oldValue.prompt, toolConfiguration.prompt) {
+                promptConfigurationRevision += 1
+            }
+        }
+    }
+    /// Tool schemas used both for prompt rendering and tool-call parsing.
+    ///
+    /// This property preserves the original ``ChatSession`` behavior for callers
+    /// that use a single tool schema list. Assigning it updates
+    /// ``toolConfiguration`` for both prompt rendering and parsing.
+    public var tools: [ToolSpec]? {
+        get { toolConfiguration.prompt }
+        set {
+            toolConfiguration = .init(newValue)
+        }
+    }
     public var toolDispatch: (@Sendable (ToolCall) async throws -> String)?
+    private var promptConfigurationRevision = 0
+
+    private static func toolSpecsEqual(_ lhs: [ToolSpec]?, _ rhs: [ToolSpec]?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case (let lhs?, let rhs?):
+            guard
+                let lhsData = try? JSONSerialization.data(
+                    withJSONObject: lhs, options: [.sortedKeys]),
+                let rhsData = try? JSONSerialization.data(
+                    withJSONObject: rhs, options: [.sortedKeys])
+            else {
+                return false
+            }
+            return lhsData == rhsData
+        default:
+            return false
+        }
+    }
 
     /// Speculative decoding configuration, nil if disabled.
     public let speculativeDecoding: SpeculativeDecodingConfig?
@@ -190,7 +293,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -223,7 +326,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -260,7 +363,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -297,7 +400,7 @@ public final class ChatSession {
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -310,13 +413,13 @@ public final class ChatSession {
     /// across multiple sessions to avoid re-prefilling the same tokens each time.
     ///
     /// > Important: If the cache was built from a session that already included system
-    /// > instructions, do not pass the same `instructions` here — they would be
-    /// > re-tokenized on each call to ``respond(to:role:images:videos:audios:)`` without matching
-    /// > KV state, producing incoherent output.
+    /// > instructions or prompt-rendered tools, do not pass the same values here; they
+    /// > would be re-tokenized on each call to ``respond(to:role:images:videos:audios:)``
+    /// > without matching KV state, producing incoherent output.
     ///
     /// - Parameters:
     ///   - model: the ``ModelContainer``
-    ///   - instructions: optional system instructions for the session — leave `nil` if the
+    ///   - instructions: optional system instructions for the session; leave `nil` if the
     ///     cache already encodes a system prompt
     ///   - cache: a non-empty `[KVCache]` previously loaded with ``loadPromptCache(url:)``,
     ///     matching the given model
@@ -339,11 +442,12 @@ public final class ChatSession {
     ) {
         self.model = model
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.cache = .init(
+            .kvcache(cache, draftKVCache: nil, prompt: .restored, ledger: .empty))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -356,13 +460,13 @@ public final class ChatSession {
     /// across multiple sessions to avoid re-prefilling the same tokens each time.
     ///
     /// > Important: If the cache was built from a session that already included system
-    /// > instructions, do not pass the same `instructions` here — they would be
-    /// > re-tokenized on each call to ``respond(to:role:images:videos:audios:)`` without matching
-    /// > KV state, producing incoherent output.
+    /// > instructions or prompt-rendered tools, do not pass the same values here; they
+    /// > would be re-tokenized on each call to ``respond(to:role:images:videos:audios:)``
+    /// > without matching KV state, producing incoherent output.
     ///
     /// - Parameters:
     ///   - model: the ``ModelContext``
-    ///   - instructions: optional system instructions for the session — leave `nil` if the
+    ///   - instructions: optional system instructions for the session; leave `nil` if the
     ///     cache already encodes a system prompt
     ///   - cache: a non-empty `[KVCache]` previously loaded with ``loadPromptCache(url:)``,
     ///     matching the given model
@@ -385,11 +489,12 @@ public final class ChatSession {
     ) {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.cache = .init(
+            .kvcache(cache, draftKVCache: nil, prompt: .restored, ledger: .empty))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
-        self.tools = tools
+        self.toolConfiguration = .init(tools)
         self.toolDispatch = toolDispatch
         self.additionalContext = additionalContext
         self.speculativeDecoding = speculativeDecoding
@@ -452,8 +557,10 @@ public final class ChatSession {
     ///
     /// - Important: Initializing a new session from history must prefill that
     ///   history once. Reuse the same session with this method for subsequent
-    ///   tool or agent turns to avoid repeatedly pre-filling the accumulated
-    ///   transcript.
+    ///   text-transcript tool or agent turns to opportunistically avoid
+    ///   repeatedly pre-filling the accumulated transcript. Templates that
+    ///   require structured assistant tool calls or tool call identifiers may
+    ///   fall back to normal incremental prompting.
     ///
     /// - Parameter messages: chat messages to append before generation
     /// - Returns: the model's response
@@ -539,6 +646,182 @@ public final class ChatSession {
         }
     }
 
+    /// Groups prompt rendering, exact-prefix validation, and prompt-cache state transitions.
+    ///
+    /// The canonical prompt is rendered each turn. When the processor and cache support safe
+    /// prefix reuse, an exact already-cached transcript prefix is sliced before model prefill.
+    private enum Prompt {
+        enum State: Equatable, Sendable {
+            case pending
+            case applied(promptConfigurationRevision: Int)
+            case restored
+        }
+
+        struct Configuration: Sendable {
+            var instructions: String?
+            var processing: UserInput.Processing
+            var toolConfiguration: ToolConfiguration
+            var additionalContext: [String: any Sendable]?
+            var revision: Int
+            var allowsPrefixReuse: Bool
+        }
+
+        struct PreparedInput {
+            var input: LMInput
+            var state: State
+        }
+
+        enum LedgerInput {
+            case prepared(PreparedInput)
+            case unavailable
+            case invalid
+        }
+
+        static func fullMessages(
+            turnMessages: [Chat.Message],
+            instructions: String?
+        ) -> [Chat.Message] {
+            guard let instructions else {
+                return turnMessages
+            }
+
+            return [.system(instructions)] + turnMessages
+        }
+
+        static func suffixInput(fullInput: LMInput, dropping prefixTokens: [Int]) -> LMInput? {
+            guard fullInput.text.tokens.ndim == 1, fullInput.text.mask == nil else {
+                return nil
+            }
+
+            let fullTokens = fullInput.text.tokens.asArray(Int.self)
+            guard fullTokens.starts(with: prefixTokens) else {
+                return nil
+            }
+
+            return LMInput(
+                text: .init(tokens: fullInput.text.tokens[prefixTokens.count...]),
+                image: fullInput.image,
+                video: fullInput.video,
+                audio: fullInput.audio)
+        }
+
+        static func prepareLedgerInput(
+            processor: any UserInputProcessor,
+            ledger: PromptLedger,
+            turnMessages: [Chat.Message],
+            kvCache: [KVCache],
+            promptState: State,
+            configuration: Configuration
+        ) async throws -> LedgerInput {
+            if case .applied(let storedRevision) = promptState,
+                storedRevision != configuration.revision
+            {
+                throw ChatSessionError.promptCacheMismatch
+            }
+
+            guard configuration.allowsPrefixReuse,
+                !ledger.transcript.isEmpty,
+                !ledger.tokens.isEmpty,
+                !kvCache.isEmpty,
+                kvCache.allSatisfy({
+                    $0.supportsStaticPrefixReuse && $0.offset == ledger.tokens.count
+                })
+            else {
+                return .unavailable
+            }
+
+            let fullUserInput = UserInput(
+                chat: fullMessages(
+                    turnMessages: ledger.chatTranscript + turnMessages,
+                    instructions: configuration.instructions),
+                processing: configuration.processing,
+                tools: configuration.toolConfiguration.prompt,
+                additionalContext: configuration.additionalContext)
+            let fullInput: LMInput
+            do {
+                fullInput = try await processor.prepare(input: fullUserInput)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                return .invalid
+            }
+
+            guard fullInput.text.tokens.ndim == 1,
+                fullInput.text.mask == nil,
+                fullInput.image == nil,
+                fullInput.video == nil,
+                fullInput.audio == nil,
+                let suffixInput = suffixInput(fullInput: fullInput, dropping: ledger.tokens)
+            else {
+                return .invalid
+            }
+
+            return .prepared(PreparedInput(input: suffixInput, state: promptState))
+        }
+
+        static func prepareInput(
+            processor: any UserInputProcessor,
+            turnMessages: [Chat.Message],
+            kvCache: [KVCache],
+            promptState: State,
+            configuration: Configuration
+        ) async throws -> PreparedInput {
+            switch promptState {
+            case .restored:
+                let userInput = UserInput(
+                    chat: fullMessages(
+                        turnMessages: turnMessages,
+                        instructions: configuration.instructions),
+                    processing: configuration.processing,
+                    tools: configuration.toolConfiguration.prompt,
+                    additionalContext: configuration.additionalContext)
+                return PreparedInput(
+                    input: try await processor.prepare(input: userInput),
+                    state: promptState)
+
+            case .applied(let storedRevision) where storedRevision != configuration.revision:
+                throw ChatSessionError.promptCacheMismatch
+
+            case .pending, .applied:
+                let hasPromptTools = configuration.toolConfiguration.prompt != nil
+                if configuration.instructions == nil && !hasPromptTools {
+                    let userInput = UserInput(
+                        chat: turnMessages,
+                        processing: configuration.processing,
+                        tools: nil,
+                        additionalContext: configuration.additionalContext)
+                    let preparedState =
+                        if promptState == .pending {
+                            State.applied(
+                                promptConfigurationRevision: configuration.revision)
+                        } else {
+                            promptState
+                        }
+                    return PreparedInput(
+                        input: try await processor.prepare(input: userInput),
+                        state: preparedState)
+                }
+
+                let userInput = UserInput(
+                    chat: fullMessages(
+                        turnMessages: turnMessages,
+                        instructions: configuration.instructions),
+                    processing: configuration.processing,
+                    tools: configuration.toolConfiguration.prompt,
+                    additionalContext: configuration.additionalContext)
+                let preparedState =
+                    if promptState == .pending {
+                        State.applied(promptConfigurationRevision: configuration.revision)
+                    } else {
+                        promptState
+                    }
+                return PreparedInput(
+                    input: try await processor.prepare(input: userInput),
+                    state: preparedState)
+            }
+        }
+    }
+
     /// Produces a streaming response to a prompt by transforming the
     /// raw `Generation` values.
     ///
@@ -573,13 +856,27 @@ public final class ChatSession {
         // images and videos are not Sendable (MLXArray) but they are consumed
         // and are only being sent to the inner async
         let inputMessages = SendableBox<[Chat.Message]>(messages)
+        let model = self.model
+        let instructions = self.instructions
+        let processing = self.processing
+        let toolConfiguration = self.toolConfiguration
+        let toolDispatch = self.toolDispatch
+        let additionalContext = self.additionalContext
+        let promptInputConfiguration = Prompt.Configuration(
+            instructions: instructions,
+            processing: processing,
+            toolConfiguration: toolConfiguration,
+            additionalContext: additionalContext,
+            revision: self.promptConfigurationRevision,
+            allowsPrefixReuse: generateParameters.processor() == nil
+                && self.speculativeDecoding == nil
+                && !generateParameters.usesDynamicKVQuantization)
+        let cache = self.cache
+        let loadedDraftModel = self.loadedDraftModel
+        let generateParameters = self.generateParameters
+        let speculativeDecoding = self.speculativeDecoding
 
-        let task = Task {
-            [
-                model,
-                instructions, processing, tools, toolDispatch,
-                additionalContext, cache, loadedDraftModel, generateParameters, speculativeDecoding
-            ] in
+        let task = Task { @Sendable in
             do {
                 try await cache.update { cache in
 
@@ -589,9 +886,6 @@ public final class ChatSession {
                     let modelConfiguration = await model.configuration
 
                     var messages: [Chat.Message] = []
-                    if let instructions {
-                        messages.append(.system(instructions))
-                    }
 
                     // prepare the cache, if needed.  note:
                     // this is using the LanguageModel (not Sendable) outside
@@ -612,19 +906,30 @@ public final class ChatSession {
 
                     var kvCache: [KVCache]
                     var draftKVCache: [KVCache]?
+                    var promptState: Prompt.State
+                    var ledger: PromptLedger
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil)
+                        promptState = .pending
+                        ledger = .empty
+                        cache = .kvcache(
+                            kvCache, draftKVCache: nil, prompt: promptState, ledger: ledger)
 
-                    case .kvcache(let array, let storedDraftCache):
+                    case .kvcache(
+                        let array, let storedDraftCache, let storedPromptState, let storedLedger):
                         kvCache = array
                         draftKVCache = storedDraftCache
+                        promptState = storedPromptState
+                        ledger = storedLedger
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil)
+                        promptState = .pending
+                        ledger = .empty
+                        cache = .kvcache(
+                            kvCache, draftKVCache: nil, prompt: promptState, ledger: ledger)
                         messages.append(contentsOf: history)
                     }
 
@@ -633,29 +938,65 @@ public final class ChatSession {
 
                     // loop can restart on tool calls
                     restart: while !messages.isEmpty {
-                        let userInput = UserInput(
-                            chat: messages,
-                            processing: processing,
-                            tools: tools, additionalContext: additionalContext)
-                        let input = try await processor.prepare(input: userInput)
+                        let turnMessages = messages
                         messages.removeAll()
 
+                        let preparedPrompt: Prompt.PreparedInput
+                        func prepareFullTurn() async throws -> Prompt.PreparedInput {
+                            try await Prompt.prepareInput(
+                                processor: processor,
+                                turnMessages: turnMessages,
+                                kvCache: kvCache,
+                                promptState: promptState,
+                                configuration: promptInputConfiguration)
+                        }
+                        switch try await Prompt.prepareLedgerInput(
+                            processor: processor,
+                            ledger: ledger,
+                            turnMessages: turnMessages,
+                            kvCache: kvCache,
+                            promptState: promptState,
+                            configuration: promptInputConfiguration)
+                        {
+                        case .prepared(let ledgerPrompt):
+                            preparedPrompt = ledgerPrompt
+                        case .invalid:
+                            ledger = .empty
+                            preparedPrompt = try await prepareFullTurn()
+                        case .unavailable:
+                            preparedPrompt = try await prepareFullTurn()
+                        }
+                        let input = preparedPrompt.input
+                        let preparedPromptState = preparedPrompt.state
+                        let canTraceLedgerTokens =
+                            promptInputConfiguration.allowsPrefixReuse
+                            && input.text.tokens.ndim == 1
+                            && input.text.mask == nil
+                            && input.image == nil
+                            && input.video == nil
+                            && input.audio == nil
+                        let prefillLedgerTokenCount =
+                            canTraceLedgerTokens ? ledger.tokens.count + input.text.tokens.size : 0
+                        let shouldCollectLedgerTrace = prefillLedgerTokenCount > 0
                         // Select the token iterator based on speculative decoding configuration.
-                        let (genStream, genTask): (AsyncStream<Generation>, Task<Void, Never>)
+                        let (genStream, genTask):
+                            (
+                                AsyncStream<Generation>, Task<GenerationTrace, Never>
+                            )
                         func defaultGeneration() throws -> (
-                            AsyncStream<Generation>, Task<Void, Never>
+                            AsyncStream<Generation>, Task<GenerationTrace, Never>
                         ) {
                             let iterator = try TokenIterator(
                                 input: input, model: model, cache: kvCache,
                                 parameters: generateParameters)
 
-                            return MLXLMCommon.generateTask(
+                            return MLXLMCommon.generateTaskWithGenerationTrace(
                                 promptTokenCount: input.text.tokens.size,
                                 modelConfiguration: modelConfiguration,
                                 tokenizer: tokenizer,
                                 iterator: iterator,
-                                tools: tools
-                            )
+                                collectTokenTrace: shouldCollectLedgerTrace,
+                                tools: toolConfiguration.parser)
                         }
 
                         if let speculativeDecoding {
@@ -723,7 +1064,11 @@ public final class ChatSession {
                                     if draftKVCache == nil {
                                         draftKVCache = draftModel.newCache(
                                             parameters: generateParameters)
-                                        cache = .kvcache(kvCache, draftKVCache: draftKVCache)
+                                        cache = .kvcache(
+                                            kvCache,
+                                            draftKVCache: draftKVCache,
+                                            prompt: promptState,
+                                            ledger: ledger)
                                     }
                                     let draftCache = draftKVCache!
 
@@ -737,18 +1082,26 @@ public final class ChatSession {
                                         numDraftTokens: speculativeDecoding.numDraftTokens
                                     )
 
-                                    (genStream, genTask) = MLXLMCommon.generateTask(
-                                        promptTokenCount: input.text.tokens.size,
-                                        modelConfiguration: modelConfiguration,
-                                        tokenizer: tokenizer,
-                                        iterator: iterator,
-                                        tools: tools
-                                    )
+                                    (genStream, genTask) =
+                                        MLXLMCommon.generateTaskWithGenerationTrace(
+                                            promptTokenCount: input.text.tokens.size,
+                                            modelConfiguration: modelConfiguration,
+                                            tokenizer: tokenizer,
+                                            iterator: iterator,
+                                            collectTokenTrace: shouldCollectLedgerTrace,
+                                            tools: toolConfiguration.parser)
                                 }
                             }
                         } else {
                             // Standard path with no speculative decoding.
                             (genStream, genTask) = try defaultGeneration()
+                        }
+
+                        if preparedPromptState != promptState {
+                            promptState = preparedPromptState
+                            cache = .kvcache(
+                                kvCache, draftKVCache: draftKVCache, prompt: promptState,
+                                ledger: ledger)
                         }
 
                         var pendingToolCalls: [ToolCall] = []
@@ -769,7 +1122,55 @@ public final class ChatSession {
                         // wait for the task to complete -- this is important in
                         // the case where we broke the loop early as the generation
                         // work may continue (briefly) and use the KVCache
-                        await genTask.value
+                        let generationTrace = await genTask.value
+                        if let finalCache = generationTrace.finalCache {
+                            kvCache = finalCache.consume()
+                        }
+                        if let finalDraftCache = generationTrace.finalDraftCache {
+                            draftKVCache = finalDraftCache.consume()
+                        }
+                        let committedLedgerTokenCount =
+                            prefillLedgerTokenCount + generationTrace.committedTokens.count
+                        let canCommitLedger =
+                            shouldCollectLedgerTrace
+                            && generationTrace.isLedgerSafe
+                            && kvCache.allSatisfy {
+                                $0.supportsStaticPrefixReuse
+                                    && $0.offset == committedLedgerTokenCount
+                            }
+                        if canCommitLedger {
+                            let contentTokens = generationTrace.contentTokens
+                            var assistantOutput = ""
+                            if !contentTokens.isEmpty {
+                                assistantOutput = tokenizer.decode(
+                                    tokenIds: contentTokens, skipSpecialTokens: false)
+                                if assistantOutput.isEmpty {
+                                    assistantOutput = tokenizer.decode(
+                                        tokenIds: contentTokens, skipSpecialTokens: true)
+                                }
+                            }
+
+                            ledger.append(contentsOf: turnMessages)
+                            let hasAssistantTurn =
+                                !contentTokens.isEmpty
+                                || (generationTrace.stopReason == .stop
+                                    && !generationTrace.committedTokens.isEmpty)
+                            if hasAssistantTurn {
+                                ledger.appendAssistant(assistantOutput)
+                            }
+                            var committedLedgerTokens = ledger.tokens
+                            committedLedgerTokens.reserveCapacity(committedLedgerTokenCount)
+                            committedLedgerTokens.append(
+                                contentsOf: input.text.tokens.asArray(Int.self))
+                            committedLedgerTokens.append(
+                                contentsOf: generationTrace.committedTokens)
+                            ledger.tokens = committedLedgerTokens
+                        } else {
+                            ledger = .empty
+                        }
+                        cache = .kvcache(
+                            kvCache, draftKVCache: draftKVCache, prompt: promptState,
+                            ledger: ledger)
 
                         // dispatch all tool calls from this generation pass
                         if let toolDispatch, !pendingToolCalls.isEmpty,
@@ -842,7 +1243,7 @@ public final class ChatSession {
     {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _):
+            case .kvcache(let cache, _, _, _):
                 return try await body(cache)
             default:
                 return try await body(nil)
@@ -861,7 +1262,7 @@ public final class ChatSession {
     public func saveCache(to url: URL) async throws {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _):
+            case .kvcache(let cache, _, _, _):
                 try savePromptCache(url: url, cache: cache)
             default:
                 throw ChatSessionError.noCacheAvailable
@@ -874,8 +1275,15 @@ public final class ChatSession {
 public enum ChatSessionError: LocalizedError {
     /// ``ChatSession/saveCache(to:)`` was called before any generation occurred.
     case noCacheAvailable
+    /// The stored prompt prefix no longer matches the rendered prompt.
+    case promptCacheMismatch
 
     public var errorDescription: String? {
-        "No KV cache is available. Call respond() or streamResponse() before saveCache(to:)."
+        switch self {
+        case .noCacheAvailable:
+            "No KV cache is available. Call respond() or streamResponse() before saveCache(to:)."
+        case .promptCacheMismatch:
+            "The cached prompt prefix no longer matches the rendered prompt. Call clear() after changing instructions, tools, or additionalContext."
+        }
     }
 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -586,7 +586,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.processor = parameters.processor()
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
-        self.returnsReusableCache = parameters.usesDynamicKVQuantization
+        self.returnsReusableCache = !parameters.usesDynamicKVQuantization
 
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
@@ -621,7 +621,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.processor = parameters.processor()
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
-        self.returnsReusableCache = parameters.usesDynamicKVQuantization
+        self.returnsReusableCache = !parameters.usesDynamicKVQuantization
 
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
@@ -837,7 +837,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.maxTokens = parameters.maxTokens
         self.numDraftTokens = numDraftTokens
-        self.returnsReusableCaches = parameters.usesDynamicKVQuantization
+        self.returnsReusableCaches = !parameters.usesDynamicKVQuantization
 
         self.quantizeKVCache = { cache in
             maybeQuantizeKVCache(
@@ -1859,16 +1859,16 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
     let handler = SendableBox(handler)
 
     // Launch a Task to perform iteration asynchronously.
-        let task = Task {
-            let performIteration = {
-                var iterator = iterator.consume()
-                var handler = handler.consume()
-                _ = runGenerateLoop(
-                    promptTokenCount: promptTokenCount,
-                    modelConfiguration: modelConfiguration,
-                    tokenizer: tokenizer,
-                    iterator: &iterator,
-                    includeStopToken: includeStopToken,
+    let task = Task {
+        let performIteration = {
+            var iterator = iterator.consume()
+            var handler = handler.consume()
+            _ = runGenerateLoop(
+                promptTokenCount: promptTokenCount,
+                modelConfiguration: modelConfiguration,
+                tokenizer: tokenizer,
+                iterator: &iterator,
+                includeStopToken: includeStopToken,
                 collectTrace: false,
                 handler: &handler,
                 continuation: continuation)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -145,6 +145,10 @@ public struct GenerateParameters: Sendable {
         self.prefillStepSize = prefillStepSize
     }
 
+    var usesDynamicKVQuantization: Bool {
+        kvBits != nil || resolveAffineScheme(kvScheme) != nil
+    }
+
     public func sampler() -> LogitSampler {
         let usesTopP = topP > 0 && topP < 1
         let usesTopK = topK > 0
@@ -504,11 +508,15 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
     var tokenCount: Int { get }
     var promptPrefillTime: TimeInterval { get }
     var speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? { get }
+    var reusableCache: [KVCache]? { get }
+    var reusableDraftCache: [KVCache]? { get }
     mutating func discardGeneratedToken()
 }
 
 extension TokenIteratorProtocol {
     public var speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? { nil }
+    public var reusableCache: [KVCache]? { nil }
+    public var reusableDraftCache: [KVCache]? { nil }
     public mutating func discardGeneratedToken() {}
 }
 
@@ -546,6 +554,8 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     public var tokenCount = 0
     public let maxTokens: Int?
+    let returnsReusableCache: Bool
+    public var reusableCache: [KVCache]? { returnsReusableCache ? cache : nil }
 
     // Cache quantization parameters
     let kvBits: Int?
@@ -576,6 +586,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.processor = parameters.processor()
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
+        self.returnsReusableCache = parameters.usesDynamicKVQuantization
 
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
@@ -610,6 +621,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.processor = parameters.processor()
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
+        self.returnsReusableCache = parameters.usesDynamicKVQuantization
 
         self.kvBits = parameters.kvBits
         self.kvGroupSize = parameters.kvGroupSize
@@ -643,6 +655,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.processor = processor
         self.sampler = sampler
         self.maxTokens = maxTokens
+        self.returnsReusableCache = false
 
         // No cache quantization for this direct initialization
         self.kvBits = nil
@@ -769,6 +782,9 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
     public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
+    let returnsReusableCaches: Bool
+    public var reusableCache: [KVCache]? { returnsReusableCaches ? mainCache : nil }
+    public var reusableDraftCache: [KVCache]? { returnsReusableCaches ? draftCache : nil }
     let numDraftTokens: Int
 
     // Buffer of accepted tokens from the current speculation round
@@ -821,13 +837,15 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.maxTokens = parameters.maxTokens
         self.numDraftTokens = numDraftTokens
+        self.returnsReusableCaches = parameters.usesDynamicKVQuantization
 
         self.quantizeKVCache = { cache in
             maybeQuantizeKVCache(
                 cache: &cache,
                 kvBits: parameters.kvBits,
                 kvGroupSize: parameters.kvGroupSize,
-                quantizedKVStart: parameters.quantizedKVStart
+                quantizedKVStart: parameters.quantizedKVStart,
+                kvScheme: parameters.kvScheme
             )
         }
 
@@ -1548,6 +1566,39 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
     )
 }
 
+struct GenerationTrace: Sendable {
+    let contentTokens: [Int]
+    let committedTokens: [Int]
+    let stopReason: GenerateStopReason
+    let isLedgerSafe: Bool
+    let finalCache: SendableBox<[KVCache]>?
+    let finalDraftCache: SendableBox<[KVCache]>?
+}
+
+func generateTaskWithGenerationTrace<TOKEN: TokenIteratorProtocol>(
+    promptTokenCount: Int,
+    modelConfiguration: ModelConfiguration,
+    tokenizer: Tokenizer,
+    iterator: consuming TOKEN,
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    collectTokenTrace: Bool = true,
+    tools: [[String: any Sendable]]? = nil
+) -> (AsyncStream<Generation>, Task<GenerationTrace, Never>) {
+    generateLoopTaskWithGenerationTrace(
+        promptTokenCount: promptTokenCount,
+        modelConfiguration: modelConfiguration,
+        tokenizer: tokenizer,
+        iterator: iterator,
+        wiredMemoryTicket: wiredMemoryTicket,
+        collectTokenTrace: collectTokenTrace,
+        handler: TextToolTokenLoopHandler(
+            tokenizer: tokenizer,
+            format: modelConfiguration.toolCallFormat ?? .json,
+            tools: tools
+        )
+    )
+}
+
 /// Generates raw token IDs asynchronously using the provided language model input, parameters, and context.
 ///
 /// This is similar to `generate(input:cache:parameters:context:)`, but yields raw token IDs instead of decoded text/tool calls.
@@ -1802,109 +1853,25 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
     includeStopToken: Bool = false,
     handler: consuming Handler
 ) -> (AsyncStream<Handler.Output>, Task<Void, Never>) {
-
     let (stream, continuation) = AsyncStream<Handler.Output>.makeStream()
 
     let iterator = SendableBox(iterator)
     let handler = SendableBox(handler)
 
     // Launch a Task to perform iteration asynchronously.
-    let task = Task {
-        let performIteration = {
-            var iterator = iterator.consume()
-            var handler = handler.consume()
-
-            var start = Date.timeIntervalSinceReferenceDate
-            var promptTime: TimeInterval = 0
-            var tokenCount = 0
-            var stopReason: GenerateStopReason?
-
-            let stopTokenIds = buildStopTokenIds(
-                modelConfiguration: modelConfiguration,
-                tokenizer: tokenizer
-            )
-
-            tokenLoop: while let token = iterator.next() {
-                // Check for cancellation on every loop iteration.
-                if Task.isCancelled {
-                    stopReason = .cancelled
-                    break
-                }
-
-                if promptTime == 0 {
-                    let now = Date.timeIntervalSinceReferenceDate
-                    promptTime = now - start
-                    start = now
-                }
-
-                // Check for end-of-sequence tokens
-                if token == tokenizer.unknownTokenId || stopTokenIds.contains(token) {
-                    if includeStopToken {
-                        tokenCount += 1
-                        switch handler.onStopToken(token, emit: continuation.yield) {
-                        case .more:
-                            break
-                        case .stop:
-                            stopReason = .stop
-                            break tokenLoop
-                        case .cancelled:
-                            stopReason = .cancelled
-                            break tokenLoop
-                        }
-                    } else {
-                        iterator.discardGeneratedToken()
-                    }
-                    stopReason = .stop
-                    break
-                }
-
-                tokenCount += 1
-                switch handler.onToken(token, emit: continuation.yield) {
-                case .more:
-                    break
-                case .stop:
-                    stopReason = .stop
-                    break tokenLoop
-                case .cancelled:
-                    stopReason = .cancelled
-                    break tokenLoop
-                }
-            }
-
-            if stopReason == nil {
-                if Task.isCancelled {
-                    stopReason = .cancelled
-                } else if let maxTokens = iterator.maxTokens, iterator.tokenCount >= maxTokens {
-                    stopReason = .length
-                } else {
-                    stopReason = .cancelled
-                }
-            }
-
-            handler.onGenerationEnd(emit: continuation.yield)
-
-            let now = Date.timeIntervalSinceReferenceDate
-            let generateTime = now - start
-
-            let mtpStats = iterator as? MTPStatsCollecting
-            let info = GenerateCompletionInfo(
-                promptTokenCount: promptTokenCount,
-                generationTokenCount: tokenCount,
-                promptTime: promptTime + iterator.promptPrefillTime,
-                generationTime: generateTime,
-                stopReason: stopReason ?? .cancelled,
-                proposedDraftTokens: mtpStats?.proposedDraftTokens,
-                acceptedDraftTokens: mtpStats?.acceptedDraftTokens,
-                passthroughReason: mtpStats?.passthroughReason,
-                speculativeDecodingTelemetry: iterator.speculativeDecodingTelemetry
-            )
-            _ = continuation.yield(handler.infoEvent(info))
-
-            // Synchronize with the stream to ensure tasks are completed
-            Stream().synchronize()
-
-            // Finalize the stream
-            continuation.finish()
+        let task = Task {
+            let performIteration = {
+                var iterator = iterator.consume()
+                var handler = handler.consume()
+                _ = runGenerateLoop(
+                    promptTokenCount: promptTokenCount,
+                    modelConfiguration: modelConfiguration,
+                    tokenizer: tokenizer,
+                    iterator: &iterator,
+                    includeStopToken: includeStopToken,
+                collectTrace: false,
+                handler: &handler,
+                continuation: continuation)
         }
 
         if let ticket = wiredMemoryTicket {
@@ -1924,6 +1891,208 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
     }
 
     return (stream, task)
+}
+
+private func generateLoopTaskWithGenerationTrace<Handler: TokenLoopHandler>(
+    promptTokenCount: Int,
+    modelConfiguration: ModelConfiguration,
+    tokenizer: Tokenizer,
+    iterator: consuming any TokenIteratorProtocol,
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    includeStopToken: Bool = false,
+    collectTokenTrace: Bool = true,
+    handler: consuming Handler
+) -> (AsyncStream<Handler.Output>, Task<GenerationTrace, Never>) {
+
+    let (stream, continuation) = AsyncStream<Handler.Output>.makeStream()
+
+    let iterator = SendableBox(iterator)
+    let handler = SendableBox(handler)
+
+    // Launch a Task to perform iteration asynchronously.
+    let task = Task { () -> GenerationTrace in
+        let performIteration = { () -> GenerationTrace in
+            var iterator = iterator.consume()
+            var handler = handler.consume()
+            return runGenerateLoop(
+                promptTokenCount: promptTokenCount,
+                modelConfiguration: modelConfiguration,
+                tokenizer: tokenizer,
+                iterator: &iterator,
+                includeStopToken: includeStopToken,
+                collectTrace: collectTokenTrace,
+                handler: &handler,
+                continuation: continuation)!
+        }
+
+        if let ticket = wiredMemoryTicket {
+            return await WiredMemoryTicket.withWiredLimit(ticket) {
+                performIteration()
+            }
+        } else {
+            return performIteration()
+        }
+    }
+
+    // When the consumer cancels (or ends) the stream, cancel our underlying task.
+    continuation.onTermination = { termination in
+        if case .cancelled = termination {
+            task.cancel()
+        }
+    }
+
+    return (stream, task)
+}
+
+private struct GenerationTraceBuilder {
+    private var contentTokens: [Int]?
+    private var committedTokens: [Int]?
+
+    init(enabled: Bool) {
+        if enabled {
+            contentTokens = []
+            committedTokens = []
+        }
+    }
+
+    mutating func recordCommitted(_ token: Int) {
+        committedTokens?.append(token)
+    }
+
+    mutating func recordContent(_ token: Int) {
+        contentTokens?.append(token)
+    }
+
+    func finish(
+        stopReason: GenerateStopReason,
+        finalCache: SendableBox<[KVCache]>?,
+        finalDraftCache: SendableBox<[KVCache]>?
+    ) -> GenerationTrace? {
+        return GenerationTrace(
+            contentTokens: contentTokens ?? [],
+            committedTokens: committedTokens ?? [],
+            stopReason: stopReason,
+            isLedgerSafe: stopReason != .cancelled,
+            finalCache: finalCache,
+            finalDraftCache: finalDraftCache)
+    }
+}
+
+private func runGenerateLoop<Handler: TokenLoopHandler>(
+    promptTokenCount: Int,
+    modelConfiguration: ModelConfiguration,
+    tokenizer: Tokenizer,
+    iterator: inout any TokenIteratorProtocol,
+    includeStopToken: Bool,
+    collectTrace: Bool,
+    handler: inout Handler,
+    continuation: AsyncStream<Handler.Output>.Continuation
+) -> GenerationTrace? {
+    var traceBuilder = GenerationTraceBuilder(enabled: collectTrace)
+    var start = Date.timeIntervalSinceReferenceDate
+    var promptTime: TimeInterval = 0
+    var tokenCount = 0
+    var stopReason: GenerateStopReason?
+
+    let stopTokenIds = buildStopTokenIds(
+        modelConfiguration: modelConfiguration,
+        tokenizer: tokenizer
+    )
+
+    tokenLoop: while let token = iterator.next() {
+        if collectTrace {
+            // TokenIterator.next() has already advanced the KV cache with this token.
+            traceBuilder.recordCommitted(token)
+        }
+
+        // Check for cancellation on every loop iteration.
+        if Task.isCancelled {
+            stopReason = .cancelled
+            break
+        }
+
+        if promptTime == 0 {
+            let now = Date.timeIntervalSinceReferenceDate
+            promptTime = now - start
+            start = now
+        }
+
+        // Check for end-of-sequence tokens
+        if token == tokenizer.unknownTokenId || stopTokenIds.contains(token) {
+            if includeStopToken {
+                tokenCount += 1
+                traceBuilder.recordContent(token)
+                switch handler.onStopToken(token, emit: continuation.yield) {
+                case .more:
+                    break
+                case .stop:
+                    stopReason = .stop
+                    break tokenLoop
+                case .cancelled:
+                    stopReason = .cancelled
+                    break tokenLoop
+                }
+            } else {
+                iterator.discardGeneratedToken()
+            }
+            stopReason = .stop
+            break
+        }
+
+        tokenCount += 1
+        traceBuilder.recordContent(token)
+        switch handler.onToken(token, emit: continuation.yield) {
+        case .more:
+            break
+        case .stop:
+            stopReason = .stop
+            break tokenLoop
+        case .cancelled:
+            stopReason = .cancelled
+            break tokenLoop
+        }
+    }
+
+    if stopReason == nil {
+        if Task.isCancelled {
+            stopReason = .cancelled
+        } else if let maxTokens = iterator.maxTokens, iterator.tokenCount >= maxTokens {
+            stopReason = .length
+        } else {
+            stopReason = .cancelled
+        }
+    }
+
+    let finalStopReason = stopReason ?? .cancelled
+    handler.onGenerationEnd(emit: continuation.yield)
+
+    let now = Date.timeIntervalSinceReferenceDate
+    let generateTime = now - start
+
+    let mtpStats = iterator as? MTPStatsCollecting
+    let info = GenerateCompletionInfo(
+        promptTokenCount: promptTokenCount,
+        generationTokenCount: tokenCount,
+        promptTime: promptTime + iterator.promptPrefillTime,
+        generationTime: generateTime,
+        stopReason: finalStopReason,
+        proposedDraftTokens: mtpStats?.proposedDraftTokens,
+        acceptedDraftTokens: mtpStats?.acceptedDraftTokens,
+        passthroughReason: mtpStats?.passthroughReason,
+        speculativeDecodingTelemetry: iterator.speculativeDecodingTelemetry
+    )
+    _ = continuation.yield(handler.infoEvent(info))
+
+    // Synchronize with the stream to ensure tasks are completed
+    Stream().synchronize()
+
+    // Finalize the stream
+    continuation.finish()
+
+    return traceBuilder.finish(
+        stopReason: finalStopReason,
+        finalCache: iterator.reusableCache.map { SendableBox($0) },
+        finalDraftCache: iterator.reusableDraftCache.map { SendableBox($0) })
 }
 
 /// Measures the execution time of a closure.
@@ -2120,7 +2289,7 @@ private enum TokenLoopDisposition {
 }
 
 private protocol TokenLoopHandler {
-    associatedtype Output
+    associatedtype Output: Sendable
 
     /// Return `.stop` for semantic generation stops, or `.cancelled` for consumer termination.
     mutating func onToken(

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -53,6 +53,9 @@ public protocol KVCache: Evaluatable {
     /// get the maximum size (if any)
     var maxSize: Int? { get }
 
+    /// Whether this cache preserves its initial prefix for safe static prefix reuse.
+    var supportsStaticPrefixReuse: Bool { get }
+
     /// update the cache with new keys and values and return all keys/values
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray)
 
@@ -99,6 +102,10 @@ public protocol KVCache: Evaluatable {
 extension KVCache {
     public var ropeOffset: RoPEOffset {
         .scalar(offset)
+    }
+
+    public var supportsStaticPrefixReuse: Bool {
+        false
     }
 
     public func prepare(lengths: [Int]?) {}
@@ -173,6 +180,7 @@ public protocol QuantizedKVCacheProtocol: KVCache {
 open class BaseKVCache: KVCache {
     public var offset: Int = 0
     public var maxSize: Int? { nil }
+    open var supportsStaticPrefixReuse: Bool { false }
 
     public func innerState() -> [MLXArray] { [] }
 
@@ -373,6 +381,8 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     internal var keys: MLXArray?
     internal var values: MLXArray?
     public var step = 256
+
+    public override var supportsStaticPrefixReuse: Bool { type(of: self) == KVCacheSimple.self }
 
     public override init() {
         super.init()
@@ -826,6 +836,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
     public private(set) var bits: Int
     public let mode: QuantizationMode
 
+    public override var supportsStaticPrefixReuse: Bool { true }
+
     public init(groupSize: Int = 64, bits: Int = 8, mode: QuantizationMode = .affine) {
         self.groupSize = groupSize
         self.bits = bits
@@ -1111,6 +1123,8 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
 public class ChunkedKVCache: KVCacheSimple {
     private var chunkSize: Int?
     private var startPosition: Int = 0
+
+    public override var supportsStaticPrefixReuse: Bool { chunkSize == nil }
 
     public init(chunkSize: Int? = nil) {
         self.chunkSize = chunkSize

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -46,6 +46,8 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
     public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
+    let returnsReusableCache: Bool
+    public var reusableCache: [KVCache]? { returnsReusableCache ? mainCache : nil }
     /// Total tokens proposed per round (`blockSize - 1` drafted, plus the
     /// bonus token from the previous verify). Mirrors mlx-vlm's
     /// `draft_block_size` parameter.
@@ -122,13 +124,15 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.maxTokens = parameters.maxTokens
         self.blockSize = blockSize
+        self.returnsReusableCache = parameters.usesDynamicKVQuantization
 
         self.quantizeKVCache = { cache in
             maybeQuantizeKVCache(
                 cache: &cache,
                 kvBits: parameters.kvBits,
                 kvGroupSize: parameters.kvGroupSize,
-                quantizedKVStart: parameters.quantizedKVStart
+                quantizedKVStart: parameters.quantizedKVStart,
+                kvScheme: parameters.kvScheme
             )
         }
 

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -124,7 +124,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.maxTokens = parameters.maxTokens
         self.blockSize = blockSize
-        self.returnsReusableCache = parameters.usesDynamicKVQuantization
+        self.returnsReusableCache = !parameters.usesDynamicKVQuantization
 
         self.quantizeKVCache = { cache in
             maybeQuantizeKVCache(

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -155,6 +155,203 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
+    private final class GoldenLogitRecorder: Sendable {
+        private let values = OSAllocatedUnfairLock(initialState: [[Float]]())
+
+        func append(_ value: MLXArray) {
+            let value = value.asArray(Float.self)
+            values.withLock {
+                $0.append(value)
+            }
+        }
+
+        var snapshot: [[Float]] {
+            values.withLock { $0 }
+        }
+    }
+
+    private final class GoldenKVCache: BaseKVCache {
+        private(set) var tokenHistory: [Int] = []
+
+        override var supportsStaticPrefixReuse: Bool { true }
+
+        func append(tokens: [Int]) {
+            tokenHistory.append(contentsOf: tokens)
+            offset = tokenHistory.count
+        }
+
+        override func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+            offset += keys.dim(2)
+            return (keys, values)
+        }
+
+        override func copy() -> any KVCache {
+            let new = GoldenKVCache()
+            new.tokenHistory = tokenHistory
+            new.offset = offset
+            return new
+        }
+    }
+
+    private final class GoldenLogitLanguageModel: Module, LanguageModel {
+        let vocabularySize = 128
+        let recorder: GoldenLogitRecorder?
+
+        init(recorder: GoldenLogitRecorder? = nil) {
+            self.recorder = recorder
+            super.init()
+        }
+
+        func newCache(parameters: GenerateParameters?) -> [KVCache] {
+            [GoldenKVCache()]
+        }
+
+        func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+            -> PrepareResult
+        {
+            let tokens = input.text.tokens.asArray(Int.self)
+            let state = append(tokens: tokens, to: cache)
+            let logits = logits(for: state, tokenCount: max(1, tokens.count))
+            recorder?.append(logits[0, -1, 0...])
+            return .logits(.init(logits: logits, state: nil))
+        }
+
+        func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+            -> LMOutput
+        {
+            let tokens = input.tokens.asArray(Int.self)
+            let state = append(tokens: tokens, to: cache ?? [])
+            return .init(logits: logits(for: state, tokenCount: max(1, tokens.count)))
+        }
+
+        private func append(tokens: [Int], to cache: [KVCache]) -> [Int] {
+            if let cache = cache.first as? GoldenKVCache {
+                cache.append(tokens: tokens)
+                return cache.tokenHistory
+            }
+            return tokens
+        }
+
+        private func logits(for tokens: [Int], tokenCount: Int) -> MLXArray {
+            var hash = 17
+            for token in tokens {
+                hash = (hash &* 31 &+ token &+ 1) % 1_000_003
+            }
+            let target = 10 + (abs(hash) % (vocabularySize - 10))
+            let row = (0 ..< vocabularySize).map { index -> Float in
+                index == target ? 1_000 : Float(-abs(index - target))
+            }
+            return MLXArray(Array(repeating: row, count: tokenCount).flatMap { $0 })
+                .reshaped(1, tokenCount, vocabularySize)
+        }
+    }
+
+    private struct GoldenTokenizer: Tokenizer {
+        let eosTokenId = 2
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            var tokens: [Int] = []
+            var index = text.startIndex
+            while index < text.endIndex {
+                if text[index...].hasPrefix("<eos>") {
+                    tokens.append(eosTokenId)
+                    index = text.index(index, offsetBy: 5)
+                    continue
+                }
+                if text[index...].hasPrefix("<g") {
+                    var cursor = text.index(index, offsetBy: 2)
+                    var digits = ""
+                    while cursor < text.endIndex, text[cursor].isNumber {
+                        digits.append(text[cursor])
+                        cursor = text.index(after: cursor)
+                    }
+                    if cursor < text.endIndex, text[cursor] == ">", let token = Int(digits) {
+                        tokens.append(token)
+                        index = text.index(after: cursor)
+                        continue
+                    }
+                }
+                let scalarValue = Int(String(text[index]).unicodeScalars.first?.value ?? 0)
+                tokens.append(20 + (scalarValue % 90))
+                index = text.index(after: index)
+            }
+            return tokens
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map { "<g\($0)>" }.joined()
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            token == "<eos>" ? 2 : nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            "<g\(id)>"
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { "<eos>" }
+        var unknownToken: String? { nil }
+        var unknownTokenId: Int? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            var tokens = [3]
+            if tools != nil {
+                tokens += [4, 5]
+            }
+            for message in messages {
+                switch message["role"] as? String {
+                case Chat.Message.Role.system.rawValue:
+                    tokens.append(11)
+                case Chat.Message.Role.user.rawValue:
+                    tokens.append(12)
+                case Chat.Message.Role.assistant.rawValue:
+                    tokens.append(17)
+                    tokens += encode(
+                        text: message["content"] as? String ?? "",
+                        addSpecialTokens: false)
+                    continue
+                case Chat.Message.Role.tool.rawValue:
+                    tokens.append(14)
+                default:
+                    tokens.append(15)
+                }
+                tokens += encode(text: message["content"] as? String ?? "", addSpecialTokens: false)
+                tokens.append(16)
+            }
+            tokens.append(17)
+            return tokens
+        }
+    }
+
+    private struct GoldenInputProcessor: UserInputProcessor {
+        let tokenizer = GoldenTokenizer()
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = DefaultMessageGenerator().generate(from: input)
+            let tokens = try tokenizer.applyChatTemplate(
+                messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+            return LMInput(tokens: MLXArray(tokens))
+        }
+    }
+
+    private struct SeededGenerator: RandomNumberGenerator {
+        var state: UInt64
+
+        mutating func next() -> UInt64 {
+            state &+= 0x9E3779B97F4A7C15
+            var value = state
+            value = (value ^ (value >> 30)) &* 0xBF58476D1CE4E5B9
+            value = (value ^ (value >> 27)) &* 0x94D049BB133111EB
+            return value ^ (value >> 31)
+        }
+    }
+
     private struct RecordingMessageGenerator: MessageGenerator {
         let continuation: AsyncStream<[RecordedMessage]>.Continuation
 
@@ -524,6 +721,31 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
+    private struct MultimodalLedgerInputProcessor: UserInputProcessor {
+        let tokenizer: Tokenizer
+        let configuration: ModelConfiguration
+        let messageGenerator: MessageGenerator
+        let recorder: PreparedTokenRecorder
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = messageGenerator.generate(from: input)
+            let promptTokens = try tokenizer.applyChatTemplate(
+                messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+            recorder.append(promptTokens, shape: [promptTokens.count])
+
+            let image =
+                if input.images.isEmpty {
+                    nil as LMInput.ProcessedImage?
+                } else {
+                    LMInput.ProcessedImage(pixels: MLXArray.zeros([1, 1, 3]))
+                }
+
+            return LMInput(
+                text: .init(tokens: MLXArray(promptTokens)),
+                image: image)
+        }
+    }
+
     private struct TwoDimensionalInputProcessor: UserInputProcessor {
         let configuration = ModelConfiguration(id: "test")
 
@@ -699,6 +921,52 @@ public class ChatSessionTests: XCTestCase {
             tools: lookupTools)
     }
 
+    private func goldenFullRenderLogits(
+        conversation: [Chat.Message],
+        instructions: String,
+        tools: [ToolSpec]
+    ) throws -> [Float] {
+        let processor = GoldenInputProcessor()
+        let model = GoldenLogitLanguageModel()
+        let input = try processor.prepare(
+            input: UserInput(
+                chat: [.system(instructions)] + conversation,
+                tools: tools))
+        let result = try model.prepare(
+            input,
+            cache: model.newCache(parameters: nil),
+            windowSize: nil)
+        guard case .logits(let output) = result else {
+            XCTFail("Expected logits from golden model")
+            return []
+        }
+        return output.logits[0, -1, 0...].asArray(Float.self)
+    }
+
+    private func randomGoldenMessage(using rng: inout SeededGenerator) -> Chat.Message {
+        let corpus = [
+            "",
+            " ",
+            "\n\t  ",
+            "hello",
+            "こんにちは",
+            "emoji 👩‍💻",
+            "<eos>",
+            "<|endoftext|>",
+            "<s>[INST] not a real special token [/INST]",
+            "<tool_call>{\"name\":\"lookup\",\"arguments\":{\"q\":\"x\"}}</tool_call>",
+            "{\"tool_call_id\":\"abc\",\"output\":\"ok\"}",
+            " leading and trailing whitespace ",
+            "line\nbreak",
+        ]
+        let roles: [Chat.Message.Role] = [.user, .user, .tool, .assistant]
+        let role = roles[Int.random(in: 0 ..< roles.count, using: &rng)]
+        let first = corpus[Int.random(in: 0 ..< corpus.count, using: &rng)]
+        let second = corpus[Int.random(in: 0 ..< corpus.count, using: &rng)]
+        let content = Bool.random(using: &rng) ? first : first + second
+        return Chat.Message(role: role, content: content)
+    }
+
     private let generationParameters = GenerateParameters(maxTokens: 50)
 
     private let targetLength = 1
@@ -861,6 +1129,100 @@ public class ChatSessionTests: XCTestCase {
                 [101],
                 [102],
             ])
+    }
+
+    func testMultimodalTurnSkipsLedgerValidationBeforePrepare() async throws {
+        let modelRecorder = PreparedTokenRecorder()
+        let processorRecorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = MultimodalLedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator(),
+            recorder: processorRecorder)
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: modelRecorder,
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1, temperature: 0),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(
+            to: "second",
+            images: [.array(MLXArray.zeros([1, 1, 3]))],
+            videos: [],
+            audios: [])
+
+        XCTAssertEqual(
+            processorRecorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+        XCTAssertEqual(
+            modelRecorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testGoldenLogitsMatchFullRenderAcrossRandomCachedTranscripts() async throws {
+        let instructions = "System prompt with Unicode 🧪 and <eos> marker."
+        var rng = SeededGenerator(state: 0xC0FFEE)
+
+        for transcriptIndex in 0 ..< 40 {
+            let processor = GoldenInputProcessor()
+            let recorder = GoldenLogitRecorder()
+            let sessionModel = GoldenLogitLanguageModel(recorder: recorder)
+            let context = ModelContext(
+                configuration: ModelConfiguration(id: "golden"),
+                model: sessionModel,
+                processor: processor,
+                tokenizer: processor.tokenizer)
+            let session = ChatSession(
+                context,
+                instructions: instructions,
+                generateParameters: GenerateParameters(maxTokens: 1, temperature: 0),
+                tools: lookupTools)
+            var conversation: [Chat.Message] = []
+            let turnCount = Int.random(in: 3 ... 7, using: &rng)
+
+            for turnIndex in 0 ..< turnCount {
+                let message = randomGoldenMessage(using: &rng)
+                conversation.append(message)
+
+                let expected = try goldenFullRenderLogits(
+                    conversation: conversation,
+                    instructions: instructions,
+                    tools: lookupTools)
+                let previousPrepareCount = recorder.snapshot.count
+                _ = try await session.respond(to: [message])
+
+                let logits = recorder.snapshot
+                XCTAssertEqual(
+                    logits.count,
+                    previousPrepareCount + 1,
+                    "transcript \(transcriptIndex), turn \(turnIndex)")
+                let actual = try XCTUnwrap(
+                    logits.last,
+                    "transcript \(transcriptIndex), turn \(turnIndex)")
+                XCTAssertEqual(
+                    actual,
+                    expected,
+                    "transcript \(transcriptIndex), turn \(turnIndex), message \(message)")
+
+                let generatedToken = actual.indices.max { actual[$0] < actual[$1] }!
+                let assistantText = processor.tokenizer.decode(
+                    tokenIds: [generatedToken],
+                    skipSpecialTokens: false)
+                conversation.append(.assistant(assistantText))
+            }
+        }
     }
 
     func testMultiTokenAssistantTranscriptUsesExactLedger() async throws {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -494,17 +494,17 @@ public class ChatSessionTests: XCTestCase {
     }
 
     private struct ToolCallLedgerTokenizer: Tokenizer {
-        private let prose = "I'll inspect the file.\n"
-        private let toolCall =
-            "<tool_call>{\"name\":\"lookup\",\"arguments\":{}}</tool_call>"
+        static let prose = "I'll inspect the file.\n"
+        static let toolCall =
+            "<tool_call>{\"id\":\"call_lookup\",\"name\":\"lookup\",\"arguments\":{}}</tool_call>"
 
         func encode(text: String, addSpecialTokens: Bool) -> [Int] {
             switch text {
-            case prose:
+            case Self.prose:
                 return [201]
-            case toolCall:
+            case Self.toolCall:
                 return [202]
-            case prose + toolCall:
+            case Self.prose + Self.toolCall:
                 return [201, 202]
             case "first":
                 return [101]
@@ -530,9 +530,9 @@ public class ChatSessionTests: XCTestCase {
         func convertIdToToken(_ id: Int) -> String? {
             switch id {
             case 201:
-                return prose
+                return Self.prose
             case 202:
-                return toolCall
+                return Self.toolCall
             default:
                 return nil
             }
@@ -555,10 +555,28 @@ public class ChatSessionTests: XCTestCase {
                         text: message["content"] as? String ?? "",
                         addSpecialTokens: false)
                 case Chat.Message.Role.assistant.rawValue:
-                    tokens += encode(
-                        text: message["content"] as? String ?? "",
-                        addSpecialTokens: false)
+                    let content = message["content"] as? String ?? ""
+                    if content == Self.prose + Self.toolCall {
+                        tokens += [201]
+                    } else {
+                        tokens += encode(text: content, addSpecialTokens: false)
+                    }
+                    if let toolCalls = message["tool_calls"] as? [[String: any Sendable]] {
+                        tokens += toolCalls.map { toolCall in
+                            let function = toolCall["function"] as? [String: any Sendable]
+                            if toolCall["id"] as? String == "call_lookup",
+                                function?["name"] as? String == "lookup"
+                            {
+                                return 202
+                            }
+                            return 999
+                        }
+                    }
                 case Chat.Message.Role.tool.rawValue:
+                    guard message["tool_call_id"] as? String == "call_lookup" else {
+                        tokens += [999]
+                        continue
+                    }
                     tokens += encode(
                         text: message["content"] as? String ?? "",
                         addSpecialTokens: false)
@@ -1745,6 +1763,45 @@ public class ChatSessionTests: XCTestCase {
             [
                 [11, 12, 101],
                 [103],
+            ])
+    }
+
+    func testHistoryLedgerPreservesStructuredToolMetadata() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = ToolCallLedgerTokenizer()
+        let configuration = ModelConfiguration(id: "test", toolCallFormat: .json)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: configuration,
+            messageGenerator: DefaultMessageGenerator())
+        let toolCall = ToolCall(
+            function: .init(name: "lookup", arguments: [:]),
+            id: "call_lookup")
+        let context = ModelContext(
+            configuration: configuration,
+            model: SequenceLanguageModel(recorder: recorder, tokens: [201, 201]),
+            processor: processor,
+            tokenizer: tokenizer)
+        let session = ChatSession(
+            context,
+            history: [
+                .user("first"),
+                .assistant(
+                    ToolCallLedgerTokenizer.prose + ToolCallLedgerTokenizer.toolCall,
+                    toolCalls: [toolCall]),
+                .tool("tool result", id: "call_lookup"),
+            ],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "second")
+        _ = try await session.respond(to: "first")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101, 201, 202, 103, 102],
+                [101],
             ])
     }
 

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -344,10 +344,10 @@ public class ChatSessionTests: XCTestCase {
         var state: UInt64
 
         mutating func next() -> UInt64 {
-            state &+= 0x9E3779B97F4A7C15
+            state &+= 0x9E37_79B9_7F4A_7C15
             var value = state
-            value = (value ^ (value >> 30)) &* 0xBF58476D1CE4E5B9
-            value = (value ^ (value >> 27)) &* 0x94D049BB133111EB
+            value = (value ^ (value >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            value = (value ^ (value >> 27)) &* 0x94D0_49BB_1331_11EB
             return value ^ (value >> 31)
         }
     }
@@ -1952,6 +1952,34 @@ public class ChatSessionTests: XCTestCase {
 
         XCTAssertEqual(calls.map { $0.messages.map(\.role) }, [[.system, .user]])
         XCTAssertEqual(calls.map(\.toolCount), [1])
+    }
+
+    func testRestoredCachePromptConfigurationChangeThrowsAfterFirstGeneration() async throws {
+        let recorder = PreparedTokenRecorder()
+        let restoredCache = KVCacheSimple()
+        let keys = MLXArray.zeros([1, 1, 1, 1])
+        let values = MLXArray.zeros([1, 1, 1, 1])
+        _ = restoredCache.update(keys: keys, values: values)
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let session = ChatSession(
+            recordingModel(
+                tokenizer: tokenizer,
+                recorder: recorder,
+                nextToken: 7),
+            instructions: "Initial prefix.",
+            cache: [restoredCache],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        session.instructions = "Changed prefix."
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101]])
+        }
     }
 
     func testClearRebuildsStaticInstructionsAndPromptTools() async throws {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -6,6 +6,7 @@ import MLXLLM
 import MLXNN
 import MLXOptimizers
 import XCTest
+import os
 
 @testable import MLXLMCommon
 
@@ -17,6 +18,143 @@ public class ChatSessionTests: XCTestCase {
         var content: String
     }
 
+    private struct RecordedTemplate: Equatable, Sendable {
+        var messages: [RecordedMessage]
+        var toolCount: Int?
+    }
+
+    private final class PreparedTokenRecorder: Sendable {
+        private let values = OSAllocatedUnfairLock(initialState: [[Int]]())
+        private let shapes = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        func append(_ value: [Int], shape: [Int]) {
+            values.withLock {
+                $0.append(value)
+            }
+            shapes.withLock {
+                $0.append(shape)
+            }
+        }
+
+        var snapshot: [[Int]] {
+            values.withLock { $0 }
+        }
+
+        var shapeSnapshot: [[Int]] {
+            shapes.withLock { $0 }
+        }
+    }
+
+    private final class RecordingLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
+        let recorder: PreparedTokenRecorder
+        let kvHeads: [Int]
+        let kvHeadDim: Int
+        let nextToken: Int
+
+        init(
+            recorder: PreparedTokenRecorder,
+            kvHeadCount: Int = 1,
+            kvHeadDim: Int = 1,
+            nextToken: Int = 0
+        ) {
+            self.recorder = recorder
+            self.kvHeads = Array(repeating: 1, count: kvHeadCount)
+            self.kvHeadDim = kvHeadDim
+            self.nextToken = nextToken
+            super.init()
+        }
+
+        func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+            -> PrepareResult
+        {
+            recorder.append(
+                input.text.tokens.asArray(Int.self),
+                shape: input.text.tokens.shape)
+            let tokenCount = input.text.tokens.size
+            update(cache: cache, tokenCount: tokenCount)
+            return .logits(.init(logits: logits(tokenCount: tokenCount), state: nil))
+        }
+
+        func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+            let tokenCount = max(1, inputs.asArray(Int.self).count)
+            if let cache {
+                update(cache: cache, tokenCount: tokenCount)
+            }
+            return logits(tokenCount: tokenCount)
+        }
+
+        private func update(cache: [KVCache], tokenCount: Int) {
+            for (index, layerCache) in cache.enumerated() {
+                let heads = kvHeads[min(index, kvHeads.count - 1)]
+                let keys = MLXArray.zeros([1, heads, tokenCount, kvHeadDim])
+                let values = MLXArray.zeros([1, heads, tokenCount, kvHeadDim])
+                if let quantizedCache = layerCache as? QuantizedKVCacheProtocol {
+                    _ = quantizedCache.updateQuantized(keys: keys, values: values)
+                } else {
+                    _ = layerCache.update(keys: keys, values: values)
+                }
+            }
+        }
+
+        private func logits(tokenCount: Int) -> MLXArray {
+            let row = (0 ..< 8).map { $0 == nextToken ? Float(1_000) : Float(-1_000) }
+            return MLXArray(Array(repeating: row, count: tokenCount).flatMap { $0 })
+                .reshaped(1, tokenCount, 8)
+        }
+    }
+
+    private final class SequenceLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
+        let recorder: PreparedTokenRecorder
+        let kvHeads = [1]
+        let tokens: [Int]
+        private let index = OSAllocatedUnfairLock(initialState: 0)
+
+        init(recorder: PreparedTokenRecorder, tokens: [Int]) {
+            self.recorder = recorder
+            self.tokens = tokens
+            super.init()
+        }
+
+        func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+            -> PrepareResult
+        {
+            recorder.append(
+                input.text.tokens.asArray(Int.self),
+                shape: input.text.tokens.shape)
+            update(cache: cache, tokenCount: input.text.tokens.size)
+            return .logits(.init(logits: logits(tokenCount: input.text.tokens.size), state: nil))
+        }
+
+        func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+            let tokenCount = max(1, inputs.asArray(Int.self).count)
+            if let cache {
+                update(cache: cache, tokenCount: tokenCount)
+            }
+            return logits(tokenCount: tokenCount)
+        }
+
+        private func update(cache: [KVCache], tokenCount: Int) {
+            for layerCache in cache {
+                let keys = MLXArray.zeros([1, 1, tokenCount, 1])
+                let values = MLXArray.zeros([1, 1, tokenCount, 1])
+                _ = layerCache.update(keys: keys, values: values)
+            }
+        }
+
+        private func logits(tokenCount: Int) -> MLXArray {
+            let tokens = self.tokens
+            let token = index.withLock { index in
+                let token = tokens[min(index, tokens.count - 1)]
+                index += 1
+                return token
+            }
+            let vocabularySize = (tokens.max() ?? token) + 1
+            let row = (0 ..< vocabularySize).map { $0 == token ? Float(1_000) : Float(-1_000) }
+            return MLXArray(Array(repeating: row, count: tokenCount).flatMap { $0 })
+                .reshaped(1, tokenCount, vocabularySize)
+        }
+    }
+
     private struct RecordingMessageGenerator: MessageGenerator {
         let continuation: AsyncStream<[RecordedMessage]>.Continuation
 
@@ -24,6 +162,412 @@ public class ChatSessionTests: XCTestCase {
             continuation.yield(messages.map { .init(role: $0.role, content: $0.content) })
 
             return DefaultMessageGenerator().generate(messages: messages)
+        }
+    }
+
+    private struct RecordingTokenizer: Tokenizer {
+        let continuation: AsyncStream<RecordedTemplate>.Continuation
+        let base = TestTokenizer()
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            base.encode(text: text, addSpecialTokens: addSpecialTokens)
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            base.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            base.convertTokenToId(token)
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            base.convertIdToToken(id)
+        }
+
+        var bosToken: String? { base.bosToken }
+        var eosToken: String? { base.eosToken }
+        var unknownToken: String? { base.unknownToken }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            let recordedMessages = messages.map { message in
+                RecordedMessage(
+                    role: Chat.Message.Role(rawValue: message["role"] as? String ?? "")!,
+                    content: message["content"] as? String ?? "")
+            }
+            continuation.yield(.init(messages: recordedMessages, toolCount: tools?.count))
+            return base.encode(text: "")
+        }
+    }
+
+    private struct LedgerTokenizer: Tokenizer {
+        let unsafeDynamicTemplate: Bool
+        var staticOnlyAssistantHeader = false
+        var eosTokenId: Int? = nil
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            []
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: " ")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            if let eosToken, token == eosToken {
+                return eosTokenId
+            }
+            return nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            String(id)
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { eosTokenId == nil ? nil : "<eos>" }
+        var unknownToken: String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            let dynamicTokens: [Int] = messages.flatMap { message -> [Int] in
+                let role = message["role"] as? String
+                let content = message["content"] as? String
+                if role == Chat.Message.Role.assistant.rawValue,
+                    content?.isEmpty == true,
+                    let eosTokenId
+                {
+                    return [eosTokenId]
+                }
+
+                switch content {
+                case "first":
+                    return [101]
+                case "second":
+                    return [102]
+                case "tool result":
+                    return [103]
+                case "First continuation":
+                    return [104]
+                case "Second continuation":
+                    return [105]
+                case "0":
+                    return [0]
+                case "7":
+                    return [7]
+                case "7 7":
+                    return [7, 7]
+                default:
+                    return []
+                }
+            }
+
+            let hasSystem = messages.contains { $0["role"] as? String == "system" }
+            if hasSystem || tools != nil {
+                let systemContent =
+                    messages.first { $0["role"] as? String == "system" }?[
+                        "content"] as? String
+                let staticTokens = systemContent == "Changed prefix." ? [21, 22] : [11, 12]
+                return staticTokens + dynamicTokens
+                    + (addGenerationPrompt && staticOnlyAssistantHeader ? [200] : [])
+            }
+
+            return (unsafeDynamicTemplate ? [99] : []) + dynamicTokens
+        }
+    }
+
+    private struct ToolCallLedgerTokenizer: Tokenizer {
+        private let prose = "I'll inspect the file.\n"
+        private let toolCall =
+            "<tool_call>{\"name\":\"lookup\",\"arguments\":{}}</tool_call>"
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            switch text {
+            case prose:
+                return [201]
+            case toolCall:
+                return [202]
+            case prose + toolCall:
+                return [201, 202]
+            case "first":
+                return [101]
+            case "second":
+                return [102]
+            case "tool result":
+                return [103]
+            default:
+                return []
+            }
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map {
+                skipSpecialTokens && $0 == 202 ? "" : convertIdToToken($0) ?? ""
+            }.joined()
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            switch id {
+            case 201:
+                return prose
+            case 202:
+                return toolCall
+            default:
+                return nil
+            }
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            var tokens = tools == nil ? [] : [11, 12]
+            for message in messages {
+                switch message["role"] as? String {
+                case Chat.Message.Role.user.rawValue:
+                    tokens += encode(
+                        text: message["content"] as? String ?? "",
+                        addSpecialTokens: false)
+                case Chat.Message.Role.assistant.rawValue:
+                    tokens += encode(
+                        text: message["content"] as? String ?? "",
+                        addSpecialTokens: false)
+                case Chat.Message.Role.tool.rawValue:
+                    tokens += encode(
+                        text: message["content"] as? String ?? "",
+                        addSpecialTokens: false)
+                default:
+                    break
+                }
+            }
+            return tokens
+        }
+    }
+
+    private struct UserHeaderPrefixTokenizer: Tokenizer {
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            switch text {
+            case "first": [101]
+            case "second": [102]
+            case "0": [0]
+            case "7": [7]
+            default: []
+            }
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: " ")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            String(id)
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            let dynamicTokens = messages.flatMap { message -> [Int] in
+                switch message["content"] as? String {
+                case "first": [101]
+                case "second": [102]
+                default: []
+                }
+            }
+            let hasStaticPrompt =
+                messages.contains { $0["role"] as? String == "system" }
+                || tools != nil
+            let staticTokens = hasStaticPrompt ? [11, 12, 50] : []
+            return staticTokens + dynamicTokens + (addGenerationPrompt ? [200] : [])
+        }
+    }
+
+    private struct LiteralQwenStyleTokenizer: Tokenizer {
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            switch text {
+            case "first": [101]
+            case "second": [102]
+            case "0": [0]
+            case "7": [7]
+            default: []
+            }
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: " ")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            nil
+        }
+
+        func convertIdToToken(_ id: Int) -> String? {
+            String(id)
+        }
+
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            var tokens: [Int] = []
+            if messages.contains(where: { $0["role"] as? String == "system" }) || tools != nil {
+                tokens += [151_644, 9_125]
+                if tools != nil {
+                    tokens += [27_091, 25_791]
+                }
+                tokens += [151_645]
+            }
+            for message in messages {
+                switch message["role"] as? String {
+                case "user":
+                    tokens += [151_644, 872]
+                    tokens += encode(
+                        text: message["content"] as? String ?? "",
+                        addSpecialTokens: false)
+                    tokens += [151_645]
+                case "assistant":
+                    tokens += [151_644, 77_091]
+                    tokens += encode(
+                        text: message["content"] as? String ?? "",
+                        addSpecialTokens: false)
+                default:
+                    break
+                }
+            }
+            if addGenerationPrompt {
+                tokens += [151_644, 77091]
+            }
+            return tokens
+        }
+    }
+
+    private struct LedgerInputProcessor: UserInputProcessor {
+        let tokenizer: Tokenizer
+        let configuration: ModelConfiguration
+        let messageGenerator: MessageGenerator
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = messageGenerator.generate(from: input)
+            let promptTokens = try tokenizer.applyChatTemplate(
+                messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+
+            return LMInput(tokens: MLXArray(promptTokens))
+        }
+    }
+
+    private struct TwoDimensionalInputProcessor: UserInputProcessor {
+        let configuration = ModelConfiguration(id: "test")
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = DefaultMessageGenerator().generate(from: input)
+            let dynamicTokens: [Int] = messages.flatMap { message -> [Int] in
+                switch message["content"] as? String {
+                case "first":
+                    return [101]
+                case "second":
+                    return [102]
+                default:
+                    return []
+                }
+            }
+            let hasSystem = messages.contains { $0["role"] as? String == "system" }
+            let tokens = (hasSystem || input.tools != nil ? [11, 12] : []) + dynamicTokens
+            return LMInput(tokens: MLXArray(tokens).reshaped(1, tokens.count))
+        }
+    }
+
+    private struct FullHistoryRejectingProcessor: UserInputProcessor {
+        struct FullHistoryError: Error {}
+
+        let configuration = ModelConfiguration(id: "test")
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let recorder: PreparedTokenRecorder
+        var throwsCancellationOnFullHistory = false
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = DefaultMessageGenerator().generate(from: input)
+            if messages.count > 2 {
+                if throwsCancellationOnFullHistory {
+                    throw CancellationError()
+                }
+                throw FullHistoryError()
+            }
+
+            let promptTokens = try tokenizer.applyChatTemplate(
+                messages: messages,
+                tools: input.tools,
+                additionalContext: input.additionalContext)
+            recorder.append(promptTokens, shape: [promptTokens.count])
+            return LMInput(tokens: MLXArray(promptTokens))
         }
     }
 
@@ -70,6 +614,89 @@ public class ChatSessionTests: XCTestCase {
 
     private func model(processor: TestInputProcessor = TestInputProcessor()) -> ModelContext {
         Self.makeModel(processor: processor)
+    }
+
+    private func recordingModel(
+        tokenizer: Tokenizer,
+        recorder: PreparedTokenRecorder,
+        kvHeadCount: Int = 1,
+        kvHeadDim: Int = 1,
+        nextToken: Int = 0
+    ) -> ModelContext {
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        return recordingModel(
+            processor: processor,
+            tokenizer: tokenizer,
+            recorder: recorder,
+            kvHeadCount: kvHeadCount,
+            kvHeadDim: kvHeadDim,
+            nextToken: nextToken)
+    }
+
+    private func recordingModel(
+        processor: any UserInputProcessor,
+        tokenizer: Tokenizer,
+        recorder: PreparedTokenRecorder,
+        kvHeadCount: Int = 1,
+        kvHeadDim: Int = 1,
+        nextToken: Int = 0
+    ) -> ModelContext {
+        return .init(
+            configuration: ModelConfiguration(id: "test"),
+            model: RecordingLanguageModel(
+                recorder: recorder,
+                kvHeadCount: kvHeadCount,
+                kvHeadDim: kvHeadDim,
+                nextToken: nextToken),
+            processor: processor,
+            tokenizer: tokenizer)
+    }
+
+    private var lookupTools: [ToolSpec] {
+        [
+            [
+                "type": "function",
+                "function": [
+                    "name": "lookup",
+                    "description": "Look up a value",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+    }
+
+    private func ledgerSession(
+        recorder: PreparedTokenRecorder,
+        unsafeDynamicTemplate: Bool = false,
+        staticOnlyAssistantHeader: Bool = false,
+        maxKVSize: Int? = nil,
+        repetitionPenalty: Float? = nil
+    ) -> ChatSession {
+        let tokenizer = LedgerTokenizer(
+            unsafeDynamicTemplate: unsafeDynamicTemplate,
+            staticOnlyAssistantHeader: staticOnlyAssistantHeader)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        return ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder,
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(
+                maxTokens: 1,
+                maxKVSize: maxKVSize,
+                repetitionPenalty: repetitionPenalty),
+            tools: lookupTools)
     }
 
     private let generationParameters = GenerateParameters(maxTokens: 50)
@@ -170,6 +797,901 @@ public class ChatSessionTests: XCTestCase {
             $0 + history.count + $1 + 1
         }
         XCTAssertLessThan(actualPreparedMessageCount, replayedHistoryPreparedMessageCount)
+    }
+
+    func testStaticInstructionsAndPromptToolsUseExactCachedPrefix() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+        _ = try await session.respond(to: [.tool("tool result")])
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+                [103],
+            ])
+    }
+
+    func testGenericProcessorReusesExactTokenLedger() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ChatSession(
+            recordingModel(
+                tokenizer: LedgerTokenizer(unsafeDynamicTemplate: false),
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1, temperature: 0),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testPlainTextSessionUsesExactTranscriptLedger() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder,
+                nextToken: 7),
+            generateParameters: GenerateParameters(maxTokens: 1, temperature: 0))
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [101],
+                [102],
+            ])
+    }
+
+    func testMultiTokenAssistantTranscriptUsesExactLedger() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+        session.generateParameters.maxTokens = 2
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testExactLedgerFallsBackWhenGenerationPromptIsNotTranscriptPrefix() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(
+            unsafeDynamicTemplate: false,
+            staticOnlyAssistantHeader: true)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1, temperature: 0),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101, 200],
+                [11, 12, 102, 200],
+            ])
+    }
+
+    func testExactLedgerRejectsPrefixEndingWithUserTurnHeader() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = UserHeaderPrefixTokenizer()
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 50, 101, 200],
+                [11, 12, 50, 102, 200],
+            ])
+    }
+
+    func testExactLedgerDoesNotInferPrefixForEmptyUserTurnHeader() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = UserHeaderPrefixTokenizer()
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder,
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 50, 200],
+                [11, 12, 50, 102, 200],
+            ])
+    }
+
+    func testLiteralQwenStyleToolPrefixCanReusePromptTools() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LiteralQwenStyleTokenizer()
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [
+                    151_644, 9_125, 27_091, 25_791, 151_645, 151_644, 872, 101,
+                    151_645, 151_644, 77_091,
+                ],
+                [151_644, 872, 102, 151_645, 151_644, 77_091],
+            ])
+    }
+
+    func testExactLedgerReuseDisabledForBoundedKVCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder, maxKVSize: 2)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testExactLedgerReuseDisabledForDynamicKVQuantization() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder,
+                kvHeadDim: 32,
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(
+                maxTokens: 2,
+                kvBits: 4,
+                quantizedKVStart: 0),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testExactLedgerReuseDisabledForRepetitionPenalty() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder, repetitionPenalty: 1.1)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testExactLedgerReuseDisabledForPresencePenalty() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+        session.generateParameters.presencePenalty = 0.5
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testExactLedgerReuseDisabledForFrequencyPenalty() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+        session.generateParameters.frequencyPenalty = 0.5
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testFullHistoryRenderFailureFallsBackToIncrementalPrompt() async throws {
+        let recorder = PreparedTokenRecorder()
+        let processor = FullHistoryRejectingProcessor(recorder: recorder)
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: PreparedTokenRecorder(),
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testFullHistoryRenderCancellationPropagates() async throws {
+        let recorder = PreparedTokenRecorder()
+        let processor = FullHistoryRejectingProcessor(
+            recorder: recorder,
+            throwsCancellationOnFullHistory: true)
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: PreparedTokenRecorder(),
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101]])
+        }
+    }
+
+    func testStreamCancellationInvalidatesExactLedger() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder,
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 20),
+            tools: lookupTools)
+
+        for try await _ in session.streamResponse(to: "first") {
+            break
+        }
+        _ = try await session.respond(to: "second")
+        await session.synchronize()
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testHistorySessionReusesExactLedgerAfterInitialHydration() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            history: [
+                .system("Historical system prompt"),
+                .user("Old question"),
+                .assistant("Old answer"),
+            ],
+            generateParameters: GenerateParameters(maxTokens: 1))
+
+        _ = try await session.respond(to: "First continuation")
+        _ = try await session.respond(to: "Second continuation")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 104],
+                [105],
+            ])
+    }
+
+    func testEOSTerminatedGenerationKeepsLedgerAlignedWithCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false, eosTokenId: 7)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder,
+                nextToken: 7),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 5),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testHistorySessionInstructionChangeThrowsAfterHydration() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "Initial prefix.",
+            history: [.user("first"), .assistant("7")],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "second")
+        session.instructions = "Changed prefix."
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101, 7, 102]])
+        }
+    }
+
+    func testHistorySessionPromptToolChangeThrowsAfterHydration() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "Initial prefix.",
+            history: [.user("first"), .assistant("7")],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "second")
+        session.tools = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "changed_lookup",
+                    "description": "Changed prompt-rendered tool",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101, 7, 102]])
+        }
+    }
+
+    func testHistorySessionAdditionalContextChangeThrowsAfterHydration() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "Initial prefix.",
+            history: [.user("first"), .assistant("7")],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "second")
+        session.additionalContext = ["chat_template_kwargs": ["enable_thinking": false]]
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101, 7, 102]])
+        }
+    }
+
+    func testToolCallLedgerUsesRawGeneratedTextNotDisplayChunks() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = ToolCallLedgerTokenizer()
+        let configuration = ModelConfiguration(id: "test", toolCallFormat: .json)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: configuration,
+            messageGenerator: DefaultMessageGenerator())
+        let context = ModelContext(
+            configuration: configuration,
+            model: SequenceLanguageModel(recorder: recorder, tokens: [201, 202]),
+            processor: processor,
+            tokenizer: tokenizer)
+        let session = ChatSession(
+            context,
+            generateParameters: GenerateParameters(maxTokens: 2),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testParsedToolCallAndToolResultContinuationUsesExactLedger() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = ToolCallLedgerTokenizer()
+        let configuration = ModelConfiguration(id: "test", toolCallFormat: .json)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: configuration,
+            messageGenerator: DefaultMessageGenerator())
+        let context = ModelContext(
+            configuration: configuration,
+            model: SequenceLanguageModel(
+                recorder: recorder,
+                tokens: [201, 202, 201, 201, 201]),
+            processor: processor,
+            tokenizer: tokenizer)
+        let session = ChatSession(
+            context,
+            generateParameters: GenerateParameters(maxTokens: 2),
+            tools: lookupTools
+        ) { toolCall in
+            XCTAssertEqual(toolCall.function.name, "lookup")
+            return "tool result"
+        }
+
+        _ = try await session.respond(to: "first")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [103],
+            ])
+    }
+
+    func testExactLedgerReuseDisabledForSpeculativeDecoding() async throws {
+        let recorder = PreparedTokenRecorder()
+        let tokenizer = LedgerTokenizer(unsafeDynamicTemplate: false)
+        let processor = LedgerInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let draft = ModelContainer(
+            context: recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: PreparedTokenRecorder()))
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: tokenizer,
+                recorder: recorder),
+            instructions: "You are concise.",
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModel: draft,
+                numDraftTokens: 2,
+                memoryPolicy: SpeculativeDecodingMemoryPolicy(
+                    limitBytes: 0,
+                    action: .fallbackToDefault)),
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+    }
+
+    func testExactLedgerReuseSkipsTwoDimensionalTokens() async throws {
+        let recorder = PreparedTokenRecorder()
+        let processor = TwoDimensionalInputProcessor()
+        let session = ChatSession(
+            recordingModel(
+                processor: processor,
+                tokenizer: TestTokenizer(),
+                recorder: recorder),
+            instructions: "You are concise.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [11, 12, 102],
+            ])
+        XCTAssertEqual(recorder.shapeSnapshot, [[1, 3], [1, 3]])
+    }
+
+    func testExactLedgerReuseUsesRenderedTranscriptSuffix() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder, unsafeDynamicTemplate: true)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testParserOnlyToolConfigurationChangeDoesNotInvalidatePromptCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        session.toolConfiguration.parser = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "new_parser_only_tool",
+                    "description": "Used only for parsing",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+        _ = try await session.respond(to: "second")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+            ])
+    }
+
+    func testPromptConfigurationChangeThrowsInsteadOfCorruptingCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        session.instructions = "Changed prefix."
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101]])
+        }
+    }
+
+    func testPromptToolChangeThrowsInsteadOfCorruptingCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        session.tools = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "changed_lookup",
+                    "description": "Changed prompt-rendered tool",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101]])
+        }
+    }
+
+    func testAdditionalContextChangeThrowsInsteadOfCorruptingCache() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        session.additionalContext = ["chat_template_kwargs": ["enable_thinking": false]]
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101]])
+        }
+    }
+
+    func testPromptConfigurationChangeThrowsAfterCachedPrompt() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(
+            recorder: recorder,
+            staticOnlyAssistantHeader: true)
+
+        _ = try await session.respond(to: "first")
+        session.instructions = "Changed prefix."
+
+        do {
+            _ = try await session.respond(to: "second")
+            XCTFail("Expected promptCacheMismatch")
+        } catch ChatSessionError.promptCacheMismatch {
+            XCTAssertEqual(recorder.snapshot, [[11, 12, 101, 200]])
+        }
+    }
+
+    func testRestoredCacheRendersConfiguredInstructionsAndPromptTools() async throws {
+        let (recordedTemplates, continuation) = AsyncStream<RecordedTemplate>.makeStream()
+        let tokenizer = RecordingTokenizer(continuation: continuation)
+        let recorder = PreparedTokenRecorder()
+        let restoredCache = KVCacheSimple()
+        let keys = MLXArray.zeros([1, 1, 1, 1])
+        let values = MLXArray.zeros([1, 1, 1, 1])
+        _ = restoredCache.update(keys: keys, values: values)
+        let session = ChatSession(
+            recordingModel(tokenizer: tokenizer, recorder: recorder),
+            instructions: "Restored instructions.",
+            cache: [restoredCache],
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: lookupTools)
+
+        _ = try await session.respond(to: "first")
+        continuation.finish()
+
+        var calls: [RecordedTemplate] = []
+        for await call in recordedTemplates {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(calls.map { $0.messages.map(\.role) }, [[.system, .user]])
+        XCTAssertEqual(calls.map(\.toolCount), [1])
+    }
+
+    func testClearRebuildsStaticInstructionsAndPromptTools() async throws {
+        let (recordedTemplates, continuation) = AsyncStream<RecordedTemplate>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: RecordingTokenizer(continuation: continuation),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let tools: [ToolSpec] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "lookup",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+        let session = ChatSession(
+            model(processor: processor),
+            instructions: "Static prefix.",
+            generateParameters: GenerateParameters(maxTokens: 1),
+            tools: tools)
+
+        _ = try await session.respond(to: "first")
+        await session.clear()
+        _ = try await session.respond(to: "after clear")
+        continuation.finish()
+
+        var calls: [RecordedTemplate] = []
+        for await call in recordedTemplates {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(
+            calls.map { $0.messages.map(\.role) },
+            [
+                [.system, .user],
+                [.system, .user],
+            ])
+        XCTAssertEqual(calls.map(\.toolCount), [1, 1])
+    }
+
+    func testClearErasesExactLedgerReuse() async throws {
+        let recorder = PreparedTokenRecorder()
+        let session = ledgerSession(recorder: recorder)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+        await session.clear()
+        _ = try await session.respond(to: "first")
+
+        XCTAssertEqual(
+            recorder.snapshot,
+            [
+                [11, 12, 101],
+                [102],
+                [11, 12, 101],
+            ])
+    }
+
+    func testParserOnlyToolsAreNotRenderedIntoPrompt() async throws {
+        let (recordedTemplates, continuation) = AsyncStream<RecordedTemplate>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: RecordingTokenizer(continuation: continuation),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let tools: [ToolSpec] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "lookup",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 1))
+        session.toolConfiguration = .init(prompt: nil, parser: tools)
+
+        _ = try await session.respond(to: "first")
+        _ = try await session.respond(to: "second")
+        continuation.finish()
+
+        var calls: [RecordedTemplate] = []
+        for await call in recordedTemplates {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(
+            calls.map { $0.messages.map(\.role) },
+            [
+                [.user],
+                [.user],
+            ])
+        XCTAssertEqual(calls.map(\.toolCount), [nil, nil])
     }
 
     func testChatSessionAsyncInterrupt() async throws {

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -260,6 +260,20 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     #expect(lifecycle.finalizeCallCount == 1)
 }
 
+@Test func testCachesReportStaticPrefixReuseSupport() throws {
+    #expect(KVCacheSimple().supportsStaticPrefixReuse)
+    #expect(QuantizedKVCache().supportsStaticPrefixReuse)
+    #expect(!RotatingKVCache(maxSize: 32).supportsStaticPrefixReuse)
+    #expect(ChunkedKVCache().supportsStaticPrefixReuse)
+    #expect(!ChunkedKVCache(chunkSize: 32).supportsStaticPrefixReuse)
+}
+
+@Test func testKVCacheSimpleSubclassMustOptInToStaticPrefixReuse() throws {
+    final class PrefixChangingKVCache: KVCacheSimple {}
+
+    #expect(!PrefixChangingKVCache().supportsStaticPrefixReuse)
+}
+
 @Test func testWithPreparedCacheScopesSequenceMetadata() throws {
     let cache = ArraysCache(size: 2)
 

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -244,6 +244,31 @@ func testMTPSpeculateRoundSmokeWithSynthetics() throws {
     #expect(main.lastIncomingEmitFlag == true)
 }
 
+@Test
+func testMTPIteratorReusableCacheIsWithheldOnlyForDynamicKVQuantization() throws {
+    let input = LMInput(tokens: MLXArray([Int32(1), 2, 3]))
+
+    let reusableIterator = try MTPSpeculativeTokenIterator(
+        input: input,
+        mainModel: MockMainModel(nextLogitTokens: [0, 0, 5]),
+        drafter: MockDrafter(),
+        mainCache: nil,
+        parameters: GenerateParameters(maxTokens: 1),
+        blockSize: 4
+    )
+    let quantizedIterator = try MTPSpeculativeTokenIterator(
+        input: input,
+        mainModel: MockMainModel(nextLogitTokens: [0, 0, 5]),
+        drafter: MockDrafter(),
+        mainCache: nil,
+        parameters: GenerateParameters(maxTokens: 1, kvBits: 4),
+        blockSize: 4
+    )
+
+    #expect(reusableIterator.reusableCache != nil)
+    #expect(quantizedIterator.reusableCache == nil)
+}
+
 // MARK: - Passthrough fallback when state is absent
 
 @Test

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -214,6 +214,49 @@ struct SpeculativeDecodingTests {
         #expect(tokenCount == 3)
         #expect(telemetry.emittedTokenCount == tokenCount)
     }
+
+    @Test func `Token iterator reusable cache is withheld only for dynamic KV quantization`() throws
+    {
+        let model = StableTransitionLanguageModel(vocabularySize: 100)
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+
+        let reusableIterator = try TokenIterator(
+            input: input,
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0.0))
+        let quantizedIterator = try TokenIterator(
+            input: input,
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, kvBits: 4, temperature: 0.0))
+
+        #expect(reusableIterator.reusableCache != nil)
+        #expect(quantizedIterator.reusableCache == nil)
+    }
+
+    @Test
+    func `Speculative iterator reusable caches are withheld only for dynamic KV quantization`()
+        throws
+    {
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+
+        let reusableIterator = try SpeculativeTokenIterator(
+            input: input,
+            mainModel: StableTransitionLanguageModel(vocabularySize: 100),
+            draftModel: StableTransitionLanguageModel(vocabularySize: 100),
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0.0),
+            numDraftTokens: 2)
+        let quantizedIterator = try SpeculativeTokenIterator(
+            input: input,
+            mainModel: StableTransitionLanguageModel(vocabularySize: 100),
+            draftModel: StableTransitionLanguageModel(vocabularySize: 100),
+            parameters: GenerateParameters(maxTokens: 1, kvBits: 4, temperature: 0.0),
+            numDraftTokens: 2)
+
+        #expect(reusableIterator.reusableCache != nil)
+        #expect(reusableIterator.reusableDraftCache != nil)
+        #expect(quantizedIterator.reusableCache == nil)
+        #expect(quantizedIterator.reusableDraftCache == nil)
+    }
 }
 
 /// Deterministic causal model for speculative decoding contract tests.


### PR DESCRIPTION
## Proposed changes

Changes ChatSession to reuse the KV cache for chat prefixes automatically.
Instead of repeatedly prefilling prompt-rendered chat-prefix tokens on later turns, the session keeps an exact token ledger for the prompt and generated assistant output. On the next turn it re-renders the full transcript, checks that the cached tokens are an exact prefix and that KV cache offsets match, then prefills only the new suffix. If anything does not line up, it falls back to full prefill or throws when the prompt configuration changed.
Reuse is intentionally disabled for unsafe paths like logit processors, speculative decoding, bounded/non-reusable caches, and multimodal or masked inputs.

This should improve performance on coding agents using the library.

## Notes

**This is the first step to make a Codex-like app based on the library.** At the moment prefix reuse is enabled just for `KVCacheSimple` with no logit processors, no speculative decoding, and no dynamic KV quantization. The safest subset. Each opt-out is a known performance floor with a clear unlock path:

- **`RotatingKVCache`** — The transcript prefix eventually gets overwritten once `offset > maxSize`. A future two-tier cache (static prefix + rotating suffix) would enable reuse for the dominant production config (anyone setting `maxKVSize`).

- **Logit processors** — `PenaltyProcessor`'s `TokenRing` state is stale when skipping the prefix. On a prefix-reused turn, calling `processor.prompt()` with the prefix tokens before generation would sync the rings. Small mechanical change once plumbing is ready.

- **Speculative decoding** — `trimPromptCache` after rejected draft tokens can desync KV offsets from the ledger. The speculative iterator already tracks accepted/rejected per round — wiring `GenerationTrace.committedTokens` to the net effect would unlock this.

The `supportsStaticPrefixReuse` / `allowsPrefixReuse` gates are single-point switches designed for independent enablement.

#### Important 

 Once [#360](https://github.com/ml-explore/mlx-swift-lm/pull/360) lands, `PromptLedger.Message` should carry the structured tool metadata, not just `role` and `content`, so cached replay preserves correlated tool calls exactly.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
