### PR TITLE
ci: pin swift-format version so lint doesn't drift across PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,12 +30,12 @@ jobs:
         id: swift-format
         shell: sh
         run: |
-          cd /tmp
-          LATEST_TAG=$(curl -s https://api.github.com/repos/swiftlang/swift-format/releases/latest | \
-            grep '"tag_name":' | \
-            sed -E 's/.*"([^"]+)".*/\1/')
-          echo "swift-format $LATEST_TAG"
-          echo "SWIFT_FORMAT_VERSION=$LATEST_TAG" >> $GITHUB_OUTPUT
+          # Pinned instead of releases/latest: a new swift-format release can
+          # change formatting rules and reformat files no PR touched, turning
+          # the whole-repo `pre-commit run --all` red on every open PR at once.
+          # Bump this deliberately (with the matching reformat) rather than
+          # tracking latest. 603.0.0 is what `latest` resolved to at pin time.
+          echo "SWIFT_FORMAT_VERSION=603.0.0" >> $GITHUB_OUTPUT
 
       - name: Cache swift-format build
         uses: actions/cache@v4


### PR DESCRIPTION
## What

- Pin the CI `lint` job's swift-format to a fixed tag (`603.0.0`) instead of resolving `releases/latest` at run time.
- Reformat the one file that the 603.0.0 rules changed (`Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift` — attributed-import grouping).

## Why

The `lint` job builds swift-format from `releases/latest`:

```sh
LATEST_TAG=$(curl -s https://api.github.com/repos/swiftlang/swift-format/releases/latest | ...)
```

So CI silently adopts each new swift-format release. When **603.0.0** shipped, its `OrderedImports` rule began grouping attributed imports (`@_spi` / `@testable`) into a trailing block. That reformatted `MTPSpeculativeTokenIteratorTests.swift` — a file no in-flight PR had touched — and because the step runs `pre-commit run --all` over the **whole repo**, every open PR's lint went red at once with a diff unrelated to its own change (observed on #383 and #384).

Pinning makes lint **reproducible**: the rules only change when someone deliberately bumps the tag (and reformats in the same PR), not whenever upstream cuts a release. `603.0.0` is exactly what `latest` resolves to today, so this is a no-op to the tool version — it just freezes it.

## Note

The `pre-commit` hook is `language: system`, so contributors' local swift-format still isn't locked to CI's version. Matching the pinned tag locally is the reliable way to reproduce lint; if you'd prefer, a follow-up could switch the hook to a pinned swift-format rev so local and CI are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)