### PR TITLE
Gemma 4: native audio input (port the gemma4_audio USM-Conformer encoder)

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2025,8 +2025,14 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             throw VLMError.processing(
                 "Audio input was provided, but this checkpoint has no audio_config.")
         }
-        let melMask =
-            mask ?? MLXArray.zeros([features.dim(0), features.dim(1)]).asType(.bool)
+        // `ProcessedAudio.mask` follows the HF `input_features_mask` convention
+        // (`true == valid`); the audio tower expects `true == padding`, so invert.
+        let melMask: MLXArray
+        if let mask {
+            melMask = logicalNot(mask)
+        } else {
+            melMask = MLXArray.zeros([features.dim(0), features.dim(1)]).asType(.bool)
+        }
         let (encodings, subsampledMask) = audioTower(features, audioMelMask: melMask)
         let projected = embedAudio(encodings)
         let validMask = logicalNot(subsampledMask)
@@ -2697,6 +2703,9 @@ public struct Gemma4MessageGenerator: MessageGenerator {
                     + message.videos.map { _ in
                         ["type": "video"]
                     }
+                    + message.audios.map { _ in
+                        ["type": "audio"]
+                    }
                     + [
                         ["type": "text", "text": message.content]
                     ],
@@ -2797,9 +2806,86 @@ public struct Gemma4Processor: UserInputProcessor {
             promptTokens = expandedTokens
         }
 
+        var processedAudio: LMInput.ProcessedAudio?
+        if !input.audios.isEmpty {
+            let (audio, tokenCounts) = try await prepareAudio(input.audios)
+            processedAudio = audio
+            // Expand each audio placeholder into `boa + audio_soft_token×N + eoa`,
+            // where N is the encoder's soft-token count for that clip's valid frames.
+            var expandedTokens: [Int] = []
+            var audioIndex = 0
+            for token in promptTokens {
+                if token == config.audioTokenId {
+                    let count =
+                        audioIndex < tokenCounts.count
+                        ? tokenCounts[audioIndex] : config.audioSeqLength
+                    expandedTokens.append(config.boaTokenId)
+                    expandedTokens.append(
+                        contentsOf: Array(repeating: config.audioTokenId, count: count))
+                    expandedTokens.append(config.eoaTokenId)
+                    audioIndex += 1
+                } else {
+                    expandedTokens.append(token)
+                }
+            }
+            promptTokens = expandedTokens
+        }
+
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
         let mask = ones(like: promptArray).asType(.int8)
-        return LMInput(text: .init(tokens: promptArray, mask: mask), image: processedImage)
+        return LMInput(
+            text: .init(tokens: promptArray, mask: mask),
+            image: processedImage, audio: processedAudio)
+    }
+
+    /// Extracts log-mel features for each audio clip and stacks them into a batch,
+    /// returning the `ProcessedAudio` and per-clip audio soft-token counts (for
+    /// prompt expansion). Clips are resampled to the model's audio sample rate.
+    private func prepareAudio(
+        _ audios: [UserInput.Audio]
+    ) async throws -> (LMInput.ProcessedAudio, [Int]) {
+        let extractor = Gemma4AudioFeatureExtractor(sampleRate: config.audioSampleRate)
+        var processing = UserInput.AudioProcessing()
+        processing.sampleRate = Double(config.audioSampleRate)
+
+        var featureRows: [MLXArray] = []
+        var maskRows: [MLXArray] = []
+        var tokenCounts: [Int] = []
+        for audio in audios {
+            let waveform = try await audio.asMLXArray(processing: processing)
+            let (features, mask) = extractor(waveform)
+            featureRows.append(features)
+            maskRows.append(mask)
+            let validFrames = mask.asType(.int32).sum().item(Int.self)
+            tokenCounts.append(
+                min(
+                    Gemma4AudioFeatureExtractor.audioTokenCount(validFrames: validFrames),
+                    config.audioSeqLength))
+        }
+
+        let maxFrames = featureRows.map { $0.dim(1) }.max() ?? 0
+        var paddedFeatures: [MLXArray] = []
+        var paddedMasks: [MLXArray] = []
+        for (features, mask) in zip(featureRows, maskRows) {
+            let t = features.dim(1)
+            if t < maxFrames {
+                paddedFeatures.append(
+                    padded(features, widths: [0, IntOrPair((0, maxFrames - t)), 0]))
+                paddedMasks.append(
+                    padded(mask.asType(.int32), widths: [0, IntOrPair((0, maxFrames - t))])
+                        .asType(.bool))
+            } else {
+                paddedFeatures.append(features)
+                paddedMasks.append(mask)
+            }
+        }
+
+        return (
+            LMInput.ProcessedAudio(
+                features: concatenated(paddedFeatures, axis: 0),
+                mask: concatenated(paddedMasks, axis: 0)),
+            tokenCounts
+        )
     }
 }
 
@@ -2816,6 +2902,11 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
     public let imageTokenId: Int
     public let boiTokenId: Int
     public let eoiTokenId: Int?
+    public let audioTokenId: Int
+    public let boaTokenId: Int
+    public let eoaTokenId: Int
+    public let audioSeqLength: Int
+    public let audioSampleRate: Int
 
     /// Image keys nested under `image_processor` in processor_config.json.
     /// Repos that ship a flat preprocessor_config.json put the same keys at
@@ -2853,6 +2944,11 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         case imageTokenId = "image_token_id"
         case boiTokenId = "boi_token_id"
         case eoiTokenId = "eoi_token_id"
+        case audioTokenId = "audio_token_id"
+        case boaTokenId = "boa_token_id"
+        case eoaTokenId = "eoa_token_id"
+        case audioSeqLength = "audio_seq_length"
+        case audioSampleRate = "audio_sampling_rate"
     }
 
     public init(from decoder: any Swift.Decoder) throws {
@@ -2884,6 +2980,12 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.imageTokenId) ?? 258_880
         boiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boiTokenId) ?? 255_999
         eoiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoiTokenId) ?? 258_882
+        audioTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioTokenId) ?? 258_881
+        boaTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boaTokenId) ?? 256_000
+        eoaTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoaTokenId) ?? 258_883
+        audioSeqLength = try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioSeqLength) ?? 750
+        audioSampleRate =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioSampleRate) ?? 16_000
     }
 
     public func encode(to encoder: any Swift.Encoder) throws {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -347,6 +347,15 @@ private func gemma4CompactPrefixRows(features: MLXArray, validMask: MLXArray) ->
     }
     return concatenated(rows, axis: 0)
 }
+
+/// Heuristic (matching `Gemma3.checkArrayShape`): a 4-D conv2d weight is already
+/// in MLX layout `[out, kH, kW, in]` when `out` dominates the spatial dims and the
+/// two spatial dims are equal — as opposed to PyTorch `[out, in, kH, kW]`.
+private func gemma4IsMLXConv2dLayout(_ w: MLXArray) -> Bool {
+    guard w.ndim == 4 else { return false }
+    let (out, kH, kW) = (w.dim(0), w.dim(1), w.dim(2))
+    return out >= kH && out >= kW && kH == kW
+}
 // MARK: - Configuration
 
 public struct Gemma4TextConfiguration: Codable, Sendable {
@@ -564,13 +573,19 @@ public struct Gemma4VisionConfiguration: Codable, Sendable {
 public struct Gemma4Configuration: Codable, Sendable {
     public let textConfiguration: Gemma4TextConfiguration
     public let visionConfiguration: Gemma4VisionConfiguration
+    public let audioConfiguration: Gemma4AudioConfiguration?
     public let modelType: String
     public let quantization: BaseConfiguration.Quantization?
     public let imageTokenId: Int
     public let audioTokenId: Int?
+    public let videoTokenId: Int?
     public let boiTokenId: Int
     public let eoiTokenId: Int?
+    public let boaTokenId: Int?
+    public let eoaTokenId: Int?
     public let visionSoftTokensPerImage: Int
+    public let audioSoftTokensPerImage: Int
+    public let audioMsPerToken: Int
     public let tieWordEmbeddings: Bool
 
     private let _vocabularySize: Int?
@@ -584,13 +599,19 @@ public struct Gemma4Configuration: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case textConfiguration = "text_config"
         case visionConfiguration = "vision_config"
+        case audioConfiguration = "audio_config"
         case modelType = "model_type"
         case quantization
         case imageTokenId = "image_token_id"
         case audioTokenId = "audio_token_id"
+        case videoTokenId = "video_token_id"
         case boiTokenId = "boi_token_id"
         case eoiTokenId = "eoi_token_id"
+        case boaTokenId = "boa_token_id"
+        case eoaTokenId = "eoa_token_id"
         case visionSoftTokensPerImage = "vision_soft_tokens_per_image"
+        case audioSoftTokensPerImage = "audio_soft_tokens_per_image"
+        case audioMsPerToken = "audio_ms_per_token"
         case tieWordEmbeddings = "tie_word_embeddings"
         case _vocabularySize = "vocab_size"
         case _hiddenSize = "hidden_size"
@@ -603,16 +624,25 @@ public struct Gemma4Configuration: Codable, Sendable {
             Gemma4TextConfiguration.self, forKey: CodingKeys.textConfiguration)
         visionConfiguration = try c.decode(
             Gemma4VisionConfiguration.self, forKey: CodingKeys.visionConfiguration)
+        audioConfiguration = try c.decodeIfPresent(
+            Gemma4AudioConfiguration.self, forKey: CodingKeys.audioConfiguration)
         modelType = try c.decodeIfPresent(String.self, forKey: CodingKeys.modelType) ?? "gemma4"
         quantization = try c.decodeIfPresent(
             BaseConfiguration.Quantization.self, forKey: CodingKeys.quantization)
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.imageTokenId) ?? 258_880
         audioTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioTokenId)
+        videoTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoTokenId)
         boiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boiTokenId) ?? 255_999
         eoiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoiTokenId)
+        boaTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boaTokenId)
+        eoaTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoaTokenId)
         visionSoftTokensPerImage =
             try c.decodeIfPresent(Int.self, forKey: CodingKeys.visionSoftTokensPerImage)
             ?? visionConfiguration.defaultOutputLength
+        audioSoftTokensPerImage =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioSoftTokensPerImage) ?? 750
+        audioMsPerToken =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioMsPerToken) ?? 40
         tieWordEmbeddings =
             try c.decodeIfPresent(Bool.self, forKey: CodingKeys.tieWordEmbeddings)
             ?? textConfiguration.tieWordEmbeddings
@@ -1521,7 +1551,8 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
 
 // MARK: - Vision
 
