### PR TITLE
Convert Gemma tool parameters by schema type

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -59,7 +59,8 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
                 argsStr = String(argsStr.dropFirst(marker.count))
                 guard let endEscape = argsStr.range(of: marker) else { break }
                 let value = String(argsStr[..<endEscape.lowerBound])
-                arguments[key] = value
+                arguments[key] = convertParameterValue(
+                    value, paramName: key, funcName: funcName, tools: tools)
                 argsStr = String(argsStr[endEscape.upperBound...])
                 // Skip comma if present
                 if argsStr.hasPrefix(",") {
@@ -76,7 +77,10 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
                 ? String(argsStr[argsStr.index(after: commaIdx)...]) : ""
 
             // Try JSON decode, fallback to string
-            if let data = value.data(using: .utf8),
+            if getParameterType(funcName: funcName, paramName: key, tools: tools) != nil {
+                arguments[key] = convertParameterValue(
+                    value, paramName: key, funcName: funcName, tools: tools)
+            } else if let data = value.data(using: .utf8),
                 let json = deserializeJSON(data)
             {
                 arguments[key] = json

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 import MLX
-@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
+
+@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -807,6 +807,36 @@ struct ToolTests {
         #expect(toolCall.function.arguments["query"] == .string("hello, world!"))
     }
 
+    @Test("Test Gemma 4 Function Parser - Type Conversion")
+    func testGemma4ParserTypeConversion() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "mail_read",
+                    "parameters": [
+                        "properties": [
+                            "account": ["type": "string"],
+                            "mailbox": ["type": "string"],
+                            "id": ["type": "integer"],
+                        ]
+                    ],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content =
+            #"<|tool_call>call:mail_read{account:<|"|>me@example.com<|"|>,mailbox:<|"|>INBOX<|"|>,id:<|"|>158348<|"|>}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(toolCall.function.name == "mail_read")
+        #expect(toolCall.function.arguments["account"] == .string("me@example.com"))
+        #expect(toolCall.function.arguments["mailbox"] == .string("INBOX"))
+        #expect(toolCall.function.arguments["id"] == .int(158_348))
+        #expect(toolCall.function.arguments["id"] != .string("158348"))
+    }
+
     @Test("Test Gemma Format via ToolCallProcessor")
     func testGemmaFormatProcessor() throws {
         let processor = ToolCallProcessor(format: .gemma)


### PR DESCRIPTION
## Proposed changes

`GemmaFunctionParser.parse(content:tools:)` was missing calls to `convertParameterValue(_:paramName:funcName:tools:)`, which means that all tool call arguments were being passed as strings instead of being coerced into the types the functions expected. This pull request adds the missing calls to `convertParameterValue(_:paramName:funcName:tools:)` and a unit test to verify the fix.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
