### PR TITLE
Validate RoPE model configurations

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -10,6 +10,9 @@ private func create<C: Codable, M>(
 ) -> (Data) throws -> M {
     { data in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        if let validating = configuration as? ModelConfigurationValidating {
+            try validating.validateModelConfiguration()
+        }
         return modelInit(configuration)
     }
 }

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -267,6 +267,12 @@ public struct Qwen3Configuration: Codable, Sendable {
     }
 }
 
+extension Qwen3Configuration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "Qwen3Configuration.rope_scaling")
+    }
+}
+
 // MARK: - LoRA
 
 extension Qwen3Model: LoRAModel {

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -351,6 +351,12 @@ public struct Qwen3MoEConfiguration: Codable, Sendable {
     }
 }
 
+extension Qwen3MoEConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "Qwen3MoEConfiguration.rope_scaling")
+    }
+}
+
 // MARK: - LoRA
 
 extension Qwen3MoEModel: LoRAModel {

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -668,6 +668,12 @@ public struct Qwen3NextConfiguration: Codable, Sendable {
     }
 }
 
+extension Qwen3NextConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "Qwen3NextConfiguration.rope_scaling")
+    }
+}
+
 // MARK: - LoRA
 
 extension Qwen3NextModel: LoRAModel {

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -11,6 +11,7 @@ public enum ModelFactoryError: LocalizedError {
     case unsupportedProcessorType(String)
     case configurationFileError(String, String, Error)
     case configurationDecodingError(String, String, DecodingError)
+    case invalidConfiguration(String)
     case noModelFactoryAvailable
 
     public var errorDescription: String? {
@@ -21,6 +22,8 @@ public enum ModelFactoryError: LocalizedError {
             return "Unsupported processor type: \(type)"
         case .configurationFileError(let file, let modelName, let error):
             return "Error reading '\(file)' for model '\(modelName)': \(error.localizedDescription)"
+        case .invalidConfiguration(let message):
+            return "Invalid model configuration: \(message)"
         case .noModelFactoryAvailable:
             return "No model factory available via ModelFactoryRegistry"
         case .configurationDecodingError(let file, let modelName, let decodingError):
@@ -51,6 +54,10 @@ public enum ModelFactoryError: LocalizedError {
             return error.localizedDescription
         }
     }
+}
+
+public protocol ModelConfigurationValidating {
+    func validateModelConfiguration() throws
 }
 
 /// Context of types that work together to provide a ``LanguageModel``.

--- a/Libraries/MLXLMCommon/RoPEUtils.swift
+++ b/Libraries/MLXLMCommon/RoPEUtils.swift
@@ -9,6 +9,80 @@ import Foundation
 import MLX
 import MLXNN
 
+private let yarnTypes: Set<String> = ["yarn", "deepseek_yarn", "telechat3-yarn"]
+private let supportedRoPETypes: Set<String> = Set([
+    "default", "linear", "proportional", "llama3", "longrope", "mrope",
+]).union(yarnTypes)
+
+private func ropeType(in scalingConfig: [String: StringOrNumber]?) -> String? {
+    guard let value = scalingConfig?["type"] ?? scalingConfig?["rope_type"] else { return nil }
+    guard case .string(let ropeType) = value else { return nil }
+    return ropeType
+}
+
+private func invalidRoPEConfiguration(_ context: String, _ message: String) -> ModelFactoryError {
+    .invalidConfiguration("\(context): \(message)")
+}
+
+public func validateRoPEConfiguration(
+    _ scalingConfig: [String: StringOrNumber]?,
+    context: String = "rope_scaling",
+    supportedTypes: Set<String>? = nil
+) throws {
+    guard let scalingConfig else { return }
+    let supportedTypes = supportedTypes ?? supportedRoPETypes
+
+    if let typeValue = scalingConfig["type"] ?? scalingConfig["rope_type"] {
+        guard case .string(let ropeType) = typeValue else {
+            throw invalidRoPEConfiguration(context, "type must be a string")
+        }
+        guard supportedTypes.contains(ropeType) else {
+            throw invalidRoPEConfiguration(context, "unsupported type '\(ropeType)'")
+        }
+    }
+
+    if let factor = scalingConfig["factor"], factor.asFloat() == nil {
+        throw invalidRoPEConfiguration(context, "factor must be numeric")
+    }
+
+    switch ropeType(in: scalingConfig) {
+    case "llama3":
+        for key in ["low_freq_factor", "high_freq_factor", "original_max_position_embeddings"] {
+            if let value = scalingConfig[key], value.asFloat() == nil {
+                throw invalidRoPEConfiguration(context, "\(key) must be numeric")
+            }
+        }
+    case "longrope":
+        guard scalingConfig["original_max_position_embeddings"]?.asInt() != nil else {
+            throw invalidRoPEConfiguration(
+                context, "longrope requires original_max_position_embeddings")
+        }
+        guard scalingConfig["short_factor"]?.asFloats() != nil else {
+            throw invalidRoPEConfiguration(context, "longrope requires numeric short_factor")
+        }
+        guard scalingConfig["long_factor"]?.asFloats() != nil else {
+            throw invalidRoPEConfiguration(context, "longrope requires numeric long_factor")
+        }
+    case "mrope":
+        try validateMROPESection(scalingConfig, context: context)
+    default:
+        break
+    }
+}
+
+public func validateMROPESection(
+    _ scalingConfig: [String: StringOrNumber]?,
+    context: String = "rope_scaling"
+) throws {
+    guard let section = scalingConfig?["mrope_section"]?.asInts() else {
+        throw invalidRoPEConfiguration(context, "mrope_section must be an array of integers")
+    }
+    guard section.count == 3, section.allSatisfy({ $0 > 0 }) else {
+        throw invalidRoPEConfiguration(
+            context, "mrope_section must contain three positive integers")
+    }
+}
+
 public class Llama3RoPE: Module, OffsetLayer, ArrayOffsetLayer {
     let dims: Int
     let maxPositionEmbeddings: Int
@@ -330,8 +404,6 @@ public class YarnRoPE: Module, OffsetLayer, ArrayOffsetLayer {
     }
 
 }
-
-private let yarnTypes: Set = ["yarn", "deepseek_yarn", "telechat3-yarn"]
 
 public typealias RoPELayer = OffsetLayer & ArrayOffsetLayer
 

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -1356,6 +1356,14 @@ public struct Qwen25VLConfiguration: Codable, Sendable {
     }
 }
 
+extension Qwen25VLConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateMROPESection(
+            textConfiguration.ropeScaling,
+            context: "Qwen25VLConfiguration.text_config.rope_scaling")
+    }
+}
+
 /// Configuration for ``Qwen25VLProcessor``
 public struct Qwen25VLProcessorConfiguration: Codable, Sendable {
     public struct Size: Codable, Sendable {

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -871,6 +871,14 @@ public struct Qwen2VLConfiguration: Codable, Sendable {
     }
 }
 
+extension Qwen2VLConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateMROPESection(
+            textConfiguration.ropeScaling,
+            context: "Qwen2VLConfiguration.text_config.rope_scaling")
+    }
+}
+
 /// Configuration for ``Qwen2VLProcessor``
 public struct Qwen2VLProcessorConfiguration: Codable, Sendable {
 

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -56,6 +56,9 @@ private func create<C: Decodable, M>(
 ) -> (Data) throws -> M {
     { data in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        if let validating = configuration as? ModelConfigurationValidating {
+            try validating.validateModelConfiguration()
+        }
         return modelInit(configuration)
     }
 }
@@ -70,6 +73,9 @@ private func create<C: Decodable, P>(
 ) -> (Data, any Tokenizer) throws -> P {
     { data, tokenizer in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        if let validating = configuration as? ModelConfigurationValidating {
+            try validating.validateModelConfiguration()
+        }
         return processorInit(configuration, tokenizer)
     }
 }

--- a/Tests/MLXLMTests/RoPEConfigurationValidationTests.swift
+++ b/Tests/MLXLMTests/RoPEConfigurationValidationTests.swift
@@ -1,0 +1,92 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Test
+func qwen3RegistryRejectsUnsupportedRoPEType() async {
+    let json = """
+        {
+          "hidden_size": 4,
+          "num_hidden_layers": 1,
+          "intermediate_size": 8,
+          "num_attention_heads": 2,
+          "rms_norm_eps": 1e-6,
+          "vocab_size": 16,
+          "num_key_value_heads": 1,
+          "head_dim": 2,
+          "rope_scaling": {
+            "rope_type": "not_supported",
+            "factor": 2.0
+          }
+        }
+        """
+
+    await expectInvalidConfiguration(
+        containing: "unsupported type 'not_supported'"
+    ) {
+        _ = try await LLMTypeRegistry.shared.createModel(
+            configuration: Data(json.utf8), modelType: "qwen3")
+    }
+}
+
+@Test
+func qwen2VLRegistryRejectsInvalidMRoPESection() async {
+    let json = """
+        {
+          "model_type": "qwen2_vl",
+          "hidden_size": 4,
+          "num_hidden_layers": 1,
+          "intermediate_size": 8,
+          "num_attention_heads": 2,
+          "rms_norm_eps": 1e-6,
+          "vocab_size": 16,
+          "num_key_value_heads": 1,
+          "image_token_id": 151655,
+          "video_token_id": 151656,
+          "rope_scaling": {
+            "type": "mrope",
+            "mrope_section": [16, 16]
+          },
+          "vision_config": {
+            "depth": 1,
+            "embed_dim": 4,
+            "hidden_size": 4,
+            "num_heads": 2,
+            "patch_size": 14,
+            "mlp_ratio": 2.0,
+            "spatial_patch_size": 14,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2
+          }
+        }
+        """
+
+    await expectInvalidConfiguration(
+        containing: "mrope_section must contain three positive integers"
+    ) {
+        _ = try await VLMTypeRegistry.shared.createModel(
+            configuration: Data(json.utf8), modelType: "qwen2_vl")
+    }
+}
+
+private func expectInvalidConfiguration(
+    containing expectedMessage: String,
+    _ operation: () async throws -> Void
+) async {
+    do {
+        try await operation()
+        Issue.record("expected invalidConfiguration to throw")
+    } catch let error as ModelFactoryError {
+        guard case .invalidConfiguration(let message) = error else {
+            Issue.record("unexpected ModelFactoryError: \(error)")
+            return
+        }
+        #expect(message.contains(expectedMessage))
+    } catch {
+        Issue.record("unexpected error: \(error)")
+    }
+}

--- a/Tests/MLXLMTests/RoPEConfigurationValidationTests.swift
+++ b/Tests/MLXLMTests/RoPEConfigurationValidationTests.swift
@@ -34,6 +34,32 @@ func qwen3RegistryRejectsUnsupportedRoPEType() async {
 }
 
 @Test
+func qwen3ValidationAcceptsSupportedYarnRoPEScaling() async throws {
+    let json = """
+        {
+          "hidden_size": 4,
+          "num_hidden_layers": 1,
+          "intermediate_size": 8,
+          "num_attention_heads": 2,
+          "rms_norm_eps": 1e-6,
+          "vocab_size": 16,
+          "num_key_value_heads": 1,
+          "head_dim": 2,
+          "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768
+          }
+        }
+        """
+
+    let configuration = try JSONDecoder.json5().decode(
+        Qwen3Configuration.self, from: Data(json.utf8))
+
+    try configuration.validateModelConfiguration()
+}
+
+@Test
 func qwen2VLRegistryRejectsInvalidMRoPESection() async {
     let json = """
         {
@@ -71,6 +97,44 @@ func qwen2VLRegistryRejectsInvalidMRoPESection() async {
         _ = try await VLMTypeRegistry.shared.createModel(
             configuration: Data(json.utf8), modelType: "qwen2_vl")
     }
+}
+
+@Test
+func qwen2VLValidationAcceptsValidMRoPESection() async throws {
+    let json = """
+        {
+          "model_type": "qwen2_vl",
+          "hidden_size": 4,
+          "num_hidden_layers": 1,
+          "intermediate_size": 8,
+          "num_attention_heads": 2,
+          "rms_norm_eps": 1e-6,
+          "vocab_size": 16,
+          "num_key_value_heads": 1,
+          "image_token_id": 151655,
+          "video_token_id": 151656,
+          "rope_scaling": {
+            "type": "mrope",
+            "mrope_section": [16, 24, 24]
+          },
+          "vision_config": {
+            "depth": 1,
+            "embed_dim": 4,
+            "hidden_size": 4,
+            "num_heads": 2,
+            "patch_size": 14,
+            "mlp_ratio": 2.0,
+            "spatial_patch_size": 14,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2
+          }
+        }
+        """
+
+    let configuration = try JSONDecoder.json5().decode(
+        Qwen2VLConfiguration.self, from: Data(json.utf8))
+
+    try configuration.validateModelConfiguration()
 }
 
 private func expectInvalidConfiguration(


### PR DESCRIPTION
## Summary
- validate RoPE scaling configuration before model construction
- apply the validation through the LLM and VLM model factory paths that consume RoPE config
- add regression coverage for unsupported RoPE types and malformed multimodal RoPE sections

## Validation
- swift test --filter RoPEConfigurationValidationTests
- swift build --target MLXVLM
- pre-commit run --all-files
- git diff --check