### PR TITLE
Fix silent state truncation for non-multiple-of-32 GDN key dim

### DIFF
--- a/Libraries/MLXLMCommon/GatedDelta.swift
+++ b/Libraries/MLXLMCommon/GatedDelta.swift
@@ -298,7 +298,14 @@ public func gatedDeltaUpdate(
         state = state.asType(.float32)
     }
 
-    if GatedDeltaKernelManager.shared.kernel != nil {
+    // The fused kernel distributes Dk over exactly 32 simd lanes
+    // (`n_per_t = Dk / 32`, integer-truncating). A key head dim that is not a
+    // multiple of 32 would silently drop its trailing `Dk % 32` state
+    // dimensions and produce wrong output with no error. Stock Qwen3.5 uses
+    // Dk = 192 (a multiple of 32), but the value is config-driven, so route any
+    // non-multiple-of-32 Dk to the ops fallback, which handles an arbitrary key
+    // dimension correctly (slower, but never truncating).
+    if GatedDeltaKernelManager.shared.kernel != nil, Dk % 32 == 0 {
         return gatedDeltaKernel(q: q, k: k, v: v, g: g, beta: beta, state: state, mask: mask)
     }
 

--- a/Tests/MLXLMTests/GatedDeltaTests.swift
+++ b/Tests/MLXLMTests/GatedDeltaTests.swift
@@ -78,4 +78,48 @@ public class GatedDeltaTests: XCTestCase {
         )
     }
 
+    /// A key head dim that is not a multiple of 32 must use every dim.
+    ///
+    /// The fused kernel distributes Dk over exactly 32 simd lanes
+    /// (`n_per_t = Dk / 32`, integer-truncating), so for Dk = 48 it covers only
+    /// dims 0..<32 and silently drops dims 32..<48. `gatedDeltaUpdate` guards
+    /// against this by routing any non-multiple-of-32 Dk to the ops fallback.
+    /// Proof: perturbing only the trailing `Dk % 32` dims of q/k must change the
+    /// output. Pre-guard the kernel ignores those dims (output unchanged); with
+    /// the guard the ops path uses them (output changes).
+    func testGatedDeltaNonMultipleOf32KeyDimUsesAllDims() throws {
+        let inputs = makeInputs(Dk: 48)
+
+        let (yBase, _) = gatedDeltaUpdate(
+            q: inputs.q, k: inputs.k, v: inputs.v,
+            a: inputs.a, b: inputs.b,
+            aLog: inputs.aLog, dtBias: inputs.dtBias
+        )
+
+        // Perturb only the trailing dims the truncating kernel would drop.
+        var qP = inputs.q
+        var kP = inputs.k
+        qP[0..., 0..., 0..., 32...] = qP[0..., 0..., 0..., 32...] + MLXArray(1).asType(.bfloat16)
+        kP[0..., 0..., 0..., 32...] = kP[0..., 0..., 0..., 32...] + MLXArray(1).asType(.bfloat16)
+
+        let (yPerturbed, _) = gatedDeltaUpdate(
+            q: qP, k: kP, v: inputs.v,
+            a: inputs.a, b: inputs.b,
+            aLog: inputs.aLog, dtBias: inputs.dtBias
+        )
+
+        let diff = abs(yBase.asType(.float32) - yPerturbed.asType(.float32)).max()
+        eval(diff)
+        let maxDiff = diff.item(Float.self)
+
+        // Pre-guard: kernel drops dims 32..<48, so the perturbation is invisible
+        // (maxDiff ≈ 0). With the guard: ops fallback uses all dims, output moves.
+        XCTAssertGreaterThan(
+            maxDiff, 1e-3,
+            "Perturbing trailing Dk dims (32..<48) left GDN output unchanged "
+                + "(\(maxDiff) max abs) — Dk % 32 != 0 was routed to the truncating "
+                + "kernel instead of the ops fallback."
+        )
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

The fused gated-delta kernel distributes the key head dim `Dk` over exactly 32 simd lanes (`n_per_t = Dk / 32`, integer-truncating). When `Dk` is **not** a multiple of 32 the kernel covers only dims `0..<(32 * n_per_t)` and silently drops the trailing `Dk % 32` state dimensions, producing wrong output with no error.

Stock Qwen3.5 uses `Dk = 192` (a multiple of 32) so this never fires there, but the dimension is config-driven, so a model with a non-multiple-of-32 key dim would hit it.

This guards `gatedDeltaUpdate` so any non-multiple-of-32 `Dk` routes to the ops fallback (`gatedDeltaOps`), which handles an arbitrary key dimension correctly (slower, but never truncating).

## Test

Adds `testGatedDeltaNonMultipleOf32KeyDimUsesAllDims`: builds inputs with `Dk = 48`, perturbs **only** the trailing `Dk % 32` dims (32..<48) of q/k, and asserts the output moves. The truncating kernel ignores those dims (max abs diff `0.0`); the ops fallback uses them. Verified the test fails without the guard and passes with it.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)