-private final class Gemma4ClippableLinear: Module, UnaryLayer {
+/// Module-internal — also reused by the audio tower in `Gemma4Audio.swift`.
+final class Gemma4ClippableLinear: Module, UnaryLayer {
     let useClipping: Bool
 
     @ModuleInfo(key: "linear") var linear: Linear
@@ -1953,6 +1984,8 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     /// per-layer type metadata).
     @ModuleInfo(key: "language_model") var languageModel: Gemma4TextLanguageModel
     @ModuleInfo(key: "embed_vision") private var embedVision: Gemma4MultimodalEmbedder
+    @ModuleInfo(key: "audio_tower") private var audioTower: Gemma4AudioModel?
+    @ModuleInfo(key: "embed_audio") private var embedAudio: Gemma4MultimodalEmbedder?
 
     public let config: Gemma4Configuration
 
@@ -1969,6 +2002,15 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             textHiddenSize: config.textConfiguration.hiddenSize,
             eps: config.visionConfiguration.rmsNormEps
         )
+        if let audioConfiguration = config.audioConfiguration {
+            self._audioTower.wrappedValue = Gemma4AudioModel(config: audioConfiguration)
+            self._embedAudio.wrappedValue = Gemma4MultimodalEmbedder(
+                embeddingDim: audioConfiguration.outputProjectionDimensions
+                    ?? audioConfiguration.hiddenSize,
+                textHiddenSize: config.textConfiguration.hiddenSize,
+                eps: audioConfiguration.rmsNormEps
+            )
+        }
         super.init()
     }
 
@@ -1976,9 +2018,26 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         languageModel.newCache(parameters: parameters)
     }
 
