### PR TITLE
Fix Gemma 4 VLM load: KV-shared layers must not declare k_proj/v_proj

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1112,8 +1112,19 @@ final class Gemma4TextBackbone: Module {
 
         self._embedTokens.wrappedValue = Embedding(
             embeddingCount: config.vocabularySize, dimensions: config.hiddenSize)
-        self._layers.wrappedValue = (0 ..< config.hiddenLayers).map {
-            Gemma4TextDecoderLayer(config: config, layerIdx: $0)
+        // KV-shared tail layers (`layer_idx >= hidden_layers - num_kv_shared_layers`)
+        // reuse an earlier same-type layer's K/V and own no local K/V projection or
+        // K norm. Build them with `kvSharedOnly: true` so the module tree omits those
+        // tensors — matching what `sanitize` drops from the checkpoint, and mirroring
+        // both `Gemma4AssistantDraftInner` and upstream mlx-lm (`Attention.has_kv`).
+        // Without this, shared layers declare a `v_proj`/`k_proj`/`k_norm` that no
+        // weight fills, so loading a Gemma 4 checkpoint fails under the strict loader
+        // verify with e.g. `keyNotFound(… layers.24.self_attn.v_proj.weight …)`.
+        let firstKVSharedLayer = config.hiddenLayers - config.numKVSharedLayers
+        self._layers.wrappedValue = (0 ..< config.hiddenLayers).map { idx in
+            Gemma4TextDecoderLayer(
+                config: config, layerIdx: idx,
+                kvSharedOnly: firstKVSharedLayer > 0 && idx >= firstKVSharedLayer)
         }
         self._norm.wrappedValue = Gemma4RMSNormZeroShift(
             dimensions: config.hiddenSize, eps: config.rmsNormEps)

--- a/Tests/MLXLMTests/Gemma4KVSharedLoadTests.swift
+++ b/Tests/MLXLMTests/Gemma4KVSharedLoadTests.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import MLXVLM
+
+// MARK: - Regression: KV-shared layers must not declare local K/V projections
+//
+// Gemma 4's tail layers (`layer_idx >= num_hidden_layers - num_kv_shared_layers`)
+// reuse an earlier same-type layer's K/V and own no `k_proj` / `v_proj` / `k_norm`.
+// `Gemma4TextLanguageModel.sanitize` drops those tensors from the checkpoint, and
+// the runtime forward feeds the shared layers a `sharedKV` instead of computing
+// their own. If the module tree still *constructs* those projections (the default
+// `kvSharedOnly: false`), loading any real Gemma 4 checkpoint fails under the
+// strict loader verify with e.g.
+//
+//   keyNotFound(path: ["language_model","model","layers","24","self_attn",
+//                      "v_proj","weight"], modules: [... "Gemma4TextAttention","Linear"])
+//
+// (`mlx-community/gemma-4-e4b-it-4bit`: num_hidden_layers=42, num_kv_shared_layers=18
+//  → the first shared layer is 24.) These tests pin the construction side to the
+// sanitize side so the two can't drift apart again.
+
+struct Gemma4KVSharedLoadTests {
+
+    /// The module tree of a model with KV sharing must not contain
+    /// `k_proj` / `v_proj` / `k_norm` for the shared tail layers, while the
+    /// non-shared head layers must still own them.
+    @Test("KV-shared layers own no local k_proj/v_proj/k_norm")
+    func kvSharedLayersOwnNoLocalKVProjections() {
+        // 4 layers, 2 KV-shared → layers 0,1 own K/V; layers 2,3 share it.
+        let model = Gemma4TextLanguageModel(Self.textConfig(numKVSharedLayers: 2))
+        let keys = Set(model.parameters().flattened().map(\.0))
+
+        // Head (KV-owning) layers keep their projections.
+        for owning in [0, 1] {
+            #expect(keys.contains { $0.contains("layers.\(owning).self_attn.k_proj") })
+            #expect(keys.contains { $0.contains("layers.\(owning).self_attn.v_proj") })
+        }
+        // Tail (KV-shared) layers must own none of them.
+        for shared in [2, 3] {
+            #expect(!keys.contains { $0.contains("layers.\(shared).self_attn.k_proj") })
+            #expect(!keys.contains { $0.contains("layers.\(shared).self_attn.v_proj") })
+            #expect(!keys.contains { $0.contains("layers.\(shared).self_attn.k_norm") })
+        }
+    }
+
+    /// End-to-end reproduction of the production load failure: build a
+    /// checkpoint that carries K/V projections on every layer (a dense export),
+    /// sanitize it the way real Gemma 4 checkpoints are sanitized (drop the
+    /// KV-shared tail's `k_proj`/`v_proj`/`k_norm`), then load it into the
+    /// KV-sharing model through the exact call the production loader uses.
+    /// Before the fix this threw `keyNotFound(… self_attn.v_proj.weight …)`.
+    @Test("Sanitized Gemma 4 checkpoint loads into a KV-sharing model")
+    func sanitizedCheckpointLoadsWithoutKeyNotFound() throws {
+        // A "dense" sibling (no KV sharing) supplies weights for every layer,
+        // independent of how the KV-sharing model constructs its own tree.
+        let dense = Gemma4TextLanguageModel(Self.textConfig(numKVSharedLayers: 0))
+        eval(dense)
+
+        let firstKVSharedLayer = 4 - 2
+        var checkpoint = [String: MLXArray]()
+        for (key, value) in dense.parameters().flattened() {
+            if let layerIdx = Self.layerIndex(in: key), layerIdx >= firstKVSharedLayer,
+                key.contains(".self_attn.k_proj")
+                    || key.contains(".self_attn.v_proj")
+                    || key.contains(".self_attn.k_norm")
+            {
+                continue  // dropped by sanitize for KV-shared layers
+            }
+            checkpoint[key] = value
+        }
+
+        let model = Gemma4TextLanguageModel(Self.textConfig(numKVSharedLayers: 2))
+        // `[.all]` is what `MLXLMCommon.loadWeights` applies — it throws on any
+        // module parameter that has no matching weight (the original bug).
+        try model.update(
+            parameters: ModuleParameters.unflattened(checkpoint), verify: [.all])
+        eval(model)
+    }
+
+    // MARK: - Helpers
+
+    private static func layerIndex(in key: String) -> Int? {
+        guard let range = key.range(of: "layers.") else { return nil }
+        return Int(key[range.upperBound...].prefix { $0.isNumber })
+    }
+
+    /// Tiny all-`full_attention` text config. `use_double_wide_mlp` is off so the
+    /// dense and KV-sharing models differ *only* in the shared layers' K/V tensors,
+    /// keeping every other weight shape-compatible across the two.
+    private static func textConfig(numKVSharedLayers: Int) -> Gemma4TextConfiguration {
+        let json = """
+            {
+              "model_type": "gemma4_text",
+              "hidden_size": 8,
+              "num_hidden_layers": 4,
+              "intermediate_size": 16,
+              "num_attention_heads": 2,
+              "num_key_value_heads": 1,
+              "head_dim": 4,
+              "global_head_dim": 4,
+              "vocab_size": 12,
+              "vocab_size_per_layer_input": 12,
+              "num_kv_shared_layers": \(numKVSharedLayers),
+              "hidden_size_per_layer_input": 0,
+              "sliding_window": 8,
+              "sliding_window_pattern": 1,
+              "max_position_embeddings": 32,
+              "rms_norm_eps": 1e-6,
+              "rope_traditional": false,
+              "use_double_wide_mlp": false,
+              "enable_moe_block": false,
+              "attention_k_eq_v": false,
+              "layer_types": [
+                "full_attention", "full_attention", "full_attention", "full_attention"
+              ],
+              "rope_parameters": {},
+              "tie_word_embeddings": true
+            }
+            """
+        return try! JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 import MLX
-@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
+
+@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,10 +2,9 @@
 
 import Foundation
 import MLX
+@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
-
-@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 


### PR DESCRIPTION
## Summary

Loading any Gemma 4 (`model_type: "gemma4"`) checkpoint that uses cross-layer KV
sharing — e.g. `mlx-community/gemma-4-e4b-it-4bit` — fails at weight load with:

```
keyNotFound(path: ["language_model","model","layers","24","self_attn","v_proj","weight"],
            modules: ["Gemma4","Gemma4TextLanguageModel","Gemma4TextBackbone",
                      "Gemma4TextDecoderLayer","Gemma4TextAttention","Linear"])
```

(`gemma-4-e4b-it-4bit` has `num_hidden_layers: 42`, `num_kv_shared_layers: 18`, so
the first KV-shared layer is exactly `42 - 18 = 24` — the layer named in the error.)

## Root cause

Gemma 4's tail layers (`layer_idx >= num_hidden_layers - num_kv_shared_layers`) reuse
an earlier same-type layer's K/V and own no `k_proj` / `v_proj` / `k_norm`. Everything
in the stack already knows this **except** the module construction:

- `Gemma4TextAttention.init` takes `kvSharedOnly:` and, when set, skips building
  `k_proj` / `v_proj` / `k_norm` / `v_norm`.
- `Gemma4TextLanguageModel.sanitize` **drops** `self_attn.k_proj` / `v_proj` / `k_norm`
  for layers `>= firstKVSharedLayer` (added in #330).
- The runtime forward feeds those layers a `sharedKV`, so they never compute their own
  K/V (they never touch the projections at all).
- `Gemma4AssistantDraftInner` (the MTP drafter) already builds its layers with
  `kvSharedOnly: true`.
- Upstream `mlx-lm`'s `gemma4_text.py` gates the same tensors on
  `has_kv = layer_idx < num_hidden_layers - num_kv_shared_layers`, and the third-party
  `VincentGourbin/gemma-4-swift-mlx` (which runs E4B) likewise omits `k_proj`/`v_proj`
  for `isKvSharedLayer` layers.

But `Gemma4TextBackbone.init` builds **every** layer with the default
`kvSharedOnly: false`:

```swift
self._layers.wrappedValue = (0 ..< config.hiddenLayers).map {
    Gemma4TextDecoderLayer(config: config, layerIdx: $0)   // ← never kvSharedOnly: true
}
```

So the module tree declares a `v_proj` (and `k_proj` / `k_norm`) on the KV-shared
layers that `sanitize` has just removed from the checkpoint. The strict loader verify
(`model.update(parameters:verify: [.all])` in `MLXLMCommon/Load.swift`) then throws
`keyNotFound` on the first such tensor — `layers.24.self_attn.v_proj.weight`.

This is the construction-side complement of #330: that PR fixed the checkpoint side
(drop the redundant tensors) but the module side still instantiates them, so the two
disagree. Both QAT checkpoints (which omit the tensors) and PTQ checkpoints (whose
redundant tensors #330 now drops) hit this.

## Fix

Wire the construction to the same predicate the attention, the sanitizer, and the
drafter already use — build the KV-shared tail with `kvSharedOnly: true`:

```swift
let firstKVSharedLayer = config.hiddenLayers - config.numKVSharedLayers
self._layers.wrappedValue = (0 ..< config.hiddenLayers).map { idx in
    Gemma4TextDecoderLayer(
        config: config, layerIdx: idx,
        kvSharedOnly: firstKVSharedLayer > 0 && idx >= firstKVSharedLayer)
}
```

The predicate is identical to `Gemma4TextAttention.isKVSharedLayer`
(`layerIdx >= firstKVSharedLayer && firstKVSharedLayer > 0`) and to the
`sanitize` drop condition, so the module tree now matches the sanitized checkpoint
exactly. Runtime behavior is unchanged: those layers already consumed `sharedKV` and
never invoked the now-absent projections, so no forward output changes — only the
dead, unfillable parameters go away. `Gemma4Unified` (`num_kv_shared_layers: 0`) and
any non-sharing config are unaffected (`firstKVSharedLayer > 0 && …` stays false).

## Test

`Tests/MLXLMTests/Gemma4KVSharedLoadTests.swift`:

1. **Structural** — a KV-sharing `Gemma4TextLanguageModel`'s parameter tree contains
   `k_proj`/`v_proj` for the head layers and none for the shared tail.
2. **Load round-trip** — build a dense checkpoint (K/V on every layer), sanitize it
   the way real Gemma 4 checkpoints are (drop the shared tail's `k_proj`/`v_proj`/
   `k_norm`), then load it into the KV-sharing model via the exact
   `update(parameters:verify: [.all])` the production loader uses. This throws
   `keyNotFound(… self_attn.v_proj.weight …)` before the fix and passes after.

## Relation to #282

Issue ml-explore/mlx-swift-lm#282 bundles three Gemma 4 loader gaps (the
`gemma4_assistant` MTP drafter, the 26B MoE variant, and the 31B SIGTRAP). Those have
since landed. This is a distinct, more basic gap on the same stack: the base
`gemma4` E4B/E2B model doesn't finish loading at all when KV sharing is active.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
