### PR TITLE
Add reranker API support

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/RerankerIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/RerankerIntegrationTests.swift
@@ -1,0 +1,30 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import HuggingFace
+import IntegrationTestHelpers
+import MLXHuggingFace
+import MLXLMCommon
+import Testing
+import Tokenizers
+
+@Suite(.serialized)
+struct RerankerModelIntegrationTests {
+    private let downloader = #hubDownloader()
+    private let tokenizerLoader = #huggingFaceTokenizerLoader()
+
+    @Test func bgeV2M3ReferenceScores() async throws {
+        try await RerankerIntegrationTests.bgeV2M3(
+            downloader: downloader, tokenizerLoader: tokenizerLoader)
+    }
+
+    @Test func qwen3ReferenceScores() async throws {
+        try await RerankerIntegrationTests.qwen3(
+            downloader: downloader, tokenizerLoader: tokenizerLoader)
+    }
+
+    @Test func jinaV3RelevanceScores() async throws {
+        try await RerankerIntegrationTests.jinaV3(
+            downloader: downloader, tokenizerLoader: tokenizerLoader)
+    }
+}

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -7,6 +7,7 @@ import MLX
 import MLXEmbedders
 import MLXLLM
 import MLXLMCommon
+import MLXRerankers
 import MLXVLM
 
 #if canImport(CoreImage)
@@ -761,6 +762,148 @@ public enum EmbedderTests {
                 "Similarity mismatch for \(documentNames[index]): expected \(expectedSimilarities[index]), got \(resultSimilarity)"
             )
         }
+    }
+}
+
+// MARK: - Reranker Tests
+
+/// End-to-end checks against reference checkpoint outputs.
+///
+/// These checks download large model weights and belong in the separate IntegrationTesting
+/// project rather than the package test suite.
+public enum RerankerIntegrationTests {
+    /// Validate BGE v2 M3 logits against the values published in its model card.
+    public static func bgeV2M3(
+        downloader: any Downloader,
+        tokenizerLoader: any TokenizerLoader
+    ) async throws {
+        let modelID = "BAAI/bge-reranker-v2-m3"
+        let reranker = try await RerankerModelFactory.shared.loadContainer(
+            from: downloader, using: tokenizerLoader,
+            configuration: ModelConfiguration(
+                id: modelID,
+                revision: "953dc6f6f85a1b2dbfca4c34a2796e7dde08d41e"),
+            progressHandler: logProgress(modelID))
+        let response = try await reranker.scores(
+            query: "what is panda?",
+            documents: [
+                "hi",
+                "The giant panda (Ailuropoda melanoleuca), sometimes called a panda bear or simply panda, is a bear species endemic to China.",
+            ])
+
+        try check(
+            response.scoreKind == .normalizedRelevance,
+            "BGE must return normalized relevance scores")
+        try check(response.results.count == 2, "BGE returned an unexpected score count")
+        let logits = try response.results.map {
+            try inverseSigmoid($0.score, modelID: modelID)
+        }
+        try check(
+            abs(logits[0] - -8.1875) < 0.15,
+            "BGE irrelevant-passage logit diverged: expected -8.1875, received \(logits[0])")
+        try check(
+            abs(logits[1] - 5.261_718_75) < 0.15,
+            "BGE relevant-passage logit diverged: expected 5.26171875, received \(logits[1])")
+    }
+
+    /// Validate Qwen3 reranker logit margins against its published reference values.
+    public static func qwen3(
+        downloader: any Downloader,
+        tokenizerLoader: any TokenizerLoader
+    ) async throws {
+        let modelID = "Qwen/Qwen3-Reranker-0.6B"
+        let reranker = try await RerankerModelFactory.shared.loadContainer(
+            from: downloader, using: tokenizerLoader,
+            configuration: ModelConfiguration(
+                id: modelID,
+                revision: "e61197ed45024b0ed8a2d74b80b4d909f1255473"),
+            progressHandler: logProgress(modelID))
+        let response = try await reranker.scores(
+            query: "What is the capital of China?",
+            documents: [
+                "The capital of China is Beijing.",
+                "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.",
+            ])
+        let sequentialResponse = try await reranker.scores(
+            query: "What is the capital of China?",
+            documents: [
+                "The capital of China is Beijing.",
+                "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.",
+            ],
+            options: .init(maxBatchSize: 1))
+
+        try check(
+            response.scoreKind == .normalizedRelevance,
+            "Qwen3 must return normalized relevance scores")
+        try check(response.results.count == 2, "Qwen3 returned an unexpected score count")
+        let margins = try response.results.map {
+            try inverseSigmoid($0.score, modelID: modelID)
+        }
+        let sequentialMargins = try sequentialResponse.results.map {
+            try inverseSigmoid($0.score, modelID: modelID)
+        }
+        for index in margins.indices {
+            try check(
+                abs(margins[index] - sequentialMargins[index]) < 0.01,
+                "Qwen3 batched and sequential margins diverged at index \(index): \(margins[index]) versus \(sequentialMargins[index])"
+            )
+        }
+        try check(
+            abs(margins[0] - 7.625) < 0.25,
+            "Qwen3 relevant-passage logit margin diverged: expected 7.625, received \(margins[0])")
+        try check(
+            abs(margins[1] - -11.375) < 1,
+            "Qwen3 irrelevant-passage logit margin diverged: expected -11.375, received \(margins[1])"
+        )
+    }
+
+    /// Validate Jina reranker v3 scores against its published MLX implementation.
+    public static func jinaV3(
+        downloader: any Downloader,
+        tokenizerLoader: any TokenizerLoader
+    ) async throws {
+        let modelID = "jinaai/jina-reranker-v3-mlx"
+        let reranker = try await RerankerModelFactory.shared.loadContainer(
+            from: downloader, using: tokenizerLoader,
+            configuration: ModelConfiguration(
+                id: modelID,
+                revision: "1d19fe38ae4e6658221479747c1152d6136dd6ab"),
+            progressHandler: logProgress(modelID))
+        let response = try await reranker.scores(
+            query: "What is the capital of China?",
+            documents: [
+                "Gravity attracts bodies toward one another.",
+                "Beijing is the capital city of China.",
+            ])
+
+        try check(
+            response.scoreKind == .cosineSimilarity,
+            "Jina must return cosine-similarity scores")
+        try check(response.results.count == 2, "Jina returned an unexpected score count")
+        // Generated by rerank.py from the pinned Jina checkpoint revision above.
+        let expectedScores = [-0.156_369_954_347_610_47, 0.402_552_098_035_812_4]
+        // Quantized kernels can vary slightly with backend evaluation order.
+        let tolerance = 3e-3
+        for index in expectedScores.indices {
+            let result = response.results[index]
+            try check(
+                result.index == index,
+                "Jina scores did not preserve document order at index \(index)")
+            try check(
+                abs(result.score - expectedScores[index]) < tolerance,
+                "Jina score diverged at index \(index): expected \(expectedScores[index]), received \(result.score)"
+            )
+        }
+        try check(
+            response.results[1].score > response.results[0].score,
+            "Jina did not score the relevant passage above the irrelevant passage")
+    }
+
+    private static func inverseSigmoid(_ score: Double, modelID: String) throws -> Double {
+        try check(
+            score > 0 && score < 1,
+            "\(modelID) returned a normalized score at a non-invertible boundary")
+        return Foundation.log(score / (1 - score))
     }
 }
 