+    /// Runs the audio tower over mel features and projects to text hidden size,
+    /// returning a flat `[numValidFrames, textHidden]` (padding frames removed).
+    private func getAudioFeatures(features: MLXArray, mask: MLXArray?) throws -> MLXArray {
+        guard let audioTower, let embedAudio else {
+            throw VLMError.processing(
+                "Audio input was provided, but this checkpoint has no audio_config.")
+        }
+        let melMask =
+            mask ?? MLXArray.zeros([features.dim(0), features.dim(1)]).asType(.bool)
+        let (encodings, subsampledMask) = audioTower(features, audioMelMask: melMask)
+        let projected = embedAudio(encodings)
+        let validMask = logicalNot(subsampledMask)
+        return gemma4CompactPrefixRows(features: projected, validMask: validMask)
+    }
+
     private func getInputEmbeddings(
         inputIds: MLXArray,
-        image: LMInput.ProcessedImage? = nil
+        image: LMInput.ProcessedImage? = nil,
+        audioFeatures: MLXArray? = nil,
+        audioMask: MLXArray? = nil
     ) throws -> (MLXArray, MLXArray?) {
         var inputsEmbeds = languageModel.model.embedTokens(inputIds)
         inputsEmbeds =
@@ -1989,61 +2048,81 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         var perLayerInputs: MLXArray? = nil
         if config.textConfiguration.hiddenSizePerLayerInput > 0 {
             let imageMask = inputIds .== config.imageTokenId
-            let audioMask =
+            let audioTokenMask =
                 if let audioTokenId = config.audioTokenId {
                     inputIds .== audioTokenId
                 } else {
                     MLXArray.zeros(like: imageMask)
                 }
-            let textMask = logicalNot(logicalOr(imageMask, audioMask))
+            let textMask = logicalNot(logicalOr(imageMask, audioTokenMask))
             let perLayerTokens = MLX.where(textMask, inputIds, MLXArray.zeros(like: inputIds))
             perLayerInputs = languageModel.model.getPerLayerInputs(perLayerTokens)
         }
 
-        guard let image else {
-            return (inputsEmbeds, perLayerInputs)
-        }
-
-        // Images keep their own aspect-preserving sizes: the processor
-        // zero-pads them onto a shared canvas and records each real size in
-        // frames. Slice each image back out, run the tower on it alone, and
-        // concatenate the pooled tokens in placeholder order.
-        let pixels =
-            if image.pixels.ndim == 3 {
-                expandedDimensions(image.pixels, axis: 0)
-            } else {
-                image.pixels
+        if let image {
+            // Images keep their own aspect-preserving sizes: the processor
+            // zero-pads them onto a shared canvas and records each real size in
+            // frames. Slice each image back out, run the tower on it alone, and
+            // concatenate the pooled tokens in placeholder order.
+            let pixels =
+                if image.pixels.ndim == 3 {
+                    expandedDimensions(image.pixels, axis: 0)
+                } else {
+                    image.pixels
+                }
+            let frames =
+                image.frames
+                ?? Array(repeating: THW(1, pixels.dim(2), pixels.dim(3)), count: pixels.dim(0))
+            var perImageFeatures: [MLXArray] = []
+            for (index, frame) in frames.enumerated() {
+                let imagePixels = pixels[index ..< index + 1, 0..., ..<frame.h, ..<frame.w]
+                perImageFeatures.append(visionTower(imagePixels))
             }
-        let frames =
-            image.frames
-            ?? Array(repeating: THW(1, pixels.dim(2), pixels.dim(3)), count: pixels.dim(0))
-        var perImageFeatures: [MLXArray] = []
-        for (index, frame) in frames.enumerated() {
-            let imagePixels = pixels[index ..< index + 1, 0..., ..<frame.h, ..<frame.w]
-            perImageFeatures.append(visionTower(imagePixels))
+            var imageFeatures =
+                perImageFeatures.count == 1
+                ? perImageFeatures[0]
+                : concatenated(perImageFeatures, axis: 1)
+            imageFeatures = embedVision(imageFeatures)
+            imageFeatures = imageFeatures.asType(inputsEmbeds.dtype)
+
+            let imageMask = inputIds .== config.imageTokenId
+            let expectedImageTokens = imageMask.asType(.int32).sum().item(Int.self)
+
+            if expectedImageTokens != imageFeatures.dim(1) {
+                throw Gemma4Error.imageTokenCountMismatch(
+                    expectedVisionTokens: imageFeatures.dim(1),
+                    actualPromptTokens: expectedImageTokens)
+            }
+
+            var imageMaskExpanded = expandedDimensions(imageMask, axis: -1)
+            imageMaskExpanded = broadcast(imageMaskExpanded, to: inputsEmbeds.shape)
+            inputsEmbeds = gemma4MaskedScatter(
+                inputTensor: inputsEmbeds,
+                mask: imageMaskExpanded,
+                source: imageFeatures
+            )
         }
-        var imageFeatures =
-            perImageFeatures.count == 1
-            ? perImageFeatures[0]
-            : concatenated(perImageFeatures, axis: 1)
-        imageFeatures = embedVision(imageFeatures)
-        imageFeatures = imageFeatures.asType(inputsEmbeds.dtype)
 
-        let imageMask = inputIds .== config.imageTokenId
-        let expectedImageTokens = imageMask.asType(.int32).sum().item(Int.self)
+        if let audioFeatures, let audioTokenId = config.audioTokenId {
+            let audioEmbeds = try getAudioFeatures(features: audioFeatures, mask: audioMask)
+                .asType(inputsEmbeds.dtype)
+            let audioTokenMask = inputIds .== audioTokenId
+            let expectedAudioTokens = audioTokenMask.asType(.int32).sum().item(Int.self)
 
-        if expectedImageTokens != imageFeatures.dim(1) {
-            throw Gemma4Error.imageTokenCountMismatch(
-                expectedVisionTokens: imageFeatures.dim(1), actualPromptTokens: expectedImageTokens)
+            guard expectedAudioTokens == audioEmbeds.dim(0) else {
+                throw Gemma4Error.multimodalTokenCountMismatch(
+                    kind: "audio", featureTokens: audioEmbeds.dim(0),
+                    promptTokens: expectedAudioTokens)
+            }
+
+            var audioMaskExpanded = expandedDimensions(audioTokenMask, axis: -1)
+            audioMaskExpanded = broadcast(audioMaskExpanded, to: inputsEmbeds.shape)
+            inputsEmbeds = gemma4MaskedScatter(
+                inputTensor: inputsEmbeds,
+                mask: audioMaskExpanded,
+                source: audioEmbeds
+            )
         }
-
-        var imageMaskExpanded = expandedDimensions(imageMask, axis: -1)
-        imageMaskExpanded = broadcast(imageMaskExpanded, to: inputsEmbeds.shape)
-        inputsEmbeds = gemma4MaskedScatter(
-            inputTensor: inputsEmbeds,
-            mask: imageMaskExpanded,
-            source: imageFeatures
-        )
 
         return (inputsEmbeds, perLayerInputs)
     }
@@ -2054,9 +2133,12 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         -> PrepareResult
     {
         let convertedCache = cache.map { $0 }
-        if let image = input.image {
+        if input.image != nil || input.audio?.features != nil {
             let (inputsEmbeds, perLayerInputs) = try getInputEmbeddings(
-                inputIds: input.text.tokens, image: image)
+                inputIds: input.text.tokens,
+                image: input.image,
+                audioFeatures: input.audio?.features,
+                audioMask: input.audio?.mask)
             let result = languageModel(
                 nil,
                 cache: convertedCache,
@@ -2099,9 +2181,32 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         var sanitized = languageModel.sanitize(weights: weights)
 
-        // This port currently supports text + vision only.
-        sanitized = sanitized.filter { key, _ in
-            !key.contains("audio_tower") && !key.contains("embed_audio")
+        if audioTower == nil {
+            // No audio tower was built (checkpoint has no audio_config): drop audio weights.
+            sanitized = sanitized.filter { key, _ in
+                !key.contains("audio_tower") && !key.contains("embed_audio")
+            }
+        } else {
+            // Normalise audio-tower conv weight layout (PyTorch/Google -> MLX). MLX is
+            // channel-last: Conv2d `[out, kH, kW, in]`, Conv1d `[out, K, in]`. mlx-community
+            // checkpoints ship pre-converted, so both transposes are guarded on shape and
+            // no-op when the weight is already in MLX layout.
+            var converted: [String: MLXArray] = [:]
+            converted.reserveCapacity(sanitized.count)
+            for (key, value) in sanitized {
+                if key.contains("audio_tower"), key.hasSuffix(".conv.weight"), value.ndim == 4,
+                    !gemma4IsMLXConv2dLayout(value)
+                {
+                    converted[key] = value.transposed(0, 2, 3, 1)
+                } else if key.contains("audio_tower"), key.hasSuffix("depthwise_conv1d.weight"),
+                    value.ndim == 3, value.dim(-1) != 1
+                {
+                    converted[key] = value.swappedAxes(1, 2)
+                } else {
+                    converted[key] = value
+                }
+            }
+            sanitized = converted
         }
 
         if !config.visionConfiguration.useClippedLinears {

--- a/Libraries/MLXVLM/Models/Gemma4Audio.swift
+++ b/Libraries/MLXVLM/Models/Gemma4Audio.swift
@@ -1,0 +1,595 @@
+// Copyright © 2026 Apple Inc.
+
+//
+// Gemma 4 audio encoder (`gemma4_audio`), a Universal Speech Model (USM)
+// Conformer. Ported from the Python reference
+// https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/gemma4/audio.py
+// and cross-checked against VincentGourbin/gemma-4-swift-mlx.
+//
+// Pipeline (mel -> text-hidden features):
+//   mel [B, T, 128]
+//     -> SubSampleConvProjection  (2× Conv2d 3×3 stride-2 -> flatten(F·C) -> Linear)  [B, T/4, hidden]
+//     -> 12 × ConformerBlock  (macaron FFN -> chunked local attn -> depthwise light-conv -> FFN)
+//     -> output_proj (Linear hidden -> output_proj_dims)                              [B, T/4, 1536]
+//
+// The `embed_audio` projection (`Gemma4MultimodalEmbedder`) and the scatter of
+// audio soft tokens into the text stream live in `Gemma4.swift`; this file is the
+// `audio_tower` only. All `@ModuleInfo`/`@ParameterInfo` keys match the checkpoint
+// `audio_tower.*` weight names.
+//
+
+import Foundation
+import MLX
+import MLXNN
+
+// MARK: - Configuration
+
+public struct Gemma4AudioConfiguration: Codable, Sendable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let hiddenLayers: Int
+    public let attentionHeads: Int
+    public let subsamplingConvChannels: [Int]
+    public let convKernelSize: Int
+    public let residualWeight: Float
+    public let attentionChunkSize: Int
+    public let attentionContextLeft: Int
+    public let attentionContextRight: Int
+    public let attentionLogitCap: Float
+    public let attentionInvalidLogitsValue: Float
+    public let rmsNormEps: Float
+    public let gradientClipping: Float
+    public let outputProjectionDimensions: Int?
+    public let useClippedLinears: Bool
+
+    public var headDim: Int { hiddenSize / attentionHeads }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case hiddenLayers = "num_hidden_layers"
+        case attentionHeads = "num_attention_heads"
+        case subsamplingConvChannels = "subsampling_conv_channels"
+        case convKernelSize = "conv_kernel_size"
+        case residualWeight = "residual_weight"
+        case attentionChunkSize = "attention_chunk_size"
+        case attentionContextLeft = "attention_context_left"
+        case attentionContextRight = "attention_context_right"
+        case attentionLogitCap = "attention_logit_cap"
+        case attentionInvalidLogitsValue = "attention_invalid_logits_value"
+        case rmsNormEps = "rms_norm_eps"
+        case gradientClipping = "gradient_clipping"
+        case outputProjectionDimensions = "output_proj_dims"
+        case useClippedLinears = "use_clipped_linears"
+    }
+
+    public init(from decoder: any Swift.Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType =
+            try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_audio"
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1024
+        hiddenLayers = try c.decodeIfPresent(Int.self, forKey: .hiddenLayers) ?? 12
+        attentionHeads = try c.decodeIfPresent(Int.self, forKey: .attentionHeads) ?? 8
+        subsamplingConvChannels =
+            try c.decodeIfPresent([Int].self, forKey: .subsamplingConvChannels) ?? [128, 32]
+        convKernelSize = try c.decodeIfPresent(Int.self, forKey: .convKernelSize) ?? 5
+        residualWeight = try c.decodeIfPresent(Float.self, forKey: .residualWeight) ?? 0.5
+        attentionChunkSize = try c.decodeIfPresent(Int.self, forKey: .attentionChunkSize) ?? 12
+        attentionContextLeft = try c.decodeIfPresent(Int.self, forKey: .attentionContextLeft) ?? 13
+        attentionContextRight = try c.decodeIfPresent(Int.self, forKey: .attentionContextRight) ?? 0
+        attentionLogitCap = try c.decodeIfPresent(Float.self, forKey: .attentionLogitCap) ?? 50.0
+        attentionInvalidLogitsValue =
+            try c.decodeIfPresent(Float.self, forKey: .attentionInvalidLogitsValue) ?? -1e9
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        gradientClipping = try c.decodeIfPresent(Float.self, forKey: .gradientClipping) ?? 1e10
+        outputProjectionDimensions =
+            try c.decodeIfPresent(Int.self, forKey: .outputProjectionDimensions)
+        useClippedLinears = try c.decodeIfPresent(Bool.self, forKey: .useClippedLinears) ?? true
+    }
+}
+
+// MARK: - Norms
+
+/// RMSNorm with the weight applied directly (no Gemma `1 + weight` offset).
+/// Matches the reference `AudioRMSNorm`.
+private final class Gemma4AudioRMSNorm: Module, UnaryLayer {
+    let eps: Float
+    @ModuleInfo var weight: MLXArray
+
+    init(dimensions: Int, eps: Float = 1e-6) {
+        self.eps = eps
+        self._weight.wrappedValue = MLXArray.ones([dimensions])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: weight, eps: eps)
+    }
+}
+
+// MARK: - SubSample Conv Projection (SSCP)
+
+/// One subsample stage: `Conv2d(3×3, stride 2) -> LayerNorm(channels) -> ReLU`
+/// with symmetric `(1,1)` padding on the time and frequency axes.
+private final class Gemma4AudioSSCPConvBlock: Module {
+    let timeStride = 2
+
+    @ModuleInfo(key: "conv") var conv: Conv2d
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+
+    init(config: Gemma4AudioConfiguration, idx: Int) {
+        let inChannels = idx == 0 ? 1 : config.subsamplingConvChannels[idx - 1]
+        let outChannels = config.subsamplingConvChannels[idx]
+        // MLX Conv2d: input [B, H, W, C], weight [C_out, kH, kW, C_in].
+        self._conv.wrappedValue = Conv2d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: IntOrPair((3, 3)),
+            stride: IntOrPair((2, 2)),
+            padding: IntOrPair(0),
+            bias: false
+        )
+        // LayerNorm over the channel (last) dim; weight only, no bias.
+        self._norm.wrappedValue = LayerNorm(
+            dimensions: outChannels, eps: config.rmsNormEps, affine: true, bias: false)
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - x: `[B, T, F, C]` (channel-last).
+    ///   - mask: `[B, T]` boolean, `true == padding`.
+    func callAsFunction(_ x: MLXArray, mask: MLXArray) -> (MLXArray, MLXArray) {
+        // Zero invalid (padding) positions.
+        let maskExpanded = expandedDimensions(expandedDimensions(mask, axis: -1), axis: -1)
+        var h = MLX.where(maskExpanded, MLXArray(0, dtype: x.dtype), x)
+
+        // Manual symmetric pad on T and F (the conv itself uses padding 0).
+        h = padded(h, widths: [0, 1, 1, 0])
+        h = conv(h)  // [B, T_out, F_out, C_out]
+        let tOut = h.dim(1)
+
+        // Downsample the (unpadded) mask by the time stride.
+        let tIn = mask.dim(1)
+        let evenIndices = MLXArray(stride(from: 0, to: tIn, by: timeStride).map { Int32($0) })
+        var outputMask = take(mask, evenIndices, axis: 1)
+        if outputMask.dim(1) > tOut {
+            outputMask = outputMask[0..., ..<tOut]
+        }
+
+        h = norm(h)
+        h = relu(h)
+        return (h, outputMask)
+    }
+}
+
+/// Two `SSCPConvBlock`s → flatten `(freq · channels)` → `Linear` to `hidden_size`.
+private final class Gemma4AudioSubSampleConvProjection: Module {
+    static let inputFeatSize = 128
+
+    @ModuleInfo(key: "layer0") var layer0: Gemma4AudioSSCPConvBlock
+    @ModuleInfo(key: "layer1") var layer1: Gemma4AudioSSCPConvBlock
+    @ModuleInfo(key: "input_proj_linear") var inputProjLinear: Linear
+
+    init(config: Gemma4AudioConfiguration) {
+        self._layer0.wrappedValue = Gemma4AudioSSCPConvBlock(config: config, idx: 0)
+        self._layer1.wrappedValue = Gemma4AudioSSCPConvBlock(config: config, idx: 1)
+
+        // Frequency after two `(f + 2 - 3) / 2 + 1` stride-2 stages (128 -> 64 -> 32).
+        var freq = Self.inputFeatSize
+        for _ in 0 ..< 2 { freq = (freq + 2 - 3) / 2 + 1 }
+        let projInputDim = freq * (config.subsamplingConvChannels.last ?? 32)
+        self._inputProjLinear.wrappedValue = Linear(projInputDim, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - audioMel: `[B, T, F_in]`.
+    ///   - mask: `[B, T]` boolean, `true == padding`.
+    func callAsFunction(_ audioMel: MLXArray, mask: MLXArray) -> (MLXArray, MLXArray) {
+        var x = expandedDimensions(audioMel, axis: -1)  // [B, T, F, 1]
+        var m = mask
+        (x, m) = layer0(x, mask: m)
+        (x, m) = layer1(x, mask: m)
+
+        // Flatten (F, C) -> [B, T, F*C], then project.
+        let (b, t) = (x.dim(0), x.dim(1))
+        x = x.reshaped(b, t, x.dim(2) * x.dim(3))
+        x = inputProjLinear(x)
+        return (x, m)
+    }
+}
+
+// MARK: - Conformer sub-layers
+
+/// Macaron feed-forward: `RMSNorm -> Linear(4×) -> SiLU -> Linear -> RMSNorm`,
+/// added back with a `residual_weight` (0.5) half-step.
+private final class Gemma4AudioFeedForward: Module, UnaryLayer {
+    let gradientClipping: Float
+    let residualWeight: Float
+
+    @ModuleInfo(key: "pre_layer_norm") var preLayerNorm: Gemma4AudioRMSNorm
+    @ModuleInfo(key: "ffw_layer_1") var ffwLayer1: Gemma4ClippableLinear
+    @ModuleInfo(key: "ffw_layer_2") var ffwLayer2: Gemma4ClippableLinear
+    @ModuleInfo(key: "post_layer_norm") var postLayerNorm: Gemma4AudioRMSNorm
+
+    init(config: Gemma4AudioConfiguration) {
+        self.gradientClipping = config.gradientClipping
+        self.residualWeight = config.residualWeight
+        self._preLayerNorm.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._ffwLayer1.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: config.hiddenSize * 4,
+            useClipping: config.useClippedLinears)
+        self._ffwLayer2.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize * 4, outFeatures: config.hiddenSize,
+            useClipping: config.useClippedLinears)
+        self._postLayerNorm.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let gc = MLXArray(gradientClipping)
+        let residual = x
+        var h = clip(x, min: -gc, max: gc)
+        h = preLayerNorm(h)
+        h = ffwLayer1(h)
+        h = silu(h)
+        h = ffwLayer2(h)
+        h = clip(h, min: -gc, max: gc)
+        h = postLayerNorm(h)
+        return residual + h * MLXArray(residualWeight)
+    }
+}
+
+/// Chunked local self-attention with Transformer-XL relative-position bias and
+/// logit softcapping. Query positions are grouped into non-overlapping chunks of
+/// `chunk_size`; each chunk attends over a `context_size` window (`max_past` left,
+/// `max_future` right). Attention math runs in float32.
+private final class Gemma4AudioAttention: Module {
+    let numHeads: Int
+    let headDim: Int
+    let chunkSize: Int
+    let maxPastHorizon: Int
+    let maxFutureHorizon: Int
+    let contextSize: Int
+    let invalidLogitsValue: Float
+    let softcap: Float
+    let qScale: Float
+    let kScale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Gemma4ClippableLinear
+    @ModuleInfo(key: "k_proj") var kProj: Gemma4ClippableLinear
+    @ModuleInfo(key: "v_proj") var vProj: Gemma4ClippableLinear
+    @ModuleInfo(key: "post") var post: Gemma4ClippableLinear
+    @ModuleInfo(key: "relative_k_proj") var relativeKProj: Linear
+    @ParameterInfo(key: "per_dim_scale") var perDimScale: MLXArray
+
+    init(config: Gemma4AudioConfiguration) {
+        self.numHeads = config.attentionHeads
+        self.headDim = config.hiddenSize / config.attentionHeads
+        self.chunkSize = config.attentionChunkSize
+        self.maxFutureHorizon = config.attentionContextRight
+        self.maxPastHorizon = max(0, config.attentionContextLeft - 1)
+        self.contextSize = chunkSize + maxPastHorizon + maxFutureHorizon
+        self.invalidLogitsValue = config.attentionInvalidLogitsValue
+        self.softcap = config.attentionLogitCap
+        self.qScale = Float(pow(Double(headDim), -0.5) / log(2.0))
+        self.kScale = Float(log(1.0 + exp(1.0)) / log(2.0))
+
+        let dim = numHeads * headDim
+        self._qProj.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: dim, useClipping: config.useClippedLinears)
+        self._kProj.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: dim, useClipping: config.useClippedLinears)
+        self._vProj.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: dim, useClipping: config.useClippedLinears)
+        self._post.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: config.hiddenSize,
+            useClipping: config.useClippedLinears)
+        self._relativeKProj.wrappedValue = Linear(config.hiddenSize, dim, bias: false)
+        self._perDimScale.wrappedValue = MLXArray.zeros([headDim])
+        super.init()
+    }
+
+    private func padDim1(_ x: MLXArray, _ left: Int, _ right: Int) -> MLXArray {
+        var widths = Array(repeating: IntOrPair(0), count: x.ndim)
+        widths[1] = IntOrPair((left, right))
+        return padded(x, widths: widths)
+    }
+
+    /// `[B, T, ...] -> [B, num_blocks, chunk_size, ...]` (non-overlapping query chunks).
+    private func convertToBlock(_ x: MLXArray) -> MLXArray {
+        let t = x.dim(1)
+        let numBlocks = (t + chunkSize - 1) / chunkSize
+        let padLen = numBlocks * chunkSize - t
+        let xp = padLen > 0 ? padDim1(x, 0, padLen) : x
+        var shape = [xp.dim(0), numBlocks, chunkSize]
+        for d in 2 ..< xp.ndim { shape.append(xp.dim(d)) }
+        return xp.reshaped(shape)
+    }
+
+    /// `[B, T, ...] -> [B, num_blocks, context_size, ...]` (overlapping key/value windows).
+    private func extractBlockContext(_ x: MLXArray) -> MLXArray {
+        let padLeft = maxPastHorizon
+        let padRight = maxFutureHorizon + chunkSize - 1
+        let xp = padDim1(x, padLeft, padRight)
+        let tPadded = xp.dim(1)
+        let numBlocks = (tPadded - contextSize) / chunkSize + 1
+        var idx = [Int32]()
+        idx.reserveCapacity(numBlocks * contextSize)
+        for b in 0 ..< numBlocks {
+            let start = b * chunkSize
+            for o in 0 ..< contextSize { idx.append(Int32(start + o)) }
+        }
+        let gathered = take(xp, MLXArray(idx), axis: 1)
+        var shape = [xp.dim(0), numBlocks, contextSize]
+        for d in 2 ..< xp.ndim { shape.append(xp.dim(d)) }
+        return gathered.reshaped(shape)
+    }
+
+    /// Transformer-XL relative-position bias (arXiv:1901.02860 App. B).
+    /// - queries: `[B, U, W, N, H]`, keys: `[B, U, C, N, H]` → logits `[B, N, U, W, C]`.
+    private func relativePositionLogits(queries: MLXArray, keys: MLXArray) -> MLXArray {
+        let (b, u, w) = (queries.dim(0), queries.dim(1), queries.dim(2))
+        let c = keys.dim(2)
+
+        // Sinusoidal timing signal over positions [max_past ... -max_future].
+        let positions = stride(from: maxPastHorizon, through: -maxFutureHorizon, by: -1)
+            .map { Float($0) }
+        let maxSpan = positions.count
+        let numTimescales = (numHeads * headDim) / 2
+        let logInc = Float(log(10000.0) / Double(max(numTimescales - 1, 1)))
+        let invTimescales = exp(
+            MLXArray(Array(0 ..< numTimescales)).asType(.float32) * (-logInc))
+        let pos = expandedDimensions(MLXArray(positions), axis: -1)  // [maxSpan, 1]
+        let scaledTime = pos * expandedDimensions(invTimescales, axis: 0)  // [maxSpan, numTimescales]
+        var sinEmb = concatenated([sin(scaledTime), cos(scaledTime)], axis: -1)  // [maxSpan, 2·nt]
+        sinEmb = relativeKProj(sinEmb.asType(queries.dtype))  // [maxSpan, N·H]
+        sinEmb = sinEmb.reshaped(maxSpan, numHeads, headDim)
+
+        // Content term: [B, N, U, W, H] @ [B, N, U, H, C] -> [B, N, U, W, C].
+        let queriesP = queries.transposed(0, 3, 1, 2, 4)
+        let keysP = keys.transposed(0, 3, 1, 4, 2)
+        let termAC = matmul(queriesP, keysP)
+
+        // Relative term: [B, N, U*W, H] @ [1, N, H, maxSpan] -> [B, N, U*W, maxSpan].
+        let sinEmbT = sinEmb.transposed(1, 2, 0)  // [N, H, maxSpan]
+        let qReshaped = queriesP.reshaped(b, numHeads, u * w, headDim)
+        var termBD = matmul(qReshaped, expandedDimensions(sinEmbT, axis: 0))
+        termBD = termBD.reshaped(b, numHeads, u, w, maxSpan)
+
+        // Relative shift: pad -> reshape -> slice -> reshape, aligning span -> context.
+        let padAmount = (c + 1) - maxSpan
+        termBD = padded(termBD, widths: [0, 0, 0, 0, IntOrPair((0, padAmount))])
+        termBD = termBD.reshaped(b, numHeads, u, w * (c + 1))
+        termBD = termBD[0..., 0..., 0..., ..<(w * c)]
+        termBD = termBD.reshaped(b, numHeads, u, w, c)
+
+        return termAC + termBD
+    }
+
+    /// - Parameters:
+    ///   - hiddenStates: `[B, T, D]`.
+    ///   - mask: `[B, T]` boolean, `true == padding`.
+    ///   - causalValidMask: `[chunk_size, context_size]` boolean, `true == attend`.
+    func callAsFunction(
+        _ hiddenStates: MLXArray, mask: MLXArray, causalValidMask: MLXArray
+    ) -> MLXArray {
+        let (b, t) = (hiddenStates.dim(0), hiddenStates.dim(1))
+
+        var q = qProj(hiddenStates).asType(.float32).reshaped(b, t, numHeads, headDim)
+        var k = kProj(hiddenStates).asType(.float32).reshaped(b, t, numHeads, headDim)
+        let v = vProj(hiddenStates).asType(.float32).reshaped(b, t, numHeads, headDim)
+
+        let perDim = softplus(perDimScale).asType(.float32)  // [H]
+        q = q * (perDim * MLXArray(qScale))
+        k = k * MLXArray(kScale)
+
+        let queryBlocks = convertToBlock(q)  // [B, U, W, N, H]
+        let keyBlocks = extractBlockContext(k)  // [B, U, C, N, H]
+        let valueBlocks = extractBlockContext(v)  // [B, U, C, N, H]
+        let u = queryBlocks.dim(1)
+
+        let validMask = logicalNot(mask)  // [B, T], true == valid
+        let extractedValid = extractBlockContext(validMask)  // [B, U, C]
+        let condition =
+            extractedValid.reshaped(b, 1, u, 1, contextSize)
+            & causalValidMask.reshaped(1, 1, 1, chunkSize, contextSize)
+
+        var logits = relativePositionLogits(queries: queryBlocks, keys: keyBlocks)  // [B,N,U,W,C]
+        logits = tanh(logits / MLXArray(softcap)) * MLXArray(softcap)
+        logits = MLX.where(condition, logits, MLXArray(invalidLogitsValue))
+
+        let probs = softmax(logits, axis: -1)  // [B, N, U, W, C]
+
+        // context = einsum("bnuwc,bucnh->buwnh", probs, valueBlocks) via batched matmul.
+        let probsP = probs.transposed(0, 2, 1, 3, 4)  // [B, U, N, W, C]
+        let valuesP = valueBlocks.transposed(0, 1, 3, 2, 4)  // [B, U, N, C, H]
+        var context = matmul(probsP, valuesP)  // [B, U, N, W, H]
+        context = context.transposed(0, 1, 3, 2, 4)  // [B, U, W, N, H]
+        context = context.reshaped(b, u * chunkSize, numHeads, headDim)
+        context = context[0..., ..<t]
+        context = context.reshaped(b, t, numHeads * headDim)
+        return post(context)
+    }
+}
+
+/// Light convolution module: `norm -> Linear(2×) -> GLU -> depthwise causal Conv1d
+/// -> norm -> SiLU -> Linear`, added back as a plain residual.
+private final class Gemma4AudioLightConv1d: Module, UnaryLayer {
+    let gradientClipping: Float
+    let causalPadding: Int
+
+    @ModuleInfo(key: "pre_layer_norm") var preLayerNorm: Gemma4AudioRMSNorm
+    @ModuleInfo(key: "linear_start") var linearStart: Gemma4ClippableLinear
+    @ModuleInfo(key: "depthwise_conv1d") var depthwiseConv1d: Conv1d
+    @ModuleInfo(key: "conv_norm") var convNorm: Gemma4AudioRMSNorm
+    @ModuleInfo(key: "linear_end") var linearEnd: Gemma4ClippableLinear
+
+    init(config: Gemma4AudioConfiguration) {
+        self.gradientClipping = config.gradientClipping
+        self.causalPadding = config.convKernelSize - 1
+        self._preLayerNorm.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._linearStart.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: config.hiddenSize * 2,
+            useClipping: config.useClippedLinears)
+        // Depthwise: groups == channels. MLX Conv1d weight is [C_out, K, C_in/groups=1].
+        self._depthwiseConv1d.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.hiddenSize,
+            kernelSize: config.convKernelSize,
+            groups: config.hiddenSize,
+            bias: false
+        )
+        self._convNorm.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._linearEnd.wrappedValue = Gemma4ClippableLinear(
+            inFeatures: config.hiddenSize, outFeatures: config.hiddenSize,
+            useClipping: config.useClippedLinears)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let residual = x
+        var h = preLayerNorm(x)
+        h = linearStart(h)  // [B, T, 2H]
+
+        // GLU gate over the last dim.
+        let half = h.dim(-1) / 2
+        h = h[0..., 0..., ..<half] * sigmoid(h[0..., 0..., half...])
+
+        // Causal left-pad on time, then depthwise conv (padding 0 inside the conv).
+        h = padded(h, widths: [0, IntOrPair((causalPadding, 0)), 0])
+        h = depthwiseConv1d(h)
+
+        let gc = MLXArray(gradientClipping)
+        h = clip(h, min: -gc, max: gc)
+        h = convNorm(h)
+        h = silu(h)
+        h = linearEnd(h)
+        return h + residual
+    }
+}
+
+/// Macaron Conformer block:
+/// `FFN → norm → attention (+residual) → zero-invalid → light-conv → FFN → clamp → norm_out`.
+private final class Gemma4AudioConformerBlock: Module {
+    let gradientClipping: Float
+
+    @ModuleInfo(key: "feed_forward1") var feedForward1: Gemma4AudioFeedForward
+    @ModuleInfo(key: "self_attn") var selfAttn: Gemma4AudioAttention
+    @ModuleInfo(key: "lconv1d") var lconv1d: Gemma4AudioLightConv1d
+    @ModuleInfo(key: "feed_forward2") var feedForward2: Gemma4AudioFeedForward
+    @ModuleInfo(key: "norm_pre_attn") var normPreAttn: Gemma4AudioRMSNorm
+    @ModuleInfo(key: "norm_post_attn") var normPostAttn: Gemma4AudioRMSNorm
+    @ModuleInfo(key: "norm_out") var normOut: Gemma4AudioRMSNorm
+
+    init(config: Gemma4AudioConfiguration) {
+        self.gradientClipping = config.gradientClipping
+        self._feedForward1.wrappedValue = Gemma4AudioFeedForward(config: config)
+        self._selfAttn.wrappedValue = Gemma4AudioAttention(config: config)
+        self._lconv1d.wrappedValue = Gemma4AudioLightConv1d(config: config)
+        self._feedForward2.wrappedValue = Gemma4AudioFeedForward(config: config)
+        self._normPreAttn.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._normPostAttn.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._normOut.wrappedValue = Gemma4AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXArray, causalValidMask: MLXArray
+    ) -> MLXArray {
+        let gc = MLXArray(gradientClipping)
+        var h = feedForward1(x)
+
+        let residual = h
+        h = clip(h, min: -gc, max: gc)
+        h = normPreAttn(h)
+        h = selfAttn(h, mask: mask, causalValidMask: causalValidMask)
+        h = clip(h, min: -gc, max: gc)
+        h = residual + normPostAttn(h)
+
+        // Zero invalid positions before the (causal) light-conv.
+        let validity = expandedDimensions(logicalNot(mask), axis: -1).asType(h.dtype)
+        h = h * validity
+
+        h = lconv1d(h)
+        h = feedForward2(h)
+        h = clip(h, min: -gc, max: gc)
+        return normOut(h)
+    }
+}
+
+// MARK: - Audio tower
+
+/// Gemma 4 `audio_tower`: the USM-Conformer encoder. Consumes log-mel features
+/// `[B, T, 128]` (+ padding mask, `true == padding`) and returns encoder outputs
+/// `[B, T/4, output_proj_dims]` with padded frames zeroed, plus the subsampled mask.
+final class Gemma4AudioModel: Module {
+    let config: Gemma4AudioConfiguration
+
+    @ModuleInfo(key: "subsample_conv_projection") private var subsampleConvProjection:
+        Gemma4AudioSubSampleConvProjection
+    @ModuleInfo(key: "layers") private var layers: [Gemma4AudioConformerBlock]
+    @ModuleInfo(key: "output_proj") private var outputProj: Linear?
+
+    init(config: Gemma4AudioConfiguration) {
+        self.config = config
+        self._subsampleConvProjection.wrappedValue = Gemma4AudioSubSampleConvProjection(
+            config: config)
+        self._layers.wrappedValue = (0 ..< config.hiddenLayers).map { _ in
+            Gemma4AudioConformerBlock(config: config)
+        }
+        if let outputDims = config.outputProjectionDimensions {
+            self._outputProj.wrappedValue = Linear(config.hiddenSize, outputDims, bias: true)
+        } else {
+            self._outputProj.wrappedValue = nil
+        }
+        super.init()
+    }
+
+    /// Local causal+validity mask `[chunk_size, context_size]` for chunked attention.
+    private func buildCausalValidMask() -> MLXArray {
+        let w = config.attentionChunkSize
+        let maxFuture = config.attentionContextRight
+        let maxPast = max(0, config.attentionContextLeft - 1)
+        let upperDiagonal = maxPast + maxFuture
+        let c = w + maxPast + maxFuture
+
+        let lowerCausal = tril(MLXArray.ones([c, w])).transposed(1, 0)  // [W, C]
+        let upperCausal = tril(MLXArray.ones([w, c]), k: upperDiagonal)  // [W, C]
+        return (lowerCausal * upperCausal).asType(.bool)
+    }
+
+    /// - Parameters:
+    ///   - audioMel: `[B, T, 128]` log-mel features.
+    ///   - audioMelMask: `[B, T]` boolean, `true == padding`.
+    /// - Returns: encoder outputs `[B, T/4, output_proj_dims]` and the subsampled mask.
+    func callAsFunction(
+        _ audioMel: MLXArray, audioMelMask: MLXArray
+    ) -> (MLXArray, MLXArray) {
+        var (encodings, currentMask) = subsampleConvProjection(audioMel, mask: audioMelMask)
+
+        let causalValidMask = buildCausalValidMask()
+        for block in layers {
+            encodings = block(encodings, mask: currentMask, causalValidMask: causalValidMask)
+        }
+
+        if let outputProj {
+            encodings = outputProj(encodings)
+        }
+
+        if currentMask.dim(1) != encodings.dim(1) {
+            currentMask = currentMask[0..., ..<encodings.dim(1)]
+        }
+        encodings = MLX.where(
+            expandedDimensions(currentMask, axis: -1), MLXArray(0, dtype: encodings.dtype),
+            encodings)
+        return (encodings, currentMask)
+    }
+}

