### PR TITLE
Add optional seed to GenerateParameters for reproducible sampling

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -89,6 +89,13 @@ public struct GenerateParameters: Sendable {
     /// Min-p sampling threshold relative to the highest probability token (0 disables)
     public var minP: Float
 
+    /// Optional seed for reproducible sampling. When set, the sampler's RNG
+    /// (`TopPSampler` / `CategoricalSampler`) is seeded deterministically, so
+    /// the same `(seed, prompt, parameters)` produces the same sampled
+    /// tokens. `nil` ⇒ the sampler is seeded from system entropy (the prior
+    /// default). Inert at `temperature == 0` (argmax has no RNG).
+    public var seed: UInt64?
+
     /// Penalty factor for repeating tokens
     public var repetitionPenalty: Float?
 
@@ -124,7 +131,8 @@ public struct GenerateParameters: Sendable {
         presenceContextSize: Int = 20,
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
-        prefillStepSize: Int = 512
+        prefillStepSize: Int = 512,
+        seed: UInt64? = nil
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -143,6 +151,7 @@ public struct GenerateParameters: Sendable {
         self.frequencyPenalty = frequencyPenalty
         self.frequencyContextSize = frequencyContextSize
         self.prefillStepSize = prefillStepSize
+        self.seed = seed
     }
 
     public func sampler() -> LogitSampler {
@@ -153,9 +162,10 @@ public struct GenerateParameters: Sendable {
         if temperature == 0 {
             return ArgMaxSampler()
         } else if usesTopP || usesTopK || usesMinP {
-            return TopPSampler(temperature: temperature, topP: topP, topK: topK, minP: minP)
+            return TopPSampler(
+                temperature: temperature, topP: topP, topK: topK, minP: minP, seed: seed)
         } else {
-            return CategoricalSampler(temperature: temperature)
+            return CategoricalSampler(temperature: temperature, seed: seed)
         }
     }
 
@@ -226,7 +236,10 @@ public struct TopPSampler: LogitSampler {
     let negInf: MLXArray
     let randomState: MLXRandom.RandomState
 
-    public init(temperature: Float, topP: Float = 1.0, topK: Int = 0, minP: Float = 0.0) {
+    public init(
+        temperature: Float, topP: Float = 1.0, topK: Int = 0, minP: Float = 0.0,
+        seed: UInt64? = nil
+    ) {
         self.temp = MLXArray(temperature)
         if topP > 0 && topP < 1 {
             self.topP = MLXArray(topP)
@@ -236,7 +249,9 @@ public struct TopPSampler: LogitSampler {
         self.topK = topK > 0 ? topK : nil
         self.minP = minP > 0 ? MLXArray(minP) : nil
         self.negInf = MLXArray(-Float.infinity)
-        self.randomState = MLXRandom.RandomState()
+        // A seed makes sampling reproducible; nil keeps the prior
+        // entropy-seeded behavior.
+        self.randomState = seed.map { MLXRandom.RandomState(seed: $0) } ?? MLXRandom.RandomState()
     }
 
     public func sample(logits: MLXArray) -> MLXArray {
@@ -302,9 +317,11 @@ public struct CategoricalSampler: LogitSampler {
     let temp: MLXArray
     let randomState: MLXRandom.RandomState
 
-    public init(temperature: Float) {
+    public init(temperature: Float, seed: UInt64? = nil) {
         self.temp = MLXArray(temperature)
-        self.randomState = MLXRandom.RandomState()
+        // A seed makes sampling reproducible; nil keeps the prior
+        // entropy-seeded behavior.
+        self.randomState = seed.map { MLXRandom.RandomState(seed: $0) } ?? MLXRandom.RandomState()
     }
 
     public func sample(logits: MLXArray) -> MLXArray {

--- a/Tests/MLXLMTests/SampleTests.swift
+++ b/Tests/MLXLMTests/SampleTests.swift
@@ -305,4 +305,54 @@ public class SampleTests: XCTestCase {
         let valuesAfter = afterAppend[0].asArray(Float.self)
         XCTAssertEqual(valuesAfter[2], 2.5, accuracy: 1e-6)
     }
+
+    // MARK: - Seeded (reproducible) sampling
+
+    /// Flat 4-way distribution so sampling actually varies between draws (not
+    /// argmax-dominated); reproducibility under a fixed seed is then meaningful.
+    private func flatLogits() -> MLXArray {
+        log(MLXArray([0.25, 0.25, 0.25, 0.25] as [Float]))[.newAxis, .ellipsis]
+    }
+
+    private func drawTopP(seed: UInt64?, draws: Int) -> [Int] {
+        let sampler = TopPSampler(temperature: 1.0, seed: seed)
+        let logits = flatLogits()
+        return (0 ..< draws).map { _ in sampler.sample(logits: logits).item(Int.self) }
+    }
+
+    func testTopPSamplerSameSeedIsReproducible() {
+        XCTAssertEqual(drawTopP(seed: 42, draws: 24), drawTopP(seed: 42, draws: 24))
+    }
+
+    func testTopPSamplerDifferentSeedsDiverge() {
+        // Over 24 draws across 4 equiprobable tokens, identical sequences from
+        // distinct seeds would be ~(1/4)^24 — effectively impossible.
+        XCTAssertNotEqual(drawTopP(seed: 1, draws: 24), drawTopP(seed: 2, draws: 24))
+    }
+
+    func testCategoricalSamplerSameSeedIsReproducible() {
+        let logits = flatLogits()
+        func draw(seed: UInt64) -> [Int] {
+            let sampler = CategoricalSampler(temperature: 1.0, seed: seed)
+            return (0 ..< 24).map { _ in sampler.sample(logits: logits).item(Int.self) }
+        }
+        XCTAssertEqual(draw(seed: 7), draw(seed: 7))
+    }
+
+    func testGenerateParametersThreadsSeedToSampler() {
+        let logits = flatLogits()
+        func draw() -> [Int] {
+            let sampler = GenerateParameters(temperature: 1.0, topK: 4, seed: 99).sampler()
+            return (0 ..< 24).map { _ in sampler.sample(logits: logits).item(Int.self) }
+        }
+        // Two independently-built samplers carrying the same seed agree.
+        XCTAssertEqual(draw(), draw())
+    }
+
+    func testNilSeedPreservesUnseededSamplingPath() {
+        // nil seed must remain valid (entropy-seeded) and produce in-range tokens.
+        let tokens = drawTopP(seed: nil, draws: 8)
+        XCTAssertEqual(tokens.count, 8)
+        for t in tokens { XCTAssertTrue((0 ..< 4).contains(t)) }
+    }
 }


### PR DESCRIPTION
## Proposed changes

Adds an optional `seed: UInt64?` to `GenerateParameters`, threaded into `TopPSampler` and `CategoricalSampler`, so that a given `(seed, prompt, parameters)` deterministically reproduces the same sampled tokens. This brings reproducible sampling to mlx-swift-lm, matching the seed support already in Python `mlx-lm`.

Fully backward-compatible: `seed` defaults to `nil`, which preserves the existing entropy-seeded `MLXRandom.RandomState()` behavior. The seed is inert at `temperature == 0` (the argmax path has no RNG).

Tests (`SampleTests`): the same seed reproduces a 24-draw sequence; distinct seeds diverge; `GenerateParameters` threads the seed through to the constructed sampler; and a `nil` seed still produces valid in-range draws. Verified via `xcodebuild test ... -only-testing:MLXLMTests/SampleTests` → 24 tests, 0 failures, **TEST SUCCEEDED**.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
