### PR TITLE
Add end-to-end video input to the base Gemma 4 (gemma4) VLM

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -7,15 +7,11 @@ import MLXNN
 // Based on https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/gemma4
 
 private enum Gemma4Error: LocalizedError {
-    case imageTokenCountMismatch(expectedVisionTokens: Int, actualPromptTokens: Int)
     case multimodalTokenCountMismatch(kind: String, featureTokens: Int, promptTokens: Int)
     case imagePlaceholderMismatch(images: Int, placeholders: Int)
 
     var errorDescription: String? {
         switch self {
-        case .imageTokenCountMismatch(let expectedVisionTokens, let actualPromptTokens):
-            return
-                "Gemma4 image token count mismatch: vision encoder produced \(expectedVisionTokens) soft tokens, but the prompt contains \(actualPromptTokens) image tokens."
         case .multimodalTokenCountMismatch(let kind, let featureTokens, let promptTokens):
             return
                 "Gemma4 \(kind) token count mismatch: encoder produced \(featureTokens) soft tokens, but the prompt contains \(promptTokens) \(kind) tokens."
@@ -568,6 +564,7 @@ public struct Gemma4Configuration: Codable, Sendable {
     public let quantization: BaseConfiguration.Quantization?
     public let imageTokenId: Int
     public let audioTokenId: Int?
+    public let videoTokenId: Int?
     public let boiTokenId: Int
     public let eoiTokenId: Int?
     public let visionSoftTokensPerImage: Int
@@ -588,6 +585,7 @@ public struct Gemma4Configuration: Codable, Sendable {
         case quantization
         case imageTokenId = "image_token_id"
         case audioTokenId = "audio_token_id"
+        case videoTokenId = "video_token_id"
         case boiTokenId = "boi_token_id"
         case eoiTokenId = "eoi_token_id"
         case visionSoftTokensPerImage = "vision_soft_tokens_per_image"
@@ -608,6 +606,7 @@ public struct Gemma4Configuration: Codable, Sendable {
             BaseConfiguration.Quantization.self, forKey: CodingKeys.quantization)
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.imageTokenId) ?? 258_880
         audioTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioTokenId)
+        videoTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoTokenId)
         boiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boiTokenId) ?? 255_999
         eoiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoiTokenId)
         visionSoftTokensPerImage =