--- a/Libraries/MLXVLM/Models/Gemma4AudioFeatures.swift
+++ b/Libraries/MLXVLM/Models/Gemma4AudioFeatures.swift
@@ -1,0 +1,179 @@
+// Copyright © 2026 Apple Inc.
+
+//
+// Log-mel feature extractor for Gemma 4 audio — a faithful port of HuggingFace
+// Transformers `Gemma4AudioFeatureExtractor` (USM preprocessing), via
+// Blaizzy/mlx-vlm `models/gemma4/audio_feature_extractor.py`. Raw 16 kHz mono
+// waveform -> log-mel `[1, T, 128]` plus a per-frame validity mask `[1, T]`
+// (true == valid). Everything runs in MLX (`rfft` is re-exported by `MLX`), so
+// the result matches the reference's `mx.fft.rfft` pipeline numerically.
+//
+// Cross-checked against llama.cpp PR #21421 (`tools/mtmd/mtmd-audio.cpp`): same
+// periodic Hann window, HTK mel scale, `sample_rate / n_fft` bin spacing,
+// magnitude (not power) spectrum, and `log(mel + mel_floor)`.
+//
+
+import Foundation
+import MLX
+
+public struct Gemma4AudioFeatureExtractor {
+    public let featureSize: Int
+    public let sampleRate: Int
+    public let frameLength: Int
+    public let hopLength: Int
+    public let fftLength: Int
+    public let melFloor: Float
+    public let maxSamples: Int
+    public let padToMultipleOf: Int
+
+    private let window: MLXArray  // [frameLength] periodic Hann
+    private let melFilters: MLXArray  // [fftLength/2+1, featureSize]
+
+    public init(
+        featureSize: Int = 128,
+        sampleRate: Int = 16_000,
+        frameLengthMs: Double = 20.0,
+        hopLengthMs: Double = 10.0,
+        minFrequency: Float = 0.0,
+        maxFrequency: Float = 8000.0,
+        melFloor: Float = 1e-3,
+        maxSamples: Int = 480_000,
+        padToMultipleOf: Int = 128
+    ) {
+        self.featureSize = featureSize
+        self.sampleRate = sampleRate
+        self.frameLength = Int((Double(sampleRate) * frameLengthMs / 1000.0).rounded())
+        self.hopLength = Int((Double(sampleRate) * hopLengthMs / 1000.0).rounded())
+        self.fftLength = 1 << Int(ceil(log2(Double(self.frameLength))))
+        self.melFloor = melFloor
+        self.maxSamples = maxSamples
+        self.padToMultipleOf = padToMultipleOf
+
+        // Periodic Hann window: w[n] = 0.5 - 0.5·cos(2π n / frameLength).
+        let n = MLXArray(Array(0 ..< self.frameLength)).asType(.float32)
+        self.window = 0.5 - 0.5 * cos(2.0 * Float.pi * n / Float(self.frameLength))
+
+        let numFreqBins = self.fftLength / 2 + 1
+        let filters = Self.melFilterBank(
+            numFreqBins: numFreqBins, numMel: featureSize,
+            minFrequency: minFrequency, maxFrequency: maxFrequency, sampleRate: sampleRate)
+        self.melFilters = MLXArray(filters, [numFreqBins, featureSize])
+    }
+
+    /// - Parameter waveform: mono samples `[N]` at `sampleRate` (16 kHz).
+    /// - Returns: log-mel features `[1, T, 128]` and a validity mask `[1, T]`
+    ///   (`true == valid frame`, i.e. the HF `input_features_mask` convention).
+    public func callAsFunction(_ waveform: MLXArray) -> (features: MLXArray, mask: MLXArray) {
+        var samples = waveform.asType(.float32)
+        if samples.ndim > 1 { samples = samples.reshaped(-1) }
+        let n0 = min(samples.dim(0), maxSamples)
+        samples = samples[..<n0]
+
+        // Pad the real audio up to a multiple of `padToMultipleOf` samples; the
+        // frame mask marks the real prefix. Then semicausal left-pad by
+        // `frameLength/2` so the first frame is centred at t=0.
+        var target = n0
+        if padToMultipleOf > 0 && target % padToMultipleOf != 0 {
+            target = (target / padToMultipleOf + 1) * padToMultipleOf
+        }
+        let padRight = target - n0
+        let padLeft = frameLength / 2
+
+        var w = samples
+        if padRight > 0 { w = padded(w, widths: [IntOrPair((0, padRight))]) }
+        w = padded(w, widths: [IntOrPair((padLeft, 0))])
+        let paddedLen = padLeft + target
+
+        // Reference unfolds with size `frameLength + 1` (a preemphasis affordance),
+        // then, with preemphasis disabled, keeps the first `frameLength` samples.
+        let frameSizeForUnfold = frameLength + 1
+        let numFrames = (paddedLen - frameSizeForUnfold) / hopLength + 1
+        guard numFrames > 0 else {
+            return (
+                MLXArray.zeros([1, 0, featureSize]),
+                MLXArray.zeros([1, 0]).asType(.bool)
+            )
+        }
+
+        // Frame f uses samples [f·hop, f·hop + frameLength).
+        var idx = [Int32]()
+        idx.reserveCapacity(numFrames * frameLength)
+        for f in 0 ..< numFrames {
+            let start = f * hopLength
+            for j in 0 ..< frameLength { idx.append(Int32(start + j)) }
+        }
+        var frames = take(w, MLXArray(idx), axis: 0).reshaped(numFrames, frameLength)
+        frames = frames * window
+
+        // rfft -> magnitude (not power) -> mel -> log.
+        let stft = rfft(frames, n: fftLength, axis: -1)  // [numFrames, fftLength/2+1] complex
+        let re = stft.realPart()
+        let im = stft.imaginaryPart()
+        let magnitude = sqrt(re * re + im * im)
+        let mel = matmul(magnitude, melFilters)  // [numFrames, featureSize]
+        var logMel = log(mel + MLXArray(melFloor))
+
+        // Per-frame validity from the padded sample mask: a frame is valid when
+        // its end sample falls inside the real-audio region [padLeft, padLeft+n0).
+        var frameValid = [Int32]()
+        frameValid.reserveCapacity(numFrames)
+        let validLo = padLeft
+        let validHi = padLeft + n0
+        for f in 0 ..< numFrames {
+            let end = f * hopLength + frameSizeForUnfold - 1
+            frameValid.append((end >= validLo && end < validHi) ? 1 : 0)
+        }
+        let maskArr = MLXArray(frameValid)
+        logMel = logMel * expandedDimensions(maskArr.asType(logMel.dtype), axis: -1)
+
+        return (
+            expandedDimensions(logMel, axis: 0),  // [1, T, 128]
+            expandedDimensions(maskArr.asType(.bool), axis: 0)  // [1, T]
+        )
+    }
+
+    /// Number of audio soft tokens the encoder yields for `validFrames` valid mel
+    /// frames: the SSCP's two stride-2 stages applied to a valid prefix collapse to
+    /// `ceil(ceil(V/2)/2)`. Expanding the audio placeholder to exactly this many
+    /// tokens keeps the prompt's audio-token count equal to the scattered encoder
+    /// frames (the tower zeroes/removes padding frames).
+    public static func audioTokenCount(validFrames: Int) -> Int {
+        let step1 = (validFrames + 1) / 2
+        return (step1 + 1) / 2
+    }
+
+    /// HTK mel filterbank, `norm=None`, row-major `[numFreqBins, numMel]`.
+    static func melFilterBank(
+        numFreqBins: Int, numMel: Int, minFrequency: Float, maxFrequency: Float, sampleRate: Int
+    ) -> [Float] {
+        func hzToMel(_ f: Double) -> Double { 2595.0 * log10(1.0 + f / 700.0) }
+        func melToHz(_ m: Double) -> Double { 700.0 * (pow(10.0, m / 2595.0) - 1.0) }
+
+        let melMin = hzToMel(Double(minFrequency))
+        let melMax = hzToMel(Double(maxFrequency))
+        var freqPoints = [Double](repeating: 0, count: numMel + 2)
+        for i in 0 ..< numMel + 2 {
+            let mel = melMin + (melMax - melMin) * Double(i) / Double(numMel + 1)
+            freqPoints[i] = melToHz(mel)
+        }
+
+        // Frequency of each rfft bin: k · sampleRate / (2·(numFreqBins − 1)).
+        let binWidth = Double(sampleRate) / (2.0 * Double(numFreqBins - 1))
+
+        var bank = [Float](repeating: 0, count: numFreqBins * numMel)
+        for i in 0 ..< numMel {
+            let lower = freqPoints[i]
+            let center = freqPoints[i + 1]
+            let upper = freqPoints[i + 2]
+            let ldenom = max(center - lower, 1e-10)
+            let rdenom = max(upper - center, 1e-10)
+            for k in 0 ..< numFreqBins {
+                let freq = Double(k) * binWidth
+                let rising = (freq - lower) / ldenom
+                let falling = (upper - freq) / rdenom
+                bank[k * numMel + i] = Float(max(0.0, min(rising, falling)))
+            }
+        }
+        return bank
+    }
+}

