### PR TITLE
Set indentConditionalCompilationBlocks to false in .swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -4,4 +4,5 @@
         "spaces": 4
     },
     "spacesAroundRangeFormationOperators": true,
+    "indentConditionalCompilationBlocks": false,
 }

--- a/Libraries/MLXLMCommon/WiredMemoryPolicies.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryPolicies.swift
@@ -5,9 +5,9 @@ import MLX
 
 private func recommendedWorkingSetBytes() -> Int? {
     #if canImport(Metal)
-        GPU.maxRecommendedWorkingSetBytes()
+    GPU.maxRecommendedWorkingSetBytes()
     #else
-        nil
+    nil
     #endif
 }
 

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -19,9 +19,9 @@ public struct ProcessedFrames {
 // per-process IOSurface limit of 16384, crashing the render pipeline.
 // Batch-processing never re-renders the same frame twice, so the cache buys nothing.
 #if compiler(>=6.2)  // proxy check for macOS 26 SDK, where CIContext is Sendable
-    private let context = CIContext(options: [.cacheIntermediates: false])
+private let context = CIContext(options: [.cacheIntermediates: false])
 #else
-    nonisolated(unsafe) private let context = CIContext(options: [.cacheIntermediates: false])
+nonisolated(unsafe) private let context = CIContext(options: [.cacheIntermediates: false])
 #endif
 
 /// Collection of methods for processing media (images, video, etc.).


### PR DESCRIPTION
Aligns the body of #if/#else/#endif blocks with the directive instead of indenting it one level deeper.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
