### PR TITLE
Decode PoolingConfiguration with optional pooling_mode flags

### DIFF
--- a/Libraries/MLXEmbedders/Pooling.swift
+++ b/Libraries/MLXEmbedders/Pooling.swift
@@ -33,6 +33,23 @@ public struct PoolingConfiguration: Codable {
         case poolingModeMaxTokens = "pooling_mode_max_tokens"
         case poolingModeLastToken = "pooling_mode_lasttoken"
     }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // `word_embedding_dimension` is always present in the sentence-transformers spec.
+        dimension = try container.decode(Int.self, forKey: .dimension)
+        // The `pooling_mode_*` flags are optional: some sentence-transformers configs (e.g.
+        // all-MiniLM-L6-v2) omit keys such as `pooling_mode_lasttoken`. An absent key means
+        // that mode is off, so default each missing flag to `false`.
+        poolingModeClsToken =
+            try container.decodeIfPresent(Bool.self, forKey: .poolingModeClsToken) ?? false
+        poolingModeMeanTokens =
+            try container.decodeIfPresent(Bool.self, forKey: .poolingModeMeanTokens) ?? false
+        poolingModeMaxTokens =
+            try container.decodeIfPresent(Bool.self, forKey: .poolingModeMaxTokens) ?? false
+        poolingModeLastToken =
+            try container.decodeIfPresent(Bool.self, forKey: .poolingModeLastToken) ?? false
+    }
 }
 
 /// Loads a `Pooling` module from a specific model directory.

--- a/Tests/MLXLMTests/EmbeddingPoolingTests.swift
+++ b/Tests/MLXLMTests/EmbeddingPoolingTests.swift
@@ -61,4 +61,27 @@ struct EmbeddingPoolingTests {
         #expect(pooling.strategy == .last)
         #expect(pooling.dimension == nil)
     }
+
+    @Test("PoolingConfiguration decodes when optional pooling_mode flags are missing")
+    func testPoolingConfigurationDecodesWithMissingFlags() throws {
+        // all-MiniLM-L6-v2 shape: `pooling_mode_lasttoken` is absent from the config.
+        let config = try JSONDecoder().decode(
+            PoolingConfiguration.self,
+            from: Data(
+                """
+                {
+                  "word_embedding_dimension": 384,
+                  "pooling_mode_cls_token": false,
+                  "pooling_mode_mean_tokens": true,
+                  "pooling_mode_max_tokens": false
+                }
+                """.utf8))
+
+        #expect(config.dimension == 384)
+        #expect(config.poolingModeLastToken == false)
+
+        let pooling = Pooling(config: config)
+        #expect(pooling.strategy == .mean)
+        #expect(pooling.dimension == 384)
+    }
 }


### PR DESCRIPTION
## Proposed changes

Fixes #26. Some sentence-transformers pooling configs omit `pooling_mode_*` keys — e.g. all-MiniLM-L6-v2 has no `pooling_mode_lasttoken`. Today the synthesized `Codable` decoder requires all four flags, so `PoolingConfiguration` decoding throws and `loadPooling` silently falls back to the model's built-in strategy instead of using the config file.

This adds a custom `init(from:)` that decodes each `pooling_mode_*` flag with `decodeIfPresent(...) ?? false` — an absent key means that mode is off — while keeping `word_embedding_dimension` required. It mirrors the optional-decode pattern already used by `Qwen3Configuration` / `Gemma3Configuration`.

Re: the open question on the default — `false` matches the sentence-transformers convention that an absent `pooling_mode_*` key means that mode is disabled.

Behavior note: a config missing *all four* flags now resolves to `.first` (previously it threw and fell back to the model strategy); configs that set at least one flag (the common case, incl. all-MiniLM) are unaffected beyond no longer throwing.

Test: `EmbeddingPoolingTests` decodes an all-MiniLM-L6-v2-shaped config (no `pooling_mode_lasttoken`) and asserts it resolves to `.mean` pooling. Verified via `xcodebuild test ... -only-testing:MLXLMTests/EmbeddingPoolingTests` → **TEST SUCCEEDED**.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