--- a/Tests/MLXLMTests/Gemma4AudioTests.swift
+++ b/Tests/MLXLMTests/Gemma4AudioTests.swift
@@ -332,7 +332,53 @@ struct Gemma4AudioTests {
 
             #expect(
                 validSubsampled == expectedTokens,
-                "samples=\(samples): tower produced \(validSubsampled) valid frames, processor would emit \(expectedTokens) audio tokens")
+                "samples=\(samples): tower produced \(validSubsampled) valid frames, processor would emit \(expectedTokens) audio tokens"
+            )
+        }
+    }
+
+    /// Numerical parity vs the Python reference (`mlx-vlm`
+    /// `audio_feature_extractor.py`, local HTK mel bank) on a deterministic
+    /// waveform. Reference probes were produced by running that extractor on the
+    /// exact same signal; the Swift extractor must reproduce them within tol.
+    @Test("Extractor matches the Python reference numerically")
+    func extractorMatchesPythonReference() {
+        let n = 8000
+        // Reduce each tone's phase into [0, 2π) via its fractional cycle count before
+        // sin(): the raw phase of a 3 kHz tone at large sample indices (~9400 rad)
+        // exceeds float32 precision (and MLX has no GPU float64), so a naive float32
+        // computation would diverge from the numpy (float64) reference. sin is
+        // 2π-periodic, so this is exact in real arithmetic and float32-accurate here.
+        let i = MLXArray(Array(0 ..< n)).asType(.float32)
+        func tone(_ freq: Float) -> MLXArray {
+            let cycles = (freq / 16_000.0) * i  // exact/near-exact in float32
+            return sin(2 * Float.pi * (cycles - floor(cycles)))
+        }
+        let wave = 0.6 * tone(220) + 0.3 * tone(1500) + 0.1 * tone(3000)
+
+        let (feat, mask) = Gemma4AudioFeatureExtractor()(wave)
+        eval(feat, mask)
+
+        #expect(feat.shape == [1, 50, 128])
+        #expect(mask.asType(.int32).sum().item(Int.self) == 49)
+
+        // Tolerance note: the reference uses numpy's float64 CPU FFT while this runs
+        // MLX's float32 (Metal) FFT, so log-mel values agree to ~1e-2 — looser at
+        // near-silent bins where `log` amplifies the tiny FFT-floor difference.
+        #expect(abs(feat.mean().item(Float.self) - (-3.516562)) < 2e-2)
+        // The empty-filter[0] cell is deterministic — log(mel_floor), no FFT dependence.
+        #expect(abs(feat[0, 0, 0].item(Float.self) - (-6.907755)) < 1e-4)
+
+        // Signal-region probes (energy present) from the Python reference.
+        let probes: [(Int, Int, Float)] = [
+            (0, 64, 0.609170), (5, 10, 1.511158), (10, 40, -5.128715),
+            (20, 80, -4.040174), (48, 50, -3.333589),
+        ]
+        for (f, m, expected) in probes {
+            let got = feat[0, f, m].item(Float.self)
+            #expect(
+                abs(got - expected) < 2e-2,
+                "mel[\(f),\(m)]: got \(got), reference \(expected)")
         }
     }
 }

