### PR TITLE
Add DeepSeek-V2 model

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -50,6 +50,7 @@ public enum LLMTypeRegistry {
         "cohere": create(CohereConfiguration.self, CohereModel.init),
         "openelm": create(OpenElmConfiguration.self, OpenELMModel.init),
         "internlm2": create(InternLM2Configuration.self, InternLM2Model.init),
+        "deepseek_v2": create(DeepseekV2Configuration.self, DeepseekV2Model.init),
         "deepseek_v3": create(DeepseekV3Configuration.self, DeepseekV3Model.init),
         "granite": create(GraniteConfiguration.self, GraniteModel.init),
         "granitemoehybrid": create(

--- a/Libraries/MLXLLM/Models/DeepseekV2.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV2.swift
@@ -17,7 +17,9 @@ public struct DeepseekV2Configuration: Codable, Sendable {
     var nRoutedExperts: Int?
     var routedScalingFactor: Float = 1.0
     var kvLoraRank: Int = 512
-    var qLoraRank: Int = 1536
+    // Optional: DeepSeek-V2-Lite sets `q_lora_rank: null` (direct q_proj, no
+    // low-rank q compression); full DeepSeek-V2 sets it to 1536. nil ⇒ q_proj.
+    var qLoraRank: Int?
     var qkRopeHeadDim: Int = 64
     var vHeadDim: Int = 128
     var qkNopeHeadDim: Int = 128
@@ -77,7 +79,7 @@ public struct DeepseekV2Configuration: Codable, Sendable {
         self.routedScalingFactor =
             try c.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1.0
         self.kvLoraRank = try c.decodeIfPresent(Int.self, forKey: .kvLoraRank) ?? 512
-        self.qLoraRank = try c.decodeIfPresent(Int.self, forKey: .qLoraRank) ?? 1536
+        self.qLoraRank = try c.decodeIfPresent(Int.self, forKey: .qLoraRank)
         self.qkRopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkRopeHeadDim) ?? 64
         self.vHeadDim = try c.decodeIfPresent(Int.self, forKey: .vHeadDim) ?? 128
         self.qkNopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkNopeHeadDim) ?? 128
@@ -121,7 +123,7 @@ class DeepseekV2Attention: Module {
     init(config: DeepseekV2Configuration) {
         self.config = config
         self.numHeads = config.numAttentionHeads
-        self.qLoraRank = config.qLoraRank == 0 ? nil : config.qLoraRank
+        self.qLoraRank = (config.qLoraRank ?? 0) > 0 ? config.qLoraRank : nil
         self.qkRopeHeadDim = config.qkRopeHeadDim
         self.kvLoraRank = config.kvLoraRank
         self.vHeadDim = config.vHeadDim

--- a/Libraries/MLXLLM/Models/DeepseekV2.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV2.swift
@@ -23,7 +23,7 @@ public struct DeepseekV2Configuration: Codable, Sendable {
     var qkRopeHeadDim: Int = 64
     var vHeadDim: Int = 128
     var qkNopeHeadDim: Int = 128
-    var topkMethod: String = "gready"
+    var topkMethod: String = "greedy"
     var nGroup: Int?
     var topkGroup: Int?
     var numExpertsPerTok: Int?
@@ -83,7 +83,7 @@ public struct DeepseekV2Configuration: Codable, Sendable {
         self.qkRopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkRopeHeadDim) ?? 64
         self.vHeadDim = try c.decodeIfPresent(Int.self, forKey: .vHeadDim) ?? 128
         self.qkNopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkNopeHeadDim) ?? 128
-        self.topkMethod = try c.decodeIfPresent(String.self, forKey: .topkMethod) ?? "gready"
+        self.topkMethod = try c.decodeIfPresent(String.self, forKey: .topkMethod) ?? "greedy"
         self.nGroup = try c.decodeIfPresent(Int.self, forKey: .nGroup)
         self.topkGroup = try c.decodeIfPresent(Int.self, forKey: .topkGroup)
         self.numExpertsPerTok = try c.decodeIfPresent(Int.self, forKey: .numExpertsPerTok)
@@ -190,21 +190,14 @@ class DeepseekV2Attention: Module {
         kv = kv.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
         let splitKv2 = split(kv, indices: [qkNopeHeadDim], axis: -1)
         let kNope = splitKv2[0]
-        var values = splitKv2[1]
+        let values = splitKv2[1]
 
         let offset = cache?.ropeOffset
         qPe = applyRotaryPosition(rope, to: qPe, offset: offset)
         kPe = applyRotaryPosition(rope, to: kPe, offset: offset)
         kPe = repeated(kPe, count: numHeads, axis: 1)
 
-        var keys: MLXArray
-        if let cache = cache {
-            (keys, values) = cache.update(
-                keys: concatenated([kNope, kPe], axis: -1), values: values)
-        } else {
-            keys = concatenated([kNope, kPe], axis: -1)
-        }
-
+        let keys = concatenated([kNope, kPe], axis: -1)
         let queries = concatenated([qNope, qPe], axis: -1)
 
         let output = attentionWithCacheUpdate(

--- a/Libraries/MLXLLM/Models/DeepseekV2.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV2.swift
@@ -1,0 +1,411 @@
+// port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/deepseek_v2.py
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+public struct DeepseekV2Configuration: Codable, Sendable {
+    var vocabSize: Int = 102400
+    var hiddenSize: Int = 4096
+    var intermediateSize: Int = 11008
+    var moeIntermediateSize: Int = 1407
+    var numHiddenLayers: Int = 30
+    var numAttentionHeads: Int = 32
+    var numKeyValueHeads: Int = 32
+    var nSharedExperts: Int?
+    var nRoutedExperts: Int?
+    var routedScalingFactor: Float = 1.0
+    var kvLoraRank: Int = 512
+    var qLoraRank: Int = 1536
+    var qkRopeHeadDim: Int = 64
+    var vHeadDim: Int = 128
+    var qkNopeHeadDim: Int = 128
+    var topkMethod: String = "gready"
+    var nGroup: Int?
+    var topkGroup: Int?
+    var numExpertsPerTok: Int?
+    var moeLayerFreq: Int = 1
+    var firstKDenseReplace: Int = 0
+    var maxPositionEmbeddings: Int = 2048
+    var rmsNormEps: Float = 1e-6
+    var ropeTheta: Float = 10000.0
+    var ropeScaling: [String: StringOrNumber]?
+    var attentionBias: Bool = false
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case nSharedExperts = "n_shared_experts"
+        case nRoutedExperts = "n_routed_experts"
+        case routedScalingFactor = "routed_scaling_factor"
+        case kvLoraRank = "kv_lora_rank"
+        case qLoraRank = "q_lora_rank"
+        case qkRopeHeadDim = "qk_rope_head_dim"
+        case vHeadDim = "v_head_dim"
+        case qkNopeHeadDim = "qk_nope_head_dim"
+        case topkMethod = "topk_method"
+        case nGroup = "n_group"
+        case topkGroup = "topk_group"
+        case numExpertsPerTok = "num_experts_per_tok"
+        case moeLayerFreq = "moe_layer_freq"
+        case firstKDenseReplace = "first_k_dense_replace"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeTheta = "rope_theta"
+        case ropeScaling = "rope_scaling"
+        case attentionBias = "attention_bias"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 102400
+        self.hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 4096
+        self.intermediateSize = try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 11008
+        self.moeIntermediateSize =
+            try c.decodeIfPresent(Int.self, forKey: .moeIntermediateSize) ?? 1407
+        self.numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 30
+        self.numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 32
+        self.numKeyValueHeads = try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 32
+        self.nSharedExperts = try c.decodeIfPresent(Int.self, forKey: .nSharedExperts)
+        self.nRoutedExperts = try c.decodeIfPresent(Int.self, forKey: .nRoutedExperts)
+        self.routedScalingFactor =
+            try c.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1.0
+        self.kvLoraRank = try c.decodeIfPresent(Int.self, forKey: .kvLoraRank) ?? 512
+        self.qLoraRank = try c.decodeIfPresent(Int.self, forKey: .qLoraRank) ?? 1536
+        self.qkRopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkRopeHeadDim) ?? 64
+        self.vHeadDim = try c.decodeIfPresent(Int.self, forKey: .vHeadDim) ?? 128
+        self.qkNopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkNopeHeadDim) ?? 128
+        self.topkMethod = try c.decodeIfPresent(String.self, forKey: .topkMethod) ?? "gready"
+        self.nGroup = try c.decodeIfPresent(Int.self, forKey: .nGroup)
+        self.topkGroup = try c.decodeIfPresent(Int.self, forKey: .topkGroup)
+        self.numExpertsPerTok = try c.decodeIfPresent(Int.self, forKey: .numExpertsPerTok)
+        self.moeLayerFreq = try c.decodeIfPresent(Int.self, forKey: .moeLayerFreq) ?? 1
+        self.firstKDenseReplace = try c.decodeIfPresent(Int.self, forKey: .firstKDenseReplace) ?? 0
+        self.maxPositionEmbeddings =
+            try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 2048
+        self.rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        self.ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10000.0
+        self.ropeScaling = try c.decodeIfPresent(
+            [String: StringOrNumber].self, forKey: .ropeScaling)
+        self.attentionBias = try c.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+    }
+}
+
+class DeepseekV2Attention: Module {
+    let config: DeepseekV2Configuration
+    let numHeads: Int
+    let qLoraRank: Int?
+    let qkRopeHeadDim: Int
+    let kvLoraRank: Int
+    let vHeadDim: Int
+    let qkNopeHeadDim: Int
+    let qHeadDim: Int
+    var scale: Float
+
+    let rope: RoPELayer
+    @ModuleInfo(key: "q_proj") var qProj: Linear?
+    @ModuleInfo(key: "q_a_proj") var qAProj: Linear?
+    @ModuleInfo(key: "q_a_layernorm") var qALayerNorm: RMSNorm?
+    @ModuleInfo(key: "q_b_proj") var qBProj: Linear?
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "kv_a_proj_with_mqa") var kvAProjWithMqa: Linear
+    @ModuleInfo(key: "kv_a_layernorm") var kvALayerNorm: RMSNorm
+    @ModuleInfo(key: "kv_b_proj") var kvBProj: Linear
+
+    init(config: DeepseekV2Configuration) {
+        self.config = config
+        self.numHeads = config.numAttentionHeads
+        self.qLoraRank = config.qLoraRank == 0 ? nil : config.qLoraRank
+        self.qkRopeHeadDim = config.qkRopeHeadDim
+        self.kvLoraRank = config.kvLoraRank
+        self.vHeadDim = config.vHeadDim
+        self.qkNopeHeadDim = config.qkNopeHeadDim
+        self.qHeadDim = config.qkNopeHeadDim + config.qkRopeHeadDim
+        self.scale = pow(Float(qHeadDim), -0.5)
+
+        if let qLoraRank = self.qLoraRank {
+            self._qAProj.wrappedValue = Linear(
+                config.hiddenSize, qLoraRank, bias: config.attentionBias)
+            self._qALayerNorm.wrappedValue = RMSNorm(dimensions: qLoraRank, eps: 1e-6)
+            self._qBProj.wrappedValue = Linear(qLoraRank, numHeads * qHeadDim, bias: false)
+        } else {
+            self._qProj.wrappedValue = Linear(
+                config.hiddenSize, numHeads * qHeadDim, bias: false)
+        }
+
+        self._kvAProjWithMqa.wrappedValue = Linear(
+            config.hiddenSize, kvLoraRank + qkRopeHeadDim, bias: config.attentionBias)
+        self._kvALayerNorm.wrappedValue = RMSNorm(dimensions: kvLoraRank, eps: 1e-6)
+        self._kvBProj.wrappedValue = Linear(
+            kvLoraRank, numHeads * (qHeadDim - qkRopeHeadDim + vHeadDim), bias: false)
+        self._oProj.wrappedValue = Linear(
+            numHeads * vHeadDim, config.hiddenSize, bias: config.attentionBias)
+
+        // YaRN mscale applied to the attention scale, mirroring deepseek_v2.py.
+        if let ropeScaling = config.ropeScaling {
+            let mScaleAllDim = ropeScaling["mscale_all_dim"]?.asFloat() ?? 0.0
+            let scalingFactor = ropeScaling["factor"]?.asFloat() ?? 1.0
+            if mScaleAllDim != 0, scalingFactor > 1 {
+                let s = 0.1 * mScaleAllDim * log(scalingFactor) + 1.0
+                self.scale = self.scale * s * s
+            }
+        }
+
+        self.rope = initializeRope(
+            dims: qkRopeHeadDim, base: config.ropeTheta, traditional: true,
+            scalingConfig: config.ropeScaling, maxPositionEmbeddings: config.maxPositionEmbeddings)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (B, L, _) = (x.dim(0), x.dim(1), x.dim(2))
+
+        var q: MLXArray
+        if qLoraRank == nil {
+            q = qProj!(x)
+        } else {
+            q = qBProj!(qALayerNorm!(qAProj!(x)))
+        }
+        q = q.reshaped(B, L, numHeads, qHeadDim).transposed(0, 2, 1, 3)
+        let splitQ = split(q, indices: [qkNopeHeadDim], axis: -1)
+        let qNope = splitQ[0]
+        var qPe = splitQ[1]
+
+        var compressedKv = kvAProjWithMqa(x)
+        let splitKv = split(compressedKv, indices: [kvLoraRank], axis: -1)
+        compressedKv = splitKv[0]
+        var kPe = splitKv[1]
+        kPe = kPe.reshaped(B, L, 1, qkRopeHeadDim).transposed(0, 2, 1, 3)
+
+        var kv = kvBProj(kvALayerNorm(compressedKv))
+        kv = kv.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
+        let splitKv2 = split(kv, indices: [qkNopeHeadDim], axis: -1)
+        let kNope = splitKv2[0]
+        var values = splitKv2[1]
+
+        let offset = cache?.ropeOffset
+        qPe = applyRotaryPosition(rope, to: qPe, offset: offset)
+        kPe = applyRotaryPosition(rope, to: kPe, offset: offset)
+        kPe = repeated(kPe, count: numHeads, axis: 1)
+
+        var keys: MLXArray
+        if let cache = cache {
+            (keys, values) = cache.update(
+                keys: concatenated([kNope, kPe], axis: -1), values: values)
+        } else {
+            keys = concatenated([kNope, kPe], axis: -1)
+        }
+
+        let queries = concatenated([qNope, qPe], axis: -1)
+
+        let output = attentionWithCacheUpdate(
+            queries: queries, keys: keys, values: values,
+            cache: cache, scale: scale, mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return oProj(output)
+    }
+}
+
+class DeepseekV2MLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(config: DeepseekV2Configuration, hiddenSize: Int? = nil, intermediateSize: Int? = nil) {
+        let h = hiddenSize ?? config.hiddenSize
+        let i = intermediateSize ?? config.intermediateSize
+        self._gateProj.wrappedValue = Linear(h, i, bias: false)
+        self._upProj.wrappedValue = Linear(h, i, bias: false)
+        self._downProj.wrappedValue = Linear(i, h, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+class DeepseekV2MoEGate: Module {
+    let topK: Int
+    let nRoutedExperts: Int
+    let routedScalingFactor: Float
+    let topkMethod: String
+    let nGroup: Int
+    let topkGroup: Int
+
+    var weight: MLXArray
+
+    init(config: DeepseekV2Configuration) {
+        self.topK = config.numExpertsPerTok ?? 1
+        self.nRoutedExperts = config.nRoutedExperts ?? 1
+        self.routedScalingFactor = config.routedScalingFactor
+        self.topkMethod = config.topkMethod
+        self.nGroup = config.nGroup ?? 1
+        self.topkGroup = config.topkGroup ?? 1
+        self.weight = zeros([nRoutedExperts, config.hiddenSize])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        let (bsz, seqLen, _) = (x.dim(0), x.dim(1), x.dim(2))
+
+        let gates = x.matmul(weight.T)
+        var scores = softmax(gates, axis: -1, precise: true)
+
+        if topkMethod == "group_limited_greedy" {
+            // Mask out all but the top `topkGroup` expert groups (by the group's
+            // max score), then top-k over the surviving experts.
+            scores = scores.reshaped(bsz, seqLen, nGroup, -1)
+            let groupScores = MLX.max(scores, axis: -1, keepDims: true)
+            let k = nGroup - topkGroup
+            var groupIdx = argPartition(groupScores, kth: k - 1, axis: -2)[.ellipsis, ..<k, 0...]
+            groupIdx = broadcast(groupIdx, to: [bsz, seqLen, k, nRoutedExperts / nGroup])
+            scores = putAlong(scores, stopGradient(groupIdx), values: MLXArray(0.0), axis: -2)
+            scores = flattened(scores, start: -2, end: -1)
+        }
+
+        let inds = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+        scores = takeAlong(scores, inds, axis: -1)
+        scores = scores * routedScalingFactor
+        return (inds, scores)
+    }
+}
+
+class DeepseekV2MoE: Module, UnaryLayer {
+    let numExpertsPerTok: Int
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    let gate: DeepseekV2MoEGate
+    @ModuleInfo(key: "shared_experts") var sharedExperts: DeepseekV2MLP?
+
+    init(config: DeepseekV2Configuration) {
+        self.numExpertsPerTok = config.numExpertsPerTok ?? 1
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: config.hiddenSize,
+            hiddenDims: config.moeIntermediateSize,
+            numExperts: config.nRoutedExperts ?? 1)
+        self.gate = DeepseekV2MoEGate(config: config)
+
+        if let shared = config.nSharedExperts {
+            self._sharedExperts.wrappedValue = DeepseekV2MLP(
+                config: config, intermediateSize: config.moeIntermediateSize * shared)
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (inds, scores) = gate(x)
+        var y = switchMLP(x, inds)
+        y = weightedExpertSum(y, scores)
+        if let shared = sharedExperts {
+            y = y + shared(x)
+        }
+        return y
+    }
+}
+
+class DeepseekV2DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: DeepseekV2Attention
+    var mlp: UnaryLayer
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(config: DeepseekV2Configuration, layerIdx: Int) {
+        self._selfAttn.wrappedValue = DeepseekV2Attention(config: config)
+
+        if config.nRoutedExperts != nil,
+            layerIdx >= config.firstKDenseReplace,
+            layerIdx % config.moeLayerFreq == 0
+        {
+            self.mlp = DeepseekV2MoE(config: config)
+        } else {
+            self.mlp = DeepseekV2MLP(config: config)
+        }
+
+        self._inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let r = selfAttn(inputLayerNorm(x), mask: mask, cache: cache)
+        let h = x + r
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+public class DeepseekV2ModelInner: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    fileprivate let layers: [DeepseekV2DecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(config: DeepseekV2Configuration) {
+        precondition(config.vocabSize > 0)
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
+        self.layers = (0 ..< config.numHiddenLayers).map {
+            DeepseekV2DecoderLayer(config: config, layerIdx: $0)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var h = embedTokens(x)
+        let mask = createAttentionMask(h: h, cache: cache?.first)
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: mask, cache: cache?[i])
+        }
+        return norm(h)
+    }
+}
+
+public class DeepseekV2Model: Module, LLMModel, KVCacheDimensionProvider, LoRAModel {
+    public var kvHeads: [Int]
+    let config: DeepseekV2Configuration
+    public let model: DeepseekV2ModelInner
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    public init(_ config: DeepseekV2Configuration) {
+        self.config = config
+        self.kvHeads = Array(repeating: config.numKeyValueHeads, count: config.numHiddenLayers)
+        self.model = DeepseekV2ModelInner(config: config)
+        self._lmHead.wrappedValue = Linear(config.hiddenSize, config.vocabSize, bias: false)
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+        lmHead(model(inputs, cache: cache))
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var newWeights = weights
+        for l in 0 ..< config.numHiddenLayers {
+            let prefix = "model.layers.\(l)"
+            for projName in ["gate_proj", "down_proj", "up_proj"] {
+                for key in ["weight", "scales", "biases"] {
+                    let firstKey = "\(prefix).mlp.experts.0.\(projName).\(key)"
+                    if weights[firstKey] != nil {
+                        let joined = (0 ..< (config.nRoutedExperts ?? 1)).map {
+                            newWeights.removeValue(
+                                forKey: "\(prefix).mlp.experts.\($0).\(projName).\(key)")!
+                        }
+                        newWeights["\(prefix).mlp.switch_mlp.\(projName).\(key)"] = stacked(joined)
+                    }
+                }
+            }
+        }
+        return newWeights.filter { key, _ in !key.contains("rotary_emb.inv_freq") }
+    }
+
+    public var loraLayers: [Module] {
+        model.layers
+    }
+}

--- a/Tests/MLXLMTests/DeepseekV2Tests.swift
+++ b/Tests/MLXLMTests/DeepseekV2Tests.swift
@@ -55,6 +55,29 @@ final class DeepseekV2Tests: XCTestCase {
         XCTAssertEqual(logits.shape, [1, 3, 32])
     }
 
+    /// Attention must update the KV cache exactly once per forward pass.
+    ///
+    /// The attention path builds `keys`/`values` and hands them to
+    /// `attentionWithCacheUpdate`, which performs the cache update itself. An
+    /// additional explicit `cache.update(...)` beforehand appended the returned
+    /// history a second time, so a prompt of L tokens left the cache at 2L and
+    /// every subsequent token attended over duplicated keys.
+    func testForwardPassUpdatesCacheExactlyOnce() throws {
+        let model = DeepseekV2Model(try makeConfig())
+        let cache = model.newCache(parameters: nil)
+        let tokenCount = 5
+        let inputs = MLXArray(Array(Int32(1) ... Int32(tokenCount))).reshaped(1, tokenCount)
+
+        let logits = model(inputs, cache: cache)
+        eval(logits)
+
+        for (i, layerCache) in cache.enumerated() {
+            XCTAssertEqual(
+                layerCache.offset, tokenCount,
+                "layer \(i) cache advanced by \(layerCache.offset) for \(tokenCount) tokens")
+        }
+    }
+
     func testGroupLimitedGreedyMasksLosingGroup() throws {
         let gate = DeepseekV2MoEGate(config: try makeConfig())
 

--- a/Tests/MLXLMTests/DeepseekV2Tests.swift
+++ b/Tests/MLXLMTests/DeepseekV2Tests.swift
@@ -31,7 +31,7 @@ final class DeepseekV2Tests: XCTestCase {
                 "routed_scaling_factor": 1.0,
                 "first_k_dense_replace": 1,
                 "moe_layer_freq": 1,
-                "q_lora_rank": 0,
+                "q_lora_rank": null,
                 "kv_lora_rank": 4,
                 "qk_rope_head_dim": 2,
                 "qk_nope_head_dim": 2,
@@ -77,6 +77,18 @@ final class DeepseekV2Tests: XCTestCase {
         XCTAssertEqual(
             chosen, [2, 3], "group-limited-greedy must confine top-k to the winning group")
         XCTAssertEqual(scores.reshaped(-1).asArray(Float.self).count, 2)
+    }
+
+    func testNullQLoraRankDecodesToNil() throws {
+        // DeepSeek-V2-Lite sets q_lora_rank: null → direct q_proj (no q LoRA).
+        // Regression: a null must NOT fall back to the 1536 default (that would
+        // build the q_a/q_b path and fail to load the checkpoint's q_proj).
+        XCTAssertNil(try makeConfig().qLoraRank)
+
+        let withRank = try JSONDecoder().decode(
+            DeepseekV2Configuration.self,
+            from: Data(#"{"hidden_size":8,"q_lora_rank":1536}"#.utf8))
+        XCTAssertEqual(withRank.qLoraRank, 1536)
     }
 
     func testSanitizeStacksPerExpertWeightsIntoSwitchMLP() throws {

--- a/Tests/MLXLMTests/DeepseekV2Tests.swift
+++ b/Tests/MLXLMTests/DeepseekV2Tests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+
+final class DeepseekV2Tests: XCTestCase {
+
+    // Tiny MoE config: 4 routed experts in 2 groups, top-1 group, top-2 experts.
+    private func makeConfig(topkMethod: String = "group_limited_greedy") throws
+        -> DeepseekV2Configuration
+    {
+        let json = """
+            {
+                "model_type": "deepseek_v2",
+                "vocab_size": 32,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "moe_intermediate_size": 8,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "n_routed_experts": 4,
+                "n_shared_experts": 1,
+                "num_experts_per_tok": 2,
+                "n_group": 2,
+                "topk_group": 1,
+                "topk_method": "\(topkMethod)",
+                "routed_scaling_factor": 1.0,
+                "first_k_dense_replace": 1,
+                "moe_layer_freq": 1,
+                "q_lora_rank": 0,
+                "kv_lora_rank": 4,
+                "qk_rope_head_dim": 2,
+                "qk_nope_head_dim": 2,
+                "v_head_dim": 4,
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 10000.0,
+                "max_position_embeddings": 128,
+                "rope_scaling": {"type": "yarn", "factor": 1.0, "mscale_all_dim": 0}
+            }
+            """
+        return try JSONDecoder().decode(DeepseekV2Configuration.self, from: Data(json.utf8))
+    }
+
+    func testForwardPassProducesLogitsShape() throws {
+        let model = DeepseekV2Model(try makeConfig())
+        let inputs = MLXArray([1, 2, 3] as [Int32]).reshaped(1, 3)
+
+        let logits = model(inputs, cache: nil)
+        eval(logits)
+
+        XCTAssertEqual(logits.shape, [1, 3, 32])
+    }
+
+    func testGroupLimitedGreedyMasksLosingGroup() throws {
+        let gate = DeepseekV2MoEGate(config: try makeConfig())
+
+        // weight is [n_routed_experts, hidden] = [4, 8]. Make expert e respond only
+        // to hidden dim e, so the input directly controls each expert's logit.
+        // Group layout (n_group=2): group0={e0,e1}, group1={e2,e3}.
+        var w = [Float](repeating: 0, count: 4 * 8)
+        for e in 0 ..< 4 { w[e * 8 + e] = 1 }
+        try gate.update(
+            parameters: ModuleParameters.unflattened(["weight": MLXArray(w).reshaped(4, 8)]),
+            verify: [])
+
+        // Drive experts 2 and 3 (group1) high, 0 and 1 (group0) low.
+        let x = MLXArray([0.1, 0.1, 3.0, 2.0, 0, 0, 0, 0] as [Float]).reshaped(1, 1, 8)
+        let (inds, scores) = gate(x)
+        eval(inds, scores)
+
+        let chosen = Set(inds.reshaped(-1).asArray(Int32.self).map(Int.init))
+        // top-1 group is group1 → only experts {2,3} may be selected (top-2 within it).
+        XCTAssertEqual(
+            chosen, [2, 3], "group-limited-greedy must confine top-k to the winning group")
+        XCTAssertEqual(scores.reshaped(-1).asArray(Float.self).count, 2)
+    }
+
+    func testSanitizeStacksPerExpertWeightsIntoSwitchMLP() throws {
+        let config = try makeConfig()
+        let model = DeepseekV2Model(config)
+
+        let (hidden, moeInter, experts) = (config.hiddenSize, config.moeIntermediateSize, 4)
+        var weights: [String: MLXArray] = [:]
+        for e in 0 ..< experts {
+            let p = "model.layers.1.mlp.experts.\(e)"  // layer 1 is MoE (first_k_dense_replace=1)
+            weights["\(p).gate_proj.weight"] = MLXArray.zeros([moeInter, hidden])
+            weights["\(p).down_proj.weight"] = MLXArray.zeros([hidden, moeInter])
+            weights["\(p).up_proj.weight"] = MLXArray.zeros([moeInter, hidden])
+        }
+
+        let out = model.sanitize(weights: weights)
+
+        XCTAssertNil(out["model.layers.1.mlp.experts.0.gate_proj.weight"])
+        let base = "model.layers.1.mlp.switch_mlp"
+        XCTAssertEqual(out["\(base).gate_proj.weight"]?.shape, [experts, moeInter, hidden])
+        XCTAssertEqual(out["\(base).down_proj.weight"]?.shape, [experts, hidden, moeInter])
+        XCTAssertEqual(out["\(base).up_proj.weight"]?.shape, [experts, moeInter, hidden])
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds the **DeepSeek-V2** architecture (`model_type: "deepseek_v2"`) to MLXLLM — a port of mlx-lm's [`deepseek_v2.py`](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/deepseek_v2.py). Covers DeepSeek-V2 / V2-Lite, which had no Swift implementation.

It reuses the in-tree **DeepSeek-V3** MLA machinery (`q_a`/`q_b` + `kv_a_proj_with_mqa`/`kv_b` low-rank compression, qk nope/rope split, the shared `initializeRope` YaRN path) and `SwitchGLU` MoE with shared experts.

It differs from V3 only in the router (`DeepseekV2MoEGate`):
- plain **softmax** scoring (no sigmoid + `e_score_correction_bias`),
- optional `group_limited_greedy` group masking by each group's **max** score (vs V3's top-2-per-group sum),
- an unconditional `routed_scaling_factor`.

Dense layers below `first_k_dense_replace` use the standard MLP. `sanitize()` stacks per-expert gate/up/down projections (`weight`/`scales`/`biases`) into `switch_mlp`.

Tests (`DeepseekV2Tests`, no model download): forward-pass logit shape; a **deterministic group-limited-greedy routing** test (synthetic gate weights → the winning group confines top-k); and `sanitize()` expert-stacking. Verified via `xcodebuild test ... -only-testing:MLXLMTests/DeepseekV2Tests` → 3 tests, 0 failures, **TEST SUCCEEDED**.

> Note: validation is structural/unit-level (shape + routing + weight-remap); end-to-end numerical parity against a downloaded DeepSeek-V2 checkpoint has not been run.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