--- a/Libraries/IntegrationTestHelpers/README.md
+++ b/Libraries/IntegrationTestHelpers/README.md
@@ -24,3 +24,14 @@ xcodebuild test \
 ```
 
 These tests do not run in CI.
+
+The reranker integration tests download BGE v2 M3, Qwen3 Reranker 0.6B, and Jina
+Reranker v3 checkpoints. To run only those reference checks:
+
+```bash
+xcodebuild test \
+  -project IntegrationTesting/IntegrationTesting.xcodeproj \
+  -scheme IntegrationTesting \
+  -destination 'platform=macOS' \
+  -only-testing:IntegrationTestingTests/RerankerModelIntegrationTests
+```

--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -13,13 +13,24 @@ private func create<C: Decodable, M>(
     }
 }
 
+private func createBertCompatibleModel(configuration data: Data) throws -> any EmbeddingModel {
+    let configuration = try JSONDecoder.json5().decode(BertConfiguration.self, from: data)
+    if configuration.isSequenceClassification {
+        if configuration.modelType == "bert" {
+            return BertSequenceClassificationRerankerModel(configuration)
+        }
+        return BertRerankerModel(configuration)
+    }
+    return BertModel(configuration)
+}
+
 /// Registry of model type, e.g 'bert', to functions that can instantiate the model from configuration.
 public enum EmbedderTypeRegistry {
 
     public static let shared: ModelTypeRegistry<EmbeddingModel> = .init(creators: [
-        "bert": create(BertConfiguration.self) { BertModel($0) },
-        "roberta": create(BertConfiguration.self) { BertModel($0) },
-        "xlm-roberta": create(BertConfiguration.self) { BertModel($0) },
+        "bert": createBertCompatibleModel,
+        "roberta": createBertCompatibleModel,
+        "xlm-roberta": createBertCompatibleModel,
         "distilbert": create(BertConfiguration.self) { BertModel($0) },
 
         "nomic_bert": create(NomicBertConfiguration.self) { NomicBertModel($0, pooler: false) },
@@ -69,6 +80,8 @@ public class EmbedderRegistry: AbstractModelRegistry, @unchecked Sendable {
     public static let snowflake_lg = ModelConfiguration(id: "Snowflake/snowflake-arctic-embed-l")
     /// BGE-M3 - Multi-lingual, Multi-functional, Multi-granularity.
     public static let bge_m3 = ModelConfiguration(id: "BAAI/bge-m3")
+    /// BGE Reranker v2 M3 - multilingual encoder reranker.
+    public static let bge_reranker_v2_m3 = ModelConfiguration(id: "BAAI/bge-reranker-v2-m3")
     /// Mixedbread AI Large v1.
     public static let mixedbread_large = ModelConfiguration(
         id: "mixedbread-ai/mxbai-embed-large-v1")
@@ -110,6 +123,7 @@ public class EmbedderRegistry: AbstractModelRegistry, @unchecked Sendable {
             bge_large,
             snowflake_lg,
             bge_m3,
+            bge_reranker_v2_m3,
             mixedbread_large,
             qwen3_embedding,
             lfm2_embedding_350m,

--- a/Libraries/MLXEmbedders/Models/Bert.swift
+++ b/Libraries/MLXEmbedders/Models/Bert.swift
@@ -18,6 +18,8 @@ private class BertEmbedding: Module {
 
     /// The number of distinct token types the model can distinguish.
     let typeVocabularySize: Int
+    let padTokenID: Int
+    let usesPaddingAwarePositionIDs: Bool
 
     /// The embedding lookup table for the vocabulary.
     @ModuleInfo(key: "word_embeddings") var wordEmbeddings: Embedding
@@ -35,6 +37,8 @@ private class BertEmbedding: Module {
     /// - Parameter config: The `BertConfiguration` containing dimensions, vocabulary sizes, and epsilon values.
     init(_ config: BertConfiguration) {
         typeVocabularySize = config.typeVocabularySize
+        padTokenID = config.padTokenID
+        usesPaddingAwarePositionIDs = config.usesPaddingAwarePositionIDs
 
         // Initialize word embeddings based on vocab size and embedding dimension
         _wordEmbeddings.wrappedValue = Embedding(
@@ -69,13 +73,11 @@ private class BertEmbedding: Module {
         positionIds: MLXArray? = nil,
         tokenTypeIds: MLXArray? = nil
     ) -> MLXArray {
-        // Generate position IDs [0, 1, ..., N] and broadcast to the input shape if not provided
-        let posIds = positionIds ?? broadcast(MLXArray.arange(inputIds.dim(1)), to: inputIds.shape)
+        let posIds = positionIds ?? defaultPositionIDs(for: inputIds)
 
         // Combine word and position embeddings
         var words = wordEmbeddings(inputIds) + positionEmbeddings(posIds)
 
-        // Add token type (segment) embeddings if both IDs and the layer exist
         if let tokenTypeIds, let tokenTypeEmbeddings {
             words += tokenTypeEmbeddings(tokenTypeIds)
         }
@@ -83,6 +85,25 @@ private class BertEmbedding: Module {
         // Final normalization pass
         return norm(words)
     }
+
+    private func defaultPositionIDs(for inputIDs: MLXArray) -> MLXArray {
+        bertPositionIDs(
+            inputIDs: inputIDs,
+            padTokenID: padTokenID,
+            paddingAware: usesPaddingAwarePositionIDs)
+    }
+}
+
+package func bertPositionIDs(
+    inputIDs: MLXArray,
+    padTokenID: Int,
+    paddingAware: Bool
+) -> MLXArray {
+    guard paddingAware else {
+        return broadcast(MLXArray.arange(inputIDs.dim(1)), to: inputIDs.shape)
+    }
+    let nonPadding = (inputIDs .!= padTokenID).asType(.int32)
+    return MLX.cumsum(nonPadding, axis: 1) * nonPadding + padTokenID
 }
 
 /// A single Transformer Encoder layer implementing BERT-style architecture.
@@ -235,6 +256,21 @@ private class LMHead: Module {
     }
 }
 
+/// Sequence-classification head used by BERT/RoBERTa reranker checkpoints.
+private class SequenceClassificationHead: Module {
+    @ModuleInfo(key: "dense") var dense: Linear
+    @ModuleInfo(key: "out_proj") var outProjection: Linear
+
+    init(_ config: BertConfiguration) {
+        _dense.wrappedValue = Linear(config.embedDim, config.embedDim, bias: true)
+        _outProjection.wrappedValue = Linear(config.embedDim, config.numLabels, bias: true)
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        outProjection(tanh(dense(hiddenStates[0..., 0])))
+    }
+}
+
 // MARK: - BERT Model
 
 /// The complete BERT model implementation.
@@ -302,35 +338,14 @@ public class BertModel: Module, EmbeddingModel {
         tokenTypeIds: MLXArray? = nil,
         attentionMask: MLXArray? = nil
     ) -> EmbeddingModelOutput {
-        var inp = inputs
-        if inp.ndim == 1 {
-            inp = inp.reshaped(1, -1)
-        }
-        var mask = attentionMask
-        var typeIds = tokenTypeIds
-        var posIds = positionIds
-        if _maxPositionEmbeddings > 0, inp.dim(1) > _maxPositionEmbeddings {
-            print(
-                "Warning: Input length \(inp.dim(1)) exceeds maxPositionEmbeddings"
-                    + " (\(_maxPositionEmbeddings)), truncating."
-            )
-            inp = inp[0..., ..<_maxPositionEmbeddings]
-            mask = mask?[0..., ..<_maxPositionEmbeddings]
-            typeIds = typeIds?[0..., ..<_maxPositionEmbeddings]
-            posIds = posIds?[0..., ..<_maxPositionEmbeddings]
-        }
-        let embeddings = embedder(inp, positionIds: posIds, tokenTypeIds: typeIds)
-        if mask != nil {
-            // Cast mask to the same dtype as the embeddings output so it is
-            // compatible with scaled_dot_product_attention's type promotion
-            // rules. Using the embedding weight dtype can produce a mismatch
-            // when Linear layers are quantized to float16 but Embedding
-            // weights remain float32.
-            mask = mask!.asType(embeddings.dtype).expandedDimensions(axes: [
-                1, 2,
-            ]).log()
-        }
-        let outputs = encoder(embeddings, attentionMask: mask)
+        let outputs = encodedBertHiddenStates(
+            inputs,
+            maxPositionEmbeddings: _maxPositionEmbeddings,
+            embedder: embedder,
+            encoder: encoder,
+            positionIds: positionIds,
+            tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
         if let lmHead {
             return EmbeddingModelOutput(hiddenStates: lmHead(outputs), pooledOutput: nil)
         } else {
@@ -344,37 +359,230 @@ public class BertModel: Module, EmbeddingModel {
     /// This is essential for loading pre-trained weights, as it renames keys
     /// like `attention.output.dense` to `attention.out_proj`.
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        weights.reduce(into: [:]) { result, item in
-            let key = item.key
-                .replacingOccurrences(of: ".layer.", with: ".layers.")
-                .replacingOccurrences(of: ".self.key.", with: ".key_proj.")
-                .replacingOccurrences(of: ".self.query.", with: ".query_proj.")
-                .replacingOccurrences(of: ".self.value.", with: ".value_proj.")
-                .replacingOccurrences(of: ".attention.output.dense.", with: ".attention.out_proj.")
-                .replacingOccurrences(of: ".attention.output.LayerNorm.", with: ".ln1.")
-                .replacingOccurrences(of: ".output.LayerNorm.", with: ".ln2.")
-                .replacingOccurrences(of: ".intermediate.dense.", with: ".linear1.")
-                .replacingOccurrences(of: ".output.dense.", with: ".linear2.")
-                .replacingOccurrences(of: ".LayerNorm.", with: ".norm.")
-                .replacingOccurrences(of: "pooler.dense.", with: "pooler.")
-                .replacingOccurrences(
-                    of: "cls.predictions.transform.dense.", with: "lm_head.dense."
-                )
-                .replacingOccurrences(
-                    of: "cls.predictions.transform.LayerNorm.", with: "lm_head.ln."
-                )
-                .replacingOccurrences(of: "cls.predictions.decoder", with: "lm_head.decoder")
-                .replacingOccurrences(
-                    of: "cls.predictions.transform.norm.weight", with: "lm_head.ln.weight"
-                )
-                .replacingOccurrences(
-                    of: "cls.predictions.transform.norm.bias", with: "lm_head.ln.bias"
-                )
-                .replacingOccurrences(of: "cls.predictions.bias", with: "lm_head.decoder.bias")
-                .replacingOccurrences(of: "bert.", with: "")
+        sanitizeBertWeights(weights)
+    }
+}
 
-            result[key] = item.value
-        }.filter { key, _ in key != "embeddings.position_ids" }
+/// BERT/RoBERTa-style sequence-classification model used by encoder reranker checkpoints.
+public class BertRerankerModel: Module, RerankerModel {
+
+    @ModuleInfo(key: "embeddings") fileprivate var embedder: BertEmbedding
+    fileprivate let encoder: Encoder
+
+    /// Sequence-classification head that produces reranker logits.
+    @ModuleInfo(key: "classifier") fileprivate var classifier: SequenceClassificationHead
+
+    /// The total count of tokens in the model's vocabulary.
+    public var vocabularySize: Int
+
+    public var maxPositionEmbeddings: Int? {
+        _maxPositionEmbeddings > 0 ? _maxPositionEmbeddings : nil
+    }
+    private let _maxPositionEmbeddings: Int
+    package let rerankerConfiguration: EncoderRerankerModelConfiguration
+
+    public init(_ config: BertConfiguration) {
+        precondition(config.vocabularySize > 0)
+        vocabularySize = config.vocabularySize
+        rerankerConfiguration = config.encoderRerankerConfiguration
+        _maxPositionEmbeddings = config.maxPositionEmbeddings
+        _embedder.wrappedValue = BertEmbedding(config)
+        encoder = Encoder(config)
+        _classifier.wrappedValue = SequenceClassificationHead(config)
+    }
+
+    public func callAsFunction(
+        _ inputs: MLXArray,
+        positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    ) -> EmbeddingModelOutput {
+        let outputs = encodedBertHiddenStates(
+            inputs,
+            maxPositionEmbeddings: _maxPositionEmbeddings,
+            embedder: embedder,
+            encoder: encoder,
+            positionIds: positionIds,
+            tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
+        return EmbeddingModelOutput(hiddenStates: outputs, pooledOutput: nil)
+    }
+
+    public func score(
+        _ inputs: MLXArray,
+        positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    ) -> MLXArray {
+        let outputs = encodedBertHiddenStates(
+            inputs,
+            maxPositionEmbeddings: _maxPositionEmbeddings,
+            embedder: embedder,
+            encoder: encoder,
+            positionIds: positionIds,
+            tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
+        return classifier(outputs)
+    }
+
+    /// Maps external weight names (e.g., from Hugging Face) to this class's internal structure.
+    ///
+    /// This is essential for loading pre-trained weights, as it renames keys
+    /// like `attention.output.dense` to `attention.out_proj`.
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        sanitizeBertWeights(weights)
+    }
+}
+
+/// BERT sequence-classification model used by reranker checkpoints with pooled-output heads.
+public class BertSequenceClassificationRerankerModel: Module, RerankerModel {
+
+    @ModuleInfo(key: "embeddings") fileprivate var embedder: BertEmbedding
+    fileprivate let encoder: Encoder
+
+    /// A linear layer used to pool the [CLS] token before classification.
+    @ModuleInfo fileprivate var pooler: Linear
+
+    /// BERT classifier head that produces reranker logits from pooled output.
+    @ModuleInfo fileprivate var classifier: Linear
+
+    /// The total count of tokens in the model's vocabulary.
+    public var vocabularySize: Int
+
+    public var maxPositionEmbeddings: Int? {
+        _maxPositionEmbeddings > 0 ? _maxPositionEmbeddings : nil
+    }
+    private let _maxPositionEmbeddings: Int
+    package let rerankerConfiguration: EncoderRerankerModelConfiguration
+
+    public init(_ config: BertConfiguration) {
+        precondition(config.vocabularySize > 0)
+        vocabularySize = config.vocabularySize
+        rerankerConfiguration = config.encoderRerankerConfiguration
+        _maxPositionEmbeddings = config.maxPositionEmbeddings
+        _embedder.wrappedValue = BertEmbedding(config)
+        encoder = Encoder(config)
+        _pooler.wrappedValue = Linear(config.embedDim, config.embedDim)
+        _classifier.wrappedValue = Linear(config.embedDim, config.numLabels, bias: true)
+    }
+
+    public func callAsFunction(
+        _ inputs: MLXArray,
+        positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    ) -> EmbeddingModelOutput {
+        let outputs = encodedBertHiddenStates(
+            inputs,
+            maxPositionEmbeddings: _maxPositionEmbeddings,
+            embedder: embedder,
+            encoder: encoder,
+            positionIds: positionIds,
+            tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
+        return EmbeddingModelOutput(hiddenStates: outputs, pooledOutput: pooledOutput(outputs))
+    }
+
+    public func score(
+        _ inputs: MLXArray,
+        positionIds: MLXArray? = nil,
+        tokenTypeIds: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
+    ) -> MLXArray {
+        let outputs = encodedBertHiddenStates(
+            inputs,
+            maxPositionEmbeddings: _maxPositionEmbeddings,
+            embedder: embedder,
+            encoder: encoder,
+            positionIds: positionIds,
+            tokenTypeIds: tokenTypeIds,
+            attentionMask: attentionMask)
+        return classifier(pooledOutput(outputs))
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        sanitizeBertWeights(weights)
+    }
+
+    private func pooledOutput(_ hiddenStates: MLXArray) -> MLXArray {
+        tanh(pooler(hiddenStates[0..., 0]))
+    }
+}
+
+private func encodedBertHiddenStates(
+    _ inputs: MLXArray,
+    maxPositionEmbeddings: Int,
+    embedder: BertEmbedding,
+    encoder: Encoder,
+    positionIds: MLXArray? = nil,
+    tokenTypeIds: MLXArray? = nil,
+    attentionMask: MLXArray? = nil
+) -> MLXArray {
+    var inp = inputs
+    if inp.ndim == 1 {
+        inp = inp.reshaped(1, -1)
+    }
+    var mask = attentionMask
+    var typeIds = tokenTypeIds
+    var posIds = positionIds
+    if maxPositionEmbeddings > 0, inp.dim(1) > maxPositionEmbeddings {
+        print(
+            "Warning: Input length \(inp.dim(1)) exceeds maxPositionEmbeddings"
+                + " (\(maxPositionEmbeddings)), truncating."
+        )
+        inp = inp[0..., ..<maxPositionEmbeddings]
+        mask = mask?[0..., ..<maxPositionEmbeddings]
+        typeIds = typeIds?[0..., ..<maxPositionEmbeddings]
+        posIds = posIds?[0..., ..<maxPositionEmbeddings]
+    }
+    let embeddings = embedder(inp, positionIds: posIds, tokenTypeIds: typeIds)
+    if mask != nil {
+        // Cast mask to the same dtype as the embeddings output so it is
+        // compatible with scaled_dot_product_attention's type promotion
+        // rules. Using the embedding weight dtype can produce a mismatch
+        // when Linear layers are quantized to float16 but Embedding
+        // weights remain float32.
+        mask = mask!.asType(embeddings.dtype).expandedDimensions(axes: [
+            1, 2,
+        ]).log()
+    }
+    return encoder(embeddings, attentionMask: mask)
+}
+
+private func sanitizeBertWeights(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+    weights.reduce(into: [:]) { result, item in
+        let key = item.key
+            .replacingOccurrences(of: ".layer.", with: ".layers.")
+            .replacingOccurrences(of: ".self.key.", with: ".key_proj.")
+            .replacingOccurrences(of: ".self.query.", with: ".query_proj.")
+            .replacingOccurrences(of: ".self.value.", with: ".value_proj.")
+            .replacingOccurrences(of: ".attention.output.dense.", with: ".attention.out_proj.")
+            .replacingOccurrences(of: ".attention.output.LayerNorm.", with: ".ln1.")
+            .replacingOccurrences(of: ".output.LayerNorm.", with: ".ln2.")
+            .replacingOccurrences(of: ".intermediate.dense.", with: ".linear1.")
+            .replacingOccurrences(of: ".output.dense.", with: ".linear2.")
+            .replacingOccurrences(of: ".LayerNorm.", with: ".norm.")
+            .replacingOccurrences(of: "pooler.dense.", with: "pooler.")
+            .replacingOccurrences(
+                of: "cls.predictions.transform.dense.", with: "lm_head.dense."
+            )
+            .replacingOccurrences(
+                of: "cls.predictions.transform.LayerNorm.", with: "lm_head.ln."
+            )
+            .replacingOccurrences(of: "cls.predictions.decoder", with: "lm_head.decoder")
+            .replacingOccurrences(
+                of: "cls.predictions.transform.norm.weight", with: "lm_head.ln.weight"
+            )
+            .replacingOccurrences(
+                of: "cls.predictions.transform.norm.bias", with: "lm_head.ln.bias"
+            )
+            .replacingOccurrences(of: "cls.predictions.bias", with: "lm_head.decoder.bias")
+            .replacingOccurrences(of: "bert.", with: "")
+            .replacingOccurrences(of: "roberta.", with: "")
+
+        result[key] = item.value
+    }.filter { key, _ in
+        key != "embeddings.position_ids"
     }
 }
 
@@ -463,6 +671,71 @@ public struct BertConfiguration: Decodable, Sendable {
     /// The identifier for the model (e.g., "bert" or "distilbert").
     var modelType: String
 
+    /// Declared Hugging Face architecture names.
+    var architectures: [String] = []
+
+    /// Number of labels for sequence-classification heads.
+    var numLabels: Int = 1
+
+    /// Class labels declared by Hugging Face configuration metadata.
+    var idToLabel: [Int: String] = [:]
+
+    /// Token ID used for padding.
+    var padTokenID: Int = 0
+
+    var usesPaddingAwarePositionIDs: Bool {
+        modelType == "roberta" || modelType == "xlm-roberta"
+    }
+
+    var encoderRerankerConfiguration: EncoderRerankerModelConfiguration {
+        let inputKind: EncoderRerankerModelConfiguration.InputKind =
+            usesPaddingAwarePositionIDs ? .xlmRoberta : .bert
+        let maximumInputTokens: Int? =
+            if maxPositionEmbeddings > 0 {
+                usesPaddingAwarePositionIDs
+                    ? maxPositionEmbeddings - padTokenID - 1
+                    : maxPositionEmbeddings
+            } else {
+                nil
+            }
+        if numLabels == 1 {
+            return .init(
+                inputKind: inputKind,
+                padTokenID: padTokenID,
+                maxInputTokens: maximumInputTokens,
+                scorePolicy: .singleLogit(transform: .sigmoid),
+                scoreKind: .normalizedRelevance)
+        }
+        guard let positiveClassIndex else {
+            return .init(
+                inputKind: inputKind,
+                padTokenID: padTokenID,
+                maxInputTokens: maximumInputTokens,
+                scorePolicy: nil,
+                scoreKind: .normalizedRelevance)
+        }
+        return .init(
+            inputKind: inputKind,
+            padTokenID: padTokenID,
+            maxInputTokens: maximumInputTokens,
+            scorePolicy: .softmaxProbability(classIndex: positiveClassIndex),
+            scoreKind: .normalizedRelevance)
+    }
+
+    private var positiveClassIndex: Int? {
+        let positiveLabels: Set<String> = [
+            "entailment", "label1", "positive", "relevant", "relevance", "true", "yes",
+        ]
+        return idToLabel.first { _, label in
+            let normalized = label.lowercased().filter { $0.isLetter || $0.isNumber }
+            return positiveLabels.contains(normalized)
+        }?.key
+    }
+
+    var isSequenceClassification: Bool {
+        architectures.contains { $0.contains("ForSequenceClassification") }
+    }
+
     // MARK: - Decoding Keys
 
     enum CodingKeys: String, CodingKey {
@@ -471,6 +744,11 @@ public struct BertConfiguration: Decodable, Sendable {
         case vocabularySize = "vocab_size"
         case maxPositionEmbeddings = "max_position_embeddings"
         case modelType = "model_type"
+        case architectures
+        case numLabels = "num_labels"
+        case padTokenID = "pad_token_id"
+        case idToLabel = "id2label"
+        case labelToID = "label2id"
     }
 
     /// Standard BERT naming conventions in JSON.
@@ -502,6 +780,22 @@ public struct BertConfiguration: Decodable, Sendable {
         maxPositionEmbeddings =
             try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 0
         modelType = try container.decode(String.self, forKey: .modelType)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        let stringIDToLabel =
+            try container.decodeIfPresent([String: String].self, forKey: .idToLabel) ?? [:]
+        idToLabel = Dictionary(
+            uniqueKeysWithValues: stringIDToLabel.compactMap { key, value in
+                Int(key).map { ($0, value) }
+            })
+        let labelToID =
+            try container.decodeIfPresent([String: Int].self, forKey: .labelToID) ?? [:]
+        for (label, id) in labelToID where idToLabel[id] == nil {
+            idToLabel[id] = label
+        }
+        numLabels =
+            try container.decodeIfPresent(Int.self, forKey: .numLabels)
+            ?? max((idToLabel.keys.max() ?? -1) + 1, 1)
+        padTokenID = try container.decodeIfPresent(Int.self, forKey: .padTokenID) ?? 0
 
         // Switch decoding logic based on model type
         if modelType == "distilbert" {

--- a/Libraries/MLXEmbedders/Reranker.swift
+++ b/Libraries/MLXEmbedders/Reranker.swift
@@ -1,0 +1,300 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+package enum EncoderRerankerScorePolicy: Sendable, Equatable {
+    case singleLogit(transform: ScalarTransform)
+    case classLogit(index: Int, transform: ScalarTransform)
+    case binaryMargin(positive: Int, negative: Int, transform: ScalarTransform)
+    case softmaxProbability(classIndex: Int)
+
+    package enum ScalarTransform: Sendable, Equatable {
+        case identity
+        case sigmoid
+
+        func callAsFunction(_ value: Double) -> Double {
+            switch self {
+            case .identity:
+                value
+            case .sigmoid:
+                if value >= 0 {
+                    1 / (1 + Foundation.exp(-value))
+                } else {
+                    Foundation.exp(value) / (1 + Foundation.exp(value))
+                }
+            }
+        }
+    }
+}
+
+package struct EncoderRerankerModelConfiguration: Sendable {
+    package enum InputKind: Sendable {
+        case bert
+        case xlmRoberta
+    }
+
+    package var inputKind: InputKind
+    package var padTokenID: Int
+    package var maxInputTokens: Int?
+    package var scorePolicy: EncoderRerankerScorePolicy?
+    package var scoreKind: RerankScoreKind
+}
+
+/// Encoder models with a sequence-classification head that produces reranker logits.
+package protocol RerankerModel: EmbeddingModel {
+    var rerankerConfiguration: EncoderRerankerModelConfiguration { get }
+
+    func score(
+        _ inputs: MLXArray,
+        positionIds: MLXArray?,
+        tokenTypeIds: MLXArray?,
+        attentionMask: MLXArray?
+    ) throws -> MLXArray
+}
+
+extension EmbedderModelContainer {
+    /// The score semantics declared by the loaded encoder reranker.
+    package var rerankerScoreKind: RerankScoreKind? {
+        get async {
+            await perform { context in
+                guard
+                    let configuration =
+                        (context.model as? any RerankerModel)?.rerankerConfiguration,
+                    configuration.scorePolicy != nil
+                else {
+                    return nil
+                }
+                return configuration.scoreKind
+            }
+        }
+    }
+
+    /// Score an encoder reranker in original document order.
+    package func rerankerScores(
+        query: String,
+        documents: [String],
+        options: RerankExecutionOptions
+    ) async throws -> [Double] {
+        guard !documents.isEmpty else { return [] }
+
+        return try await perform(nonSendable: (query, documents, options)) { context, values in
+            let (query, documents, options) = values
+            guard let model = context.model as? any RerankerModel else {
+                throw RerankerError.unsupportedModel(
+                    "\(type(of: context.model)) does not expose reranker logits.")
+            }
+
+            let configuration = model.rerankerConfiguration
+            guard let scorePolicy = configuration.scorePolicy else {
+                throw RerankerError.unsupportedModel(
+                    "Unable to identify the positive class for this encoder reranker. Provide id2label or label2id metadata in config.json."
+                )
+            }
+            let processor: any RerankerInputProcessor =
+                switch configuration.inputKind {
+                case .bert: BERTRerankerInputProcessor()
+                case .xlmRoberta: XLMRobertaRerankerInputProcessor()
+                }
+            let maxInputTokens = minimum(
+                minimum(configuration.maxInputTokens, model.maxPositionEmbeddings),
+                options.maxBatchTokens)
+
+            var encoded = try documents.enumerated().map { index, document in
+                try Task.checkCancellation()
+                let input = try processor.encode(
+                    query: query,
+                    document: document,
+                    tokenizer: context.tokenizer,
+                    maxInputTokens: maxInputTokens,
+                    truncation: options.truncation)
+                guard !input.tokenIds.isEmpty else {
+                    throw RerankerError.emptyPrompt
+                }
+                return EncodedDocument(index: index, input: input)
+            }
+            encoded.sort {
+                if $0.input.tokenIds.count == $1.input.tokenIds.count {
+                    $0.index < $1.index
+                } else {
+                    $0.input.tokenIds.count < $1.input.tokenIds.count
+                }
+            }
+
+            var scores = [Double?](repeating: nil, count: documents.count)
+            for batchDocuments in makeMicroBatches(encoded, options: options) {
+                try Task.checkCancellation()
+                let batch = try makeBatch(
+                    batchDocuments, padTokenID: configuration.padTokenID)
+                let logits = try model.score(
+                    batch.inputIDs,
+                    positionIds: nil,
+                    tokenTypeIds: batch.tokenTypeIDs,
+                    attentionMask: batch.attentionMask)
+                logits.eval()
+                let batchScores = try selectScores(
+                    logits, batchSize: batchDocuments.count,
+                    policy: scorePolicy)
+                for (item, score) in zip(batchDocuments, batchScores) {
+                    guard score.isFinite else {
+                        throw RerankerError.nonFiniteScore(index: item.index, score: score)
+                    }
+                    scores[item.index] = score
+                }
+            }
+
+            return try scores.enumerated().map { index, score in
+                guard let score else {
+                    throw RerankerError.invalidScoreCount(
+                        expected: documents.count,
+                        actual: scores.compactMap { $0 }.count)
+                }
+                guard score.isFinite else {
+                    throw RerankerError.nonFiniteScore(index: index, score: score)
+                }
+                return score
+            }
+        }
+    }
+}
+
+private struct EncodedDocument {
+    var index: Int
+    var input: RerankerInput
+}
+
+private struct RerankerBatch {
+    var inputIDs: MLXArray
+    var attentionMask: MLXArray
+    var tokenTypeIDs: MLXArray?
+}
+
+private func makeMicroBatches(
+    _ documents: [EncodedDocument],
+    options: RerankExecutionOptions
+) -> [[EncodedDocument]] {
+    var batches = [[EncodedDocument]]()
+    var batch = [EncodedDocument]()
+    var longest = 0
+
+    for document in documents {
+        let nextLongest = max(longest, document.input.tokenIds.count)
+        let nextCount = batch.count + 1
+        let exceedsSize = nextCount > options.maxBatchSize
+        let exceedsTokens = nextLongest * nextCount > options.maxBatchTokens
+        if !batch.isEmpty, exceedsSize || exceedsTokens {
+            batches.append(batch)
+            batch = []
+            longest = 0
+        }
+        batch.append(document)
+        longest = max(longest, document.input.tokenIds.count)
+    }
+    if !batch.isEmpty {
+        batches.append(batch)
+    }
+    return batches
+}
+
+private func makeBatch(
+    _ documents: [EncodedDocument],
+    padTokenID: Int
+) throws -> RerankerBatch {
+    let maxLength = documents.map(\.input.tokenIds.count).max() ?? 0
+    guard maxLength > 0 else { throw RerankerError.emptyPrompt }
+
+    let needsTokenTypes = documents.contains { $0.input.tokenTypeIds != nil }
+    var inputIDs = [Int]()
+    var attentionMask = [Int32]()
+    var tokenTypeIDs = [Int]()
+    inputIDs.reserveCapacity(documents.count * maxLength)
+    attentionMask.reserveCapacity(documents.count * maxLength)
+    tokenTypeIDs.reserveCapacity(documents.count * maxLength)
+
+    for document in documents {
+        let input = document.input
+        let paddingCount = maxLength - input.tokenIds.count
+        inputIDs += input.tokenIds
+        inputIDs += Array(repeating: padTokenID, count: paddingCount)
+        attentionMask += Array(repeating: 1, count: input.tokenIds.count)
+        attentionMask += Array(repeating: 0, count: paddingCount)
+
+        if needsTokenTypes {
+            let values = input.tokenTypeIds ?? Array(repeating: 0, count: input.tokenIds.count)
+            guard values.count == input.tokenIds.count else {
+                throw RerankerError.unsupportedModel(
+                    "tokenTypeIds count \(values.count) does not match tokenIds count \(input.tokenIds.count)."
+                )
+            }
+            tokenTypeIDs += values
+            tokenTypeIDs += Array(repeating: 0, count: paddingCount)
+        }
+    }
+
+    let shape = [documents.count, maxLength]
+    return RerankerBatch(
+        inputIDs: MLXArray(inputIDs).reshaped(shape),
+        attentionMask: MLXArray(attentionMask).reshaped(shape),
+        tokenTypeIDs: needsTokenTypes ? MLXArray(tokenTypeIDs).reshaped(shape) : nil)
+}
+
+private func selectScores(
+    _ logits: MLXArray,
+    batchSize: Int,
+    policy: EncoderRerankerScorePolicy
+) throws -> [Double] {
+    guard logits.ndim == 2, logits.dim(0) == batchSize else {
+        throw RerankerError.invalidLogitShape(logits.shape)
+    }
+    let labelCount = logits.dim(1)
+    let values = logits.asArray(Float.self).map(Double.init)
+
+    func value(row: Int, column: Int) throws -> Double {
+        guard column >= 0, column < labelCount else {
+            throw RerankerError.unsupportedModel(
+                "Reranker class index \(column) is out of bounds for \(labelCount) labels.")
+        }
+        return values[row * labelCount + column]
+    }
+
+    return try (0 ..< batchSize).map { row in
+        switch policy {
+        case .singleLogit(let transform):
+            guard labelCount == 1 else {
+                throw RerankerError.unsupportedModel(
+                    "singleLogit requires exactly one classifier output, but received \(labelCount)."
+                )
+            }
+            return transform(try value(row: row, column: 0))
+
+        case .classLogit(let index, let transform):
+            return transform(try value(row: row, column: index))
+
+        case .binaryMargin(let positive, let negative, let transform):
+            return transform(
+                try value(row: row, column: positive) - value(row: row, column: negative))
+
+        case .softmaxProbability(let classIndex):
+            let selected = try value(row: row, column: classIndex)
+            let rowValues = (0 ..< labelCount).map { values[row * labelCount + $0] }
+            guard let maximum = rowValues.max(), maximum.isFinite else {
+                throw RerankerError.nonFiniteScore(index: row, score: rowValues.max() ?? .nan)
+            }
+            let exponentials = rowValues.map { Foundation.exp($0 - maximum) }
+            let denominator = exponentials.reduce(0, +)
+            guard denominator.isFinite, denominator > 0 else {
+                throw RerankerError.nonFiniteScore(index: row, score: denominator)
+            }
+            return Foundation.exp(selected - maximum) / denominator
+        }
+    }
+}
+
+private func minimum(_ lhs: Int?, _ rhs: Int?) -> Int? {
+    switch (lhs, rhs) {
+    case (.some(let lhs), .some(let rhs)): min(lhs, rhs)
+    case (.some(let value), .none), (.none, .some(let value)): value
+    case (.none, .none): nil
+    }
+}

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -17,6 +17,31 @@ private func create<C: Codable, M>(
     }
 }
 
+private struct ArchitectureConfiguration: Decodable {
+    var architectures: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case architectures
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+    }
+}
+
+private func createQwen3CompatibleModel(configuration data: Data) throws -> any LanguageModel {
+    let architecture = try JSONDecoder.json5().decode(ArchitectureConfiguration.self, from: data)
+    let configuration = try JSONDecoder.json5().decode(Qwen3Configuration.self, from: data)
+    try configuration.validateModelConfiguration()
+
+    if architecture.architectures.contains("JinaForRanking") {
+        return JinaRerankerModel(configuration)
+    }
+
+    return Qwen3Model(configuration)
+}
+
 /// Registry of model type, e.g 'llama', to functions that can instantiate the model from configuration.
 ///
 /// Typically called via ``LLMModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:)``.
@@ -39,7 +64,7 @@ public enum LLMTypeRegistry {
         "gemma4_unified": create(Gemma4Configuration.self, Gemma4Model.init),
         "gemma4_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
         "qwen2": create(Qwen2Configuration.self, Qwen2Model.init),
-        "qwen3": create(Qwen3Configuration.self, Qwen3Model.init),
+        "qwen3": createQwen3CompatibleModel,
         "qwen3_moe": create(Qwen3MoEConfiguration.self, Qwen3MoEModel.init),
         "qwen3_next": create(Qwen3NextConfiguration.self, Qwen3NextModel.init),
         "qwen3_5": create(Qwen35Configuration.self, Qwen35Model.init),
@@ -317,6 +342,10 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         extraEOSTokens: ["<|im_end|>"]
     )
 
+    static public let jina_reranker_v3_mlx = ModelConfiguration(
+        id: "jinaai/jina-reranker-v3-mlx"
+    )
+
     static public let qwen3MoE_30b_a3b_4bit = ModelConfiguration(
         id: "mlx-community/Qwen3-30B-A3B-4bit",
         defaultPrompt: "Why is the sky blue?",
@@ -517,6 +546,7 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
             qwen3_1_7b_4bit,
             qwen3_4b_4bit,
             qwen3_8b_4bit,
+            jina_reranker_v3_mlx,
             qwen3MoE_30b_a3b_4bit,
             qwen3_5_2b_4bit,
             qwen3_6_27b_4bit,

--- a/Libraries/MLXLLM/Models/JinaReranker.swift
+++ b/Libraries/MLXLLM/Models/JinaReranker.swift
@@ -1,0 +1,127 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+private final class JinaRerankerProjector: Module {
+    @ModuleInfo(key: "linear1") var linear1: Linear
+    @ModuleInfo(key: "linear2") var linear2: Linear
+
+    init(hiddenSize: Int, projectionSize: Int = 512) {
+        _linear1.wrappedValue = Linear(hiddenSize, projectionSize, bias: false)
+        _linear2.wrappedValue = Linear(projectionSize, projectionSize, bias: false)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        linear2(relu(linear1(input)))
+    }
+}
+
+/// Jina reranker v3 listwise model.
+///
+/// The checkpoint declares `model_type: qwen3` but `architectures: ["JinaForRanking"]`.
+/// It uses Qwen3 hidden states at `<|embed_token|>` and `<|rerank_token|>` positions,
+/// projects them with `projector.safetensors`, then scores documents by cosine similarity.
+public final class JinaRerankerModel: Module, LanguageModel, KVCacheDimensionProvider,
+    ListwiseRerankerModel
+{
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+
+    @ModuleInfo(key: "model") var model: Qwen3ModelInner
+    @ModuleInfo(key: "projector") private var projector: JinaRerankerProjector
+
+    public init(_ configuration: Qwen3Configuration) {
+        self.vocabularySize = configuration.vocabularySize
+        self.kvHeads = (0 ..< configuration.hiddenLayers).map { _ in configuration.kvHeads }
+        _model.wrappedValue = Qwen3ModelInner(configuration)
+        _projector.wrappedValue = JinaRerankerProjector(hiddenSize: configuration.hiddenSize)
+    }
+
+    public func prepare(
+        _ input: LMInput,
+        cache: [KVCache],
+        state: LMOutput.State?,
+        prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    public func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+    {
+        .init(logits: callAsFunction(input.tokens, cache: cache))
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        model.embedTokens.asLinear(model(inputs, cache: cache))
+    }
+
+    package func score(input: RerankerInput, documentCount: Int) throws -> [Double] {
+        guard !input.tokenIds.isEmpty else {
+            throw RerankerError.emptyPrompt
+        }
+        guard let markerTokenIds = input.markerTokenIds else {
+            throw RerankerError.unsupportedModel(
+                "Jina reranker input is missing marker token IDs.")
+        }
+
+        let queryPositions = input.tokenIds.indices.filter {
+            input.tokenIds[$0] == markerTokenIds.query
+        }
+        let documentPositions = input.tokenIds.indices.filter {
+            input.tokenIds[$0] == markerTokenIds.document
+        }
+
+        guard let queryPosition = queryPositions.first else {
+            throw RerankerError.missingSpecialToken("<|rerank_token|>")
+        }
+        guard queryPositions.count == 1 else {
+            throw RerankerError.unsupportedModel(
+                "Expected exactly one <|rerank_token|>, found \(queryPositions.count).")
+        }
+        guard documentPositions.count == documentCount else {
+            throw RerankerError.missingSpecialToken("<|embed_token|>")
+        }
+
+        let inputIds = MLXArray(input.tokenIds).reshaped(1, -1)
+        let hiddenStates = model(inputIds, cache: nil)[0]
+
+        let queryHidden = hiddenStates[queryPosition][.newAxis, 0...]
+        let documentHidden = stacked(documentPositions.map { hiddenStates[$0] })
+
+        let queryEmbedding = projector(queryHidden)
+        let documentEmbeddings = projector(documentHidden)
+
+        let scores = jinaCosineSimilarity(documentEmbeddings, queryEmbedding)
+
+        scores.eval()
+        return scores.asArray(Float.self).map(Double.init)
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.reduce(into: [:]) { result, item in
+            switch item.key {
+            case "linear1.weight":
+                result["projector.linear1.weight"] = item.value
+            case "linear2.weight":
+                result["projector.linear2.weight"] = item.value
+            default:
+                result[item.key] = item.value
+            }
+        }
+    }
+}
+
+func jinaCosineSimilarity(_ documents: MLXArray, _ query: MLXArray) -> MLXArray {
+    let numerator = MLX.sum(documents * query, axis: -1)
+    let documentNorm = MLX.sqrt(MLX.sum(documents * documents, axis: -1))
+    let queryNorm = MLX.sqrt(MLX.sum(query * query, axis: -1))
+    let denominator = documentNorm * queryNorm
+    return MLX.clip(
+        numerator / MLX.maximum(denominator, MLXArray(1e-12)),
+        min: -1,
+        max: 1)
+}

--- a/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
@@ -9,6 +9,21 @@ Common language model code.
 - <doc:wired-memory>
 - <doc:kv-cache-quantization>
 
+## Reranking
+
+- ``Reranker``
+- ``RerankerContainer``
+- ``RerankRequest``
+- ``RerankDocument``
+- ``RerankResult``
+- ``RerankedDocument``
+- ``RerankResponse``
+- ``RerankDocumentsResponse``
+- ``RerankExecutionOptions``
+- ``RerankTruncationPolicy``
+- ``RerankScoreKind``
+- ``RerankerError``
+
 ## Other MLX Libraries Packages
 
 - [MLXEmbedders](MLXEmbedders)

--- a/Libraries/MLXLMCommon/Reranker.swift
+++ b/Libraries/MLXLMCommon/Reranker.swift
@@ -1,0 +1,1321 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// The semantic meaning and numeric range of scores returned by a reranker.
+public enum RerankScoreKind: Sendable, Equatable {
+    /// A model-specific relevance score normalized to the closed range `0...1`.
+    ///
+    /// This value is not necessarily a calibrated probability. Its scale can differ across
+    /// models, revisions, quantizations, prompts, and instructions.
+    case normalizedRelevance
+
+    /// Cosine similarity in the closed range `-1...1`.
+    case cosineSimilarity
+
+    /// An unbounded model logit.
+    case logit
+
+    package var validRange: ClosedRange<Double>? {
+        switch self {
+        case .normalizedRelevance:
+            0 ... 1
+        case .cosineSimilarity:
+            -1 ... 1
+        case .logit:
+            nil
+        }
+    }
+}
+
+/// Controls how inputs that exceed a model's context limit are handled.
+public enum RerankTruncationPolicy: Sendable {
+    /// Truncate model input content while preserving required structural prompt tokens.
+    case truncate
+
+    /// Reject an overlong input instead of truncating it.
+    case error
+}
+
+/// Resource limits and execution behavior for a reranking operation.
+public struct RerankExecutionOptions: Sendable {
+    /// Maximum number of query-document pairs in one pairwise model batch.
+    public var maxBatchSize: Int
+
+    /// Maximum number of token slots in one model forward pass.
+    ///
+    /// For pairwise models this bounds `batchSize * paddedSequenceLength`. For listwise
+    /// models it bounds the complete query-and-document prompt.
+    public var maxBatchTokens: Int
+
+    /// Preferred number of tokens processed by each cached causal-model prefill step.
+    public var prefillStepSize: Int
+
+    /// Behavior when an input exceeds the model context limit.
+    public var truncation: RerankTruncationPolicy
+
+    /// Create execution options for pairwise and listwise rerankers.
+    ///
+    /// - Parameters:
+    ///   - maxBatchSize: Maximum number of pairs evaluated in one batch.
+    ///   - maxBatchTokens: Maximum token allocation for one model forward pass.
+    ///   - prefillStepSize: Preferred cached prefill chunk size for causal models.
+    ///   - truncation: Behavior for inputs that exceed the model context limit.
+    public init(
+        maxBatchSize: Int = 16,
+        maxBatchTokens: Int = 8_192,
+        prefillStepSize: Int = 512,
+        truncation: RerankTruncationPolicy = .truncate
+    ) {
+        self.maxBatchSize = maxBatchSize
+        self.maxBatchTokens = maxBatchTokens
+        self.prefillStepSize = prefillStepSize
+        self.truncation = truncation
+    }
+}
+
+/// A request to score and order candidate documents by relevance to a query.
+public struct RerankRequest: Sendable {
+    /// The search query or user intent.
+    public var query: String
+
+    /// Candidate documents to score.
+    public var documents: [String]
+
+    /// Optional model instruction for instruction-aware rerankers.
+    public var instruction: String?
+
+    /// Maximum number of highest-scoring results to return.
+    public var topK: Int?
+
+    /// Optional inclusive lower score bound.
+    ///
+    /// Thresholds are supported only by rerankers with a declared bounded score range.
+    public var minimumScore: Double?
+
+    /// Create a request for sorted reranking.
+    ///
+    /// - Parameters:
+    ///   - query: Search query or user intent.
+    ///   - documents: Candidate documents to score.
+    ///   - instruction: Optional task instruction for instruction-aware models.
+    ///   - topK: Maximum number of sorted results to return, or `nil` for all results.
+    ///   - minimumScore: Inclusive score threshold applied before `topK`.
+    public init(
+        query: String,
+        documents: [String],
+        instruction: String? = nil,
+        topK: Int? = nil,
+        minimumScore: Double? = nil
+    ) {
+        self.query = query
+        self.documents = documents
+        self.instruction = instruction
+        self.topK = topK
+        self.minimumScore = minimumScore
+    }
+}
+
+/// A text document with an application-defined identifier and metadata.
+///
+/// The reranker evaluates only ``text``. The identifier and metadata are carried through
+/// unchanged so callers can reconnect results to their retrieval records without copying
+/// model-specific data into the scoring layer.
+public struct RerankDocument: Sendable, Identifiable, Equatable {
+    /// Application-defined stable identifier.
+    public var id: String
+
+    /// Text evaluated by the reranker.
+    public var text: String
+
+    /// Application metadata preserved in results but not evaluated by the model.
+    public var metadata: [String: String]
+
+    public init(id: String, text: String, metadata: [String: String] = [:]) {
+        self.id = id
+        self.text = text
+        self.metadata = metadata
+    }
+}
+
+/// The relevance score for one candidate document.
+public struct RerankResult: Sendable {
+    /// The document's position in the request's `documents` array.
+    public let index: Int
+
+    /// The model's relevance score.
+    public let score: Double
+
+    public init(index: Int, score: Double) {
+        self.index = index
+        self.score = score
+    }
+}
+
+/// The result of a reranking operation.
+public struct RerankResponse: Sendable {
+    /// Identifier of the model that produced the scores.
+    public let modelID: String
+
+    /// Semantic meaning and numeric range of ``results`` scores.
+    public let scoreKind: RerankScoreKind
+
+    /// Scored documents in original or descending relevance order, depending on the API used.
+    public let results: [RerankResult]
+
+    public init(modelID: String, scoreKind: RerankScoreKind, results: [RerankResult]) {
+        self.modelID = modelID
+        self.scoreKind = scoreKind
+        self.results = results
+    }
+}
+
+/// A structured document and its relevance score.
+public struct RerankedDocument: Sendable {
+    /// The document's position in the request array.
+    public let index: Int
+
+    /// The original document, including its identifier and metadata.
+    public let document: RerankDocument
+
+    /// The model's relevance score.
+    public let score: Double
+
+    public init(index: Int, document: RerankDocument, score: Double) {
+        self.index = index
+        self.document = document
+        self.score = score
+    }
+}
+
+/// The result of scoring or reranking structured documents.
+public struct RerankDocumentsResponse: Sendable {
+    /// Identifier of the model that produced the scores.
+    public let modelID: String
+
+    /// Semantic meaning and numeric range of ``results`` scores.
+    public let scoreKind: RerankScoreKind
+
+    /// Structured document results in original or descending relevance order.
+    public let results: [RerankedDocument]
+
+    public init(
+        modelID: String,
+        scoreKind: RerankScoreKind,
+        results: [RerankedDocument]
+    ) {
+        self.modelID = modelID
+        self.scoreKind = scoreKind
+        self.results = results
+    }
+}
+
+/// Architecture-neutral interface for local reranker models.
+///
+/// Use ``scores(query:documents:instruction:options:)`` when scores must stay aligned with
+/// the input documents. Use ``rerank(_:options:)`` for sorted retrieval results.
+///
+/// Rerankers consume document text rather than cached document embeddings. Pairwise
+/// cross-encoders jointly encode each query-document pair, while listwise models jointly
+/// encode the query and complete candidate set. Independently computed document embeddings
+/// therefore cannot reproduce their relevance scores.
+public protocol Reranker: Sendable {
+    /// Identifier of the loaded model.
+    var modelID: String { get }
+
+    /// Semantic meaning and numeric range of returned scores.
+    var scoreKind: RerankScoreKind { get }
+
+    /// Score documents while preserving their original order.
+    func scores(
+        query: String,
+        documents: [String],
+        instruction: String?,
+        options: RerankExecutionOptions
+    ) async throws -> RerankResponse
+}
+
+extension Reranker {
+    /// Score documents without changing their original order.
+    public func scores(
+        query: String,
+        documents: [String],
+        instruction: String? = nil,
+        options: RerankExecutionOptions = .init()
+    ) async throws -> RerankResponse {
+        try await scores(
+            query: query,
+            documents: documents,
+            instruction: instruction,
+            options: options)
+    }
+
+    /// Score and sort documents by descending relevance.
+    public func rerank(
+        _ request: RerankRequest,
+        options: RerankExecutionOptions = .init()
+    ) async throws -> RerankResponse {
+        try validate(request: request, options: options, scoreKind: scoreKind)
+        var response = try await scores(
+            query: request.query,
+            documents: request.documents,
+            instruction: request.instruction,
+            options: options)
+        try validate(
+            response: response,
+            documentCount: request.documents.count,
+            expectedModelID: modelID,
+            expectedScoreKind: scoreKind)
+
+        var results = sortedByDescendingScore(response.results)
+        if let minimumScore = request.minimumScore {
+            results.removeAll { $0.score < minimumScore }
+        }
+        if let topK = request.topK {
+            results = Array(results.prefix(topK))
+        }
+
+        response = RerankResponse(
+            modelID: response.modelID, scoreKind: response.scoreKind, results: results)
+        return response
+    }
+
+    /// Score and sort documents by descending relevance.
+    public func rerank(
+        query: String,
+        documents: [String],
+        instruction: String? = nil,
+        topK: Int? = nil,
+        minimumScore: Double? = nil,
+        options: RerankExecutionOptions = .init()
+    ) async throws -> RerankResponse {
+        try await rerank(
+            RerankRequest(
+                query: query,
+                documents: documents,
+                instruction: instruction,
+                topK: topK,
+                minimumScore: minimumScore),
+            options: options)
+    }
+
+    /// Score structured documents while preserving their original order.
+    public func scores(
+        query: String,
+        documents: [RerankDocument],
+        instruction: String? = nil,
+        options: RerankExecutionOptions = .init()
+    ) async throws -> RerankDocumentsResponse {
+        try validateUniqueDocumentIDs(documents)
+        let response = try await scores(
+            query: query,
+            documents: documents.map(\.text),
+            instruction: instruction,
+            options: options)
+        return try structuredResponse(
+            response,
+            documents: documents,
+            expectedModelID: modelID,
+            expectedScoreKind: scoreKind,
+            requiresCompleteOriginalOrder: true)
+    }
+
+    /// Score and sort structured documents by descending relevance.
+    public func rerank(
+        query: String,
+        documents: [RerankDocument],
+        instruction: String? = nil,
+        topK: Int? = nil,
+        minimumScore: Double? = nil,
+        options: RerankExecutionOptions = .init()
+    ) async throws -> RerankDocumentsResponse {
+        try validateUniqueDocumentIDs(documents)
+        let response = try await rerank(
+            query: query,
+            documents: documents.map(\.text),
+            instruction: instruction,
+            topK: topK,
+            minimumScore: minimumScore,
+            options: options)
+        return try structuredResponse(
+            response,
+            documents: documents,
+            expectedModelID: modelID,
+            expectedScoreKind: scoreKind,
+            requiresCompleteOriginalOrder: false)
+    }
+}
+
+/// A thread-safe, type-erased reranker returned by model factories.
+public final class RerankerContainer: Reranker, Sendable {
+    /// Architecture-specific scoring operation stored by the type-erased container.
+    public typealias ScoreOperation =
+        @Sendable (
+            _ query: String,
+            _ documents: [String],
+            _ instruction: String?,
+            _ options: RerankExecutionOptions
+        ) async throws -> [Double]
+
+    /// Identifier of the loaded model.
+    public let modelID: String
+
+    /// Semantic meaning and numeric range of returned scores.
+    public let scoreKind: RerankScoreKind
+    private let scoreOperation: ScoreOperation
+
+    /// Create a type-erased reranker around a scoring operation.
+    ///
+    /// The operation must return one finite score per document in original input order.
+    public init(
+        modelID: String,
+        scoreKind: RerankScoreKind,
+        scoreOperation: @escaping ScoreOperation
+    ) {
+        self.modelID = modelID
+        self.scoreKind = scoreKind
+        self.scoreOperation = scoreOperation
+    }
+
+    /// Score documents while preserving their original order.
+    public func scores(
+        query: String,
+        documents: [String],
+        instruction: String?,
+        options: RerankExecutionOptions
+    ) async throws -> RerankResponse {
+        let request = RerankRequest(
+            query: query, documents: documents, instruction: instruction)
+        try validate(request: request, options: options, scoreKind: scoreKind)
+        guard !documents.isEmpty else {
+            return RerankResponse(modelID: modelID, scoreKind: scoreKind, results: [])
+        }
+
+        try Task.checkCancellation()
+        let scores = try await scoreOperation(query, documents, instruction, options)
+        guard scores.count == documents.count else {
+            throw RerankerError.invalidScoreCount(
+                expected: documents.count, actual: scores.count)
+        }
+
+        let results = try scores.enumerated().map { index, score in
+            guard score.isFinite else {
+                throw RerankerError.nonFiniteScore(index: index, score: score)
+            }
+            if let range = scoreKind.validRange, !range.contains(score) {
+                throw RerankerError.scoreOutOfRange(index: index, score: score, range: range)
+            }
+            return RerankResult(index: index, score: score)
+        }
+        return RerankResponse(modelID: modelID, scoreKind: scoreKind, results: results)
+    }
+}
+
+/// Tokenized input for an internal reranker model implementation.
+package struct RerankerInput: Sendable {
+    /// Token IDs passed to the model.
+    public var tokenIds: [Int]
+
+    /// Optional segment IDs for BERT-style sentence-pair models.
+    public var tokenTypeIds: [Int]?
+
+    /// Optional model-specific marker IDs used to find pooled query and document states.
+    public var markerTokenIds: RerankerMarkerTokenIds?
+
+    public init(
+        tokenIds: [Int], tokenTypeIds: [Int]? = nil,
+        markerTokenIds: RerankerMarkerTokenIds? = nil
+    ) {
+        self.tokenIds = tokenIds
+        self.tokenTypeIds = tokenTypeIds
+        self.markerTokenIds = markerTokenIds
+    }
+}
+
+/// Token IDs that mark query and document representations in listwise reranker prompts.
+///
+/// Some listwise rerankers, such as Jina reranker v3, score documents by reading hidden
+/// states at special query/document marker tokens. The input processor resolves those
+/// marker IDs through the tokenizer and stores them here so the model does not depend on
+/// hard-coded tokenizer constants.
+package struct RerankerMarkerTokenIds: Sendable {
+    public var query: Int
+    public var document: Int
+
+    public init(query: Int, document: Int) {
+        self.query = query
+        self.document = document
+    }
+}
+
+/// Encodes a query-document pair for a concrete reranker family.
+///
+/// Implement this protocol for pairwise rerankers that score each document independently,
+/// including causal-LM yes/no rerankers and encoder sequence-classification rerankers.
+package protocol RerankerInputProcessor: Sendable {
+    func encode(
+        query: String,
+        document: String,
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int?,
+        truncation: RerankTruncationPolicy
+    ) throws -> RerankerInput
+}
+
+/// Encodes one query with a batch of documents for listwise reranker models.
+///
+/// Implement this protocol for models whose prompt contains the entire candidate set and
+/// whose forward pass returns one score per document.
+package protocol ListwiseRerankerInputProcessor: Sendable {
+    func encode(
+        query: String,
+        documents: [String],
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int?,
+        truncation: RerankTruncationPolicy
+    ) throws -> RerankerInput
+}
+
+/// Models that score a full document list from one reranker prompt.
+package protocol ListwiseRerankerModel: BaseLanguageModel {
+    func score(input: RerankerInput, documentCount: Int) throws -> [Double]
+}
+
+/// Applies a final scalar transform to a reranker logit or logit margin.
+///
+/// Use ``identity`` when the model already returns calibrated scores, probabilities, or
+/// cosine similarities. Use ``sigmoid`` when the raw value is a binary classifier logit or a
+/// true-minus-false logit margin.
+package enum RerankerScoreTransform: Sendable {
+    /// Return the raw score.
+    case identity
+
+    /// Return `sigmoid(score)`.
+    case sigmoid
+
+    public func callAsFunction(_ score: Double) -> Double {
+        switch self {
+        case .identity:
+            return score
+        case .sigmoid:
+            if score >= 0 {
+                return 1 / (1 + Foundation.exp(-score))
+            } else {
+                let exponent = Foundation.exp(score)
+                return exponent / (1 + exponent)
+            }
+        }
+    }
+}
+
+/// Raw classifier-token logits used internally by causal-LM rerankers.
+package struct RerankerLogits: Sendable {
+    public let trueLogit: Double
+    public let falseLogit: Double
+
+    public init(trueLogit: Double, falseLogit: Double) {
+        self.trueLogit = trueLogit
+        self.falseLogit = falseLogit
+    }
+
+    public var difference: Double {
+        trueLogit - falseLogit
+    }
+}
+
+/// Errors thrown while preparing or scoring reranker inputs.
+public enum RerankerError: LocalizedError, Sendable {
+    case emptyQuery
+    case emptyDocument(index: Int)
+    case duplicateDocumentID(String)
+    case invalidTopK(Int)
+    case invalidExecutionOption(name: String, value: Int)
+    case invalidMinimumScore(Double, validRange: ClosedRange<Double>?)
+    case thresholdUnsupported
+    case inputTooLong(actual: Int, maximum: Int)
+    case tooManyDocuments(actual: Int, maximum: Int)
+    case invalidLogitShape([Int])
+    case invalidScoreCount(expected: Int, actual: Int)
+    case invalidResultIndex(index: Int, documentCount: Int)
+    case duplicateResultIndex(Int)
+    case invalidResultOrder(expected: Int, actual: Int)
+    case nonFiniteScore(index: Int, score: Double)
+    case scoreOutOfRange(index: Int, score: Double, range: ClosedRange<Double>)
+    case emptyPrompt
+    case missingClassifierToken(String)
+    case classifierTokenIsNotSingleToken(String, [Int])
+    case missingSpecialToken(String)
+    case truncatedRequiredToken(String)
+    case tokenLimitTooSmall(maxInputTokens: Int, requiredTemplateTokens: Int)
+    case unsupportedModel(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyQuery:
+            "Reranker query must not be empty."
+        case .emptyDocument(let index):
+            "Reranker document at index \(index) must not be empty."
+        case .duplicateDocumentID(let id):
+            "Reranker document identifier '\(id)' is not unique."
+        case .invalidTopK(let value):
+            "topK must be greater than zero, but received \(value)."
+        case .invalidExecutionOption(let name, let value):
+            "\(name) must be greater than zero, but received \(value)."
+        case .invalidMinimumScore(let score, let validRange):
+            if let validRange {
+                "minimumScore \(score) is outside the valid range \(validRange)."
+            } else {
+                "minimumScore must be finite, but received \(score)."
+            }
+        case .thresholdUnsupported:
+            "minimumScore is unavailable for rerankers with unbounded logit scores."
+        case .inputTooLong(let actual, let maximum):
+            "Reranker input contains \(actual) tokens, exceeding the \(maximum)-token limit."
+        case .tooManyDocuments(let actual, let maximum):
+            "Reranker received \(actual) documents, exceeding the limit of \(maximum)."
+        case .invalidLogitShape(let shape):
+            "Reranker logits must have shape [batch, labels], but received \(shape)."
+        case .invalidScoreCount(let expected, let actual):
+            "Reranker returned \(actual) scores for \(expected) documents."
+        case .invalidResultIndex(let index, let documentCount):
+            "Reranker returned document index \(index) for a request containing \(documentCount) documents."
+        case .duplicateResultIndex(let index):
+            "Reranker returned document index \(index) more than once."
+        case .invalidResultOrder(let expected, let actual):
+            "scores must preserve document order; expected index \(expected), received \(actual)."
+        case .nonFiniteScore(let index, let score):
+            "Reranker returned non-finite score \(score) for document \(index)."
+        case .scoreOutOfRange(let index, let score, let range):
+            "Reranker score \(score) for document \(index) is outside \(range)."
+        case .emptyPrompt:
+            "Reranker prompt is empty."
+        case .missingClassifierToken(let token):
+            "Unable to resolve classifier token '\(token)'."
+        case .classifierTokenIsNotSingleToken(let token, let tokenIds):
+            "Classifier token '\(token)' must encode to exactly one token, but encoded to \(tokenIds)."
+        case .missingSpecialToken(let token):
+            "Unable to resolve required special token '\(token)'."
+        case .truncatedRequiredToken(let token):
+            "Reranker prompt truncation removed required token '\(token)'."
+        case .tokenLimitTooSmall(let maxInputTokens, let requiredTemplateTokens):
+            "maxInputTokens (\(maxInputTokens)) is too small for the reranker template (\(requiredTemplateTokens) tokens)."
+        case .unsupportedModel(let message):
+            message
+        }
+    }
+}
+
+/// Qwen3 causal-LM reranker input processing.
+///
+/// This builds the instruction/query/document prompt used by yes/no causal-LM rerankers.
+/// The scoring path reads the next-token logits for the configured positive and negative
+/// classifier tokens and ranks by their margin.
+package struct Qwen3RerankerInputProcessor: RerankerInputProcessor {
+    package var instruction: String
+
+    package init(
+        instruction: String =
+            "Given a web search query, retrieve relevant passages that answer the query"
+    ) {
+        self.instruction = instruction
+    }
+
+    package func encode(
+        query: String,
+        document: String,
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int?,
+        truncation: RerankTruncationPolicy
+    ) throws -> RerankerInput {
+        let prefixTokens = tokenizer.encode(text: Self.prefix, addSpecialTokens: false)
+        let bodyTokens = tokenizer.encode(
+            text:
+                """
+                <Instruct>: \(instruction)
+                <Query>: \(query)
+                <Document>: \(document)
+                """,
+            addSpecialTokens: false)
+        let suffixTokens = tokenizer.encode(text: Self.suffix, addSpecialTokens: false)
+
+        let templateTokenCount = prefixTokens.count + suffixTokens.count
+        let body: ArraySlice<Int>
+        if let maxInputTokens, bodyTokens.count + templateTokenCount > maxInputTokens {
+            guard truncation == .truncate else {
+                throw RerankerError.inputTooLong(
+                    actual: bodyTokens.count + templateTokenCount, maximum: maxInputTokens)
+            }
+            let bodyBudget = maxInputTokens - templateTokenCount
+            guard bodyBudget > 0 else {
+                throw RerankerError.tokenLimitTooSmall(
+                    maxInputTokens: maxInputTokens,
+                    requiredTemplateTokens: templateTokenCount)
+            }
+            body = bodyTokens.prefix(bodyBudget)
+        } else {
+            body = bodyTokens[...]
+        }
+
+        return RerankerInput(tokenIds: prefixTokens + body + suffixTokens)
+    }
+
+    private static let prefix =
+        "<|im_start|>system\n"
+        + "Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n"
+        + "<|im_start|>user\n"
+
+    private static let suffix =
+        "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+}
+
+/// XLM-RoBERTa sentence-pair processing used by BGE v2 rerankers.
+///
+/// The encoded sequence has the standard XLM-RoBERTa pair form:
+/// `<s> query </s></s> document </s>`.
+package struct XLMRobertaRerankerInputProcessor: RerankerInputProcessor {
+    package var bosToken: String
+    package var eosToken: String
+
+    package init(bosToken: String = "<s>", eosToken: String = "</s>") {
+        self.bosToken = bosToken
+        self.eosToken = eosToken
+    }
+
+    package func encode(
+        query: String,
+        document: String,
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int?,
+        truncation: RerankTruncationPolicy
+    ) throws -> RerankerInput {
+        let bosTokenId = try resolveSpecialToken(bosToken, tokenizer: tokenizer)
+        let eosTokenId = try resolveSpecialToken(eosToken, tokenizer: tokenizer)
+
+        let queryTokens = tokenizer.encode(text: query, addSpecialTokens: false)
+        let documentTokens = tokenizer.encode(text: document, addSpecialTokens: false)
+        let truncated = try preparePair(
+            first: queryTokens, second: documentTokens,
+            maxInputTokens: maxInputTokens, specialTokenCount: 4,
+            truncation: truncation)
+
+        let tokenIds =
+            [bosTokenId] + truncated.first + [eosTokenId, eosTokenId]
+            + truncated.second + [eosTokenId]
+        return RerankerInput(
+            tokenIds: tokenIds,
+            tokenTypeIds: Array(repeating: 0, count: tokenIds.count))
+    }
+}
+
+/// BERT sentence-pair processing for sequence-classification rerankers.
+///
+/// The encoded sequence has the standard BERT pair form:
+/// `[CLS] query [SEP] document [SEP]`, with token type IDs set to 0 for the query
+/// segment and 1 for the document segment.
+package struct BERTRerankerInputProcessor: RerankerInputProcessor {
+    package var clsToken: String
+    package var sepToken: String
+
+    package init(clsToken: String = "[CLS]", sepToken: String = "[SEP]") {
+        self.clsToken = clsToken
+        self.sepToken = sepToken
+    }
+
+    package func encode(
+        query: String,
+        document: String,
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int?,
+        truncation: RerankTruncationPolicy
+    ) throws -> RerankerInput {
+        let clsTokenId = try resolveSpecialToken(clsToken, tokenizer: tokenizer)
+        let sepTokenId = try resolveSpecialToken(sepToken, tokenizer: tokenizer)
+
+        let queryTokens = tokenizer.encode(text: query, addSpecialTokens: false)
+        let documentTokens = tokenizer.encode(text: document, addSpecialTokens: false)
+        let truncated = try preparePair(
+            first: queryTokens, second: documentTokens,
+            maxInputTokens: maxInputTokens, specialTokenCount: 3,
+            truncation: truncation)
+
+        let tokenIds =
+            [clsTokenId] + truncated.first + [sepTokenId] + truncated.second
+            + [sepTokenId]
+        let querySegmentLength = truncated.first.count + 2
+        let tokenTypeIds =
+            Array(repeating: 0, count: querySegmentLength)
+            + Array(repeating: 1, count: truncated.second.count + 1)
+
+        return RerankerInput(tokenIds: tokenIds, tokenTypeIds: tokenTypeIds)
+    }
+}
+
+/// Jina reranker v3 listwise prompt processing.
+///
+/// This processor builds a single prompt containing all candidate passages. It appends
+/// the configured document marker token to each passage and the query marker token to the
+/// query block. The model then scores documents from the hidden states at those markers.
+package struct JinaRerankerInputProcessor: ListwiseRerankerInputProcessor {
+    package var instruction: String?
+    package var queryEmbedToken: String
+    package var documentEmbedToken: String
+
+    package init(
+        instruction: String? = nil,
+        queryEmbedToken: String = "<|rerank_token|>",
+        documentEmbedToken: String = "<|embed_token|>"
+    ) {
+        self.instruction = instruction
+        self.queryEmbedToken = queryEmbedToken
+        self.documentEmbedToken = documentEmbedToken
+    }
+
+    package func encode(
+        query: String,
+        documents: [String],
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int?,
+        truncation: RerankTruncationPolicy
+    ) throws -> RerankerInput {
+        let markerTokenIds = RerankerMarkerTokenIds(
+            query: try resolveSpecialToken(queryEmbedToken, tokenizer: tokenizer),
+            document: try resolveSpecialToken(documentEmbedToken, tokenizer: tokenizer))
+        let specialTokens = [queryEmbedToken, documentEmbedToken]
+        let sanitizedQuery = sanitize(query, removing: specialTokens)
+        let sanitizedDocuments = documents.map { sanitize($0, removing: specialTokens) }
+
+        let prompt = renderPrompt(query: sanitizedQuery, documents: sanitizedDocuments)
+        var tokenIds = tokenizer.encode(text: prompt, addSpecialTokens: false)
+        if let maxInputTokens, tokenIds.count > maxInputTokens {
+            guard truncation == .truncate else {
+                throw RerankerError.inputTooLong(actual: tokenIds.count, maximum: maxInputTokens)
+            }
+            tokenIds = try renderTruncatedPromptTokens(
+                query: sanitizedQuery,
+                documents: sanitizedDocuments,
+                tokenizer: tokenizer,
+                maxInputTokens: maxInputTokens,
+                markerTokenIds: markerTokenIds)
+        }
+
+        guard tokenIds.contains(markerTokenIds.query) else {
+            throw RerankerError.truncatedRequiredToken(queryEmbedToken)
+        }
+        guard tokenIds.filter({ $0 == markerTokenIds.document }).count == documents.count else {
+            throw RerankerError.truncatedRequiredToken(documentEmbedToken)
+        }
+
+        return RerankerInput(tokenIds: tokenIds, markerTokenIds: markerTokenIds)
+    }
+
+    private func renderPrompt(query: String, documents: [String]) -> String {
+        var prompt = renderPromptPrefix(query: query, documentCount: documents.count)
+
+        prompt += documents.enumerated().map { index, document in
+            renderDocumentPrefix(index: index) + document + documentEmbedToken
+                + renderDocumentSuffix()
+        }.joined(separator: "\n")
+
+        prompt += renderQueryPrefix(query: query) + queryEmbedToken + renderQuerySuffix()
+
+        return prompt
+    }
+
+    private func renderTruncatedPromptTokens(
+        query: String,
+        documents: [String],
+        tokenizer: any Tokenizer,
+        maxInputTokens: Int,
+        markerTokenIds: RerankerMarkerTokenIds
+    ) throws -> [Int] {
+        let requiredTemplateTokens = tokenizer.encode(
+            text: renderPrompt(
+                query: query,
+                documents: Array(repeating: "", count: documents.count)),
+            addSpecialTokens: false)
+
+        guard maxInputTokens >= requiredTemplateTokens.count else {
+            throw RerankerError.tokenLimitTooSmall(
+                maxInputTokens: maxInputTokens,
+                requiredTemplateTokens: requiredTemplateTokens.count)
+        }
+
+        // Tokenizers can merge across passage and marker boundaries. Always encode the complete
+        // candidate prompt so truncation produces the same token IDs as normal prompt encoding.
+        let maximumDocumentLength = documents.map(\.count).max() ?? 0
+        var lowerBound = 0
+        var upperBound = maximumDocumentLength
+        var bestTokenIds = requiredTemplateTokens
+        while lowerBound <= upperBound {
+            let maximumCharacters = lowerBound + (upperBound - lowerBound) / 2
+            let truncatedDocuments = documents.map {
+                String($0.prefix(maximumCharacters))
+            }
+            let candidateTokenIds = tokenizer.encode(
+                text: renderPrompt(query: query, documents: truncatedDocuments),
+                addSpecialTokens: false)
+            if candidateTokenIds.count <= maxInputTokens {
+                bestTokenIds = candidateTokenIds
+                lowerBound = maximumCharacters + 1
+            } else {
+                upperBound = maximumCharacters - 1
+            }
+        }
+
+        guard bestTokenIds.contains(markerTokenIds.query) else {
+            throw RerankerError.truncatedRequiredToken(queryEmbedToken)
+        }
+        guard bestTokenIds.filter({ $0 == markerTokenIds.document }).count == documents.count else {
+            throw RerankerError.truncatedRequiredToken(documentEmbedToken)
+        }
+        return bestTokenIds
+    }
+
+    private func renderPromptPrefix(query: String, documentCount: Int) -> String {
+        var prompt =
+            """
+            <|im_start|>system
+            You are a search relevance expert who can determine a ranking of the passages based on how relevant they are to the query. If the query is a question, how relevant a passage is depends on how well it answers the question. If not, try to analyze the intent of the query and assess how well each passage satisfies the intent. If an instruction is provided, you should follow the instruction when determining the ranking.<|im_end|>
+            <|im_start|>user
+            I will provide you with \(documentCount) passages, each indicated by a numerical identifier. Rank the passages based on their relevance to query: \(query)
+
+            """
+
+        if let instruction {
+            prompt +=
+                """
+                <instruct>
+                \(instruction)
+                </instruct>
+
+                """
+        }
+
+        return prompt
+    }
+
+    private func renderDocumentPrefix(index: Int) -> String {
+        "<passage id=\"\(index)\">\n"
+    }
+
+    private func renderDocumentSuffix() -> String {
+        "\n</passage>"
+    }
+
+    private func renderQueryPrefix(query: String) -> String {
+        "\n<query>\n\(query)"
+    }
+
+    private func renderQuerySuffix() -> String {
+        "\n</query><|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+    }
+
+    private func sanitize(_ text: String, removing specialTokens: [String]) -> String {
+        specialTokens.reduce(text) { result, token in
+            result.replacingOccurrences(of: token, with: "")
+        }
+    }
+}
+
+extension ModelContainer {
+    /// Score Qwen-style yes/no causal rerankers in document order.
+    package func causalRerankerScores(
+        query: String,
+        documents: [String],
+        instruction: String?,
+        maxInputTokens: Int,
+        options: RerankExecutionOptions
+    ) async throws -> [Double] {
+        guard !documents.isEmpty else { return [] }
+        let instruction =
+            instruction
+            ?? "Given a web search query, retrieve relevant passages that answer the query"
+
+        return try await perform(values: (query, documents, instruction, maxInputTokens, options)) {
+            context, values in
+            let (query, documents, instruction, maxInputTokens, options) = values
+            let scorer = CausalLMReranker(
+                tokenizer: context.tokenizer,
+                inputProcessor: Qwen3RerankerInputProcessor(instruction: instruction),
+                maxInputTokens: maxInputTokens,
+                options: options)
+
+            var encoded = try documents.enumerated().map { index, document in
+                try Task.checkCancellation()
+                return EncodedCausalDocument(
+                    index: index,
+                    input: try scorer.encode(query: query, document: document))
+            }
+            encoded.sort {
+                if $0.input.tokenIds.count == $1.input.tokenIds.count {
+                    $0.index < $1.index
+                } else {
+                    $0.input.tokenIds.count < $1.input.tokenIds.count
+                }
+            }
+
+            var scores = [Double?](repeating: nil, count: documents.count)
+            for batch in causalMicroBatches(encoded, options: options) {
+                try Task.checkCancellation()
+                let batchScores = try scorer.score(batch: batch, model: context.model)
+                for (document, score) in zip(batch, batchScores) {
+                    scores[document.index] = score
+                }
+            }
+            return try scores.enumerated().map { index, score in
+                guard let score else {
+                    throw RerankerError.invalidScoreCount(
+                        expected: documents.count,
+                        actual: scores.compactMap { $0 }.count)
+                }
+                guard score.isFinite else {
+                    throw RerankerError.nonFiniteScore(index: index, score: score)
+                }
+                return score
+            }
+        }
+    }
+
+    /// Score listwise rerankers in document order.
+    package func listwiseRerankerScores(
+        query: String,
+        documents: [String],
+        instruction: String?,
+        maxInputTokens: Int,
+        maximumDocuments: Int,
+        options: RerankExecutionOptions
+    ) async throws -> [Double] {
+        guard !documents.isEmpty else { return [] }
+        guard documents.count <= maximumDocuments else {
+            throw RerankerError.tooManyDocuments(
+                actual: documents.count, maximum: maximumDocuments)
+        }
+
+        return try await perform(
+            values: (query, documents, instruction, maxInputTokens, options)
+        ) { context, values in
+            try Task.checkCancellation()
+            let (query, documents, instruction, maxInputTokens, options) = values
+            guard let model = context.model as? any ListwiseRerankerModel else {
+                throw RerankerError.unsupportedModel(
+                    "\(type(of: context.model)) does not expose listwise reranker scores.")
+            }
+            let input = try JinaRerankerInputProcessor(instruction: instruction).encode(
+                query: query,
+                documents: documents,
+                tokenizer: context.tokenizer,
+                maxInputTokens: min(maxInputTokens, options.maxBatchTokens),
+                truncation: options.truncation)
+            return try model.score(input: input, documentCount: documents.count)
+        }
+    }
+}
+
+private struct CausalLMReranker {
+    let tokenizer: any Tokenizer
+    let inputProcessor: any RerankerInputProcessor
+    let maxInputTokens: Int
+    let options: RerankExecutionOptions
+
+    func encode(query: String, document: String) throws -> RerankerInput {
+        let input = try inputProcessor.encode(
+            query: query,
+            document: document,
+            tokenizer: tokenizer,
+            maxInputTokens: min(maxInputTokens, options.maxBatchTokens),
+            truncation: options.truncation)
+        guard !input.tokenIds.isEmpty else {
+            throw RerankerError.emptyPrompt
+        }
+        return input
+    }
+
+    func score(
+        batch: [EncodedCausalDocument], model: any LanguageModel
+    ) throws -> [Double] {
+        let classifierTokens = try resolveClassifierTokens()
+        if batch.count == 1, let input = batch.first?.input {
+            let lmInput = LMInput(tokens: MLXArray(input.tokenIds))
+            let cache = try model.newCache(parameters: nil)
+            let output = try nextTokenLogits(input: lmInput, model: model, cache: cache)
+            let logits = output[0..., -1, 0...]
+            return [probability(logits: logits, tokens: classifierTokens)]
+        }
+
+        let maxLength = batch.map(\.input.tokenIds.count).max() ?? 0
+        var inputIDs = [Int]()
+        inputIDs.reserveCapacity(batch.count * maxLength)
+        for document in batch {
+            inputIDs += document.input.tokenIds
+            inputIDs += Array(
+                repeating: 0,
+                count: maxLength - document.input.tokenIds.count)
+        }
+        let tokens = MLXArray(inputIDs).reshaped(batch.count, maxLength)
+        let logits = model(LMInput.Text(tokens: tokens), cache: nil, state: nil).logits
+        let scores = batch.enumerated().map { row, document in
+            probability(
+                logits: logits[row, document.input.tokenIds.count - 1],
+                tokens: classifierTokens)
+        }
+        MLX.eval(logits)
+        return scores
+    }
+
+    private func nextTokenLogits(
+        input: LMInput, model: any LanguageModel, cache: [KVCache]
+    ) throws -> MLXArray {
+        switch try model.prepare(
+            input,
+            cache: cache,
+            state: nil,
+            prefill: .init(stepSize: options.prefillStepSize)
+        ) {
+        case .logits(let output):
+            return output.logits
+        case .tokens(let tokens):
+            return withPreparedCache(cache, lengths: tokens.sequenceLengths) {
+                model(tokens[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: nil).logits
+            }
+        }
+    }
+
+    private func resolveClassifierTokens() throws -> (
+        trueTokenId: Int, falseTokenId: Int
+    ) {
+        let trueTokenId = try resolveClassifierToken("yes")
+        let falseTokenId = try resolveClassifierToken("no")
+        return (trueTokenId, falseTokenId)
+    }
+
+    private func resolveClassifierToken(_ token: String) throws -> Int {
+        if let tokenId = tokenizer.convertTokenToId(token) {
+            return tokenId
+        }
+
+        let tokenIds = tokenizer.encode(text: token, addSpecialTokens: false)
+        guard tokenIds.count == 1, let tokenId = tokenIds.first else {
+            if tokenIds.isEmpty {
+                throw RerankerError.missingClassifierToken(token)
+            }
+            throw RerankerError.classifierTokenIsNotSingleToken(token, tokenIds)
+        }
+        return tokenId
+    }
+
+    private func scalarLogit(_ logits: MLXArray, tokenId: Int) -> Double {
+        if logits.ndim == 1 {
+            return Double(logits[tokenId].item(Float.self))
+        }
+        return Double(logits[0, tokenId].item(Float.self))
+    }
+
+    private func probability(
+        logits: MLXArray,
+        tokens: (trueTokenId: Int, falseTokenId: Int)
+    ) -> Double {
+        let trueLogit = scalarLogit(logits, tokenId: tokens.trueTokenId)
+        let falseLogit = scalarLogit(logits, tokenId: tokens.falseTokenId)
+        return RerankerScoreTransform.sigmoid(trueLogit - falseLogit)
+    }
+}
+
+private struct EncodedCausalDocument {
+    var index: Int
+    var input: RerankerInput
+}
+
+private func causalMicroBatches(
+    _ documents: [EncodedCausalDocument],
+    options: RerankExecutionOptions
+) -> [[EncodedCausalDocument]] {
+    var batches = [[EncodedCausalDocument]]()
+    var batch = [EncodedCausalDocument]()
+    var longest = 0
+    for document in documents {
+        let nextLongest = max(longest, document.input.tokenIds.count)
+        let nextCount = batch.count + 1
+        if !batch.isEmpty,
+            nextCount > options.maxBatchSize || nextLongest * nextCount > options.maxBatchTokens
+        {
+            batches.append(batch)
+            batch = []
+            longest = 0
+        }
+        batch.append(document)
+        longest = max(longest, document.input.tokenIds.count)
+    }
+    if !batch.isEmpty {
+        batches.append(batch)
+    }
+    return batches
+}
+
+package func sortedByDescendingScore(_ results: [RerankResult]) -> [RerankResult] {
+    results.sorted {
+        if $0.score == $1.score {
+            return $0.index < $1.index
+        }
+        return $0.score > $1.score
+    }
+}
+
+private func validateUniqueDocumentIDs(_ documents: [RerankDocument]) throws {
+    var identifiers = Set<String>()
+    for document in documents where !identifiers.insert(document.id).inserted {
+        throw RerankerError.duplicateDocumentID(document.id)
+    }
+}
+
+private func structuredResponse(
+    _ response: RerankResponse,
+    documents: [RerankDocument],
+    expectedModelID: String,
+    expectedScoreKind: RerankScoreKind,
+    requiresCompleteOriginalOrder: Bool
+) throws -> RerankDocumentsResponse {
+    try validate(
+        response: response,
+        documentCount: documents.count,
+        expectedModelID: expectedModelID,
+        expectedScoreKind: expectedScoreKind,
+        requiresCompleteOriginalOrder: requiresCompleteOriginalOrder)
+    return RerankDocumentsResponse(
+        modelID: response.modelID,
+        scoreKind: response.scoreKind,
+        results: response.results.map { result in
+            RerankedDocument(
+                index: result.index,
+                document: documents[result.index],
+                score: result.score)
+        })
+}
+
+private func validate(
+    request: RerankRequest,
+    options: RerankExecutionOptions,
+    scoreKind: RerankScoreKind
+) throws {
+    guard !request.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw RerankerError.emptyQuery
+    }
+    if let index = request.documents.firstIndex(where: {
+        $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }) {
+        throw RerankerError.emptyDocument(index: index)
+    }
+    if let topK = request.topK, topK <= 0 {
+        throw RerankerError.invalidTopK(topK)
+    }
+    for (name, value) in [
+        ("maxBatchSize", options.maxBatchSize),
+        ("maxBatchTokens", options.maxBatchTokens),
+        ("prefillStepSize", options.prefillStepSize),
+    ] where value <= 0 {
+        throw RerankerError.invalidExecutionOption(name: name, value: value)
+    }
+    if let minimumScore = request.minimumScore {
+        guard minimumScore.isFinite else {
+            throw RerankerError.invalidMinimumScore(minimumScore, validRange: scoreKind.validRange)
+        }
+        guard let validRange = scoreKind.validRange else {
+            throw RerankerError.thresholdUnsupported
+        }
+        guard validRange.contains(minimumScore) else {
+            throw RerankerError.invalidMinimumScore(minimumScore, validRange: validRange)
+        }
+    }
+}
+
+private func validate(
+    response: RerankResponse,
+    documentCount: Int,
+    expectedModelID: String,
+    expectedScoreKind: RerankScoreKind,
+    requiresCompleteOriginalOrder: Bool = true
+) throws {
+    guard response.modelID == expectedModelID, response.scoreKind == expectedScoreKind else {
+        throw RerankerError.unsupportedModel(
+            "Reranker response metadata does not match the loaded model.")
+    }
+    guard !requiresCompleteOriginalOrder || response.results.count == documentCount else {
+        throw RerankerError.invalidScoreCount(
+            expected: documentCount, actual: response.results.count)
+    }
+    guard response.results.count <= documentCount else {
+        throw RerankerError.invalidScoreCount(
+            expected: documentCount, actual: response.results.count)
+    }
+    var seenIndices = Set<Int>()
+    for (expectedIndex, result) in response.results.enumerated() {
+        guard (0 ..< documentCount).contains(result.index) else {
+            throw RerankerError.invalidResultIndex(
+                index: result.index, documentCount: documentCount)
+        }
+        guard seenIndices.insert(result.index).inserted else {
+            throw RerankerError.duplicateResultIndex(result.index)
+        }
+        if requiresCompleteOriginalOrder, result.index != expectedIndex {
+            throw RerankerError.invalidResultOrder(
+                expected: expectedIndex, actual: result.index)
+        }
+        guard result.score.isFinite else {
+            throw RerankerError.nonFiniteScore(index: result.index, score: result.score)
+        }
+        if let range = response.scoreKind.validRange, !range.contains(result.score) {
+            throw RerankerError.scoreOutOfRange(
+                index: result.index, score: result.score, range: range)
+        }
+    }
+}
+
+private func resolveSpecialToken(_ token: String, tokenizer: any Tokenizer) throws -> Int {
+    if let tokenId = tokenizer.convertTokenToId(token) {
+        return tokenId
+    }
+    let tokenIds = tokenizer.encode(text: token, addSpecialTokens: false)
+    guard tokenIds.count == 1, let tokenId = tokenIds.first else {
+        throw RerankerError.missingSpecialToken(token)
+    }
+    return tokenId
+}
+
+private func preparePair(
+    first: [Int],
+    second: [Int],
+    maxInputTokens: Int?,
+    specialTokenCount: Int,
+    truncation: RerankTruncationPolicy
+) throws -> (first: [Int], second: [Int]) {
+    guard let maxInputTokens else {
+        return (first, second)
+    }
+
+    let tokenBudget = maxInputTokens - specialTokenCount
+    guard tokenBudget > 0 else {
+        throw RerankerError.tokenLimitTooSmall(
+            maxInputTokens: maxInputTokens,
+            requiredTemplateTokens: specialTokenCount)
+    }
+
+    if first.count + second.count > tokenBudget, truncation == .error {
+        throw RerankerError.inputTooLong(
+            actual: first.count + second.count + specialTokenCount,
+            maximum: maxInputTokens)
+    }
+
+    var firstCount = first.count
+    var secondCount = second.count
+    var overflow = firstCount + secondCount - tokenBudget
+    while overflow > 0 {
+        if secondCount >= firstCount, secondCount > 0 {
+            secondCount -= 1
+        } else if firstCount > 0 {
+            firstCount -= 1
+        }
+        overflow -= 1
+    }
+
+    return (Array(first.prefix(firstCount)), Array(second.prefix(secondCount)))
+}

--- a/Libraries/MLXRerankers/Documentation.docc/Documentation.md
+++ b/Libraries/MLXRerankers/Documentation.docc/Documentation.md
@@ -1,0 +1,148 @@
+# ``MLXRerankers``
+
+Load and run local text rerankers with one architecture-neutral API.
+
+`RerankerModelFactory` inspects the checkpoint configuration and selects the matching
+encoder, causal classifier, or listwise implementation. The initial model support covers
+BGE v2 sequence classifiers, Qwen3 causal rerankers, and Jina reranker v3 MLX checkpoints.
+
+## Loading A Reranker
+
+Provide the same downloader and tokenizer loader used by the other mlx-swift-lm model
+factories:
+
+```swift
+import MLXLMCommon
+import MLXRerankers
+
+let reranker = try await RerankerModelFactory.shared.loadContainer(
+    from: downloader,
+    using: tokenizerLoader,
+    id: "mlx-community/Qwen3-Reranker-0.6B-4bit"
+)
+```
+
+The returned `RerankerContainer` hides the model architecture. Loading
+`BAAI/bge-reranker-v2-m3`, `Qwen/Qwen3-Reranker-0.6B`, or
+`jinaai/jina-reranker-v3-mlx` uses the same calling code when compatible MLX weights are
+available.
+
+The downloader is provider-neutral. Applications can pass an internal implementation of
+`Downloader` for private registries or managed caches, or resolve a model themselves and use
+the local-directory overload.
+
+Automatic loading accepts checkpoints whose identifier declares that they are rerankers and
+Jina checkpoints with the explicit `JinaForRanking` architecture. A trusted private checkpoint
+with an opaque identifier can opt in explicitly:
+
+```swift
+let reranker = try await RerankerModelFactory.shared.loadContainer(
+    from: downloader,
+    using: tokenizerLoader,
+    id: "lampo/private-ranking-model",
+    allowUnverifiedModel: true
+)
+```
+
+Do not enable this option for an arbitrary language or sequence-classification model. Those
+architectures can produce valid tensors without having been trained for relevance ranking.
+
+## Reranking Documents
+
+Use `rerank` to return results sorted by descending relevance:
+
+```swift
+let response = try await reranker.rerank(
+    query: "How does Swift structured concurrency work?",
+    documents: candidates,
+    topK: 5
+)
+
+for result in response.results {
+    print(result.score, candidates[result.index])
+}
+```
+
+Use `scores` when the output must remain aligned with the original document order:
+
+```swift
+let response = try await reranker.scores(
+    query: query,
+    documents: candidates
+)
+```
+
+Use `RerankDocument` to preserve application identifiers and string metadata without exposing
+them to the model:
+
+```swift
+let documents = candidates.map {
+    RerankDocument(
+        id: $0.id,
+        text: $0.content,
+        metadata: ["source": $0.source]
+    )
+}
+
+let response = try await reranker.rerank(
+    query: query,
+    documents: documents,
+    topK: 10
+)
+
+for result in response.results {
+    print(result.document.id, result.score)
+}
+```
+
+Document identifiers must be unique within a request. Metadata is carried through unchanged
+and does not affect scoring.
+
+Each response declares its score semantics through `scoreKind`. Qwen and single-logit BGE
+rerankers return model-specific relevance scores normalized to `0...1`, while Jina reranker
+v3 returns cosine similarities. A normalized relevance score is not necessarily a calibrated
+probability. Do not compare scores or reuse thresholds across models, revisions, quantizations,
+prompts, or instructions without application-level evaluation.
+
+## Execution Limits
+
+`RerankExecutionOptions` bounds batch size and token allocation. Pairwise inputs are sorted
+by encoded length, micro-batched under both limits, then restored to their original order.
+`maxBatchTokens` is a hard forward-pass ceiling: it limits padded pairwise batches and the
+complete prompt of a listwise model.
+Choose `.error` truncation when silently shortening a candidate is not acceptable:
+
+```swift
+let options = RerankExecutionOptions(
+    maxBatchSize: 8,
+    maxBatchTokens: 4_096,
+    truncation: .error
+)
+
+let response = try await reranker.rerank(
+    RerankRequest(query: query, documents: candidates, topK: 10),
+    options: options
+)
+```
+
+Jina reranker v3 accepts at most 64 documents in one listwise request. Pairwise BGE and
+Qwen rerankers use token-budgeted micro-batches and check task cancellation between input
+encoding and model batches.
+
+## Model Compatibility
+
+Single-logit encoder rerankers use a sigmoid-normalized relevance score. Multi-label encoder checkpoints
+must provide `id2label` or `label2id` metadata that identifies a positive class such as
+`relevant`, `positive`, `yes`, or `LABEL_1`; ambiguous classifier heads are rejected. Qwen3
+rerankers use the official yes/no logit margin, and Jina reranker v3 uses its listwise marker
+representations and cosine similarity.
+
+The integration test project contains revision-pinned checkpoint checks for BGE v2 M3, Qwen3
+Reranker 0.6B, and Jina reranker v3. They download large model weights and therefore do not
+run as part of the package's normal CI suite.
+
+## Topics
+
+### Model Loading
+
+- ``RerankerModelFactory``

--- a/Libraries/MLXRerankers/RerankerModelFactory.swift
+++ b/Libraries/MLXRerankers/RerankerModelFactory.swift
@@ -1,0 +1,237 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXEmbedders
+import MLXLLM
+import MLXLMCommon
+
+/// Loads supported reranker checkpoints behind one architecture-neutral container.
+///
+/// The factory inspects `config.json` and selects the appropriate encoder, causal, or
+/// listwise implementation. Callers do not provide prompt templates, token IDs, padding
+/// IDs, classifier policies, or model architecture details.
+public final class RerankerModelFactory: Sendable {
+    /// Shared factory with the standard MLX model registries.
+    public static let shared = RerankerModelFactory()
+
+    public init() {}
+
+    /// Download and load a reranker by its model identifier.
+    ///
+    /// The checkpoint's `config.json` determines whether the factory loads an encoder,
+    /// causal, or listwise reranker.
+    ///
+    /// - Parameters:
+    ///   - downloader: Provider used to download model and tokenizer files.
+    ///   - tokenizerLoader: Loader used to construct the model tokenizer.
+    ///   - id: Model identifier, such as `mlx-community/Qwen3-Reranker-0.6B-4bit`.
+    ///   - revision: Model revision to download.
+    ///   - useLatest: Whether to check for a newer cached revision.
+    ///   - allowUnverifiedModel: Allow a custom checkpoint whose identifier does not declare
+    ///     that it is a reranker. Keep this `false` for downloaded third-party models.
+    ///   - progressHandler: Callback that receives model download progress.
+    /// - Returns: An architecture-neutral reranker container.
+    public func loadContainer(
+        from downloader: any Downloader,
+        using tokenizerLoader: any TokenizerLoader,
+        id: String,
+        revision: String = "main",
+        useLatest: Bool = false,
+        allowUnverifiedModel: Bool = false,
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    ) async throws -> RerankerContainer {
+        try await loadContainer(
+            from: downloader,
+            using: tokenizerLoader,
+            configuration: ModelConfiguration(id: id, revision: revision),
+            useLatest: useLatest,
+            allowUnverifiedModel: allowUnverifiedModel,
+            progressHandler: progressHandler)
+    }
+
+    /// Download and load a reranker model.
+    ///
+    /// - Parameters:
+    ///   - downloader: Provider used to download model and tokenizer files.
+    ///   - tokenizerLoader: Loader used to construct the model tokenizer.
+    ///   - configuration: Model and tokenizer source configuration.
+    ///   - useLatest: Whether to check for a newer cached revision.
+    ///   - allowUnverifiedModel: Allow a custom checkpoint whose identifier does not declare
+    ///     that it is a reranker. Keep this `false` for downloaded third-party models.
+    ///   - progressHandler: Callback that receives model download progress.
+    /// - Returns: An architecture-neutral reranker container.
+    public func loadContainer(
+        from downloader: any Downloader,
+        using tokenizerLoader: any TokenizerLoader,
+        configuration: ModelConfiguration,
+        useLatest: Bool = false,
+        allowUnverifiedModel: Bool = false,
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    ) async throws -> RerankerContainer {
+        let resolved = try await resolve(
+            configuration: configuration,
+            from: downloader,
+            useLatest: useLatest,
+            progressHandler: progressHandler)
+        return try await loadContainer(
+            resolved: resolved,
+            modelID: configuration.name,
+            allowUnverifiedModel: allowUnverifiedModel,
+            using: tokenizerLoader)
+    }
+
+    /// Load a reranker from a local model directory.
+    ///
+    /// - Parameters:
+    ///   - directory: Directory containing the model configuration, tokenizer, and weights.
+    ///   - tokenizerLoader: Loader used to construct the model tokenizer.
+    ///   - allowUnverifiedModel: Allow a custom checkpoint whose directory name does not
+    ///     declare that it is a reranker.
+    /// - Returns: An architecture-neutral reranker container.
+    public func loadContainer(
+        from directory: URL,
+        using tokenizerLoader: any TokenizerLoader,
+        allowUnverifiedModel: Bool = false
+    ) async throws -> RerankerContainer {
+        let resolved = ResolvedModelConfiguration(directory: directory)
+        return try await loadContainer(
+            resolved: resolved,
+            modelID: resolved.name,
+            allowUnverifiedModel: allowUnverifiedModel,
+            using: tokenizerLoader)
+    }
+
+    private func loadContainer(
+        resolved: ResolvedModelConfiguration,
+        modelID: String,
+        allowUnverifiedModel: Bool,
+        using tokenizerLoader: any TokenizerLoader
+    ) async throws -> RerankerContainer {
+        let descriptor = try loadDescriptor(from: resolved.modelDirectory)
+        let architecture = try descriptor.architecture(
+            modelID: modelID, allowUnverifiedModel: allowUnverifiedModel)
+
+        switch architecture {
+        case .jina:
+            let context = try await LLMModelFactory.shared._load(
+                configuration: resolved, tokenizerLoader: tokenizerLoader)
+            let container = ModelContainer(context: context)
+            return RerankerContainer(
+                modelID: modelID,
+                scoreKind: .cosineSimilarity
+            ) { query, documents, instruction, options in
+                try await container.listwiseRerankerScores(
+                    query: query,
+                    documents: documents,
+                    instruction: instruction,
+                    maxInputTokens: descriptor.maxPositionEmbeddings ?? 131_072,
+                    maximumDocuments: 64,
+                    options: options)
+            }
+        case .encoder:
+            let context = try await EmbedderModelFactory.shared._load(
+                configuration: resolved, tokenizerLoader: tokenizerLoader)
+            let container = EmbedderModelContainer(context: context)
+            guard let scoreKind = await container.rerankerScoreKind else {
+                throw RerankerError.unsupportedModel(
+                    "\(modelID) did not load an encoder reranker head.")
+            }
+            return RerankerContainer(modelID: modelID, scoreKind: scoreKind) {
+                query, documents, _, options in
+                try await container.rerankerScores(
+                    query: query, documents: documents, options: options)
+            }
+        case .qwen3:
+            let context = try await LLMModelFactory.shared._load(
+                configuration: resolved, tokenizerLoader: tokenizerLoader)
+            let container = ModelContainer(context: context)
+            return RerankerContainer(modelID: modelID, scoreKind: .normalizedRelevance) {
+                query, documents, instruction, options in
+                try await container.causalRerankerScores(
+                    query: query,
+                    documents: documents,
+                    instruction: instruction,
+                    maxInputTokens: min(descriptor.maxPositionEmbeddings ?? 8_192, 8_192),
+                    options: options)
+            }
+        case nil:
+            throw RerankerError.unsupportedModel(
+                "Unsupported reranker model type '\(descriptor.modelType)' with architectures \(descriptor.architectures)."
+            )
+        }
+    }
+
+    private func loadDescriptor(from directory: URL) throws -> RerankerDescriptor {
+        let url = directory.appending(component: "config.json")
+        do {
+            return try JSONDecoder.json5().decode(
+                RerankerDescriptor.self, from: Data(contentsOf: url))
+        } catch let error as DecodingError {
+            throw ModelFactoryError.configurationDecodingError(
+                url.lastPathComponent,
+                directory.lastPathComponent,
+                error)
+        } catch {
+            throw ModelFactoryError.configurationFileError(
+                url.lastPathComponent,
+                directory.lastPathComponent,
+                error)
+        }
+    }
+}
+
+package enum RerankerArchitecture: Sendable, Equatable {
+    case encoder
+    case qwen3
+    case jina
+}
+
+package struct RerankerDescriptor: Decodable, Sendable {
+    var modelType: String
+    var architectures: [String]
+    var maxPositionEmbeddings: Int?
+
+    package func architecture(
+        modelID: String,
+        allowUnverifiedModel: Bool = false
+    ) throws -> RerankerArchitecture? {
+        if architectures.contains("JinaForRanking") {
+            return .jina
+        }
+        let declaresReranker = modelID.localizedCaseInsensitiveContains("rerank")
+        let verified = allowUnverifiedModel || declaresReranker
+        if ["bert", "roberta", "xlm-roberta"].contains(modelType),
+            architectures.contains(where: { $0.contains("ForSequenceClassification") })
+        {
+            guard verified else {
+                throw RerankerError.unsupportedModel(
+                    "Sequence-classification checkpoint '\(modelID)' is not identified as a reranker. Set allowUnverifiedModel only for a trusted custom reranker."
+                )
+            }
+            return .encoder
+        }
+        if modelType == "qwen3", architectures.contains("Qwen3ForCausalLM") {
+            guard verified else {
+                throw RerankerError.unsupportedModel(
+                    "Qwen3 checkpoint '\(modelID)' is not identified as a reranker. Set allowUnverifiedModel only for a trusted custom reranker."
+                )
+            }
+            return .qwen3
+        }
+        return nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architectures
+        case maxPositionEmbeddings = "max_position_embeddings"
+    }
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try container.decode(String.self, forKey: .modelType)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        maxPositionEmbeddings = try container.decodeIfPresent(
+            Int.self, forKey: .maxPositionEmbeddings)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,9 @@ let package = Package(
             name: "MLXEmbedders",
             targets: ["MLXEmbedders"]),
         .library(
+            name: "MLXRerankers",
+            targets: ["MLXRerankers"]),
+        .library(
             name: "MLXHuggingFace",
             targets: ["MLXHuggingFace"]),
         .library(
@@ -116,6 +119,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "MLXRerankers",
+            dependencies: [
+                "MLXLMCommon",
+                "MLXLLM",
+                "MLXEmbedders",
+            ],
+            path: "Libraries/MLXRerankers"
+        ),
+        .target(
             name: "BenchmarkHelpers",
             dependencies: [
                 "MLXLMCommon",
@@ -133,6 +145,7 @@ let package = Package(
                 "MLXLLM",
                 "MLXVLM",
                 "MLXEmbedders",
+                "MLXRerankers",
                 .product(name: "MLX", package: "mlx-swift"),
             ],
             path: "Libraries/IntegrationTestHelpers",
@@ -148,6 +161,7 @@ let package = Package(
                 "MLXLLM",
                 "MLXVLM",
                 "MLXEmbedders",
+                "MLXRerankers",
             ],
             path: "Tests/MLXLMTests",
             exclude: [

--- a/Tests/MLXLMTests/RerankerTests.swift
+++ b/Tests/MLXLMTests/RerankerTests.swift
@@ -1,0 +1,987 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import MLXEmbedders
+@testable import MLXLLM
+@testable import MLXRerankers
+
+struct RerankerTests {
+    @Test func scoresPreserveDocumentOrder() async throws {
+        let reranker = RerankerContainer(
+            modelID: "test/model",
+            scoreKind: .normalizedRelevance
+        ) { _, _, _, _ in [0.2, 0.9, 0.4] }
+
+        let response = try await reranker.scores(
+            query: "swift", documents: ["a", "b", "c"])
+
+        #expect(response.modelID == "test/model")
+        #expect(response.scoreKind == .normalizedRelevance)
+        #expect(response.results.map(\.index) == [0, 1, 2])
+        #expect(response.results.map(\.score) == [0.2, 0.9, 0.4])
+    }
+
+    @Test func rerankSortsStablyFiltersAndLimitsResults() async throws {
+        let reranker = RerankerContainer(
+            modelID: "test/model",
+            scoreKind: .normalizedRelevance
+        ) { _, _, _, _ in [0.8, 0.4, 0.8, 0.9] }
+
+        let response = try await reranker.rerank(
+            query: "swift",
+            documents: ["a", "b", "c", "d"],
+            topK: 3,
+            minimumScore: 0.8)
+
+        #expect(response.results.map(\.index) == [3, 0, 2])
+    }
+
+    @Test func structuredDocumentsPreserveIdentityAndMetadata() async throws {
+        let reranker = makeConstantReranker(
+            scoreKind: .normalizedRelevance, scores: [0.2, 0.9])
+        let documents = [
+            RerankDocument(id: "first", text: "a", metadata: ["source": "one"]),
+            RerankDocument(id: "second", text: "b", metadata: ["source": "two"]),
+        ]
+
+        let response = try await reranker.rerank(
+            query: "q", documents: documents, topK: 1)
+
+        #expect(response.modelID == "test/model")
+        #expect(response.results.map(\.document.id) == ["second"])
+        #expect(response.results[0].document.metadata == ["source": "two"])
+        #expect(response.results[0].index == 1)
+        #expect(response.results[0].score == 0.9)
+    }
+
+    @Test func structuredDocumentsRequireUniqueIdentifiers() async throws {
+        let reranker = makeConstantReranker(
+            scoreKind: .normalizedRelevance, scores: [0.2, 0.9])
+        let documents = [
+            RerankDocument(id: "duplicate", text: "a"),
+            RerankDocument(id: "duplicate", text: "b"),
+        ]
+
+        await #expect(throws: RerankerError.self) {
+            try await reranker.rerank(query: "q", documents: documents)
+        }
+    }
+
+    @Test func structuredDocumentsRejectInvalidProtocolResponses() async throws {
+        let documents = [RerankDocument(id: "only", text: "document")]
+        let reranker = StubReranker(
+            results: [RerankResult(index: 1, score: 0.5)])
+
+        await #expect(throws: RerankerError.self) {
+            try await reranker.scores(query: "q", documents: documents)
+        }
+    }
+
+    @Test func structuredDocumentsRejectDuplicateProtocolResultIndexes() async throws {
+        let documents = [
+            RerankDocument(id: "first", text: "a"),
+            RerankDocument(id: "second", text: "b"),
+        ]
+        let reranker = StubReranker(
+            results: [
+                RerankResult(index: 0, score: 0.9),
+                RerankResult(index: 0, score: 0.8),
+            ])
+
+        await #expect(throws: RerankerError.self) {
+            try await reranker.rerank(query: "q", documents: documents)
+        }
+    }
+
+    @Test func invalidTopKThrows() async throws {
+        let reranker = makeConstantReranker(
+            scoreKind: .normalizedRelevance, scores: [0.5])
+
+        await #expect(throws: RerankerError.self) {
+            try await reranker.rerank(query: "q", documents: ["d"], topK: 0)
+        }
+    }
+
+    @Test func thresholdRequiresBoundedScores() async throws {
+        let reranker = makeConstantReranker(scoreKind: .logit, scores: [2])
+
+        await #expect(throws: RerankerError.self) {
+            try await reranker.rerank(
+                query: "q", documents: ["d"], minimumScore: 0.5)
+        }
+    }
+
+    @Test func nonFiniteAndOutOfRangeScoresThrow() async throws {
+        let nonFinite = makeConstantReranker(
+            scoreKind: .normalizedRelevance, scores: [.nan])
+        let outOfRange = makeConstantReranker(
+            scoreKind: .normalizedRelevance, scores: [1.1])
+
+        await #expect(throws: RerankerError.self) {
+            try await nonFinite.scores(query: "q", documents: ["d"])
+        }
+        await #expect(throws: RerankerError.self) {
+            try await outOfRange.scores(query: "q", documents: ["d"])
+        }
+    }
+
+    @Test func cancellationIsObservedBeforeInference() async throws {
+        let reranker = makeConstantReranker(
+            scoreKind: .normalizedRelevance, scores: [0.5])
+        let task = Task {
+            try await reranker.scores(query: "q", documents: ["d"])
+        }
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test func xlmRobertaUsesPaddingAwarePositionIDs() {
+        let inputIDs = MLXArray([0, 10, 11, 1, 1]).reshaped(1, 5)
+
+        let positionIDs = bertPositionIDs(
+            inputIDs: inputIDs, padTokenID: 1, paddingAware: true)
+
+        #expect(positionIDs.asArray(Int.self) == [2, 3, 4, 1, 1])
+    }
+
+    @Test func bertUsesSequentialPositionIDs() {
+        let inputIDs = MLXArray([101, 10, 0]).reshaped(1, 3)
+
+        let positionIDs = bertPositionIDs(
+            inputIDs: inputIDs, padTokenID: 0, paddingAware: false)
+
+        #expect(positionIDs.asArray(Int.self) == [0, 1, 2])
+    }
+
+    @Test func omittedTokenTypeIDsDoNotAddTypeZeroEmbeddings() throws {
+        let configuration = try JSONDecoder().decode(
+            BertConfiguration.self,
+            from: bertConfigurationData(
+                modelType: "bert",
+                architecture: "BertModel",
+                labels: 1,
+                padTokenID: 0,
+                maxPositionEmbeddings: 8,
+                numLayers: 0))
+        let model = BertModel(configuration)
+        try model.update(
+            parameters: ModuleParameters.unflattened([
+                "embeddings.word_embeddings.weight": MLXArray.zeros([256, 8]),
+                "embeddings.position_embeddings.weight": MLXArray.zeros([8, 8]),
+                "embeddings.token_type_embeddings.weight": MLXArray([
+                    Float(0), 1, 2, 3, 4, 5, 6, 7,
+                ]).reshaped(1, 8),
+                "embeddings.norm.weight": MLXArray.ones([8]),
+                "embeddings.norm.bias": MLXArray.zeros([8]),
+            ]),
+            verify: [])
+
+        let inputIDs = MLXArray([10, 11]).reshaped(1, 2)
+        let withoutTokenTypes = try #require(model(inputIDs).hiddenStates)
+        let withTypeZero = try #require(
+            model(inputIDs, tokenTypeIds: MLXArray.zeros([1, 2], dtype: .int32))
+                .hiddenStates)
+        eval(withoutTokenTypes, withTypeZero)
+
+        #expect(withoutTokenTypes.asArray(Float.self).allSatisfy { abs($0) < 0.0001 })
+        #expect(
+            zip(
+                withoutTokenTypes.asArray(Float.self),
+                withTypeZero.asArray(Float.self)
+            ).contains { abs($0 - $1) > 0.0001 })
+    }
+
+    @Test func bgeConfigurationDerivesPaddingAndContextLimit() throws {
+        let configuration = try decodeBertConfiguration(
+            modelType: "xlm-roberta",
+            architecture: "XLMRobertaForSequenceClassification",
+            labels: 1,
+            padTokenID: 1,
+            maxPositionEmbeddings: 8_194)
+
+        #expect(configuration.padTokenID == 1)
+        #expect(configuration.usesPaddingAwarePositionIDs)
+        #expect(configuration.encoderRerankerConfiguration.padTokenID == 1)
+        #expect(configuration.encoderRerankerConfiguration.maxInputTokens == 8_192)
+        #expect(configuration.encoderRerankerConfiguration.scoreKind == .normalizedRelevance)
+    }
+
+    @Test func encoderConfigurationUsesDeclaredPositiveLabel() throws {
+        let configuration = try decodeBertConfiguration(
+            modelType: "xlm-roberta",
+            architecture: "XLMRobertaForSequenceClassification",
+            labels: 2,
+            padTokenID: 1,
+            maxPositionEmbeddings: 32,
+            idToLabel: [0: "irrelevant", 1: "relevant"])
+
+        guard
+            case .softmaxProbability(classIndex: 1)? =
+                configuration.encoderRerankerConfiguration.scorePolicy
+        else {
+            Issue.record("Expected a positive-class softmax policy")
+            return
+        }
+    }
+
+    @Test func encoderConfigurationRejectsAmbiguousLabels() throws {
+        let configuration = try decodeBertConfiguration(
+            modelType: "bert",
+            architecture: "BertForSequenceClassification",
+            labels: 2,
+            padTokenID: 0,
+            maxPositionEmbeddings: 32)
+
+        #expect(configuration.encoderRerankerConfiguration.scorePolicy == nil)
+    }
+
+    @Test func encoderConfigurationDecodesSparseLabelToIDMetadata() throws {
+        let data = try bertConfigurationData(
+            modelType: "bert",
+            architecture: "BertForSequenceClassification",
+            labels: 1,
+            padTokenID: 0,
+            maxPositionEmbeddings: 32,
+            labelToID: ["irrelevant": 0, "relevant": 2],
+            includeNumLabels: false)
+        let configuration = try JSONDecoder().decode(BertConfiguration.self, from: data)
+
+        #expect(configuration.numLabels == 3)
+        #expect(
+            configuration.encoderRerankerConfiguration.scorePolicy
+                == .softmaxProbability(classIndex: 2))
+    }
+
+    @Test func sequenceClassificationConfigurationCreatesRerankerModel() async throws {
+        let data = try bertConfigurationData(
+            modelType: "xlm-roberta",
+            architecture: "XLMRobertaForSequenceClassification",
+            labels: 1,
+            padTokenID: 1,
+            maxPositionEmbeddings: 32)
+
+        let model = try await EmbedderTypeRegistry.shared.createModel(
+            configuration: data, modelType: "xlm-roberta")
+
+        #expect(model is BertRerankerModel)
+    }
+
+    @Test func existingBertWeightPathsRemainStable() throws {
+        let configuration = try decodeBertConfiguration(
+            modelType: "bert",
+            architecture: "BertModel",
+            labels: 1,
+            padTokenID: 0,
+            maxPositionEmbeddings: 32)
+        let model = BertModel(configuration)
+
+        let weights = model.sanitize(weights: [
+            "bert.embeddings.word_embeddings.weight": MLXArray.zeros([256, 8]),
+            "bert.encoder.layer.0.output.dense.weight": MLXArray.zeros([8, 16]),
+        ])
+
+        #expect(weights["embeddings.word_embeddings.weight"] != nil)
+        #expect(weights["encoder.layers.0.linear2.weight"] != nil)
+        #expect(weights.keys.allSatisfy { !$0.hasPrefix("encoder_model.") })
+    }
+
+    @Test func encoderScoringUsesTokenBudgetedMicroBatches() async throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let model = TestEncoderRerankerModel(
+            configuration: .init(
+                inputKind: .xlmRoberta,
+                padTokenID: 1,
+                maxInputTokens: 128,
+                scorePolicy: .singleLogit(transform: .sigmoid),
+                scoreKind: .normalizedRelevance))
+        let container = EmbedderModelContainer(
+            context: EmbedderModelContext(
+                configuration: ModelConfiguration(id: "test/encoder"),
+                model: model,
+                tokenizer: tokenizer,
+                pooling: Pooling(strategy: .none)))
+
+        let scores = try await container.rerankerScores(
+            query: "q",
+            documents: ["a", "bbbb", "cc", "dddddd"],
+            options: .init(maxBatchSize: 2, maxBatchTokens: 30))
+
+        #expect(scores.count == 4)
+        #expect(model.scoreCallCount == 2)
+        #expect(scores.allSatisfy { $0 >= 0 && $0 <= 1 })
+    }
+
+    @Test func encoderTokenBudgetTruncatesOversizedSingleton() async throws {
+        let model = TestEncoderRerankerModel(
+            configuration: .init(
+                inputKind: .xlmRoberta,
+                padTokenID: 1,
+                maxInputTokens: 128,
+                scorePolicy: .singleLogit(transform: .sigmoid),
+                scoreKind: .normalizedRelevance))
+        let container = makeEmbedderContainer(model: model)
+
+        _ = try await container.rerankerScores(
+            query: "query",
+            documents: [String(repeating: "d", count: 100)],
+            options: .init(maxBatchSize: 8, maxBatchTokens: 32))
+
+        #expect(model.scoredShapes == [[1, 32]])
+    }
+
+    @Test func encoderScoringRejectsAmbiguousOneDimensionalOutput() async throws {
+        let model = TestEncoderRerankerModel(
+            configuration: .init(
+                inputKind: .xlmRoberta,
+                padTokenID: 1,
+                maxInputTokens: 128,
+                scorePolicy: .singleLogit(transform: .identity),
+                scoreKind: .logit),
+            output: .oneDimensional)
+        let container = makeEmbedderContainer(model: model)
+
+        await #expect(throws: RerankerError.self) {
+            try await container.rerankerScores(
+                query: "q", documents: ["a", "b"], options: .init())
+        }
+    }
+
+    @Test func singleLogitRejectsMultipleClassifierOutputs() async throws {
+        let model = TestEncoderRerankerModel(
+            configuration: .init(
+                inputKind: .xlmRoberta,
+                padTokenID: 1,
+                maxInputTokens: 128,
+                scorePolicy: .singleLogit(transform: .sigmoid),
+                scoreKind: .normalizedRelevance),
+            output: .twoLogits)
+        let container = makeEmbedderContainer(model: model)
+
+        await #expect(throws: RerankerError.self) {
+            try await container.rerankerScores(
+                query: "q", documents: ["a"], options: .init())
+        }
+    }
+
+    @Test func softmaxProbabilityIsNotTransformedTwice() async throws {
+        let model = TestEncoderRerankerModel(
+            configuration: .init(
+                inputKind: .xlmRoberta,
+                padTokenID: 1,
+                maxInputTokens: 128,
+                scorePolicy: .softmaxProbability(classIndex: 1),
+                scoreKind: .normalizedRelevance),
+            output: .fixedTwoLogits)
+        let container = makeEmbedderContainer(model: model)
+
+        let scores = try await container.rerankerScores(
+            query: "q", documents: ["a"], options: .init())
+
+        #expect(abs(scores[0] - 0.880797) < 0.0001)
+    }
+
+    @Test func xlmRobertaPairMatchesReferenceTokenLayout() throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let input = try XLMRobertaRerankerInputProcessor().encode(
+            query: "q",
+            document: "d",
+            tokenizer: tokenizer,
+            maxInputTokens: nil,
+            truncation: .truncate)
+
+        #expect(input.tokenIds == [3, byteID("q"), 4, 4, byteID("d"), 4])
+        #expect(input.tokenTypeIds == [0, 0, 0, 0, 0, 0])
+    }
+
+    @Test func qwenPromptIsTokenIdenticalToReferenceTemplate() throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let instruction = "Find useful passages"
+        let input = try Qwen3RerankerInputProcessor(instruction: instruction).encode(
+            query: "query",
+            document: "document",
+            tokenizer: tokenizer,
+            maxInputTokens: nil,
+            truncation: .truncate)
+        let reference =
+            "<|im_start|>system\n"
+            + "Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n"
+            + "<|im_start|>user\n"
+            + "<Instruct>: \(instruction)\n<Query>: query\n<Document>: document"
+            + "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+        #expect(input.tokenIds == tokenizer.encode(text: reference, addSpecialTokens: false))
+    }
+
+    @Test func jinaPromptIsTokenIdenticalToReferenceImplementation() throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let input = try JinaRerankerInputProcessor().encode(
+            query: "query",
+            documents: ["first", "second"],
+            tokenizer: tokenizer,
+            maxInputTokens: nil,
+            truncation: .truncate)
+        let reference = jinaReferencePrompt(
+            query: "query", documents: ["first", "second"])
+
+        #expect(input.tokenIds == tokenizer.encode(text: reference, addSpecialTokens: false))
+    }
+
+    @Test func jinaTruncationRetokenizesTheCompletePrompt() throws {
+        let tokenizer = BoundaryMergingRerankerTokenizer()
+        let document = String(repeating: "d", count: 200)
+        let limit = tokenizer.encode(
+            text: jinaReferencePrompt(query: "query", documents: [String(document.prefix(40))]),
+            addSpecialTokens: false
+        ).count
+
+        let input = try JinaRerankerInputProcessor().encode(
+            query: "query",
+            documents: [document],
+            tokenizer: tokenizer,
+            maxInputTokens: limit,
+            truncation: .truncate)
+        let expected = tokenizer.encode(
+            text: jinaReferencePrompt(query: "query", documents: [String(document.prefix(40))]),
+            addSpecialTokens: false)
+
+        #expect(input.tokenIds == expected)
+        #expect(input.tokenIds.count <= limit)
+    }
+
+    @Test func truncationErrorRejectsOverlongPairs() throws {
+        let tokenizer = ByteRerankerTokenizer()
+
+        #expect(throws: RerankerError.self) {
+            try XLMRobertaRerankerInputProcessor().encode(
+                query: "query",
+                document: String(repeating: "d", count: 100),
+                tokenizer: tokenizer,
+                maxInputTokens: 12,
+                truncation: .error)
+        }
+    }
+
+    @Test func jinaRejectsMoreThanSixtyFourDocuments() async throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let model = TestCausalRerankerModel(
+            trueTokenID: tokenizer.trueTokenID,
+            falseTokenID: tokenizer.falseTokenID)
+        let container = makeModelContainer(model: model, tokenizer: tokenizer)
+
+        await #expect(throws: RerankerError.self) {
+            try await container.listwiseRerankerScores(
+                query: "q",
+                documents: Array(repeating: "d", count: 65),
+                instruction: nil,
+                maxInputTokens: 131_072,
+                maximumDocuments: 64,
+                options: .init())
+        }
+    }
+
+    @Test func jinaListwisePromptHonorsForwardPassTokenBudget() async throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let model = TestCausalRerankerModel(
+            trueTokenID: tokenizer.trueTokenID,
+            falseTokenID: tokenizer.falseTokenID)
+        let container = makeModelContainer(model: model, tokenizer: tokenizer)
+
+        let scores = try await container.listwiseRerankerScores(
+            query: "query",
+            documents: [String(repeating: "d", count: 1_000)],
+            instruction: nil,
+            maxInputTokens: 131_072,
+            maximumDocuments: 64,
+            options: .init(maxBatchTokens: 800))
+
+        #expect(scores.count == 1)
+        #expect(model.listwiseTokenCount == 800)
+    }
+
+    @Test func jinaLanguageModelOutputUsesVocabularyDimension() throws {
+        let configuration = try decodeQwenConfiguration()
+        let model = JinaRerankerModel(configuration)
+
+        let output = model(
+            MLXArray([1, 2, 3]).reshaped(1, 3),
+            cache: Optional<[KVCache]>.none)
+
+        #expect(output.shape == [1, 3, 128])
+    }
+
+    @Test func jinaCosineSimilarityRemainsInDeclaredRange() {
+        let vector = MLXArray([Float(0.1), 0.2, 0.3]).reshaped(1, 3)
+        let scores = jinaCosineSimilarity(vector, vector).asArray(Float.self)
+
+        #expect(scores.count == 1)
+        #expect(scores[0] >= -1)
+        #expect(scores[0] <= 1)
+    }
+
+    @Test func causalScoringUsesMicroBatchesAndReturnsNormalizedRelevance() async throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let model = TestCausalRerankerModel(
+            trueTokenID: tokenizer.trueTokenID,
+            falseTokenID: tokenizer.falseTokenID)
+        let container = makeModelContainer(model: model, tokenizer: tokenizer)
+
+        let scores = try await container.causalRerankerScores(
+            query: "q",
+            documents: ["a", "bbbb", "cc"],
+            instruction: nil,
+            maxInputTokens: 8_192,
+            options: .init(maxBatchSize: 2, maxBatchTokens: 4_096))
+
+        #expect(scores.count == 3)
+        #expect(model.callCount == 2)
+        #expect(scores.allSatisfy { $0 >= 0 && $0 <= 1 })
+    }
+
+    @Test func causalTokenBudgetTruncatesOversizedSingleton() async throws {
+        let tokenizer = ByteRerankerTokenizer()
+        let model = TestCausalRerankerModel(
+            trueTokenID: tokenizer.trueTokenID,
+            falseTokenID: tokenizer.falseTokenID)
+        let container = makeModelContainer(model: model, tokenizer: tokenizer)
+
+        _ = try await container.causalRerankerScores(
+            query: "query",
+            documents: [String(repeating: "d", count: 1_000)],
+            instruction: nil,
+            maxInputTokens: 8_192,
+            options: .init(maxBatchTokens: 512))
+
+        #expect(model.callShapes == [[1, 512]])
+    }
+
+    @Test func jinaFactoryRegistrationUsesArchitecture() async throws {
+        let model = try await LLMTypeRegistry.shared.createModel(
+            configuration: try jinaConfigurationData(), modelType: "qwen3")
+
+        #expect(model is JinaRerankerModel)
+    }
+
+    @Test func rerankerFactoryRoutesOnlyVerifiedRerankers() throws {
+        let bge = try JSONDecoder().decode(
+            RerankerDescriptor.self,
+            from: bertConfigurationData(
+                modelType: "xlm-roberta",
+                architecture: "XLMRobertaForSequenceClassification",
+                labels: 1,
+                padTokenID: 1,
+                maxPositionEmbeddings: 8_194))
+        let jina = try JSONDecoder().decode(
+            RerankerDescriptor.self, from: jinaConfigurationData())
+        let qwen = try JSONDecoder().decode(
+            RerankerDescriptor.self,
+            from: Data(
+                """
+                {
+                  "model_type": "qwen3",
+                  "architectures": ["Qwen3ForCausalLM"],
+                  "max_position_embeddings": 32768
+                }
+                """.utf8))
+        let unsupported = try JSONDecoder().decode(
+            RerankerDescriptor.self,
+            from: Data(
+                """
+                {
+                  "model_type": "llama",
+                  "architectures": ["LlamaForCausalLM"]
+                }
+                """.utf8))
+
+        #expect(
+            try bge.architecture(modelID: "BAAI/bge-reranker-v2-m3") == .encoder)
+        #expect(try jina.architecture(modelID: "jinaai/jina-reranker-v3-mlx") == .jina)
+        #expect(
+            try qwen.architecture(modelID: "Qwen/Qwen3-Reranker-0.6B") == .qwen3)
+        #expect(try unsupported.architecture(modelID: "test/model") == nil)
+
+        #expect(throws: RerankerError.self) {
+            try qwen.architecture(modelID: "Qwen/Qwen3-0.6B")
+        }
+        #expect(throws: RerankerError.self) {
+            try bge.architecture(modelID: "example/sentiment-classifier")
+        }
+        #expect(
+            try qwen.architecture(
+                modelID: "lampo/private-model", allowUnverifiedModel: true) == .qwen3)
+    }
+}
+
+private func makeConstantReranker(
+    scoreKind: RerankScoreKind,
+    scores: [Double]
+) -> RerankerContainer {
+    RerankerContainer(modelID: "test/model", scoreKind: scoreKind) { _, _, _, _ in scores }
+}
+
+private func makeEmbedderContainer(
+    model: TestEncoderRerankerModel
+) -> EmbedderModelContainer {
+    EmbedderModelContainer(
+        context: EmbedderModelContext(
+            configuration: ModelConfiguration(id: "test/encoder"),
+            model: model,
+            tokenizer: ByteRerankerTokenizer(),
+            pooling: Pooling(strategy: .none)))
+}
+
+private func makeModelContainer(
+    model: any LanguageModel,
+    tokenizer: any Tokenizer
+) -> ModelContainer {
+    ModelContainer(
+        context: ModelContext(
+            configuration: ModelConfiguration(id: "test/reranker"),
+            model: model,
+            processor: TestInputProcessor(tokenizer: tokenizer),
+            tokenizer: tokenizer))
+}
+
+private func byteID(_ character: Character) -> Int {
+    Int(character.asciiValue ?? 0) + 10
+}
+
+private func bertConfigurationData(
+    modelType: String,
+    architecture: String,
+    labels: Int,
+    padTokenID: Int,
+    maxPositionEmbeddings: Int,
+    idToLabel: [Int: String] = [:],
+    labelToID: [String: Int] = [:],
+    includeNumLabels: Bool = true,
+    numLayers: Int = 1
+) throws -> Data {
+    var configuration: [String: Any] = [
+        "model_type": modelType,
+        "architectures": [architecture],
+        "pad_token_id": padTokenID,
+        "vocab_size": 256,
+        "hidden_size": 8,
+        "num_attention_heads": 2,
+        "intermediate_size": 16,
+        "num_hidden_layers": numLayers,
+        "type_vocab_size": 1,
+        "max_position_embeddings": maxPositionEmbeddings,
+    ]
+    if includeNumLabels {
+        configuration["num_labels"] = labels
+    }
+    if !idToLabel.isEmpty {
+        configuration["id2label"] = Dictionary(
+            uniqueKeysWithValues: idToLabel.map { (String($0.key), $0.value) })
+    }
+    if !labelToID.isEmpty {
+        configuration["label2id"] = labelToID
+    }
+    return try JSONSerialization.data(withJSONObject: configuration, options: [.sortedKeys])
+}
+
+private func decodeBertConfiguration(
+    modelType: String,
+    architecture: String,
+    labels: Int,
+    padTokenID: Int,
+    maxPositionEmbeddings: Int,
+    idToLabel: [Int: String] = [:]
+) throws -> BertConfiguration {
+    try JSONDecoder().decode(
+        BertConfiguration.self,
+        from: bertConfigurationData(
+            modelType: modelType,
+            architecture: architecture,
+            labels: labels,
+            padTokenID: padTokenID,
+            maxPositionEmbeddings: maxPositionEmbeddings,
+            idToLabel: idToLabel))
+}
+
+private func decodeQwenConfiguration() throws -> MLXLLM.Qwen3Configuration {
+    try JSONDecoder().decode(
+        MLXLLM.Qwen3Configuration.self, from: jinaConfigurationData())
+}
+
+private func jinaConfigurationData() throws -> Data {
+    Data(
+        """
+        {
+          "model_type": "qwen3",
+          "architectures": ["JinaForRanking"],
+          "vocab_size": 128,
+          "hidden_size": 8,
+          "num_hidden_layers": 1,
+          "intermediate_size": 16,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 1,
+          "head_dim": 4,
+          "rms_norm_eps": 1e-6,
+          "tie_word_embeddings": true
+        }
+        """.utf8)
+}
+
+private func jinaReferencePrompt(query: String, documents: [String]) -> String {
+    "<|im_start|>system\n"
+        + "You are a search relevance expert who can determine a ranking of the passages based on how relevant they are to the query. "
+        + "If the query is a question, how relevant a passage is depends on how well it answers the question. "
+        + "If not, try to analyze the intent of the query and assess how well each passage satisfies the intent. "
+        + "If an instruction is provided, you should follow the instruction when determining the ranking."
+        + "<|im_end|>\n<|im_start|>user\n"
+        + "I will provide you with \(documents.count) passages, each indicated by a numerical identifier. "
+        + "Rank the passages based on their relevance to query: \(query)\n"
+        + documents.enumerated().map { index, document in
+            "<passage id=\"\(index)\">\n\(document)<|embed_token|>\n</passage>"
+        }.joined(separator: "\n")
+        + "\n<query>\n\(query)<|rerank_token|>\n</query>"
+        + "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+}
+
+private struct ByteRerankerTokenizer: Tokenizer {
+    let trueTokenID = 1
+    let falseTokenID = 2
+    let bosTokenID = 3
+    let eosTokenID = 4
+    let rerankTokenID = 5
+    let embedTokenID = 6
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        var tokenIDs = [Int]()
+        var remaining = text[...]
+        while !remaining.isEmpty {
+            if remaining.hasPrefix("<|rerank_token|>") {
+                tokenIDs.append(rerankTokenID)
+                remaining.removeFirst("<|rerank_token|>".count)
+            } else if remaining.hasPrefix("<|embed_token|>") {
+                tokenIDs.append(embedTokenID)
+                remaining.removeFirst("<|embed_token|>".count)
+            } else {
+                tokenIDs.append(Int(remaining.removeFirst().asciiValue ?? 0) + 10)
+            }
+        }
+        return tokenIDs
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        String(decoding: tokenIds.map { UInt8(max(0, $0 - 10)) }, as: UTF8.self)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        switch token {
+        case "yes": trueTokenID
+        case "no": falseTokenID
+        case "<s>": bosTokenID
+        case "</s>": eosTokenID
+        case "<|rerank_token|>": rerankTokenID
+        case "<|embed_token|>": embedTokenID
+        default: nil
+        }
+    }
+
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { "<s>" }
+    var eosToken: String? { "</s>" }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+/// Models a tokenizer merge across the document-prefix boundary.
+private struct BoundaryMergingRerankerTokenizer: Tokenizer {
+    private let base = ByteRerankerTokenizer()
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        var tokenIDs = [Int]()
+        var remaining = text[...]
+        while !remaining.isEmpty {
+            if remaining.hasPrefix("<|rerank_token|>") {
+                tokenIDs.append(base.rerankTokenID)
+                remaining.removeFirst("<|rerank_token|>".count)
+            } else if remaining.hasPrefix("<|embed_token|>") {
+                tokenIDs.append(base.embedTokenID)
+                remaining.removeFirst("<|embed_token|>".count)
+            } else if remaining.hasPrefix("\nd") {
+                tokenIDs.append(250)
+                remaining.removeFirst(2)
+            } else {
+                tokenIDs.append(Int(remaining.removeFirst().asciiValue ?? 0) + 10)
+            }
+        }
+        return tokenIDs
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        base.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        base.convertTokenToId(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? { base.convertIdToToken(id) }
+    var bosToken: String? { base.bosToken }
+    var eosToken: String? { base.eosToken }
+    var unknownToken: String? { base.unknownToken }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+private struct StubReranker: Reranker {
+    let modelID = "test/stub"
+    let scoreKind = RerankScoreKind.normalizedRelevance
+    let results: [RerankResult]
+
+    func scores(
+        query: String,
+        documents: [String],
+        instruction: String?,
+        options: RerankExecutionOptions
+    ) async throws -> RerankResponse {
+        RerankResponse(modelID: modelID, scoreKind: scoreKind, results: results)
+    }
+}
+
+private final class TestEncoderRerankerModel: Module, RerankerModel, @unchecked Sendable {
+    enum Output {
+        case oneLogit
+        case oneDimensional
+        case twoLogits
+        case fixedTwoLogits
+    }
+
+    let rerankerConfiguration: EncoderRerankerModelConfiguration
+    let output: Output
+    var scoreCallCount = 0
+    var scoredShapes = [[Int]]()
+    var vocabularySize: Int { 512 }
+    var maxPositionEmbeddings: Int? { rerankerConfiguration.maxInputTokens }
+
+    init(
+        configuration: EncoderRerankerModelConfiguration,
+        output: Output = .oneLogit
+    ) {
+        rerankerConfiguration = configuration
+        self.output = output
+    }
+
+    func callAsFunction(
+        _ inputs: MLXArray,
+        positionIds: MLXArray?,
+        tokenTypeIds: MLXArray?,
+        attentionMask: MLXArray?
+    ) -> EmbeddingModelOutput {
+        EmbeddingModelOutput(hiddenStates: inputs.asType(.float32), pooledOutput: nil)
+    }
+
+    func score(
+        _ inputs: MLXArray,
+        positionIds: MLXArray?,
+        tokenTypeIds: MLXArray?,
+        attentionMask: MLXArray?
+    ) -> MLXArray {
+        scoreCallCount += 1
+        scoredShapes.append(inputs.shape)
+        let mask = attentionMask ?? MLXArray.ones(inputs.shape, dtype: .int32)
+        let sums = MLX.sum(inputs.asType(.float32) * mask.asType(.float32), axis: 1)
+        switch output {
+        case .oneLogit:
+            return sums.reshaped(inputs.dim(0), 1)
+        case .oneDimensional:
+            return sums
+        case .twoLogits:
+            return stacked([-sums, sums], axis: 1)
+        case .fixedTwoLogits:
+            return tiled(MLXArray([Float(0), Float(2)]), repetitions: [inputs.dim(0), 1])
+        }
+    }
+}
+
+private final class TestCausalRerankerModel: Module, LanguageModel, ListwiseRerankerModel,
+    @unchecked Sendable
+{
+    let trueTokenID: Int
+    let falseTokenID: Int
+    var callCount = 0
+    var callShapes = [[Int]]()
+    var listwiseTokenCount = 0
+
+    init(trueTokenID: Int, falseTokenID: Int) {
+        self.trueTokenID = trueTokenID
+        self.falseTokenID = falseTokenID
+    }
+
+    func prepare(
+        _ input: LMInput,
+        cache: [KVCache],
+        state: LMOutput.State?,
+        prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(
+        _ input: LMInput.Text,
+        cache: [KVCache]?,
+        state: LMOutput.State?
+    ) -> LMOutput {
+        callCount += 1
+        var tokens = input.tokens
+        if tokens.ndim == 1 {
+            tokens = tokens.reshaped(1, -1)
+        }
+        callShapes.append(tokens.shape)
+        let batchSize = tokens.dim(0)
+        let sequenceLength = tokens.dim(1)
+        let vocabularySize = 128
+        let tokenValues = tokens.asArray(Int.self)
+        var values = Array(
+            repeating: Float(-100),
+            count: batchSize * sequenceLength * vocabularySize)
+        for row in 0 ..< batchSize {
+            var runningTotal = 0
+            for column in 0 ..< sequenceLength {
+                runningTotal += tokenValues[row * sequenceLength + column]
+                let offset = (row * sequenceLength + column) * vocabularySize
+                values[offset + trueTokenID] = Float(runningTotal % 100) / 20
+                values[offset + falseTokenID] = 0
+            }
+        }
+        return LMOutput(
+            logits: MLXArray(values).reshaped(batchSize, sequenceLength, vocabularySize))
+    }
+
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+
+    func score(input: RerankerInput, documentCount: Int) throws -> [Double] {
+        listwiseTokenCount = input.tokenIds.count
+        return Array(repeating: 0.5, count: documentCount)
+    }
+}
+
+extension TestInputProcessor {
+    fileprivate init(tokenizer: any Tokenizer) {
+        self.init(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test/reranker"),
+            messageGenerator: DefaultMessageGenerator())
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Adds shared reranker request/result types and public rerank APIs.
- Supports encoder sequence-classification rerankers and Jina listwise reranking.
- Handles token limits, marker validation, score selection, and reranker registry entries.
- Adds focused reranker tests covering scoring, truncation, model factories, and error 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