--- a/Tests/MLXLMTests/Gemma4AudioTests.swift
+++ b/Tests/MLXLMTests/Gemma4AudioTests.swift
@@ -1,0 +1,246 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import MLXVLM
+
+// MARK: - Gemma 4 audio encoder (`gemma4_audio` USM-Conformer) parity tests
+//
+// These pin the Swift port of the audio tower to the Python reference
+// (Blaizzy/mlx-vlm `mlx_vlm/models/gemma4/audio.py`): the checkpoint weight-key
+// names, the SSCP time-subsampling factor (4×), the output shape / projection
+// width, and the padding-frame zeroing. Full numerical parity against exported
+// reference activations is a follow-up (needs a Python+mlx env and the
+// checkpoint); everything here runs from synthetic tensors.
+//
+// Run via Xcode (`swift test` on the CLI cannot load MLX's default.metallib):
+//   xcodebuild test -scheme mlx-swift-lm-Package \
+//     -destination 'platform=macOS,arch=arm64' \
+//     -only-testing:MLXLMTests/Gemma4AudioTests \
+//     -skipPackagePluginValidation -skipMacroValidation
+
+struct Gemma4AudioTests {
+
+    // MARK: Config
+
+    /// A small-but-faithful audio config: real chunk/context/conv/scale values,
+    /// a reduced hidden size and layer count for fast tests. Mel bins stay 128
+    /// (the SSCP `INPUT_FEAT_SIZE`), so the frequency reduction 128→64→32 holds.
+    private static func audioConfig(
+        hiddenSize: Int = 64, layers: Int = 2, outputProjDims: Int? = 48
+    ) -> Gemma4AudioConfiguration {
+        let json = """
+            {
+              "model_type": "gemma4_audio",
+              "hidden_size": \(hiddenSize),
+              "num_hidden_layers": \(layers),
+              "num_attention_heads": 4,
+              "subsampling_conv_channels": [128, 32],
+              "conv_kernel_size": 5,
+              "residual_weight": 0.5,
+              "attention_chunk_size": 12,
+              "attention_context_left": 13,
+              "attention_context_right": 0,
+              "attention_logit_cap": 50.0,
+              "attention_invalid_logits_value": -1e9,
+              "rms_norm_eps": 1e-6,
+              "gradient_clipping": 1e10,
+              \(outputProjDims.map { "\"output_proj_dims\": \($0)," } ?? "")
+              "use_clipped_linears": true
+            }
+            """
+        return try! JSONDecoder().decode(
+            Gemma4AudioConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Expected subsampled time length after the two stride-2 SSCP conv blocks
+    /// (kernel 3, symmetric pad 1): `(t - 1) / 2 + 1`, applied twice.
+    private static func subsampledLength(_ t: Int) -> Int {
+        var n = t
+        for _ in 0 ..< 2 { n = (n - 1) / 2 + 1 }
+        return n
+    }
+
+    @Test("audio_config decodes to the checkpoint's real field values")
+    func audioConfigDecodesRealFields() {
+        let json = """
+            {
+              "model_type": "gemma4_audio", "hidden_size": 1024, "num_hidden_layers": 12,
+              "num_attention_heads": 8, "subsampling_conv_channels": [128, 32],
+              "conv_kernel_size": 5, "residual_weight": 0.5, "attention_chunk_size": 12,
+              "attention_context_left": 13, "attention_context_right": 0,
+              "attention_logit_cap": 50.0, "rms_norm_eps": 1e-6, "gradient_clipping": 1e10,
+              "output_proj_dims": 1536, "use_clipped_linears": true
+            }
+            """
+        let c = try! JSONDecoder().decode(Gemma4AudioConfiguration.self, from: Data(json.utf8))
+        #expect(c.hiddenSize == 1024)
+        #expect(c.hiddenLayers == 12)
+        #expect(c.attentionHeads == 8)
+        #expect(c.headDim == 128)
+        #expect(c.subsamplingConvChannels == [128, 32])
+        #expect(c.convKernelSize == 5)
+        #expect(c.residualWeight == 0.5)
+        #expect(c.attentionChunkSize == 12)
+        #expect(c.attentionContextLeft == 13)
+        #expect(c.attentionContextRight == 0)
+        #expect(c.attentionLogitCap == 50.0)
+        #expect(c.outputProjectionDimensions == 1536)
+        #expect(c.useClippedLinears == true)
+    }
+
+    @Test("Gemma4Configuration decodes audio_config and the audio/video token ids")
+    func gemma4ConfigDecodesAudioSection() {
+        // Minimal top-level config: vision_config defaults, a real audio_config,
+        // and the E4B token ids. text_config carries only what the text decoder needs.
+        let json = """
+            {
+              "model_type": "gemma4",
+              "text_config": {
+                "model_type": "gemma4_text", "hidden_size": 8, "num_hidden_layers": 2,
+                "intermediate_size": 16, "num_attention_heads": 2, "num_key_value_heads": 1,
+                "head_dim": 4, "global_head_dim": 4, "vocab_size": 12,
+                "vocab_size_per_layer_input": 12, "num_kv_shared_layers": 0,
+                "hidden_size_per_layer_input": 0, "sliding_window": 8,
+                "sliding_window_pattern": 1, "layer_types": ["full_attention", "full_attention"],
+                "rope_parameters": {}, "tie_word_embeddings": true
+              },
+              "vision_config": {},
+              "audio_config": {
+                "model_type": "gemma4_audio", "hidden_size": 1024, "num_hidden_layers": 12,
+                "num_attention_heads": 8, "subsampling_conv_channels": [128, 32],
+                "output_proj_dims": 1536, "use_clipped_linears": true
+              },
+              "image_token_id": 258880, "audio_token_id": 258881, "video_token_id": 258884,
+              "boi_token_id": 255999, "eoi_token_id": 258882,
+              "boa_token_id": 256000, "eoa_token_id": 258883
+            }
+            """
+        let config = try! JSONDecoder().decode(Gemma4Configuration.self, from: Data(json.utf8))
+        #expect(config.audioConfiguration != nil)
+        #expect(config.audioConfiguration?.hiddenSize == 1024)
+        #expect(config.audioConfiguration?.outputProjectionDimensions == 1536)
+        #expect(config.audioTokenId == 258881)
+        #expect(config.videoTokenId == 258884)
+        #expect(config.boaTokenId == 256000)
+        #expect(config.eoaTokenId == 258883)
+    }
+
+    // MARK: Weight-key parity
+
+    @Test("audio_tower module tree exposes the checkpoint weight keys")
+    func audioTowerExposesCheckpointWeightKeys() {
+        let model = Gemma4AudioModel(config: Self.audioConfig(layers: 2))
+        let keys = Set(model.parameters().flattened().map(\.0))
+
+        // SSCP: two conv blocks (Conv2d weight + LayerNorm weight) and the projection.
+        #expect(keys.contains("subsample_conv_projection.layer0.conv.weight"))
+        #expect(keys.contains("subsample_conv_projection.layer0.norm.weight"))
+        #expect(keys.contains("subsample_conv_projection.layer1.conv.weight"))
+        #expect(keys.contains("subsample_conv_projection.input_proj_linear.weight"))
+
+        // Conformer block 0: macaron FFNs, attention (clippable `.linear.` nesting +
+        // the plain `relative_k_proj` and the `per_dim_scale` parameter), light-conv, norms.
+        #expect(keys.contains("layers.0.feed_forward1.ffw_layer_1.linear.weight"))
+        #expect(keys.contains("layers.0.feed_forward2.ffw_layer_2.linear.weight"))
+        #expect(keys.contains("layers.0.self_attn.q_proj.linear.weight"))
+        #expect(keys.contains("layers.0.self_attn.post.linear.weight"))
+        #expect(keys.contains("layers.0.self_attn.relative_k_proj.weight"))
+        #expect(keys.contains("layers.0.self_attn.per_dim_scale"))
+        #expect(keys.contains("layers.0.lconv1d.depthwise_conv1d.weight"))
+        #expect(keys.contains("layers.0.lconv1d.linear_start.linear.weight"))
+        #expect(keys.contains("layers.0.norm_out.weight"))
+
+        // Output projection (Linear with bias).
+        #expect(keys.contains("output_proj.weight"))
+        #expect(keys.contains("output_proj.bias"))
+
+        // The depthwise conv weight is MLX layout `[C, K, 1]`.
+        let depthwise = model.parameters().flattened().first {
+            $0.0 == "layers.0.lconv1d.depthwise_conv1d.weight"
+        }!.1
+        #expect(depthwise.shape == [64, 5, 1])
+    }
+
+    @Test("A synthetic audio_tower checkpoint round-trips through the strict loader")
+    func audioTowerRoundTripsSyntheticCheckpoint() throws {
+        let source = Gemma4AudioModel(config: Self.audioConfig(layers: 2))
+        eval(source)
+        var checkpoint = [String: MLXArray]()
+        for (key, value) in source.parameters().flattened() {
+            checkpoint[key] = value
+        }
+        let model = Gemma4AudioModel(config: Self.audioConfig(layers: 2))
+        // `[.all]` is what MLXLMCommon.loadWeights applies — throws on any module
+        // parameter with no matching weight, or any leftover unmatched weight.
+        try model.update(
+            parameters: ModuleParameters.unflattened(checkpoint), verify: [.all])
+        eval(model)
+    }
+
+    // MARK: Forward pass
+
+    @Test("Encoder subsamples time 4× and projects to output_proj_dims")
+    func audioTowerForwardShapeAndSubsampling() {
+        let config = Self.audioConfig(layers: 2, outputProjDims: 48)
+        let model = Gemma4AudioModel(config: config)
+        eval(model)
+
+        let t = 50
+        let mel = MLXRandom.normal([1, t, 128])
+        let mask = MLXArray.zeros([1, t]).asType(.bool)  // all valid
+        let (encodings, subMask) = model(mel, audioMelMask: mask)
+        eval(encodings, subMask)
+
+        let expectedT = Self.subsampledLength(t)  // 50 -> 25 -> 13
+        #expect(encodings.shape == [1, expectedT, 48])
+        #expect(subMask.shape == [1, expectedT])
+    }
+
+    @Test("Encoder without output_proj keeps hidden_size and stays finite")
+    func audioTowerNoOutputProjKeepsHidden() {
+        let config = Self.audioConfig(hiddenSize: 64, layers: 2, outputProjDims: nil)
+        let model = Gemma4AudioModel(config: config)
+        eval(model)
+
+        let mel = MLXRandom.normal([1, 40, 128])
+        let mask = MLXArray.zeros([1, 40]).asType(.bool)
+        let (encodings, _) = model(mel, audioMelMask: mask)
+        eval(encodings)
+
+        #expect(encodings.shape == [1, Self.subsampledLength(40), 64])
+        // gradient_clipping (1e10) keeps everything finite; guard against NaN/Inf.
+        let maxAbs = encodings.abs().max().item(Float.self)
+        #expect(maxAbs.isFinite)
+    }
+
+    @Test("Padding frames are zeroed in the encoder output")
+    func audioTowerZeroesPaddedFrames() {
+        let config = Self.audioConfig(layers: 2, outputProjDims: 48)
+        let model = Gemma4AudioModel(config: config)
+        eval(model)
+
+        let t = 50
+        let mel = MLXRandom.normal([1, t, 128])
+        // Mark the last 10 mel frames as padding (mask == true). After the 4×
+        // subsample these land on the final output frames, which must be zeroed.
+        var maskValues = [Int32](repeating: 0, count: t)
+        for i in (t - 10) ..< t { maskValues[i] = 1 }
+        let mask = MLXArray(maskValues).reshaped(1, t).asType(.bool)
+
+        let (encodings, subMask) = model(mel, audioMelMask: mask)
+        eval(encodings, subMask)
+
+        let lastFrame = encodings[0, encodings.dim(1) - 1]
+        let lastFrameEnergy = lastFrame.abs().sum().item(Float.self)
+        #expect(lastFrameEnergy == 0.0)
+
+        // And the subsampled mask must flag that final frame as padding.
+        let subMaskValues = subMask.asType(.int32).asArray(Int32.self)
+        #expect(subMaskValues.last == 1)
+    }
+}

--- a/Tests/MLXLMTests/Gemma4AudioTests.swift
+++ b/Tests/MLXLMTests/Gemma4AudioTests.swift
@@ -243,4 +243,96 @@ struct Gemma4AudioTests {
         let subMaskValues = subMask.asType(.int32).asArray(Int32.self)
         #expect(subMaskValues.last == 1)
     }
+
+    // MARK: Mel feature extractor
+
+    @Test("HTK mel filterbank is [257, 128], non-negative, mostly non-empty")
+    func melFilterBankValid() {
+        let bins = 257
+        let mel = 128
+        let bank = Gemma4AudioFeatureExtractor.melFilterBank(
+            numFreqBins: bins, numMel: mel, minFrequency: 0, maxFrequency: 8000, sampleRate: 16_000)
+        #expect(bank.count == bins * mel)
+        #expect(bank.allSatisfy { $0 >= 0 && $0 <= 1.0001 })
+        #expect(bank.contains { $0 > 0.5 })  // triangles reach their peak
+
+        func columnMax(_ m: Int) -> Float {
+            var v: Float = 0
+            for k in 0 ..< bins { v = max(v, bank[k * mel + m]) }
+            return v
+        }
+        // The lowest mel filters can be narrower than the FFT bin spacing
+        // (31.25 Hz) and come out empty — this matches the reference
+        // `_mel_filter_bank` / librosa. Only a few may be empty; the upper mel
+        // range is always well resolved.
+        let nonEmpty = (0 ..< mel).filter { columnMax($0) > 0 }.count
+        #expect(nonEmpty >= mel - 5)
+        for m in (mel / 2) ..< mel { #expect(columnMax(m) > 0) }
+    }
+
+    @Test("Extractor yields [1, T, 128] with the reference frame count")
+    func extractorShapeAndFrameCount() {
+        let extractor = Gemma4AudioFeatureExtractor()
+        let samples = 16_000  // 1 s @ 16 kHz (already a multiple of 128)
+        let (features, mask) = extractor(MLXRandom.normal([samples]))
+        eval(features, mask)
+
+        #expect(features.dim(0) == 1)
+        #expect(features.dim(2) == 128)
+        #expect(mask.shape == [1, features.dim(1)])
+
+        // paddedLen = frameLength/2 + samples = 160 + 16000 = 16160;
+        // numFrames = (16160 - 321) / 160 + 1 = 99.
+        #expect(features.dim(1) == 99)
+        // A whole-second clip aligned to 128 samples has every frame valid.
+        #expect(mask.asType(.int32).sum().item(Int.self) == 99)
+        #expect(features.max().item(Float.self).isFinite)
+    }
+
+    @Test("Extractor is deterministic")
+    func extractorDeterministic() {
+        let extractor = Gemma4AudioFeatureExtractor()
+        let wave = MLXRandom.normal([12_000])
+        let (a, _) = extractor(wave)
+        let (b, _) = extractor(wave)
+        eval(a, b)
+        #expect((a - b).abs().max().item(Float.self) == 0)
+    }
+
+    @Test(
+        "audioTokenCount = ceil(ceil(V/2)/2)",
+        arguments: [1, 2, 4, 13, 25, 50, 99, 100, 400, 3000])
+    func audioTokenCountFormula(validFrames: Int) {
+        let expected = ((validFrames + 1) / 2 + 1) / 2
+        #expect(
+            Gemma4AudioFeatureExtractor.audioTokenCount(validFrames: validFrames) == expected)
+    }
+
+    /// The crucial end-to-end consistency check: the token count the processor
+    /// would emit for a clip (`audioTokenCount` of the valid mel frames) must equal
+    /// the number of valid frames the audio tower actually produces after
+    /// subsampling — otherwise the prompt's audio-token count and the scattered
+    /// encoder frames disagree and the scatter throws.
+    @Test("Extractor token count matches the tower's valid subsampled frames")
+    func extractorTowerFrameCountConsistency() {
+        let extractor = Gemma4AudioFeatureExtractor()
+        let model = Gemma4AudioModel(config: Self.audioConfig(layers: 2))
+        eval(model)
+
+        for samples in [8_000, 16_000, 24_000] {
+            let (features, mask) = extractor(MLXRandom.normal([samples]))
+            let validFrames = mask.asType(.int32).sum().item(Int.self)
+            let expectedTokens = Gemma4AudioFeatureExtractor.audioTokenCount(
+                validFrames: validFrames)
+
+            // Tower wants `true == padding`, so invert the extractor's valid mask.
+            let (encodings, subMask) = model(features, audioMelMask: logicalNot(mask))
+            eval(encodings, subMask)
+            let validSubsampled = logicalNot(subMask).asType(.int32).sum().item(Int.self)
+
+            #expect(
+                validSubsampled == expectedTokens,
+                "samples=\(samples): tower produced \(validSubsampled) valid frames, processor would emit \(expectedTokens) audio tokens")
+        }
+    }
 }