@@ -1978,7 +1977,8 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
 
     private func getInputEmbeddings(
         inputIds: MLXArray,
-        image: LMInput.ProcessedImage? = nil
+        image: LMInput.ProcessedImage? = nil,
+        video: LMInput.ProcessedVideo? = nil
     ) throws -> (MLXArray, MLXArray?) {
         var inputsEmbeds = languageModel.model.embedTokens(inputIds)
         inputsEmbeds =
@@ -1988,64 +1988,103 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
 
         var perLayerInputs: MLXArray? = nil
         if config.textConfiguration.hiddenSizePerLayerInput > 0 {
-            let imageMask = inputIds .== config.imageTokenId
-            let audioMask =
-                if let audioTokenId = config.audioTokenId {
-                    inputIds .== audioTokenId
-                } else {
-                    MLXArray.zeros(like: imageMask)
-                }
-            let textMask = logicalNot(logicalOr(imageMask, audioMask))
-            let perLayerTokens = MLX.where(textMask, inputIds, MLXArray.zeros(like: inputIds))
+            // Per-layer inputs are text-only: zero out every multimodal soft token
+            // (image / audio / video) so their ids don't index the PLE embedding.
+            var multimodalMask = inputIds .== config.imageTokenId
+            if let audioTokenId = config.audioTokenId {
+                multimodalMask = multimodalMask | (inputIds .== audioTokenId)
+            }
+            if let videoTokenId = config.videoTokenId {
+                multimodalMask = multimodalMask | (inputIds .== videoTokenId)
+            }
+            let perLayerTokens = MLX.where(
+                logicalNot(multimodalMask), inputIds, MLXArray.zeros(like: inputIds))
             perLayerInputs = languageModel.model.getPerLayerInputs(perLayerTokens)
         }
 
-        guard let image else {
-            return (inputsEmbeds, perLayerInputs)
-        }
-
-        // Images keep their own aspect-preserving sizes: the processor
-        // zero-pads them onto a shared canvas and records each real size in
-        // frames. Slice each image back out, run the tower on it alone, and
-        // concatenate the pooled tokens in placeholder order.
-        let pixels =
-            if image.pixels.ndim == 3 {
-                expandedDimensions(image.pixels, axis: 0)
-            } else {
-                image.pixels
+        if let image {
+            // Images keep their own aspect-preserving sizes: the processor
+            // zero-pads them onto a shared canvas and records each real size in
+            // frames. Slice each image back out, run the tower on it alone, and
+            // concatenate the pooled tokens in placeholder order.
+            let pixels =
+                if image.pixels.ndim == 3 {
+                    expandedDimensions(image.pixels, axis: 0)
+                } else {
+                    image.pixels
+                }
+            let frames =
+                image.frames
+                ?? Array(repeating: THW(1, pixels.dim(2), pixels.dim(3)), count: pixels.dim(0))
+            var perImageFeatures: [MLXArray] = []
+            for (index, frame) in frames.enumerated() {
+                let imagePixels = pixels[index ..< index + 1, 0..., ..<frame.h, ..<frame.w]
+                perImageFeatures.append(visionTower(imagePixels))
             }
-        let frames =
-            image.frames
-            ?? Array(repeating: THW(1, pixels.dim(2), pixels.dim(3)), count: pixels.dim(0))
-        var perImageFeatures: [MLXArray] = []
-        for (index, frame) in frames.enumerated() {
-            let imagePixels = pixels[index ..< index + 1, 0..., ..<frame.h, ..<frame.w]
-            perImageFeatures.append(visionTower(imagePixels))
+            var imageFeatures =
+                perImageFeatures.count == 1
+                ? perImageFeatures[0]
+                : concatenated(perImageFeatures, axis: 1)
+            imageFeatures = embedVision(imageFeatures)
+            imageFeatures = imageFeatures.asType(inputsEmbeds.dtype)
+
+            let imageMask = inputIds .== config.imageTokenId
+            let expectedImageTokens = imageMask.asType(.int32).sum().item(Int.self)
+
+            if expectedImageTokens != imageFeatures.dim(1) {
+                throw Gemma4Error.imageTokenCountMismatch(
+                    expectedVisionTokens: imageFeatures.dim(1),
+                    actualPromptTokens: expectedImageTokens)
+            }
+
+            var imageMaskExpanded = expandedDimensions(imageMask, axis: -1)
+            imageMaskExpanded = broadcast(imageMaskExpanded, to: inputsEmbeds.shape)
+            inputsEmbeds = gemma4MaskedScatter(
+                inputTensor: inputsEmbeds,
+                mask: imageMaskExpanded,
+                source: imageFeatures
+            )
         }
-        var imageFeatures =
-            perImageFeatures.count == 1
-            ? perImageFeatures[0]
-            : concatenated(perImageFeatures, axis: 1)
-        imageFeatures = embedVision(imageFeatures)
-        imageFeatures = imageFeatures.asType(inputsEmbeds.dtype)
 
-        let imageMask = inputIds .== config.imageTokenId
-        let expectedImageTokens = imageMask.asType(.int32).sum().item(Int.self)
-
-        if expectedImageTokens != imageFeatures.dim(1) {
-            throw Gemma4Error.imageTokenCountMismatch(
-                expectedVisionTokens: imageFeatures.dim(1), actualPromptTokens: expectedImageTokens)
+        // Gemma 4 has no separate video encoder — video frames run through the same
+        // vision tower and scatter onto the `<video>` soft-token positions, mirroring
+        // `Gemma4Unified`. Video frames come from the processor at a uniform size,
+        // so they don't need the per-image aspect-preserving slicing above.
+        if let video, let videoTokenId = config.videoTokenId {
+            inputsEmbeds = try scatterVisionFeatures(
+                into: inputsEmbeds, inputIds: inputIds, pixelValues: video.pixels,
+                tokenId: videoTokenId, kind: "video")
         }
-
-        var imageMaskExpanded = expandedDimensions(imageMask, axis: -1)
-        imageMaskExpanded = broadcast(imageMaskExpanded, to: inputsEmbeds.shape)
-        inputsEmbeds = gemma4MaskedScatter(
-            inputTensor: inputsEmbeds,
-            mask: imageMaskExpanded,
-            source: imageFeatures
-        )
 
         return (inputsEmbeds, perLayerInputs)
+    }
+
+    /// Encode `pixelValues` through the shared vision tower and scatter the resulting
+    /// soft tokens onto the `tokenId` positions of `inputsEmbeds`. Used for the video
+    /// path (Gemma 4 reuses the vision stack for video frames); still images go
+    /// through the per-image aspect-preserving path in `getInputEmbeddings`.
+    private func scatterVisionFeatures(
+        into inputsEmbeds: MLXArray,
+        inputIds: MLXArray,
+        pixelValues: MLXArray,
+        tokenId: Int,
+        kind: String
+    ) throws -> MLXArray {
+        var features = visionTower(pixelValues)
+        features = embedVision(features)
+        features = features.asType(inputsEmbeds.dtype)
+
+        let tokenMask = inputIds .== tokenId
+        let expectedTokens = tokenMask.asType(.int32).sum().item(Int.self)
+        if expectedTokens != features.dim(1) {
+            throw Gemma4Error.multimodalTokenCountMismatch(
+                kind: kind, featureTokens: features.dim(1), promptTokens: expectedTokens)
+        }
+
+        var maskExpanded = expandedDimensions(tokenMask, axis: -1)
+        maskExpanded = broadcast(maskExpanded, to: inputsEmbeds.shape)
+        return gemma4MaskedScatter(
+            inputTensor: inputsEmbeds, mask: maskExpanded, source: features)
     }
 
     public func prepare(
@@ -2054,9 +2093,9 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         -> PrepareResult
     {
         let convertedCache = cache.map { $0 }
-        if let image = input.image {
+        if input.image != nil || input.video != nil {
             let (inputsEmbeds, perLayerInputs) = try getInputEmbeddings(
-                inputIds: input.text.tokens, image: image)
+                inputIds: input.text.tokens, image: input.image, video: input.video)
             let result = languageModel(
                 nil,
                 cache: convertedCache,
@@ -2065,7 +2104,7 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
                 tokenTypeIds: gemma4TokenTypeIds(
                     inputIds: input.text.tokens,
                     imageTokenId: config.imageTokenId,
-                    videoTokenId: nil,
+                    videoTokenId: config.videoTokenId,
                     audioTokenId: config.audioTokenId)
             )
             return .logits(result)

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -568,6 +568,7 @@ public struct Gemma4Configuration: Codable, Sendable {
     public let boiTokenId: Int
     public let eoiTokenId: Int?
     public let visionSoftTokensPerImage: Int
+    public let visionSoftTokensPerVideoFrame: Int
     public let tieWordEmbeddings: Bool
 
     private let _vocabularySize: Int?
@@ -589,6 +590,7 @@ public struct Gemma4Configuration: Codable, Sendable {
         case boiTokenId = "boi_token_id"
         case eoiTokenId = "eoi_token_id"
         case visionSoftTokensPerImage = "vision_soft_tokens_per_image"
+        case visionSoftTokensPerVideoFrame = "vision_soft_tokens_per_video_frame"
         case tieWordEmbeddings = "tie_word_embeddings"
         case _vocabularySize = "vocab_size"
         case _hiddenSize = "hidden_size"
@@ -612,6 +614,8 @@ public struct Gemma4Configuration: Codable, Sendable {
         visionSoftTokensPerImage =
             try c.decodeIfPresent(Int.self, forKey: CodingKeys.visionSoftTokensPerImage)
             ?? visionConfiguration.defaultOutputLength
+        visionSoftTokensPerVideoFrame =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.visionSoftTokensPerVideoFrame) ?? 70
         tieWordEmbeddings =
             try c.decodeIfPresent(Bool.self, forKey: CodingKeys.tieWordEmbeddings)
             ?? textConfiguration.tieWordEmbeddings
@@ -2032,9 +2036,9 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             let expectedImageTokens = imageMask.asType(.int32).sum().item(Int.self)
 
             if expectedImageTokens != imageFeatures.dim(1) {
-                throw Gemma4Error.imageTokenCountMismatch(
-                    expectedVisionTokens: imageFeatures.dim(1),
-                    actualPromptTokens: expectedImageTokens)
+                throw Gemma4Error.multimodalTokenCountMismatch(
+                    kind: "image", featureTokens: imageFeatures.dim(1),
+                    promptTokens: expectedImageTokens)
             }
 
             var imageMaskExpanded = expandedDimensions(imageMask, axis: -1)
@@ -2046,39 +2050,45 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             )
         }
 
-        // Gemma 4 has no separate video encoder — video frames run through the same
-        // vision tower and scatter onto the `<video>` soft-token positions, mirroring
-        // `Gemma4Unified`. Video frames come from the processor at a uniform size,
-        // so they don't need the per-image aspect-preserving slicing above.
+        // Gemma 4 has no separate video encoder — each video frame runs through the
+        // same vision tower as images (producing `visionSoftTokensPerImage` pooled
+        // tokens per frame) and is then truncated to the smaller per-frame video
+        // budget before scattering onto the `<video>` soft-token positions. Video
+        // frames come from the processor at a uniform size, so they don't need the
+        // per-image aspect-preserving slicing above.
         if let video, let videoTokenId = config.videoTokenId {
-            inputsEmbeds = try scatterVisionFeatures(
-                into: inputsEmbeds, inputIds: inputIds, pixelValues: video.pixels,
-                tokenId: videoTokenId, kind: "video")
+            inputsEmbeds = try scatterVideoFeatures(
+                into: inputsEmbeds, inputIds: inputIds, videoPixelValues: video.pixels,
+                tokenId: videoTokenId, softTokensPerFrame: config.visionSoftTokensPerVideoFrame)
         }
 
         return (inputsEmbeds, perLayerInputs)
     }
 
-    /// Encode `pixelValues` through the shared vision tower and scatter the resulting
-    /// soft tokens onto the `tokenId` positions of `inputsEmbeds`. Used for the video
-    /// path (Gemma 4 reuses the vision stack for video frames); still images go
-    /// through the per-image aspect-preserving path in `getInputEmbeddings`.
-    private func scatterVisionFeatures(
+    /// Encode video frames (`[numFrames, C, H, W]`) through the shared vision tower,
+    /// keep the first `softTokensPerFrame` pooled tokens of each frame, and scatter the
+    /// resulting `numFrames * softTokensPerFrame` soft tokens onto the `tokenId`
+    /// positions. Gemma 4 gives video frames a smaller token budget than full images;
+    /// the processor resizes frames so those leading tokens carry the frame's content.
+    private func scatterVideoFeatures(
         into inputsEmbeds: MLXArray,
         inputIds: MLXArray,
-        pixelValues: MLXArray,
+        videoPixelValues: MLXArray,
         tokenId: Int,
-        kind: String
+        softTokensPerFrame: Int
     ) throws -> MLXArray {
-        var features = visionTower(pixelValues)
+        var features = visionTower(videoPixelValues)
         features = embedVision(features)
+        let cap = min(softTokensPerFrame, features.dim(1))
+        features = features[0..., 0 ..< cap, 0...]
         features = features.asType(inputsEmbeds.dtype)
 
+        let producedTokens = features.dim(0) * features.dim(1)
         let tokenMask = inputIds .== tokenId
         let expectedTokens = tokenMask.asType(.int32).sum().item(Int.self)
-        if expectedTokens != features.dim(1) {
+        if expectedTokens != producedTokens {
             throw Gemma4Error.multimodalTokenCountMismatch(
-                kind: kind, featureTokens: features.dim(1), promptTokens: expectedTokens)
+                kind: "video", featureTokens: producedTokens, promptTokens: expectedTokens)
         }
 
         var maskExpanded = expandedDimensions(tokenMask, axis: -1)
@@ -2672,6 +2682,38 @@ public struct Gemma4Processor: UserInputProcessor {
         return (pixelValues, THW(1, Int(targetSize.height), Int(targetSize.width)))
     }
 
+    /// Sample and preprocess the frames of each video into a single
+    /// `[totalFrames, C, H, W]` pixel tensor (frames from all videos concatenated),
+    /// plus the per-video frame count used to expand the `<video>` placeholders.
+    /// Frames are resized to `config.videoFixedSize` so the vision tower's leading
+    /// pooled tokens fit the per-frame video budget.
+    public func processVideos(_ videos: [UserInput.Video], processing: UserInput.Processing?)
+        async throws -> (pixels: MLXArray, frameCounts: [Int])
+    {
+        let targetSize = config.videoFixedSize
+        var allFrames: [MLXArray] = []
+        var frameCounts: [Int] = []
+        for video in videos {
+            let sequence = try await MediaProcessing.asProcessedSequence(
+                video, targetFPS: { _ in 1.0 }, maxFrames: config.videoMaxFrames
+            ) { frame in
+                var userProcessing = processing ?? UserInput.Processing()
+                userProcessing.resize = targetSize
+                var image = MediaProcessing.apply(frame.frame, processing: userProcessing)
+                image = MediaProcessing.inSRGBToneCurveSpace(image)
+                image = MediaProcessing.resampleBicubic(image, to: targetSize)
+                if config.doNormalize {
+                    image = MediaProcessing.normalize(
+                        image, mean: config.imageMeanTuple, std: config.imageStdTuple)
+                }
+                return VideoFrame(frame: image, timeStamp: frame.timeStamp)
+            }
+            allFrames.append(contentsOf: sequence.frames)
+            frameCounts.append(sequence.frames.count)
+        }
+        return (concatenated(allFrames), frameCounts)
+    }
+
     public func prepare(input: UserInput) async throws -> LMInput {
         let messages = Gemma4MessageGenerator().generate(from: input)
 
@@ -2731,9 +2773,42 @@ public struct Gemma4Processor: UserInputProcessor {
             promptTokens = expandedTokens
         }
 
+        var processedVideo: LMInput.ProcessedVideo?
+        if !input.videos.isEmpty, let videoTokenId = config.videoTokenId {
+            let (videoPixels, frameCounts) = try await processVideos(
+                input.videos, processing: input.processing)
+            processedVideo = LMInput.ProcessedVideo(pixels: videoPixels)
+
+            // Expand the i-th `<video>` placeholder into one block per sampled frame:
+            // BOI + video_token * videoSoftTokensPerFrame + EOI. The model produces the
+            // matching count (frames * videoSoftTokensPerFrame) from `videoPixels`.
+            var expandedTokens: [Int] = []
+            var videoIndex = 0
+            for token in promptTokens {
+                if token == videoTokenId {
+                    let frames = videoIndex < frameCounts.count ? frameCounts[videoIndex] : 0
+                    for _ in 0 ..< frames {
+                        expandedTokens.append(config.boiTokenId)
+                        expandedTokens.append(
+                            contentsOf: Array(
+                                repeating: videoTokenId, count: config.videoSoftTokensPerFrame))
+                        if let eoiTokenId = config.eoiTokenId {
+                            expandedTokens.append(eoiTokenId)
+                        }
+                    }
+                    videoIndex += 1
+                } else {
+                    expandedTokens.append(token)
+                }
+            }
+            promptTokens = expandedTokens
+        }
+
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
         let mask = ones(like: promptArray).asType(.int8)
-        return LMInput(text: .init(tokens: promptArray, mask: mask), image: processedImage)
+        return LMInput(
+            text: .init(tokens: promptArray, mask: mask), image: processedImage,
+            video: processedVideo)
     }
 }
 
@@ -2750,6 +2825,10 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
     public let imageTokenId: Int
     public let boiTokenId: Int
     public let eoiTokenId: Int?
+
+    public let videoTokenId: Int?
+    public let videoSoftTokensPerFrame: Int
+    public let videoMaxFrames: Int
 
     /// Image keys nested under `image_processor` in processor_config.json.
     /// Repos that ship a flat preprocessor_config.json put the same keys at
@@ -2787,6 +2866,9 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         case imageTokenId = "image_token_id"
         case boiTokenId = "boi_token_id"
         case eoiTokenId = "eoi_token_id"
+        case videoTokenId = "video_token_id"
+        case videoSoftTokensPerFrame = "video_soft_tokens_per_frame"
+        case videoMaxFrames = "video_max_frames"
     }
 
     public init(from decoder: any Swift.Decoder) throws {
@@ -2818,6 +2900,10 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.imageTokenId) ?? 258_880
         boiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boiTokenId) ?? 255_999
         eoiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoiTokenId) ?? 258_882
+        videoTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoTokenId) ?? 258_884
+        videoSoftTokensPerFrame =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoSoftTokensPerFrame) ?? 70
+        videoMaxFrames = try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoMaxFrames) ?? 32
     }
 
     public func encode(to encoder: any Swift.Encoder) throws {
@@ -2886,6 +2972,12 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         return CGSize(
             width: targetWidth * sideMultiple, height: targetHeight * sideMultiple)
     }
