### PR TITLE
Add runtime stop string handling

### DIFF
--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -233,6 +233,7 @@ public final class EmbedderModelFactory: GenericModelFactory {
             tokenizerSource: tokenizerSource,
             defaultPrompt: configuration.defaultPrompt,
             extraEOSTokens: configuration.extraEOSTokens,
+            stopStrings: configuration.stopStrings,
             eosTokenIds: configuration.eosTokenIds,
             toolCallFormat: configuration.toolCallFormat)
 

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -127,13 +127,15 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let phi3_5_4bit = ModelConfiguration(
         id: "mlx-community/Phi-3.5-mini-instruct-4bit",
         defaultPrompt: "What is the gravity on Mars and the moon?",
-        extraEOSTokens: ["<|end|>"]
+        extraEOSTokens: ["<|end|>"],
+        stopStrings: ["<|end|>"]
     )
 
     static public let phi3_5MoE = ModelConfiguration(
         id: "mlx-community/Phi-3.5-MoE-instruct-4bit",
         defaultPrompt: "What is the gravity on Mars and the moon?",
-        extraEOSTokens: ["<|end|>"]
+        extraEOSTokens: ["<|end|>"],
+        stopStrings: ["<|end|>"]
     )
 
     static public let gemma2bQuantized = ModelConfiguration(
@@ -157,97 +159,124 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma3_1B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-1b-it-qat-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E4B_it_lm_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-3n-E4B-it-lm-bf16",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E2B_it_lm_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-3n-E2B-it-lm-bf16",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E4B_it_lm_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3n-E4B-it-lm-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E2B_it_lm_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3n-E2B-it-lm-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma4_e4b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        stopStrings: ["<turn|>"]
     )
 
     static public let gemma4_e2b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        stopStrings: ["<turn|>"]
     )
 
     static public let qwen205b4bit = ModelConfiguration(
         id: "mlx-community/Qwen1.5-0.5B-Chat-4bit",
-        defaultPrompt: "why is the sky blue?"
+        defaultPrompt: "why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen2_5_7b = ModelConfiguration(
         id: "mlx-community/Qwen2.5-7B-Instruct-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen2_5_1_5b = ModelConfiguration(
         id: "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_0_6b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-0.6B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_1_7b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-1.7B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_4b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-4B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_8b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-8B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3MoE_30b_a3b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-30B-A3B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_5_2b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.5-2B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_6_27b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.6-27B-4bit",
-        defaultPrompt: "Why is the sky blue?"
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let openelm270m4bit = ModelConfiguration(
@@ -258,22 +287,30 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
 
     static public let llama3_1_8B_4bit = ModelConfiguration(
         id: "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit",
-        defaultPrompt: "What is the difference between a fruit and a vegetable?"
+        defaultPrompt: "What is the difference between a fruit and a vegetable?",
+        extraEOSTokens: ["<|eot_id|>"],
+        stopStrings: ["<|eot_id|>"]
     )
 
     static public let llama3_8B_4bit = ModelConfiguration(
         id: "mlx-community/Meta-Llama-3-8B-Instruct-4bit",
-        defaultPrompt: "What is the difference between a fruit and a vegetable?"
+        defaultPrompt: "What is the difference between a fruit and a vegetable?",
+        extraEOSTokens: ["<|eot_id|>"],
+        stopStrings: ["<|eot_id|>"]
     )
 
     static public let llama3_2_1B_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-1B-Instruct-4bit",
-        defaultPrompt: "What is the difference between a fruit and a vegetable?"
+        defaultPrompt: "What is the difference between a fruit and a vegetable?",
+        extraEOSTokens: ["<|eot_id|>"],
+        stopStrings: ["<|eot_id|>"]
     )
 
     static public let llama3_2_3B_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-3B-Instruct-4bit",
-        defaultPrompt: "What is the difference between a fruit and a vegetable?"
+        defaultPrompt: "What is the difference between a fruit and a vegetable?",
+        extraEOSTokens: ["<|eot_id|>"],
+        stopStrings: ["<|eot_id|>"]
     )
 
     static public let deepseek_r1_4bit = ModelConfiguration(
@@ -550,17 +587,20 @@ public final class LLMModelFactory: GenericModelFactory {
         // Load EOS token IDs from config.json, with optional override from generation_config.json
         var eosTokenIds = Set(baseConfig.eosTokenIds?.values ?? [])
         let generationConfigURL = modelDirectory.appending(component: "generation_config.json")
-        if let generationData = try? Data(contentsOf: generationConfigURL),
-            let generationConfig = try? JSONDecoder.json5().decode(
-                GenerationConfigFile.self, from: generationData),
-            let genEosIds = generationConfig.eosTokenIds?.values
-        {
+        let generationConfig: GenerationConfigFile? =
+            if let generationData = try? Data(contentsOf: generationConfigURL) {
+                try? JSONDecoder.json5().decode(GenerationConfigFile.self, from: generationData)
+            } else {
+                nil
+            }
+        if let genEosIds = generationConfig?.eosTokenIds?.values {
             eosTokenIds = Set(genEosIds)  // Override per Python mlx-lm behavior
         }
 
         // Build a ModelConfiguration with loaded EOS token IDs and tool call format
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds
+        mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat = ToolCallFormat.infer(
                 from: baseConfig.modelType, configData: configData)
@@ -593,6 +633,7 @@ public final class LLMModelFactory: GenericModelFactory {
             tokenizerSource: tokenizerSource,
             defaultPrompt: configuration.defaultPrompt,
             extraEOSTokens: mutableConfiguration.extraEOSTokens,
+            stopStrings: mutableConfiguration.stopStrings,
             eosTokenIds: mutableConfiguration.eosTokenIds,
             toolCallFormat: mutableConfiguration.toolCallFormat)
 

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -127,15 +127,13 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let phi3_5_4bit = ModelConfiguration(
         id: "mlx-community/Phi-3.5-mini-instruct-4bit",
         defaultPrompt: "What is the gravity on Mars and the moon?",
-        extraEOSTokens: ["<|end|>"],
-        stopStrings: ["<|end|>"]
+        extraEOSTokens: ["<|end|>"]
     )
 
     static public let phi3_5MoE = ModelConfiguration(
         id: "mlx-community/Phi-3.5-MoE-instruct-4bit",
         defaultPrompt: "What is the gravity on Mars and the moon?",
-        extraEOSTokens: ["<|end|>"],
-        stopStrings: ["<|end|>"]
+        extraEOSTokens: ["<|end|>"]
     )
 
     static public let gemma2bQuantized = ModelConfiguration(
@@ -159,124 +157,107 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma3_1B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-1b-it-qat-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E4B_it_lm_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-3n-E4B-it-lm-bf16",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E2B_it_lm_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-3n-E2B-it-lm-bf16",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E4B_it_lm_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3n-E4B-it-lm-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma3n_E2B_it_lm_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3n-E2B-it-lm-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma4_e4b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<turn|>"],
-        stopStrings: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_e2b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<turn|>"],
-        stopStrings: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let qwen205b4bit = ModelConfiguration(
         id: "mlx-community/Qwen1.5-0.5B-Chat-4bit",
         defaultPrompt: "why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen2_5_7b = ModelConfiguration(
         id: "mlx-community/Qwen2.5-7B-Instruct-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen2_5_1_5b = ModelConfiguration(
         id: "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_0_6b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-0.6B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_1_7b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-1.7B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_4b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-4B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_8b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-8B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3MoE_30b_a3b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-30B-A3B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_5_2b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.5-2B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_6_27b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.6-27B-4bit",
         defaultPrompt: "Why is the sky blue?",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let openelm270m4bit = ModelConfiguration(
@@ -288,29 +269,25 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let llama3_1_8B_4bit = ModelConfiguration(
         id: "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<|eot_id|>"],
-        stopStrings: ["<|eot_id|>"]
+        extraEOSTokens: ["<|eot_id|>"]
     )
 
     static public let llama3_8B_4bit = ModelConfiguration(
         id: "mlx-community/Meta-Llama-3-8B-Instruct-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<|eot_id|>"],
-        stopStrings: ["<|eot_id|>"]
+        extraEOSTokens: ["<|eot_id|>"]
     )
 
     static public let llama3_2_1B_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-1B-Instruct-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<|eot_id|>"],
-        stopStrings: ["<|eot_id|>"]
+        extraEOSTokens: ["<|eot_id|>"]
     )
 
     static public let llama3_2_3B_4bit = ModelConfiguration(
         id: "mlx-community/Llama-3.2-3B-Instruct-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<|eot_id|>"],
-        stopStrings: ["<|eot_id|>"]
+        extraEOSTokens: ["<|eot_id|>"]
     )
 
     static public let deepseek_r1_4bit = ModelConfiguration(

--- a/Libraries/MLXLMCommon/Downloader.swift
+++ b/Libraries/MLXLMCommon/Downloader.swift
@@ -82,7 +82,7 @@ public struct ResolvedModelConfiguration: Sendable {
         name: String,
         defaultPrompt: String,
         extraEOSTokens: Set<String>,
-        stopStrings: Set<String> = [],
+        stopStrings: Set<String>? = nil,
         eosTokenIds: Set<Int>,
         toolCallFormat: ToolCallFormat?
     ) {
@@ -91,7 +91,7 @@ public struct ResolvedModelConfiguration: Sendable {
         self.name = name
         self.defaultPrompt = defaultPrompt
         self.extraEOSTokens = extraEOSTokens
-        self.stopStrings = stopStrings
+        self.stopStrings = stopStrings ?? extraEOSTokens
         self.eosTokenIds = eosTokenIds
         self.toolCallFormat = toolCallFormat
     }

--- a/Libraries/MLXLMCommon/Downloader.swift
+++ b/Libraries/MLXLMCommon/Downloader.swift
@@ -72,6 +72,7 @@ public struct ResolvedModelConfiguration: Sendable {
     public var name: String
     public var defaultPrompt: String
     public var extraEOSTokens: Set<String>
+    public var stopStrings: Set<String>
     public var eosTokenIds: Set<Int>
     public var toolCallFormat: ToolCallFormat?
 
@@ -81,6 +82,7 @@ public struct ResolvedModelConfiguration: Sendable {
         name: String,
         defaultPrompt: String,
         extraEOSTokens: Set<String>,
+        stopStrings: Set<String> = [],
         eosTokenIds: Set<Int>,
         toolCallFormat: ToolCallFormat?
     ) {
@@ -89,6 +91,7 @@ public struct ResolvedModelConfiguration: Sendable {
         self.name = name
         self.defaultPrompt = defaultPrompt
         self.extraEOSTokens = extraEOSTokens
+        self.stopStrings = stopStrings
         self.eosTokenIds = eosTokenIds
         self.toolCallFormat = toolCallFormat
     }
@@ -104,6 +107,7 @@ extension ResolvedModelConfiguration {
                 + directory.lastPathComponent,
             defaultPrompt: "",
             extraEOSTokens: [],
+            stopStrings: [],
             eosTokenIds: [],
             toolCallFormat: nil)
     }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1483,6 +1483,7 @@ public func generate(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
+            stopStrings: context.configuration.stopStrings,
             format: context.configuration.toolCallFormat ?? .json
         )
     )
@@ -1540,6 +1541,7 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: tokenizer,
+            stopStrings: modelConfiguration.stopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
             tools: tools
         )
@@ -1679,6 +1681,7 @@ public func generate(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
+            stopStrings: context.configuration.stopStrings,
             format: context.configuration.toolCallFormat ?? .json
         )
     )
@@ -1821,7 +1824,7 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 tokenizer: tokenizer
             )
 
-            while let token = iterator.next() {
+            tokenLoop: while let token = iterator.next() {
                 // Check for cancellation on every loop iteration.
                 if Task.isCancelled {
                     stopReason = .cancelled
@@ -1838,9 +1841,15 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 if token == tokenizer.unknownTokenId || stopTokenIds.contains(token) {
                     if includeStopToken {
                         tokenCount += 1
-                        if !handler.onStopToken(token, emit: continuation.yield) {
-                            stopReason = .cancelled
+                        switch handler.onStopToken(token, emit: continuation.yield) {
+                        case .more:
                             break
+                        case .stop:
+                            stopReason = .stop
+                            break tokenLoop
+                        case .cancelled:
+                            stopReason = .cancelled
+                            break tokenLoop
                         }
                     } else {
                         iterator.discardGeneratedToken()
@@ -1850,9 +1859,15 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 }
 
                 tokenCount += 1
-                if !handler.onToken(token, emit: continuation.yield) {
-                    stopReason = .cancelled
+                switch handler.onToken(token, emit: continuation.yield) {
+                case .more:
                     break
+                case .stop:
+                    stopReason = .stop
+                    break tokenLoop
+                case .cancelled:
+                    stopReason = .cancelled
+                    break tokenLoop
                 }
             }
 
@@ -2098,20 +2113,26 @@ public enum TokenGeneration: Sendable {
 
 // MARK: - TokenLoopHandlers
 
+private enum TokenLoopDisposition {
+    case more
+    case stop
+    case cancelled
+}
+
 private protocol TokenLoopHandler {
     associatedtype Output
 
-    /// Return false to stop the loop early.
+    /// Return `.stop` for semantic generation stops, or `.cancelled` for consumer termination.
     mutating func onToken(
         _ token: Int,
         emit: (sending Output) -> AsyncStream<Output>.Continuation.YieldResult
-    ) -> Bool
+    ) -> TokenLoopDisposition
 
     /// Called only when includeStopToken == true and a stop token was hit.
     mutating func onStopToken(
         _ token: Int,
         emit: (sending Output) -> AsyncStream<Output>.Continuation.YieldResult
-    ) -> Bool
+    ) -> TokenLoopDisposition
 
     /// Called after the token loop finishes, before the info event.
     mutating func onGenerationEnd(
@@ -2121,51 +2142,146 @@ private protocol TokenLoopHandler {
     func infoEvent(_ info: GenerateCompletionInfo) -> Output
 }
 
+struct StopStringFilter {
+    let stopStrings: [String]
+    var buffer = ""
+    var stopped = false
+
+    init(stopStrings: Set<String>) {
+        self.stopStrings = stopStrings.filter { !$0.isEmpty }.sorted {
+            if $0.count == $1.count {
+                return $0 < $1
+            }
+            return $0.count > $1.count
+        }
+    }
+
+    var isEnabled: Bool {
+        !stopStrings.isEmpty
+    }
+
+    mutating func process(_ chunk: String) -> (text: String?, stopped: Bool) {
+        guard !stopped else {
+            return (nil, true)
+        }
+        guard isEnabled else {
+            return (chunk.isEmpty ? nil : chunk, false)
+        }
+
+        buffer += chunk
+
+        if let stopRange = earliestStopRange(in: buffer) {
+            let text = String(buffer[..<stopRange.lowerBound])
+            buffer = ""
+            stopped = true
+            return (text.isEmpty ? nil : text, true)
+        }
+
+        let suffixLength = longestStopPrefixSuffixLength(in: buffer)
+        let emitEnd = buffer.index(buffer.endIndex, offsetBy: -suffixLength)
+        let text = String(buffer[..<emitEnd])
+        buffer = String(buffer[emitEnd...])
+        return (text.isEmpty ? nil : text, false)
+    }
+
+    mutating func finish() -> String? {
+        guard isEnabled, !stopped, !buffer.isEmpty else {
+            return nil
+        }
+        let text = buffer
+        buffer = ""
+        return text
+    }
+
+    private func earliestStopRange(in text: String) -> Range<String.Index>? {
+        var earliest: Range<String.Index>?
+        for stopString in stopStrings {
+            guard let range = text.range(of: stopString) else {
+                continue
+            }
+            if let current = earliest {
+                if range.lowerBound < current.lowerBound {
+                    earliest = range
+                }
+            } else {
+                earliest = range
+            }
+        }
+        return earliest
+    }
+
+    private func longestStopPrefixSuffixLength(in text: String) -> Int {
+        var longest = 0
+        for stopString in stopStrings {
+            let maxLength = Swift.min(text.count, stopString.count - 1)
+            guard maxLength > longest else {
+                continue
+            }
+            for length in stride(from: maxLength, through: longest + 1, by: -1) {
+                if text.suffix(length) == stopString.prefix(length) {
+                    longest = length
+                    break
+                }
+            }
+        }
+        return longest
+    }
+}
+
 private struct TextToolTokenLoopHandler: TokenLoopHandler {
     typealias Output = Generation
 
     var detokenizer: NaiveStreamingDetokenizer
+    var stopStringFilter: StopStringFilter
     let toolCallProcessor: ToolCallProcessor
 
-    init(tokenizer: Tokenizer, format: ToolCallFormat, tools: [[String: any Sendable]]? = nil) {
+    init(
+        tokenizer: Tokenizer, stopStrings: Set<String> = [], format: ToolCallFormat,
+        tools: [[String: any Sendable]]? = nil
+    ) {
         detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+        stopStringFilter = StopStringFilter(stopStrings: stopStrings)
         toolCallProcessor = ToolCallProcessor(format: format, tools: tools)
     }
 
     mutating func onToken(
         _ token: Int,
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
-    ) -> Bool {
+    ) -> TokenLoopDisposition {
         detokenizer.append(token: token)
         if let chunk = detokenizer.next() {
-            // Process chunk through the tool call processor.
-            if let textToYield = toolCallProcessor.processChunk(chunk) {
-                if case .terminated = emit(.chunk(textToYield)) {
-                    return false
+            let result = stopStringFilter.process(chunk)
+            if let text = result.text {
+                let disposition = processText(text, emit: emit)
+                if case .more = disposition {
+                } else {
+                    return disposition
                 }
             }
-
-            // Emit all complete tool calls in parse order.
-            for toolCall in toolCallProcessor.drainToolCalls() {
-                if case .terminated = emit(.toolCall(toolCall)) {
-                    return false
-                }
+            if result.stopped {
+                return .stop
             }
         }
 
-        return true
+        return .more
     }
 
     mutating func onStopToken(
         _ token: Int,
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
-    ) -> Bool {
-        true
+    ) -> TokenLoopDisposition {
+        .more
     }
 
     mutating func onGenerationEnd(
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
     ) {
+        if let text = stopStringFilter.finish() {
+            guard case .more = processText(text, emit: emit) else {
+                return
+            }
+        }
+
         if let bufferedText = toolCallProcessor.processEOS(returnBufferedText: true),
             !bufferedText.isEmpty
         {
@@ -2184,6 +2300,29 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
     func infoEvent(_ info: GenerateCompletionInfo) -> Generation {
         .info(info)
     }
+
+    private mutating func processText(
+        _ text: String,
+        emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
+    ) -> TokenLoopDisposition {
+        guard !text.isEmpty else {
+            return .more
+        }
+
+        if let textToYield = toolCallProcessor.processChunk(text) {
+            if case .terminated = emit(.chunk(textToYield)) {
+                return .cancelled
+            }
+        }
+
+        for toolCall in toolCallProcessor.drainToolCalls() {
+            if case .terminated = emit(.toolCall(toolCall)) {
+                return .cancelled
+            }
+        }
+
+        return .more
+    }
 }
 
 private struct RawTokenLoopHandler: TokenLoopHandler {
@@ -2192,21 +2331,21 @@ private struct RawTokenLoopHandler: TokenLoopHandler {
     mutating func onToken(
         _ token: Int,
         emit: (sending TokenGeneration) -> AsyncStream<TokenGeneration>.Continuation.YieldResult
-    ) -> Bool {
+    ) -> TokenLoopDisposition {
         if case .terminated = emit(.token(token)) {
-            return false
+            return .cancelled
         }
-        return true
+        return .more
     }
 
     mutating func onStopToken(
         _ token: Int,
         emit: (sending TokenGeneration) -> AsyncStream<TokenGeneration>.Continuation.YieldResult
-    ) -> Bool {
+    ) -> TokenLoopDisposition {
         if case .terminated = emit(.token(token)) {
-            return false
+            return .cancelled
         }
-        return true
+        return .more
     }
 
     mutating func onGenerationEnd(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1483,7 +1483,7 @@ public func generate(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
-            stopStrings: context.configuration.stopStrings,
+            stopStrings: context.configuration.effectiveStopStrings,
             format: context.configuration.toolCallFormat ?? .json
         )
     )
@@ -1541,7 +1541,7 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: tokenizer,
-            stopStrings: modelConfiguration.stopStrings,
+            stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
             tools: tools
         )
@@ -1681,7 +1681,7 @@ public func generate(
         wiredMemoryTicket: wiredMemoryTicket,
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
-            stopStrings: context.configuration.stopStrings,
+            stopStrings: context.configuration.effectiveStopStrings,
             format: context.configuration.toolCallFormat ?? .json
         )
     )

--- a/Libraries/MLXLMCommon/GenerationConfigFile.swift
+++ b/Libraries/MLXLMCommon/GenerationConfigFile.swift
@@ -9,8 +9,46 @@ import Foundation
 /// `eos_token_id`, it takes precedence over the value in `config.json`.
 public struct GenerationConfigFile: Codable, Sendable {
     public var eosTokenIds: IntOrIntArray?
+    public var stopStrings: Set<String>
 
     enum CodingKeys: String, CodingKey {
         case eosTokenIds = "eos_token_id"
+        case stopStrings = "stop_strings"
+        case stop
+    }
+
+    public init(eosTokenIds: IntOrIntArray? = nil, stopStrings: Set<String> = []) {
+        self.eosTokenIds = eosTokenIds
+        self.stopStrings = stopStrings
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        eosTokenIds = try container.decodeIfPresent(IntOrIntArray.self, forKey: .eosTokenIds)
+
+        stopStrings = []
+        stopStrings.formUnion(Self.decodeStringSet(from: container, forKey: .stopStrings))
+        stopStrings.formUnion(Self.decodeStringSet(from: container, forKey: .stop))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(eosTokenIds, forKey: .eosTokenIds)
+        if !stopStrings.isEmpty {
+            try container.encode(stopStrings.sorted(), forKey: .stopStrings)
+        }
+    }
+
+    private static func decodeStringSet(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> Set<String> {
+        if let values = try? container.decode([String].self, forKey: key) {
+            return Set(values)
+        }
+        if let value = try? container.decode(String.self, forKey: key) {
+            return [value]
+        }
+        return []
     }
 }

--- a/Libraries/MLXLMCommon/ModelConfiguration.swift
+++ b/Libraries/MLXLMCommon/ModelConfiguration.swift
@@ -101,6 +101,9 @@ public struct ModelConfiguration: Sendable {
     /// Additional tokens to use for end of string (specified as strings, converted to IDs at runtime)
     public var extraEOSTokens: Set<String>
 
+    /// Text sequences that stop decoded generation when encountered.
+    public var stopStrings: Set<String>
+
     /// EOS token IDs loaded from config.json/generation_config.json
     public var eosTokenIds: Set<Int> = []
 
@@ -112,12 +115,16 @@ public struct ModelConfiguration: Sendable {
         tokenizerSource: TokenizerSource? = nil,
         defaultPrompt: String = "",
         extraEOSTokens: Set<String> = [],
+        stopStrings: Set<String> = [],
+        eosTokenIds: Set<Int> = [],
         toolCallFormat: ToolCallFormat? = nil
     ) {
         self.id = .id(id, revision: revision)
         self.tokenizerSource = tokenizerSource
         self.defaultPrompt = defaultPrompt
         self.extraEOSTokens = extraEOSTokens
+        self.stopStrings = stopStrings
+        self.eosTokenIds = eosTokenIds
         self.toolCallFormat = toolCallFormat
     }
 
@@ -126,6 +133,7 @@ public struct ModelConfiguration: Sendable {
         tokenizerSource: TokenizerSource? = nil,
         defaultPrompt: String = "",
         extraEOSTokens: Set<String> = [],
+        stopStrings: Set<String> = [],
         eosTokenIds: Set<Int> = [],
         toolCallFormat: ToolCallFormat? = nil
     ) {
@@ -133,6 +141,7 @@ public struct ModelConfiguration: Sendable {
         self.tokenizerSource = tokenizerSource
         self.defaultPrompt = defaultPrompt
         self.extraEOSTokens = extraEOSTokens
+        self.stopStrings = stopStrings
         self.eosTokenIds = eosTokenIds
         self.toolCallFormat = toolCallFormat
     }
@@ -151,6 +160,7 @@ public struct ModelConfiguration: Sendable {
             name: name,
             defaultPrompt: defaultPrompt,
             extraEOSTokens: extraEOSTokens,
+            stopStrings: stopStrings,
             eosTokenIds: eosTokenIds,
             toolCallFormat: toolCallFormat)
     }

--- a/Libraries/MLXLMCommon/ModelConfiguration.swift
+++ b/Libraries/MLXLMCommon/ModelConfiguration.swift
@@ -102,7 +102,15 @@ public struct ModelConfiguration: Sendable {
     public var extraEOSTokens: Set<String>
 
     /// Text sequences that stop decoded generation when encountered.
-    public var stopStrings: Set<String>
+    ///
+    /// If this is `nil`, decoded stop strings fall back to ``extraEOSTokens``.
+    /// Set this explicitly, including to an empty set, to override that fallback.
+    public var stopStrings: Set<String>?
+
+    /// Text sequences to use for decoded stop-string matching.
+    public var effectiveStopStrings: Set<String> {
+        stopStrings ?? extraEOSTokens
+    }
 
     /// EOS token IDs loaded from config.json/generation_config.json
     public var eosTokenIds: Set<Int> = []
@@ -115,7 +123,7 @@ public struct ModelConfiguration: Sendable {
         tokenizerSource: TokenizerSource? = nil,
         defaultPrompt: String = "",
         extraEOSTokens: Set<String> = [],
-        stopStrings: Set<String> = [],
+        stopStrings: Set<String>? = nil,
         eosTokenIds: Set<Int> = [],
         toolCallFormat: ToolCallFormat? = nil
     ) {
@@ -133,7 +141,7 @@ public struct ModelConfiguration: Sendable {
         tokenizerSource: TokenizerSource? = nil,
         defaultPrompt: String = "",
         extraEOSTokens: Set<String> = [],
-        stopStrings: Set<String> = [],
+        stopStrings: Set<String>? = nil,
         eosTokenIds: Set<Int> = [],
         toolCallFormat: ToolCallFormat? = nil
     ) {

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -396,7 +396,7 @@ public func loadParoQuantModel<T: LanguageModel>(
     }
 
     var config = ModelConfiguration(
-        directory: directory, stopStrings: genConfig?.stopStrings ?? [],
+        directory: directory, stopStrings: genConfig?.stopStrings,
         toolCallFormat: toolCallFormat)
     config.eosTokenIds = eosTokenIds
 

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -385,14 +385,19 @@ public func loadParoQuantModel<T: LanguageModel>(
     // 4. EOS token override from generation_config.json
     var eosTokenIds = Set(baseConfig.eosTokenIds?.values ?? [])
     let genConfigURL = directory.appendingPathComponent("generation_config.json")
-    if let genData = try? Data(contentsOf: genConfigURL),
-        let genConfig = try? JSONDecoder().decode(GenerationConfigFile.self, from: genData),
-        let genEos = genConfig.eosTokenIds?.values
-    {
+    let genConfig: GenerationConfigFile? =
+        if let genData = try? Data(contentsOf: genConfigURL) {
+            try? JSONDecoder().decode(GenerationConfigFile.self, from: genData)
+        } else {
+            nil
+        }
+    if let genEos = genConfig?.eosTokenIds?.values {
         eosTokenIds = Set(genEos)
     }
 
-    var config = ModelConfiguration(directory: directory, toolCallFormat: toolCallFormat)
+    var config = ModelConfiguration(
+        directory: directory, stopStrings: genConfig?.stopStrings ?? [],
+        toolCallFormat: toolCallFormat)
     config.eosTokenIds = eosTokenIds
 
     // 5. Load raw safetensors (top-level only; do not recurse into

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -218,25 +218,25 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma4_E2B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma4_E4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma4_31B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-31b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma4_26BA4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-26b-a4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let smolvlm = ModelConfiguration(

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -156,29 +156,25 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let qwen2VL2BInstruct4Bit = ModelConfiguration(
         id: "mlx-community/Qwen2-VL-2B-Instruct-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen2_5VL3BInstruct4Bit = ModelConfiguration(
         id: "mlx-community/Qwen2.5-VL-3B-Instruct-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3VL4BInstruct4Bit = ModelConfiguration(
         id: "lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3VL4BInstruct8Bit = ModelConfiguration(
         id: "mlx-community/Qwen3-VL-4B-Instruct-8bit",
         defaultPrompt: "Write a haiku about Swift programming",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let smolvlminstruct4bit = ModelConfiguration(
@@ -204,50 +200,43 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma3_4B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-4b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma3_12B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-12b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma3_27B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-27b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"]
     )
 
     static public let gemma4_E2B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_E4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_31B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-31b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_26BA4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-26b-a4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"],
-        stopStrings: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let smolvlm = ModelConfiguration(
@@ -264,15 +253,13 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let qwen3_5_27B_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.5-27B-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public let qwen3_5_35B_A3B_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.5-35B-A3B-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<|im_end|>"],
-        stopStrings: ["<|im_end|>"]
+        extraEOSTokens: ["<|im_end|>"]
     )
 
     static public func all() -> [ModelConfiguration] {

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -155,22 +155,30 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
 
     static public let qwen2VL2BInstruct4Bit = ModelConfiguration(
         id: "mlx-community/Qwen2-VL-2B-Instruct-4bit",
-        defaultPrompt: "Describe the image in English"
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen2_5VL3BInstruct4Bit = ModelConfiguration(
         id: "mlx-community/Qwen2.5-VL-3B-Instruct-4bit",
-        defaultPrompt: "Describe the image in English"
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3VL4BInstruct4Bit = ModelConfiguration(
         id: "lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit",
-        defaultPrompt: "Describe the image in English"
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3VL4BInstruct8Bit = ModelConfiguration(
         id: "mlx-community/Qwen3-VL-4B-Instruct-8bit",
-        defaultPrompt: "Write a haiku about Swift programming"
+        defaultPrompt: "Write a haiku about Swift programming",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let smolvlminstruct4bit = ModelConfiguration(
@@ -196,43 +204,50 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma3_4B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-4b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma3_12B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-12b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma3_27B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-27b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma4_E2B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma4_E4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma4_31B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-31b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let gemma4_26BA4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-26b-a4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        stopStrings: ["<end_of_turn>"]
     )
 
     static public let smolvlm = ModelConfiguration(
@@ -248,12 +263,16 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
 
     static public let qwen3_5_27B_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.5-27B-4bit",
-        defaultPrompt: "Describe the image in English"
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public let qwen3_5_35B_A3B_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3.5-35B-A3B-4bit",
-        defaultPrompt: "Describe the image in English"
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"],
+        stopStrings: ["<|im_end|>"]
     )
 
     static public func all() -> [ModelConfiguration] {
@@ -273,6 +292,8 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
             gemma4_31B_it_4bit,
             smolvlm,
             fastvlm,
+            qwen3_5_27B_4bit,
+            qwen3_5_35B_A3B_4bit,
         ]
     }
 
@@ -353,16 +374,19 @@ public final class VLMModelFactory: GenericModelFactory {
         // Load EOS token IDs from config.json, with optional override from generation_config.json
         var eosTokenIds = Set(baseConfig.eosTokenIds?.values ?? [])
         let generationConfigURL = modelDirectory.appending(component: "generation_config.json")
-        if let generationData = try? Data(contentsOf: generationConfigURL),
-            let generationConfig = try? JSONDecoder.json5().decode(
-                GenerationConfigFile.self, from: generationData),
-            let genEosIds = generationConfig.eosTokenIds?.values
-        {
+        let generationConfig: GenerationConfigFile? =
+            if let generationData = try? Data(contentsOf: generationConfigURL) {
+                try? JSONDecoder.json5().decode(GenerationConfigFile.self, from: generationData)
+            } else {
+                nil
+            }
+        if let genEosIds = generationConfig?.eosTokenIds?.values {
             eosTokenIds = Set(genEosIds)  // Override per Python mlx-lm behavior
         }
 
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds
+        mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
 
         // Auto-detect tool call format from model type if not explicitly set
         if mutableConfiguration.toolCallFormat == nil {
@@ -420,6 +444,7 @@ public final class VLMModelFactory: GenericModelFactory {
             tokenizerSource: tokenizerSource,
             defaultPrompt: configuration.defaultPrompt,
             extraEOSTokens: mutableConfiguration.extraEOSTokens,
+            stopStrings: mutableConfiguration.stopStrings,
             eosTokenIds: mutableConfiguration.eosTokenIds,
             toolCallFormat: mutableConfiguration.toolCallFormat)
 

--- a/Tests/MLXLMTests/StopStringTests.swift
+++ b/Tests/MLXLMTests/StopStringTests.swift
@@ -77,6 +77,28 @@ final class StopStringTests: XCTestCase {
         XCTAssertTrue(fifth.stopped)
     }
 
+    func testTokenLoopStopsOnStopStringAcrossDecodedTokenChunks() {
+        let tokenizer = DeterministicStopStringTokenizer(decoding: [
+            1: "hel",
+            2: "lo<",
+            3: "stop",
+            4: ">hidden",
+            5: "tail",
+        ])
+        let result = runStopStringLoop(
+            tokens: [1, 2, 3, 4, 5],
+            tokenizer: tokenizer,
+            stopStrings: ["<stop>"]
+        )
+
+        XCTAssertEqual(result.chunks, ["hel", "lo"])
+        XCTAssertEqual(result.consumedTokens, 4)
+        guard case .stop = result.stopReason else {
+            XCTFail("expected stop reason, got \(result.stopReason)")
+            return
+        }
+    }
+
     func testStopStringFilterFlushesBufferedSuffixWhenNoStopArrives() {
         var filter = StopStringFilter(stopStrings: ["<stop>"])
 
@@ -125,5 +147,68 @@ final class StopStringTests: XCTestCase {
     ) {
         XCTAssertTrue(configuration.extraEOSTokens.contains(token), file: file, line: line)
         XCTAssertTrue(configuration.stopStrings.contains(token), file: file, line: line)
+    }
+}
+
+private func runStopStringLoop(
+    tokens: [Int],
+    tokenizer: Tokenizer,
+    stopStrings: Set<String>
+) -> (chunks: [String], consumedTokens: Int, stopReason: GenerateStopReason) {
+    var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+    var filter = StopStringFilter(stopStrings: stopStrings)
+    var chunks: [String] = []
+    var consumedTokens = 0
+
+    for token in tokens {
+        consumedTokens += 1
+        detokenizer.append(token: token)
+        guard let chunk = detokenizer.next() else {
+            continue
+        }
+        let result = filter.process(chunk)
+        if let text = result.text {
+            chunks.append(text)
+        }
+        if result.stopped {
+            return (chunks, consumedTokens, .stop)
+        }
+    }
+
+    if let text = filter.finish() {
+        chunks.append(text)
+    }
+    return (chunks, consumedTokens, .length)
+}
+
+private struct DeterministicStopStringTokenizer: Tokenizer {
+    let decoding: [Int: String]
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        []
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.map { decoding[$0] ?? "" }.joined()
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        nil
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        decoding[id]
+    }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        []
     }
 }

--- a/Tests/MLXLMTests/StopStringTests.swift
+++ b/Tests/MLXLMTests/StopStringTests.swift
@@ -38,11 +38,10 @@ final class StopStringTests: XCTestCase {
         XCTAssertEqual(config.stopStrings, ["<turn|>", "<fallback>"])
     }
 
-    func testModelConfigurationResolutionPreservesStopStrings() {
+    func testModelConfigurationResolutionFallsBackToExtraEOSTokens() {
         let config = ModelConfiguration(
             id: "org/model",
             extraEOSTokens: ["<extra>"],
-            stopStrings: ["<stop>"],
             eosTokenIds: [7]
         )
 
@@ -51,9 +50,45 @@ final class StopStringTests: XCTestCase {
             tokenizerDirectory: URL(filePath: "/tmp/tokenizer")
         )
 
+        XCTAssertNil(config.stopStrings)
+        XCTAssertEqual(config.effectiveStopStrings, ["<extra>"])
         XCTAssertEqual(resolved.extraEOSTokens, ["<extra>"])
-        XCTAssertEqual(resolved.stopStrings, ["<stop>"])
+        XCTAssertEqual(resolved.stopStrings, ["<extra>"])
         XCTAssertEqual(resolved.eosTokenIds, [7])
+    }
+
+    func testModelConfigurationResolutionPreservesExplicitStopStrings() {
+        let config = ModelConfiguration(
+            id: "org/model",
+            extraEOSTokens: ["<extra>"],
+            stopStrings: ["<stop>"]
+        )
+
+        let resolved = config.resolved(
+            modelDirectory: URL(filePath: "/tmp/model"),
+            tokenizerDirectory: URL(filePath: "/tmp/tokenizer")
+        )
+
+        XCTAssertEqual(config.stopStrings, Set(["<stop>"]))
+        XCTAssertEqual(config.effectiveStopStrings, ["<stop>"])
+        XCTAssertEqual(resolved.stopStrings, ["<stop>"])
+    }
+
+    func testModelConfigurationResolutionPreservesExplicitEmptyStopStrings() {
+        let config = ModelConfiguration(
+            id: "org/model",
+            extraEOSTokens: ["<extra>"],
+            stopStrings: []
+        )
+
+        let resolved = config.resolved(
+            modelDirectory: URL(filePath: "/tmp/model"),
+            tokenizerDirectory: URL(filePath: "/tmp/tokenizer")
+        )
+
+        XCTAssertEqual(config.stopStrings, Set<String>())
+        XCTAssertEqual(config.effectiveStopStrings, [])
+        XCTAssertEqual(resolved.stopStrings, [])
     }
 
     func testStopStringSplitAcrossChunksStopsAndIsNotEmitted() {
@@ -133,7 +168,7 @@ final class StopStringTests: XCTestCase {
         assertStops(LLMRegistry.llama3_2_3B_4bit, "<|eot_id|>")
 
         assertStops(VLMRegistry.gemma3_4B_qat_4bit, "<end_of_turn>")
-        assertStops(VLMRegistry.gemma4_E2B_it_4bit, "<end_of_turn>")
+        assertStops(VLMRegistry.gemma4_E2B_it_4bit, "<turn|>")
         assertStops(VLMRegistry.qwen2VL2BInstruct4Bit, "<|im_end|>")
         assertStops(VLMRegistry.qwen3VL4BInstruct8Bit, "<|im_end|>")
         assertStops(VLMRegistry.qwen3_5_27B_4bit, "<|im_end|>")
@@ -146,7 +181,8 @@ final class StopStringTests: XCTestCase {
         line: UInt = #line
     ) {
         XCTAssertTrue(configuration.extraEOSTokens.contains(token), file: file, line: line)
-        XCTAssertTrue(configuration.stopStrings.contains(token), file: file, line: line)
+        XCTAssertTrue(configuration.effectiveStopStrings.contains(token), file: file, line: line)
+        XCTAssertNil(configuration.stopStrings, file: file, line: line)
     }
 }
 

--- a/Tests/MLXLMTests/StopStringTests.swift
+++ b/Tests/MLXLMTests/StopStringTests.swift
@@ -168,7 +168,6 @@ final class StopStringTests: XCTestCase {
         assertStops(LLMRegistry.llama3_2_3B_4bit, "<|eot_id|>")
 
         assertStops(VLMRegistry.gemma3_4B_qat_4bit, "<end_of_turn>")
-        assertStops(VLMRegistry.gemma4_E2B_it_4bit, "<turn|>")
         assertStops(VLMRegistry.qwen2VL2BInstruct4Bit, "<|im_end|>")
         assertStops(VLMRegistry.qwen3VL4BInstruct8Bit, "<|im_end|>")
         assertStops(VLMRegistry.qwen3_5_27B_4bit, "<|im_end|>")

--- a/Tests/MLXLMTests/StopStringTests.swift
+++ b/Tests/MLXLMTests/StopStringTests.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLLM
+import MLXVLM
+import XCTest
+
+@testable import MLXLMCommon
+
+final class StopStringTests: XCTestCase {
+
+    func testGenerationConfigDecodesStopStringsArray() throws {
+        let data = Data(
+            """
+            {
+              "eos_token_id": [1, 2],
+              "stop_strings": ["<|im_end|>", "<end_of_turn>"]
+            }
+            """.utf8)
+
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: data)
+
+        XCTAssertEqual(config.eosTokenIds?.values, [1, 2])
+        XCTAssertEqual(config.stopStrings, ["<|im_end|>", "<end_of_turn>"])
+    }
+
+    func testGenerationConfigDecodesSingleStopStringAndStopAlias() throws {
+        let data = Data(
+            """
+            {
+              "stop_strings": "<turn|>",
+              "stop": ["<fallback>"]
+            }
+            """.utf8)
+
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: data)
+
+        XCTAssertEqual(config.stopStrings, ["<turn|>", "<fallback>"])
+    }
+
+    func testModelConfigurationResolutionPreservesStopStrings() {
+        let config = ModelConfiguration(
+            id: "org/model",
+            extraEOSTokens: ["<extra>"],
+            stopStrings: ["<stop>"],
+            eosTokenIds: [7]
+        )
+
+        let resolved = config.resolved(
+            modelDirectory: URL(filePath: "/tmp/model"),
+            tokenizerDirectory: URL(filePath: "/tmp/tokenizer")
+        )
+
+        XCTAssertEqual(resolved.extraEOSTokens, ["<extra>"])
+        XCTAssertEqual(resolved.stopStrings, ["<stop>"])
+        XCTAssertEqual(resolved.eosTokenIds, [7])
+    }
+
+    func testStopStringSplitAcrossChunksStopsAndIsNotEmitted() {
+        var filter = StopStringFilter(stopStrings: ["<stop>"])
+
+        let first = filter.process("hel")
+        let second = filter.process("lo<")
+        let third = filter.process("stop")
+        let fourth = filter.process(">hidden")
+        let fifth = filter.process("tail")
+
+        XCTAssertEqual(first.text, "hel")
+        XCTAssertFalse(first.stopped)
+        XCTAssertEqual(second.text, "lo")
+        XCTAssertFalse(second.stopped)
+        XCTAssertNil(third.text)
+        XCTAssertFalse(third.stopped)
+        XCTAssertNil(fourth.text)
+        XCTAssertTrue(fourth.stopped)
+        XCTAssertNil(fifth.text)
+        XCTAssertTrue(fifth.stopped)
+    }
+
+    func testStopStringFilterFlushesBufferedSuffixWhenNoStopArrives() {
+        var filter = StopStringFilter(stopStrings: ["<stop>"])
+
+        let first = filter.process("hello<")
+        let second = filter.process("world")
+
+        XCTAssertEqual(first.text, "hello")
+        XCTAssertFalse(first.stopped)
+        XCTAssertEqual(second.text, "<world")
+        XCTAssertFalse(second.stopped)
+        XCTAssertNil(filter.finish())
+    }
+
+    func testEmptyStopStringsAreIgnored() {
+        var filter = StopStringFilter(stopStrings: [""])
+
+        let result = filter.process("visible")
+
+        XCTAssertEqual(result.text, "visible")
+        XCTAssertFalse(result.stopped)
+    }
+
+    func testKnownRegistryEntriesExposeFamilyStopDefaults() {
+        assertStops(LLMRegistry.gemma3_1B_qat_4bit, "<end_of_turn>")
+        assertStops(LLMRegistry.gemma3n_E4B_it_lm_4bit, "<end_of_turn>")
+        assertStops(LLMRegistry.gemma4_e2b_it_4bit, "<turn|>")
+        assertStops(LLMRegistry.qwen3_0_6b_4bit, "<|im_end|>")
+        assertStops(LLMRegistry.qwen3_5_2b_4bit, "<|im_end|>")
+        assertStops(LLMRegistry.phi3_5_4bit, "<|end|>")
+        assertStops(LLMRegistry.phi3_5MoE, "<|end|>")
+        assertStops(LLMRegistry.llama3_8B_4bit, "<|eot_id|>")
+        assertStops(LLMRegistry.llama3_2_3B_4bit, "<|eot_id|>")
+
+        assertStops(VLMRegistry.gemma3_4B_qat_4bit, "<end_of_turn>")
+        assertStops(VLMRegistry.gemma4_E2B_it_4bit, "<end_of_turn>")
+        assertStops(VLMRegistry.qwen2VL2BInstruct4Bit, "<|im_end|>")
+        assertStops(VLMRegistry.qwen3VL4BInstruct8Bit, "<|im_end|>")
+        assertStops(VLMRegistry.qwen3_5_27B_4bit, "<|im_end|>")
+    }
+
+    private func assertStops(
+        _ configuration: ModelConfiguration,
+        _ token: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(configuration.extraEOSTokens.contains(token), file: file, line: line)
+        XCTAssertTrue(configuration.stopStrings.contains(token), file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary
- decode stop string metadata from generation_config.json and model registry entries
- propagate stop strings through resolved model configuration and generation handlers
- stop decoded text generation when a stop string spans token chunks without emitting the stop sequence

## Scope
This PR is intentionally limited to runtime stop-string handling. It does not include the broader DFlash, MTP, or TurboQuant stack from the staging branch this was split from.

## Validation
- swift build --target MLXLMCommon
- swift build --target MLXLLM
- swift build --target MLXVLM
- swift test --filter StopStringTests
- pre-commit run --all-files
- git diff --check