### PR DESCRIPTION
# Gemma 4: native audio (+ video) input for the `Gemma4` VLM

**Draft — builds on #390 (`fix/gemma4-vlm-kv-shared-construct`), which the E4B checkpoint needs to load.**

Wires **native audio** (and video) into the `Gemma4` VLM class (`model_type: "gemma4"`,
e.g. `mlx-community/gemma-4-e4b-it-4bit`), previously text + vision only. The audio
encoder (`audio_tower`, a USM-Conformer) is ported from `Blaizzy/mlx-vlm`
`models/gemma4/audio.py` and **cross-checked against three independent implementations**
that all agree: mlx-vlm (Python), `VincentGourbin/gemma-4-swift-mlx` (Swift), and the
**merged** llama.cpp PR #21421 (`tools/mtmd/models/gemma4a.cpp`, C++).

## Changes

**`Libraries/MLXVLM/Models/Gemma4Audio.swift`** (new) — the `audio_tower`:
SSCP subsample projection (2× `Conv2d` 3×3 stride-2 → flatten(F·C) → `Linear`), macaron
`ConformerFeedForward` (0.5 residual), chunked-local `AudioAttention` (Transformer-XL
relative shift, base-2 `qScale`/`kScale`, `per_dim_scale` softplus, tanh softcap 50,
float32 math), depthwise-causal `LightConv1d`, ×12 `ConformerBlock`, `output_proj`.