+
+    /// Video frames use a smaller square (a multiple of patch_size * pooling_kernel_size
+    /// = 48) so the vision tower's leading pooled tokens cover the frame within the
+    /// ~70-token video budget: 432 → 27x27 patches → 81 pooled tokens, trimmed to
+    /// `visionSoftTokensPerVideoFrame` (70) in the model.
+    public var videoFixedSize: CGSize { CGSize(width: 432, height: 432) }
 }
 
 public struct Gemma4UnifiedProcessorConfiguration: Decodable, Sendable {

--- a/Tests/MLXLMTests/Gemma4VideoInputTests.swift
+++ b/Tests/MLXLMTests/Gemma4VideoInputTests.swift
@@ -1,5 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
+import CoreImage
+import CoreMedia
 import Foundation
 import MLX
 import MLXLMCommon
@@ -9,41 +11,40 @@ import Testing
 
 // MARK: - Video input for the base Gemma 4 (`gemma4`) VLM
 //
-// Gemma 4 has no separate video encoder: video frames run through the same
-// vision tower as images and scatter onto the `<video>` soft-token positions
-// (`video_token_id`, 258884 for E4B). These tests cover the wiring added to the
-// non-unified `Gemma4` class — decoding `video_token_id`, and routing
-// `input.video?.pixels` through the shared vision path.
+// Gemma 4 has no separate video encoder: each frame runs through the same vision
+// tower as images and is trimmed to the smaller per-frame video budget
+// (`vision_soft_tokens_per_video_frame`, 70 for E4B) before scattering onto the
+// `<video>` soft-token positions (`video_token_id`, 258884). These tests cover the
+// wiring on the non-unified `Gemma4` class and its `Gemma4Processor`.
 
 struct Gemma4VideoInputTests {
 
-    /// `Gemma4Configuration` decodes `video_token_id` when present and leaves it
-    /// nil otherwise (older text+vision checkpoints keep working unchanged).
+    /// `Gemma4Configuration` decodes `video_token_id` when present and leaves it nil
+    /// otherwise (older text+vision checkpoints keep working unchanged).
     @Test("Gemma4Configuration decodes video_token_id")
     func decodesVideoTokenId() throws {
         let withVideo = try Self.decodeConfig(videoTokenLine: "\"video_token_id\": 258884,")
         #expect(withVideo.videoTokenId == 258884)
+        #expect(withVideo.visionSoftTokensPerVideoFrame == 70)
 
         let withoutVideo = try Self.decodeConfig(videoTokenLine: "")
         #expect(withoutVideo.videoTokenId == nil)
     }
 
-    /// The same pixels fed as an image and as a video must produce identical
-    /// logits: video reuses the vision tower and scatters at `video_token_id`
-    /// exactly as the image path scatters at `image_token_id`. Also exercises
-    /// the per-layer-input mask, which must exclude video soft tokens.
-    @Test("Image and video pixels scatter identically")
+    /// With the per-frame video budget >= the vision tower's output length there is no
+    /// truncation, so the same pixels fed as an image and as a video produce identical
+    /// logits — proving video reuses the vision tower and scatters at `video_token_id`.
+    @Test("Image and video pixels scatter identically (no truncation)")
     func imageAndVideoAgree() throws {
-        let model = Gemma4(try Self.makeTinyConfig())
+        let model = Gemma4(try Self.makeTinyConfig(videoSoftTokens: 4))
         eval(model)
 
-        // 4 multimodal soft tokens == the tiny vision tower's output length
-        // (default_output_length 4, pooling_kernel_size 1).
         let imageTokenId = 100
         let videoTokenId = 101
         func prompt(_ mm: Int) -> [Int] { [5, 6, mm, mm, mm, mm, 7, 8] }
-        // Deterministic [1, 3, 4, 4] pixels (B, C, H, W); patch_size 4 → 1 patch.
-        let pixels = (MLXArray(0 ..< 48).reshaped([1, 3, 4, 4]).asType(.float32)) / 48.0
+        // 8x8 with patch_size 4 → a 2x2 patch grid → 4 soft tokens per image
+        // under the aspect-preserving tower (which emits patch-count tokens).
+        let pixels = (MLXArray(0 ..< 192).reshaped([1, 3, 8, 8]).asType(.float32)) / 192.0
 
         func lastLogits(mm: Int, asVideo: Bool) throws -> MLXArray {
             let tokens = MLXArray(prompt(mm).map { Int32($0) }).expandedDimensions(axis: 0)
@@ -52,8 +53,8 @@ struct Gemma4VideoInputTests {
                 asVideo
                 ? LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
                 : LMInput(text: text, image: LMInput.ProcessedImage(pixels: pixels))
-            let result = try model.prepare(input, cache: model.newCache(parameters: nil),
-                windowSize: 1024)
+            let result = try model.prepare(
+                input, cache: model.newCache(parameters: nil), state: nil, windowSize: 1024)
             guard case .logits(let out) = result else {
                 Issue.record("Expected .logits from Gemma4.prepare (multimodal branch)")
                 return MLXArray(0)
@@ -65,56 +66,135 @@ struct Gemma4VideoInputTests {
 
         let imageLogits = try lastLogits(mm: imageTokenId, asVideo: false)
         let videoLogits = try lastLogits(mm: videoTokenId, asVideo: true)
-
         #expect(imageLogits.shape == [1, 200])
         #expect(
             allClose(imageLogits, videoLogits, rtol: 1e-5, atol: 1e-5).item(Bool.self),
             "Video pixels must scatter through the vision tower identically to image pixels.")
     }
 
-    // MARK: - Helpers
+    /// A multi-frame video is trimmed to `visionSoftTokensPerVideoFrame` tokens per
+    /// frame, so a 2-frame clip with budget 2 scatters exactly 4 tokens.
+    @Test("Multi-frame video truncates to the per-frame budget")
+    func videoTruncatesPerFrame() throws {
+        let softPerFrame = 2
+        let numFrames = 2
+        let videoTokenId = 101
+        let model = Gemma4(try Self.makeTinyConfig(videoSoftTokens: softPerFrame))
+        eval(model)
 
-    private static func makeTinyConfig() throws -> Gemma4Configuration {
-        try decodeConfig(videoTokenLine: "\"video_token_id\": 101,")
+        var tokens: [Int32] = [5, 6]
+        tokens += Array(repeating: Int32(videoTokenId), count: numFrames * softPerFrame)
+        tokens += [7]
+        let text = LMInput.Text(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
+        // 8x8 frames → 4 tower tokens per frame, truncated to the budget of 2.
+        let pixels =
+            (MLXArray(0 ..< (numFrames * 3 * 8 * 8)).reshaped([numFrames, 3, 8, 8])
+                .asType(.float32)) / 400.0
+        let input = LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
+
+        let result = try model.prepare(
+            input, cache: model.newCache(parameters: nil), state: nil, windowSize: 1024)
+        guard case .logits(let out) = result else {
+            Issue.record("Expected .logits from Gemma4.prepare")
+            return
+        }
+        eval(out.logits)
+        #expect(out.logits.shape == [1, tokens.count, 200])
     }
 
-    /// Tiny `gemma4` config. `pooling_kernel_size 1` makes the vision tower emit
-    /// exactly `default_output_length` (4) soft tokens regardless of patch count.
-    private static func decodeConfig(videoTokenLine: String) throws -> Gemma4Configuration {
+    /// `Gemma4Processor.processVideos` samples/preprocesses frames into a
+    /// `[totalFrames, C, H, W]` tensor at the video frame size, with per-video counts
+    /// that sum to the frame axis.
+    @Test("Processor extracts video frames to [F, C, 432, 432]")
+    func processorExtractsFrames() async throws {
+        let processor = Gemma4Processor(
+            try Self.makeProcessorConfig(), tokenizer: VideoTestTokenizer())
+
+        // Four synthetic 64x64 frames at 1s spacing.
+        let frames = (0 ..< 4).map { i in
+            UserInput.VideoFrame(
+                frame: CIImage(color: CIColor(red: 0.3, green: 0.5, blue: 0.7))
+                    .cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64)),
+                timeStamp: CMTime(value: Int64(i), timescale: 1))
+        }
+        let (pixels, frameCounts) = try await processor.processVideos(
+            [.frames(frames)], processing: nil)
+        eval(pixels)
+
+        #expect(frameCounts.count == 1)
+        #expect(pixels.dim(0) == frameCounts.reduce(0, +))
+        #expect(pixels.dim(0) >= 1)
+        #expect(Array(pixels.shape.dropFirst()) == [3, 432, 432])
+    }
+
+    // MARK: - Helpers
+
+    private static func makeTinyConfig(videoSoftTokens: Int) throws -> Gemma4Configuration {
+        try decodeConfig(
+            videoTokenLine: "\"video_token_id\": 101,",
+            extraLines: "\"vision_soft_tokens_per_video_frame\": \(videoSoftTokens),")
+    }
+
+    /// Tiny `gemma4` config. `pooling_kernel_size 1` + `default_output_length 4` make the
+    /// vision tower emit 4 soft tokens per frame regardless of patch count.
+    private static func decodeConfig(videoTokenLine: String, extraLines: String = "") throws
+        -> Gemma4Configuration
+    {
         let json = """
             {
               "model_type": "gemma4",
               "image_token_id": 100,
               \(videoTokenLine)
+              \(extraLines)
               "text_config": {
-                "hidden_size": 32,
-                "num_hidden_layers": 2,
-                "intermediate_size": 64,
-                "num_attention_heads": 2,
-                "num_key_value_heads": 1,
-                "head_dim": 16,
-                "global_head_dim": 32,
-                "vocab_size": 200,
-                "vocab_size_per_layer_input": 200,
-                "num_kv_shared_layers": 0,
-                "hidden_size_per_layer_input": 8,
-                "sliding_window": 16,
-                "sliding_window_pattern": 2,
-                "max_position_embeddings": 512
+                "hidden_size": 32, "num_hidden_layers": 2, "intermediate_size": 64,
+                "num_attention_heads": 2, "num_key_value_heads": 1, "head_dim": 16,
+                "global_head_dim": 32, "vocab_size": 200, "vocab_size_per_layer_input": 200,
+                "num_kv_shared_layers": 0, "hidden_size_per_layer_input": 8,
+                "sliding_window": 16, "sliding_window_pattern": 2, "max_position_embeddings": 512
               },
               "vision_config": {
-                "num_hidden_layers": 1,
-                "hidden_size": 16,
-                "intermediate_size": 32,
-                "num_attention_heads": 2,
-                "head_dim": 8,
-                "patch_size": 4,
-                "default_output_length": 4,
-                "pooling_kernel_size": 1,
-                "position_embedding_size": 8
+                "num_hidden_layers": 1, "hidden_size": 16, "intermediate_size": 32,
+                "num_attention_heads": 2, "head_dim": 8, "patch_size": 4,
+                "default_output_length": 4, "pooling_kernel_size": 1, "position_embedding_size": 8
               }
             }
             """
         return try JSONDecoder().decode(Gemma4Configuration.self, from: Data(json.utf8))
     }
+
+    private static func makeProcessorConfig() throws -> Gemma4ProcessorConfiguration {
+        let json = """
+            {
+              "processor_class": "Gemma4Processor",
+              "do_normalize": true,
+              "image_seq_length": 280,
+              "image_token_id": 258880,
+              "video_token_id": 258884,
+              "video_soft_tokens_per_frame": 70
+            }
+            """
+        return try JSONDecoder().decode(Gemma4ProcessorConfiguration.self, from: Data(json.utf8))
+    }
+}
+
+/// Minimal tokenizer so `Gemma4Processor` can be constructed; `processVideos` never
+/// touches it, and the pixel-shape tests don't exercise the chat template.
+private struct VideoTestTokenizer: Tokenizer {
+    let vocabularySize: Int = 8
+    let bosToken: String? = nil
+    let eosToken: String? = nil
+    let eosTokenId: Int? = 1
+    let unknownToken: String? = nil
+    let unknownTokenId: Int? = 0
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { Int(token) }
+    func convertIdToToken(_ id: Int) -> String? { String(id) }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
 }

--- a/Tests/MLXLMTests/Gemma4VideoInputTests.swift
+++ b/Tests/MLXLMTests/Gemma4VideoInputTests.swift
@@ -1,0 +1,120 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXVLM
+
+// MARK: - Video input for the base Gemma 4 (`gemma4`) VLM
+//
+// Gemma 4 has no separate video encoder: video frames run through the same
+// vision tower as images and scatter onto the `<video>` soft-token positions
+// (`video_token_id`, 258884 for E4B). These tests cover the wiring added to the
+// non-unified `Gemma4` class — decoding `video_token_id`, and routing
+// `input.video?.pixels` through the shared vision path.
+
+struct Gemma4VideoInputTests {
+
+    /// `Gemma4Configuration` decodes `video_token_id` when present and leaves it
+    /// nil otherwise (older text+vision checkpoints keep working unchanged).
+    @Test("Gemma4Configuration decodes video_token_id")
+    func decodesVideoTokenId() throws {
+        let withVideo = try Self.decodeConfig(videoTokenLine: "\"video_token_id\": 258884,")
+        #expect(withVideo.videoTokenId == 258884)
+
+        let withoutVideo = try Self.decodeConfig(videoTokenLine: "")
+        #expect(withoutVideo.videoTokenId == nil)
+    }
+
+    /// The same pixels fed as an image and as a video must produce identical
+    /// logits: video reuses the vision tower and scatters at `video_token_id`
+    /// exactly as the image path scatters at `image_token_id`. Also exercises
+    /// the per-layer-input mask, which must exclude video soft tokens.
+    @Test("Image and video pixels scatter identically")
+    func imageAndVideoAgree() throws {
+        let model = Gemma4(try Self.makeTinyConfig())
+        eval(model)
+
+        // 4 multimodal soft tokens == the tiny vision tower's output length
+        // (default_output_length 4, pooling_kernel_size 1).
+        let imageTokenId = 100
+        let videoTokenId = 101
+        func prompt(_ mm: Int) -> [Int] { [5, 6, mm, mm, mm, mm, 7, 8] }
+        // Deterministic [1, 3, 4, 4] pixels (B, C, H, W); patch_size 4 → 1 patch.
+        let pixels = (MLXArray(0 ..< 48).reshaped([1, 3, 4, 4]).asType(.float32)) / 48.0
+
+        func lastLogits(mm: Int, asVideo: Bool) throws -> MLXArray {
+            let tokens = MLXArray(prompt(mm).map { Int32($0) }).expandedDimensions(axis: 0)
+            let text = LMInput.Text(tokens: tokens)
+            let input =
+                asVideo
+                ? LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
+                : LMInput(text: text, image: LMInput.ProcessedImage(pixels: pixels))
+            let result = try model.prepare(input, cache: model.newCache(parameters: nil),
+                windowSize: 1024)
+            guard case .logits(let out) = result else {
+                Issue.record("Expected .logits from Gemma4.prepare (multimodal branch)")
+                return MLXArray(0)
+            }
+            let logits = out.logits[0..., -1, 0...]
+            eval(logits)
+            return logits
+        }
+
+        let imageLogits = try lastLogits(mm: imageTokenId, asVideo: false)
+        let videoLogits = try lastLogits(mm: videoTokenId, asVideo: true)
+
+        #expect(imageLogits.shape == [1, 200])
+        #expect(
+            allClose(imageLogits, videoLogits, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+            "Video pixels must scatter through the vision tower identically to image pixels.")
+    }
+
+    // MARK: - Helpers
+
+    private static func makeTinyConfig() throws -> Gemma4Configuration {
+        try decodeConfig(videoTokenLine: "\"video_token_id\": 101,")
+    }
+
+    /// Tiny `gemma4` config. `pooling_kernel_size 1` makes the vision tower emit
+    /// exactly `default_output_length` (4) soft tokens regardless of patch count.
+    private static func decodeConfig(videoTokenLine: String) throws -> Gemma4Configuration {
+        let json = """
+            {
+              "model_type": "gemma4",
+              "image_token_id": 100,
+              \(videoTokenLine)
+              "text_config": {
+                "hidden_size": 32,
+                "num_hidden_layers": 2,
+                "intermediate_size": 64,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 16,
+                "global_head_dim": 32,
+                "vocab_size": 200,
+                "vocab_size_per_layer_input": 200,
+                "num_kv_shared_layers": 0,
+                "hidden_size_per_layer_input": 8,
+                "sliding_window": 16,
+                "sliding_window_pattern": 2,
+                "max_position_embeddings": 512
+              },
+              "vision_config": {
+                "num_hidden_layers": 1,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "head_dim": 8,
+                "patch_size": 4,
+                "default_output_length": 4,
+                "pooling_kernel_size": 1,
+                "position_embedding_size": 8
+              }
+            }
+            """
+        return try JSONDecoder().decode(Gemma4Configuration.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Summary

Add **end-to-end video input** to the base Gemma 4 VLM (`model_type: "gemma4"` — E2B/E4B). Gemma 4 has no separate video encoder: sampled frames run through the same vision tower as images, are trimmed to a smaller per-frame budget, and scatter onto the `<video>` soft-token positions. This wires both halves — the model forward **and** the `Gemma4Processor` — so a `UserInput` carrying video actually reaches the model (previously it was silently dropped).

## What was missing

An earlier revision made the `Gemma4` model *accept* `videoPixelValues` but nothing produced them: `Gemma4Processor.prepare` ignored `input.videos`, so `LMInput.video` was never populated. This PR completes the pipeline.

## Changes (`Libraries/MLXVLM/Models/Gemma4.swift`)

**Model side**
- `Gemma4Configuration` decodes `vision_soft_tokens_per_video_frame` (default **70**).
- `getInputEmbeddings` routes video through a new `scatterVideoFeatures` helper: each frame goes through the shared vision tower (producing `visionSoftTokensPerImage` pooled tokens), the first `visionSoftTokensPerVideoFrame` (70) are kept, and the resulting `frames × 70` tokens scatter onto `video_token_id`. This mirrors the reference Swift port (`VincentGourbin/gemma-4-swift-mlx`, which pools to the image budget then truncates) and the pooling behaviour of `Blaizzy/mlx-vlm`.

**Processor side**
- `Gemma4ProcessorConfiguration` decodes `video_token_id` (258884), `video_soft_tokens_per_frame` (70), `video_max_frames` (32), and exposes a `videoFixedSize` (432×432 — a multiple of `patch_size · pooling_kernel_size = 48`, giving ~81 patch-pooled tokens that trim to 70 so the kept tokens cover the frame).
- `Gemma4Processor.processVideos` samples ≤32 frames at ~1 fps via `MediaProcessing.asProcessedSequence` (handles `.frames` / `.url` / `.avAsset`), preprocesses each frame to the video size (sRGB → bicubic resize → normalize), and stacks them into `[totalFrames, C, H, W]`.
- `Gemma4Processor.prepare` now processes `input.videos`, sets `LMInput.video`, and expands each `<video>` placeholder into one `BOI + video_token×70 + EOI` block per sampled frame (per-video frame counts drive the expansion).

## Tests (`Tests/MLXLMTests/Gemma4VideoInputTests.swift`)

1. **Config decode** — `video_token_id` / `vision_soft_tokens_per_video_frame` decode with the right defaults.
2. **Image/video equivalence** — with the budget ≥ the tower output, the same pixels as image vs. video give identical logits (video reuses the vision tower, scatters at `video_token_id`).
3. **Multi-frame truncation** — a 2-frame clip with budget 2 scatters exactly 4 tokens through the language model.
4. **Processor frame extraction** — `processVideos` on synthetic frames yields `[F, C, 432, 432]` with per-video counts summing to the frame axis.

`Gemma4ChunkedPrefillTests` and `Gemma4UnifiedTests` still pass. End-to-end decode from a real clip is exercised on-device by the downstream app (the same way image and audio were validated on iPad).

## Scope / follow-ups

- **Timestamps:** the reference prepends a per-frame `mm:ss` marker inside each block; this PR emits the frame blocks without the timestamp text (temporal grounding refinement — easy follow-up).
- **`Gemma4Unified` (12B) processor** still lacks a video block. That path is encoder-free (per-frame patch tensors + position ids, a different mechanism than the E-model vision tower), so it's tracked separately; the base `gemma4` E2B/E4B path (what most on-device use targets) is complete here.

## Relation to #390 / #392

Independent of #390 (KV-shared load fix) but the `gemma4` E4B model won't load without it. The audio PR #392 vendors the video *model-level* change and will need to pick up these processor changes on rebase.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
