### PR TITLE
Fix Gemma4 VLM end token defaults

### DIFF
--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -214,25 +214,25 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma4_E2B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_E4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_31B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-31b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let gemma4_26BA4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-26b-a4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<turn|>"]
     )
 
     static public let smolvlm = ModelConfiguration(

--- a/Tests/MLXLMTests/VLMRegistryTests.swift
+++ b/Tests/MLXLMTests/VLMRegistryTests.swift
@@ -1,0 +1,18 @@
+// Copyright © 2026 Apple Inc.
+
+import MLXVLM
+import XCTest
+
+final class VLMRegistryTests: XCTestCase {
+
+    func testGemma4VLMRegistryUsesTurnEndToken() {
+        for configuration in [
+            VLMRegistry.gemma4_E2B_it_4bit,
+            VLMRegistry.gemma4_E4B_it_4bit,
+            VLMRegistry.gemma4_31B_it_4bit,
+            VLMRegistry.gemma4_26BA4B_it_4bit,
+        ] {
+            XCTAssertEqual(configuration.extraEOSTokens, ["<turn|>"])
+        }
+    }
+}


### PR DESCRIPTION
This fixes the Gemma4 VLM registry defaults to use `<turn|>`.

The LLM Gemma4 entries already use this token. This makes the VLM entries match that.

Tests:
- `swift test --filter VLMRegistryTests`
- `swift build --target MLXVLM`
- `git diff --check`