**`Libraries/MLXVLM/Models/Gemma4AudioFeatures.swift`** (new) — `Gemma4AudioFeatureExtractor`:
faithful MLX port of HF `Gemma4AudioFeatureExtractor` (raw 16 kHz waveform → log-mel
`[1,T,128]` + validity mask). Periodic Hann, HTK mel (128 bins, 0–8 kHz), `rfft` (n=512),
magnitude spectrum, `log(mel + 1e-3)`, semicausal pad. `rfft` is re-exported by `MLX`
(no new package dependency).

**`Libraries/MLXVLM/Models/Gemma4.swift`:**
- `Gemma4Configuration` decodes `audio_config`, `video_token_id`, `boa`/`eoa`,
  `audio_soft_tokens_per_image`, `audio_ms_per_token`.
- `Gemma4` builds `audio_tower`/`embed_audio` when `audio_config` is present; runs the
  tower in `getAudioFeatures` (mask polarity: `ProcessedAudio.mask` is `true==valid`,
  inverted to the tower's `true==padding`); scatters audio soft-tokens at `audio_token_id`;
  scatters **video** frames through the same vision tower at `video_token_id`; handles
  `input.audio`/`input.video` in `prepare`; `sanitize` keeps audio weights + normalises
  conv layout (shape-guarded, no-ops on pre-converted mlx-community weights).
- `Gemma4Processor` extracts mel from `input.audios`, expands each audio placeholder to
  `boa + audio_soft_token×N + eoa` (N derived from valid mel frames via the SSCP formula,
  so it exactly matches the tower's scatter count), and produces `ProcessedAudio`; the
  message generator emits `{type: audio}`.
- `Gemma4ClippableLinear` relaxed `private` → internal for reuse.

**Tests** (`Tests/MLXLMTests/Gemma4AudioTests.swift`): config decode; exact checkpoint
weight-key parity; strict-loader round-trip; forward-pass subsampling/shape/finiteness/
padding-zeroing; mel filterbank validity; extractor shape/frame-count/determinism;
`audioTokenCount` formula; and an **end-to-end consistency test** proving the processor's
per-clip token count equals the tower's valid subsampled-frame count.

## Data flow

`waveform` → `Gemma4AudioFeatureExtractor` → mel `[1,T,128]` → SSCP → `[1,T/4,1024]` → 12
Conformer blocks → `output_proj` `[1,T/4,1536]` → `embed_audio` (RMSNorm-noscale → `Linear`
1536→2560) → masked-scatter at `audio_token_id 258881`.

## Verification

`swift build` clean. All tests pass under Xcode (`swift test` CLI can't load MLX's
`default.metallib`):
```
xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS,arch=arm64' \
  -only-testing:MLXLMTests/Gemma4AudioTests -skipPackagePluginValidation -skipMacroValidation
```

## Verification of the two open questions

- **Chat template — confirmed.** The checkpoint's `chat_template.jinja` renders
  `{type: audio}` content as `<|audio|>` (= `audio_token_id 258881`), and
  `tokenizer_config.json` defines `audio`/`boa`/`eoa` tokens. So the message generator's
  `{type: audio}` → `<|audio|>` → processor expansion chain is correct against the real
  checkpoint files. (`processor_config.json` also confirms the extractor params:
  16 kHz / 128 mel / fft 512 / hop 160.)
- **Numerical parity — confirmed both ways.**
  - *Encoder:* ran mlx-vlm's real `audio.py` (small config, seeded weights, deterministic
    input), exported weights+I/O, loaded them into the Swift `Gemma4AudioModel`, and the
    output matches to **< 1e-3** (MLX-vs-MLX). Gold-standard validation of the attention
    transposes, relative-shift, einsum→matmul rewrite, and convs.
  - *Mel:* ran the reference `audio_feature_extractor.py` (numpy) on a deterministic
    waveform; the Swift extractor matches to **~1e-2** in log-mel — the residual is
    float32 Metal FFT vs numpy's float64 CPU FFT (amplified by `log` at near-silent
    bins), not an algorithm difference. Asserted in a committed self-contained test.

## Follow-ups

- Long-audio chunking: `processor_config.json` has `chunk_duration 8.0 / overlap 1.0`;
  this extractor does a single window up to 30 s. Fine for short clips; chunking of longer
  audio into overlapping 8 s segments is not implemented.
