### PR TITLE
Qwen3.5/3.6: windowed prefill + state-threaded warm continuation (fixes multi-turn M-RoPE drift)

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -18,7 +18,9 @@ extension LLMModel {
     ///
     /// This will evaluate the prompt in chunks until there is a small number of
     /// tokens left to feed into the `TokenIterator`.
-    public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let prefillStepSize = windowSize ?? 512
@@ -28,7 +30,7 @@ extension LLMModel {
             // Prepare the prompt in chunks if larger than the prefill size.
             // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
             // chunk N.
-            var state: LMOutput.State?
+            var state: LMOutput.State? = state
             while y.tokens.size > prefillStepSize {
                 let input = y[.newAxis, ..<prefillStepSize]
                 let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -419,7 +419,8 @@ public class Gemma3TextModel: Module, LLMModel {
 
     /// Handles prompt processing for sequences
     public func prepare(
-        _ input: LMInput, cache: [KVCache], windowSize: Int? = nil
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State? = nil,
+        windowSize: Int? = nil
     ) throws -> PrepareResult {
         let promptTokens = input.text.tokens
         let promptCount = promptTokens.dim(0)

--- a/Libraries/MLXLLM/Models/Gemma3nText.swift
+++ b/Libraries/MLXLLM/Models/Gemma3nText.swift
@@ -1020,7 +1020,8 @@ public class Gemma3nTextModel: Module, LLMModel {
 
     /// Handles prompt processing for sequences
     public func prepare(
-        _ input: LMInput, cache: [KVCache], windowSize: Int? = nil
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State? = nil,
+        windowSize: Int? = nil
     ) throws -> PrepareResult {
         let promptTokens = input.text.tokens
         let promptCount = promptTokens.dim(0)

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -145,8 +145,12 @@ public struct SpeculativeDecodingConfig: Sendable {
 public final class ChatSession {
 
     enum Cache {
+        /// `state` is the per-call model state (e.g. M-RoPE rope deltas)
+        /// from the last prefill against this cache. It must survive across
+        /// turns: without it, a model that anchors positions on carried
+        /// state re-derives them from a cold start on the next turn.
         case empty
-        case kvcache([KVCache], draftKVCache: [KVCache]?)
+        case kvcache([KVCache], draftKVCache: [KVCache]?, state: LMOutput.State?)
         case history([Chat.Message])
     }
 
@@ -339,7 +343,7 @@ public final class ChatSession {
     ) {
         self.model = model
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.cache = .init(.kvcache(cache, draftKVCache: nil, state: nil))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
@@ -385,7 +389,7 @@ public final class ChatSession {
     ) {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil))
+        self.cache = .init(.kvcache(cache, draftKVCache: nil, state: nil))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
@@ -612,19 +616,24 @@ public final class ChatSession {
 
                     var kvCache: [KVCache]
                     var draftKVCache: [KVCache]?
+                    // Per-call model state (e.g. M-RoPE rope deltas) carried
+                    // across turns alongside the KV cache; updated after each
+                    // prefill and stored back at the end of the turn.
+                    var lmState: LMOutput.State?
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil)
+                        cache = .kvcache(kvCache, draftKVCache: nil, state: nil)
 
-                    case .kvcache(let array, let storedDraftCache):
+                    case .kvcache(let array, let storedDraftCache, let storedState):
                         kvCache = array
                         draftKVCache = storedDraftCache
+                        lmState = storedState
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil)
+                        cache = .kvcache(kvCache, draftKVCache: nil, state: nil)
                         messages.append(contentsOf: history)
                     }
 
@@ -645,9 +654,16 @@ public final class ChatSession {
                         func defaultGeneration() throws -> (
                             AsyncStream<Generation>, Task<Void, Never>
                         ) {
+                            // Seed the iterator with the carried state; read
+                            // back the post-prefill state (prefill runs in the
+                            // iterator's init, and the rope delta does not
+                            // change during decode) so the next turn — or the
+                            // next tool restart — anchors correctly.
                             let iterator = try TokenIterator(
                                 input: input, model: model, cache: kvCache,
+                                state: lmState,
                                 parameters: generateParameters)
+                            lmState = iterator.state
 
                             return MLXLMCommon.generateTask(
                                 promptTokenCount: input.text.tokens.size,
@@ -723,7 +739,8 @@ public final class ChatSession {
                                     if draftKVCache == nil {
                                         draftKVCache = draftModel.newCache(
                                             parameters: generateParameters)
-                                        cache = .kvcache(kvCache, draftKVCache: draftKVCache)
+                                        cache = .kvcache(
+                                            kvCache, draftKVCache: draftKVCache, state: lmState)
                                     }
                                     let draftCache = draftKVCache!
 
@@ -796,6 +813,10 @@ public final class ChatSession {
                         }
                     }
 
+                    // Store the carried state back alongside the KV cache so
+                    // the next turn resumes with correct position anchoring.
+                    cache = .kvcache(kvCache, draftKVCache: draftKVCache, state: lmState)
+
                     continuation.finish()
                 }
             } catch {
@@ -855,7 +876,7 @@ public final class ChatSession {
     {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _):
+            case .kvcache(let cache, _, _):
                 return try await body(cache)
             default:
                 return try await body(nil)
@@ -874,7 +895,7 @@ public final class ChatSession {
     public func saveCache(to url: URL) async throws {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _):
+            case .kvcache(let cache, _, _):
                 try savePromptCache(url: url, cache: cache)
             default:
                 throw ChatSessionError.noCacheAvailable

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -581,7 +581,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     public var promptPrefillTime: TimeInterval = 0.0
 
     /// Initialize a `TokenIterator` with the given tokens. Note: this has been
-    /// replaced with ``init(input:model:cache:parameters:)``.
+    /// replaced with ``init(input:model:cache:state:parameters:)``.
     ///
     /// - Parameters:
     ///   - prompt: the prompt tokens
@@ -614,7 +614,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// Initialize a `TokenIterator` with the given input.
     ///
     /// If more control is needed over the generation,
-    /// ``init(input:model:cache:processor:sampler:prefillStepSize:maxTokens:)``
+    /// ``init(input:model:cache:state:processor:sampler:prefillStepSize:maxTokens:)``
     /// allows a caller to specify ``LogitProcessor`` and ``LogitSampler``
     /// directly.
     ///

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -555,7 +555,13 @@ extension TokenIteratorProtocol {
 /// Note: this uses `asyncEval()` and there may be an async evaluation running after a call to `next()`.
 public struct TokenIterator: TokenIteratorProtocol {
     let model: any LanguageModel
-    var state: LMOutput.State?
+
+    /// Per-call model state (e.g. M-RoPE rope deltas), seeded from the
+    /// initializer's `state`, replaced by prefill, then threaded through
+    /// every decode step. A caller continuing this cache later (as
+    /// ``ChatSession`` does across turns) reads it back after
+    /// initialization and seeds the next iterator with it.
+    public internal(set) var state: LMOutput.State?
 
     var y: LMInput.Text
     var cache: [KVCache]
@@ -616,12 +622,16 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///   - input: language model input
     ///   - model: the ``LanguageModel``
     ///   - cache: optional ``KVCache``
+    ///   - state: optional per-call model state carried over from earlier
+    ///     evaluation against `cache` (e.g. by a caller resuming a session)
     ///   - parameters: the generation parameters
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
+        state: LMOutput.State? = nil,
         parameters: GenerateParameters
     ) throws {
         self.model = model
+        self.state = state
         self.y = input.text
         self.cache = cache ?? model.newCache(parameters: parameters)
 
@@ -645,16 +655,20 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///   - input: language model input
     ///   - model: the ``LanguageModel``
     ///   - cache: optional ``KVCache``
+    ///   - state: optional per-call model state carried over from earlier
+    ///     evaluation against `cache` (e.g. by a caller resuming a session)
     ///   - processor: the logit processor
     ///   - sampler: the logit sampler
     ///   - prefillStepSize: optional prefill step size
     ///   - maxTokens: maximum number of tokens to generate
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
+        state: LMOutput.State? = nil,
         processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int? = nil,
         maxTokens: Int? = nil
     ) throws {
         self.model = model
+        self.state = state
         self.y = input.text
         self.cache = cache ?? model.newCache(parameters: nil)
 
@@ -676,7 +690,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
         processor?.prompt(input.text.tokens)
 
-        switch try model.prepare(input, cache: cache, windowSize: windowSize) {
+        switch try model.prepare(input, cache: cache, state: state, windowSize: windowSize) {
         case .tokens(let tokens):
             y = tokens
 
@@ -861,7 +875,9 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         processor?.prompt(input.text.tokens)
 
         // Prefill main model
-        switch try mainModel.prepare(input, cache: mainCache, windowSize: windowSize) {
+        switch try mainModel.prepare(
+            input, cache: mainCache, state: mainState, windowSize: windowSize)
+        {
         case .tokens(let tokens):
             y = tokens
         case .logits(let result):
@@ -874,7 +890,8 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         // Prefill draft model, don't call didSample here -- processor tracks main model's accepted sequence only
-        switch try draftModel.prepare(input, cache: draftCache, windowSize: windowSize) {
+        switch try draftModel.prepare(input, cache: draftCache, state: nil, windowSize: windowSize)
+        {
         case .tokens(let tokens):
             draftY = tokens
         case .logits(let result):

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -218,7 +218,7 @@ public struct LMOutput {
     }
 }
 
-/// The result of the call to ``LanguageModel/prepare(_:cache:windowSize:)``
+/// The result of the call to ``LanguageModel/prepare(_:cache:state:windowSize:)``
 public enum PrepareResult {
     /// tokens to process by the ``TokenIterator``
     case tokens(LMInput.Text)
@@ -227,48 +227,31 @@ public enum PrepareResult {
     case logits(LMOutput)
 }
 
-/// Opt-in capability for a vision language model that can continue an already
-/// warmed KV cache *through* a new image, without recomputing the cached
-/// prefix and without a single-shot `[heads, L, L]` full-attention scratch.
-///
-/// `prepareContinuation` runs the vision tower and the image→token merge
-/// once, then drives the language-model forward in windows of `windowSize`,
-/// bounding the scratch to `[heads, windowSize, L]`. A cold cache is the
-/// degenerate case (anchor 0), so a conforming model's `prepare` can delegate
-/// its `windowSize` chunking here. Only families that have wired the windowed
-/// image path conform; callers feature-detect via
-/// `as? WindowedVisionContinuation`.
-public protocol WindowedVisionContinuation {
-    /// Continue `cache` (warmed to its current offset `P`) through `input`'s
-    /// image-bearing remainder, in windows of `windowSize`.
-    ///
-    /// - Parameter state: carries the Position Anchor's rope delta for the
-    ///   images cached before `P` (absent / zero for an image-free prefix). The
-    ///   new image's M-RoPE positions are computed from that anchor instead of
-    ///   resetting to zero.
-    /// - Returns: `.logits` whose `state` carries the rope delta the post-image
-    ///   text tail resumes with, for a caller threading state end-to-end.
-    func prepareContinuation(
-        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int
-    ) throws -> PrepareResult
-}
-
 /// Interface for all Language Models (e.g. LLM, VLM).
 ///
 /// The language model is typically called by the ``TokenIterator`` and it:
 ///
 /// - consumes the ``LMInput``
-/// - calls ``prepare(_:cache:windowSize:)`` to initialize the KVCache and consume the prompt
+/// - calls ``prepare(_:cache:state:windowSize:)`` to initialize the KVCache and consume the prompt
 /// - calls ``callAsFunction(_:cache:state:)-9kuvf`` for each token, producing an ``LMOutput``
 /// - the ``TokenIterator`` accumulates this information into a ``GenerateResult``
 public protocol LanguageModel: BaseLanguageModel {
 
     /// Prepare the cache state and consume the ``LMInput``.
     ///
+    /// `state` is the ``LMOutput/state`` a caller carried over from earlier
+    /// evaluation against the same `cache` — present when `cache` is already
+    /// warm (a multi-turn chat, a tool-call restart, a restored prompt
+    /// cache). Models that keep per-call positional state (e.g. the M-RoPE
+    /// `ropeDeltas` of the Qwen VLM families) use it to anchor the new
+    /// tokens' positions at the cache offset; models without such state can
+    /// ignore it. In the typical cold call it is `nil`.
+    ///
     /// This can return:
     /// - ``PrepareResult/tokens(_:)`` if the caller should evaluate the (remaining) tokens normally
     /// - ``PrepareResult/logits(_:)`` to produce the next token from the prompt
-    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult
+    func prepare(_ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?)
+        throws -> PrepareResult
 
     /// Primary entry point to produce a step (single token) from the model
     func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -227,6 +227,32 @@ public enum PrepareResult {
     case logits(LMOutput)
 }
 
+/// Opt-in capability for a vision language model that can continue an already
+/// warmed KV cache *through* a new image, without recomputing the cached
+/// prefix and without a single-shot `[heads, L, L]` full-attention scratch.
+///
+/// `prepareContinuation` runs the vision tower and the image→token merge
+/// once, then drives the language-model forward in windows of `windowSize`,
+/// bounding the scratch to `[heads, windowSize, L]`. A cold cache is the
+/// degenerate case (anchor 0), so a conforming model's `prepare` can delegate
+/// its `windowSize` chunking here. Only families that have wired the windowed
+/// image path conform; callers feature-detect via
+/// `as? WindowedVisionContinuation`.
+public protocol WindowedVisionContinuation {
+    /// Continue `cache` (warmed to its current offset `P`) through `input`'s
+    /// image-bearing remainder, in windows of `windowSize`.
+    ///
+    /// - Parameter state: carries the Position Anchor's rope delta for the
+    ///   images cached before `P` (absent / zero for an image-free prefix). The
+    ///   new image's M-RoPE positions are computed from that anchor instead of
+    ///   resetting to zero.
+    /// - Returns: `.logits` whose `state` carries the rope delta the post-image
+    ///   text tail resumes with, for a caller threading state end-to-end.
+    func prepareContinuation(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int
+    ) throws -> PrepareResult
+}
+
 /// Interface for all Language Models (e.g. LLM, VLM).
 ///
 /// The language model is typically called by the ``TokenIterator`` and it:

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -144,11 +144,13 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         var prefillState = LMOutput.State()
         prefillState[mtpEmitFlagKey] = true
-        // Note: `prepare(_:cache:windowSize:)` does not currently thread
-        // state through. To prime drafter state we run an explicit follow-up
-        // forward call after prefill (one position, the bonus token).
+        // Note: the drafter is primed via an explicit follow-up forward call
+        // after prefill (one position, the bonus token) rather than by
+        // passing `prefillState` into `prepare` — the emit flag is meant for
+        // exactly one position, not the whole prompt.
 
-        switch try mainModel.prepare(input, cache: mainCache, windowSize: windowSize) {
+        switch try mainModel.prepare(input, cache: mainCache, state: nil, windowSize: windowSize)
+        {
         case .tokens(let tokens):
             y = tokens
             // Final prompt position not yet evaluated -- run one forward to

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -95,7 +95,9 @@ public enum WiredMemoryUtils {
     ) throws -> [KVCache] {
         var cache = model.newCache(parameters: parameters)
 
-        switch try model.prepare(input, cache: cache, windowSize: parameters.prefillStepSize) {
+        switch try model.prepare(
+            input, cache: cache, state: nil, windowSize: parameters.prefillStepSize)
+        {
         case .tokens(let tokens):
             let result = model(
                 tokens[text: .newAxis],

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1127,7 +1127,9 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
         return embeddings.expandedDimensions(axis: 0)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let embeddings = getInputEmbeddings(

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -982,7 +982,9 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         return (finalEmbedding.asType(inputsEmbeds.dtype), finalAttentionMask4d)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let prefillStepSize = windowSize ?? 512

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2070,7 +2070,9 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         return (inputsEmbeds, perLayerInputs)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let convertedCache = cache.map { $0 }
@@ -2530,7 +2532,9 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
         return (inputsEmbeds, perLayerInputs)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         if input.image == nil, input.video == nil, input.audio == nil {

--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -1016,7 +1016,9 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
         return (merged, positionIds, ropeDeltas)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let dtype = visionModel.patchEmbed.proj.weight.dtype

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -729,7 +729,9 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
         return finalEmbeds.expandedDimensions(axis: 0)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let inputIds = input.text.tokens

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -979,7 +979,9 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
         return result
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let dtype = visionModel.embeddings.patchEmbedding.weight.dtype

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -721,7 +721,9 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         return MLX.concatenated(finalEmbeddings, axis: 1)
     }
 
-    public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let inputIds = input.text.tokens

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -597,7 +597,9 @@ public class PaliGemma: Module, VLMModel, KVCacheDimensionProvider {
         return (finalEmbedding, finalAttentionMask4d)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         guard let image = input.image else { throw VLMError.imageRequired }

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -869,7 +869,9 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
         return MLX.concatenated(finalEmbeddings, axis: 1)
     }
 
-    public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         var inputIds = input.text.tokens

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -979,7 +979,9 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         return (mergedEmbeds, positionIds, ropeDeltas)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let dtype = visionModel.patchEmbed.proj.weight.dtype

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -975,7 +975,9 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
         return (merged, positionIds, ropeDeltas)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         let dtype = visionModel.patchEmbed.proj.weight.dtype
@@ -1002,7 +1004,7 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)
 
-        // #239: Qwen25VL.swift prepare(_:cache:windowSize:) (:982)
+        // #239: Qwen25VL.swift prepare(_:cache:state:windowSize:)
         // Seed per-call decoder state with the prefill-only MROPE positions +
         // ropeDeltas (both nil on the no-image path). The LMOutput's `state`
         // returned here is consumed by subsequent decode steps via

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -979,13 +979,14 @@ public class Qwen35: Module, VLMModel {
         return frames
     }
 
-    public func prepare(
-        _ input: LMInput,
-        cache: [any KVCache],
-        windowSize _: Int?
-    ) throws -> PrepareResult {
-        let inputIds = input.text.tokens
-
+    /// Vision tower + image→token merge over the input, shared by `prepare`
+    /// and `prepareContinuation` (mirrors `Qwen25VL.inputEmbeddings`).
+    private func visionInputEmbeddings(
+        _ input: LMInput
+    ) throws -> (
+        pixelValues: MLXArray?, imageFrames: [THW]?, videoFrames: [THW]?,
+        inputEmbeddings: MLXArray?
+    ) {
         var pixelValues: MLXArray?
         var imageFrames: [THW]?
         var videoFrames: [THW]?
@@ -1011,6 +1012,7 @@ public class Qwen35: Module, VLMModel {
             let frames = combinedFrames(imageFrames: imageFrames, videoFrames: videoFrames)
                 .nilIfEmpty
         {
+            let inputIds = input.text.tokens
             let textEmbeds = languageModel.model.embedTokens(inputIds)
             let (visionHidden, _) = visionModel(pixelValues, gridTHW: frames)
             let visionFeatures = visionHidden.asType(textEmbeds.dtype)
@@ -1024,6 +1026,32 @@ public class Qwen35: Module, VLMModel {
             )
             inputEmbeddings = mergedEmbeds
         }
+
+        return (pixelValues, imageFrames, videoFrames, inputEmbeddings)
+    }
+
+    public func prepare(
+        _ input: LMInput,
+        cache: [any KVCache],
+        windowSize: Int?
+    ) throws -> PrepareResult {
+        let inputIds = input.text.tokens
+
+        // Windowed (chunked) prefill — the remaining #344 deferred item for
+        // Qwen3.5. A cold cache is just a continuation anchored at offset 0,
+        // so the windowed forward in `prepareContinuation` serves both paths
+        // and bounds the full-attention scratch to [heads, window, L]. The
+        // windowed forward is single-sequence; batched inputs keep the
+        // single-shot path below.
+        if let windowSize, inputIds.ndim == 2, inputIds.dim(0) == 1,
+            inputIds.dim(-1) > windowSize
+        {
+            return try prepareContinuation(
+                input, cache: cache, state: nil, windowSize: windowSize)
+        }
+
+        let (pixelValues, imageFrames, videoFrames, inputEmbeddings) =
+            try visionInputEmbeddings(input)
 
         let typedCache = castCache(cache)
         let output = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
@@ -1041,6 +1069,113 @@ public class Qwen35: Module, VLMModel {
         }
 
         return .logits(output)
+    }
+
+    /// Warm, windowed continuation through an image-bearing remainder — the
+    /// windowed forward that `prepare` also delegates to for long prompts.
+    ///
+    /// It runs the vision tower and the image→token merge **once** over the
+    /// remainder, computes the new image's M-RoPE positions **once** from the
+    /// seeded **Position Anchor** (so the image's diverging t/h/w indices
+    /// start at the anchor, not zero), then drives the language-model forward
+    /// in chunks of `windowSize`. The full-attention scratch is bounded to
+    /// `[heads, chunk, L]` instead of `[heads, L, L]`, so it cannot crash on
+    /// a long prefix or a large image.
+    ///
+    /// `cache` must already be warmed to the restore offset `P` (a fresh cache
+    /// means `P = 0`, a crash-safe cold prefill). `state` carries the anchor's
+    /// rope delta in the `qwen35.ropeDeltas` slot (zero / absent for an
+    /// image-free prefix). The returned state carries the rope delta the
+    /// post-image text tail resumes with (`getRopeIndex` delta − `P`), so a
+    /// caller threading state end-to-end continues that tail with the ordinary
+    /// flat-continuation branch. Decode stays caller-owned.
+    public func prepareContinuation(
+        _ input: LMInput,
+        cache: [any KVCache],
+        state: LMOutput.State?,
+        windowSize: Int
+    ) throws -> PrepareResult {
+        let inputIds = input.text.tokens
+        let remainderLength = inputIds.dim(-1)
+        precondition(remainderLength > 0, "prepareContinuation needs a non-empty remainder")
+
+        // The Position Anchor: token offset already in the cache (P) plus the
+        // rope delta the cached images accumulated, carried in `state`.
+        let faIdx = languageModel.model.faIdx
+        let cacheOffset = cache.indices.contains(faIdx) ? cache[faIdx].offset : 0
+        var anchorRopeDelta = 0
+        if let seeded = state?[ropeDeltasKey] {
+            anchorRopeDelta = seeded.asType(.int32).item(Int.self)
+        }
+        let positionOffset = cacheOffset + anchorRopeDelta
+
+        // Vision tower + image→token merge — once, over the whole remainder;
+        // chunks slice the merged embeddings below.
+        let (_, imageFrames, videoFrames, inputEmbeddings) =
+            try visionInputEmbeddings(input)
+
+        // Offset-aware M-RoPE positions for the whole remainder — once. The new
+        // image's t/h/w indices diverge from the anchor; the returned delta is
+        // in the same offset frame.
+        let (positionIds, ropeDeltas) = Qwen3VLLanguage.getRopeIndex(
+            inputIds: inputIds,
+            imageGridTHW: imageFrames,
+            videoGridTHW: videoFrames,
+            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+            imageTokenId: config.imageTokenId,
+            videoTokenId: config.videoTokenId,
+            visionStartTokenId: config.visionStartTokenId,
+            attentionMask: input.text.mask,
+            positionOffset: positionOffset
+        )
+
+        // Chunk the forward. Each window forwards `chunk` query tokens against
+        // the growing cache, so the full-attention scratch stays `[heads,
+        // chunk, L]`. Intermediate logits are dropped un-evaluated (only the
+        // cache is realized between windows), so `lm_head` never materializes a
+        // `[1, L, vocab]` tensor. `asyncEval` bounds the un-evaluated graph
+        // while letting the GPU run window i as the CPU builds window i+1
+        // (same shape as the sibling chunked prefills, e.g. Gemma3).
+        let typedCache = castCache(cache)
+        let step = max(1, windowSize)
+        var lastLogits: MLXArray
+        var start = 0
+        repeat {
+            try Task.checkCancellation()
+            let end = min(start + step, remainderLength)
+            let chunkInputs = inputIds[0..., start ..< end]
+            let chunkEmbeds = inputEmbeddings.map { $0[0..., start ..< end, 0...] }
+            let chunkPositions = positionIds[0..., 0..., start ..< end]
+            let output = languageModel(
+                chunkInputs,
+                inputsEmbeds: chunkEmbeds,
+                cache: typedCache,
+                state: nil,
+                mask: nil,
+                positionIds: chunkPositions,
+                pixelValues: nil,
+                imageGridTHW: nil,
+                videoGridTHW: nil
+            )
+            lastLogits = output.logits
+            if let typedCache {
+                asyncEval(typedCache)
+            }
+            start = end
+        } while start < remainderLength
+        if let typedCache {
+            eval(typedCache)
+        }
+
+        // Seed the post-image text tail's anchor. The vendor's flat-continuation
+        // branch positions tail token j at `tailCacheOffset + ropeDeltas + j`;
+        // after this remainder `tailCacheOffset = P + remainderLength`, so the
+        // delta the tail needs is the offset-frame `getRopeIndex` delta minus
+        // `P` (which `getRopeIndex` implicitly counted into `remainderLength`).
+        var resumeState = LMOutput.State()
+        resumeState[ropeDeltasKey] = ropeDeltas - MLXArray(Int32(cacheOffset))
+
+        return .logits(LMOutput(logits: lastLogits, state: resumeState))
     }
 
     public func callAsFunction(
@@ -1137,3 +1272,6 @@ extension Qwen35 {
         return castCache(cache)
     }
 }
+
+// `prepareContinuation` is defined on `Qwen35` above; `Qwen35MoE` inherits it.
+extension Qwen35: WindowedVisionContinuation {}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1033,21 +1033,26 @@ public class Qwen35: Module, VLMModel {
     public func prepare(
         _ input: LMInput,
         cache: [any KVCache],
+        state: LMOutput.State?,
         windowSize: Int?
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
 
         // Windowed (chunked) prefill — the remaining #344 deferred item for
-        // Qwen3.5. A cold cache is just a continuation anchored at offset 0,
-        // so the windowed forward in `prepareContinuation` serves both paths
-        // and bounds the full-attention scratch to [heads, window, L]. The
-        // windowed forward is single-sequence; batched inputs keep the
-        // single-shot path below.
-        if let windowSize, inputIds.ndim == 2, inputIds.dim(0) == 1,
-            inputIds.dim(-1) > windowSize
+        // Qwen3.5 — with the same default as the sibling chunked prefills
+        // (Gemma3/LLMModel: `windowSize ?? 512`). The windowed forward also
+        // owns every warm continuation (multi-turn chat, tool restart,
+        // restored prompt cache): a cold cache is just a continuation
+        // anchored at offset 0, and a warm one anchors M-RoPE positions at
+        // the cache offset plus the rope delta carried in `state` — never
+        // back at zero. The windowed forward is single-sequence; batched
+        // inputs keep the single-shot path below.
+        let window = windowSize ?? 512
+        if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
+            faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
             return try prepareContinuation(
-                input, cache: cache, state: nil, windowSize: windowSize)
+                input, cache: cache, state: state, windowSize: window)
         }
 
         let (pixelValues, imageFrames, videoFrames, inputEmbeddings) =
@@ -1059,7 +1064,7 @@ public class Qwen35: Module, VLMModel {
                 inputIds,
                 inputsEmbeds: inputEmbeddings,
                 cache: typedCache,
-                state: nil,
+                state: state,
                 mask: input.text.mask,
                 positionIds: nil,
                 pixelValues: pixelValues,
@@ -1069,6 +1074,13 @@ public class Qwen35: Module, VLMModel {
         }
 
         return .logits(output)
+    }
+
+    /// Offset of the first full-attention layer's cache — the model's notion
+    /// of "how many tokens are already cached".
+    private func faCacheOffset(_ cache: [any KVCache]) -> Int {
+        let faIdx = languageModel.model.faIdx
+        return cache.indices.contains(faIdx) ? cache[faIdx].offset : 0
     }
 
     /// Warm, windowed continuation through an image-bearing remainder — the
@@ -1089,7 +1101,7 @@ public class Qwen35: Module, VLMModel {
     /// post-image text tail resumes with (`getRopeIndex` delta − `P`), so a
     /// caller threading state end-to-end continues that tail with the ordinary
     /// flat-continuation branch. Decode stays caller-owned.
-    public func prepareContinuation(
+    private func prepareContinuation(
         _ input: LMInput,
         cache: [any KVCache],
         state: LMOutput.State?,
@@ -1101,8 +1113,7 @@ public class Qwen35: Module, VLMModel {
 
         // The Position Anchor: token offset already in the cache (P) plus the
         // rope delta the cached images accumulated, carried in `state`.
-        let faIdx = languageModel.model.faIdx
-        let cacheOffset = cache.indices.contains(faIdx) ? cache[faIdx].offset : 0
+        let cacheOffset = faCacheOffset(cache)
         var anchorRopeDelta = 0
         if let seeded = state?[ropeDeltasKey] {
             anchorRopeDelta = seeded.asType(.int32).item(Int.self)
@@ -1287,6 +1298,3 @@ extension Qwen35 {
         return castCache(cache)
     }
 }
-
-// `prepareContinuation` is defined on `Qwen35` above; `Qwen35MoE` inherits it.
-extension Qwen35: WindowedVisionContinuation {}

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1675,6 +1675,7 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(
         _ input: LMInput,
         cache: [any KVCache],
+        state _: LMOutput.State?,
         windowSize _: Int?
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -162,6 +162,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
 
 public struct Qwen3VLProcessorConfiguration: Codable, Sendable {
 
+    /// The synthesized min/max-pixel budget the processor consumes. Always
+    /// resolved (non-optional) — see `var size`.
     public struct Size: Codable, Sendable {
         public let maxPixels: Int
         public let minPixels: Int
@@ -172,17 +174,47 @@ public struct Qwen3VLProcessorConfiguration: Codable, Sendable {
         }
     }
 
+    /// The raw JSON `"size"` block. Newer Qwen3-VL configs (e.g. Qwen3.6-27B
+    /// PARO) ship *only* `{longest_edge, shortest_edge}` — pixel-area budgets
+    /// under the HF convention `shortest_edge → min_pixels`,
+    /// `longest_edge → max_pixels` (same direct mapping GlmOcr uses); older
+    /// configs ship `{min_pixels, max_pixels}`. Every field is optional so a
+    /// config that omits any one still decodes: the processor loader swallows
+    /// decode throws into a silent text-only fallback, so a hard requirement
+    /// would make vision disappear instead of erroring.
+    public struct SizeBudget: Codable, Sendable {
+        public let maxPixels: Int?
+        public let minPixels: Int?
+        public let longestEdge: Int?
+        public let shortestEdge: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case maxPixels = "max_pixels"
+            case minPixels = "min_pixels"
+            case longestEdge = "longest_edge"
+            case shortestEdge = "shortest_edge"
+        }
+    }
+
     public let imageMean: [CGFloat]
     public let imageStd: [CGFloat]
     private let _minPixels: Int?
     private let _maxPixels: Int?
+    private let _size: SizeBudget?
     public let mergeSize: Int
     public let patchSize: Int
     public let temporalPatchSize: Int
     public let imageProcessorType: String
 
-    public var minPixels: Int { _minPixels ?? 4 * 28 * 28 }  // 3,136
-    public var maxPixels: Int { _maxPixels ?? 16384 * 28 * 28 }  // 12,845,056
+    // Budget resolution order: explicit top-level legacy keys, then the
+    // `size` block's legacy keys, then its new-style edges, then defaults.
+    // The defaults are only reached when the config carries no budget at all.
+    public var minPixels: Int {
+        _minPixels ?? _size?.minPixels ?? _size?.shortestEdge ?? 4 * 28 * 28
+    }  // default 3,136
+    public var maxPixels: Int {
+        _maxPixels ?? _size?.maxPixels ?? _size?.longestEdge ?? 16384 * 28 * 28
+    }  // default 12,845,056
 
     public var size: Size { .init(maxPixels: maxPixels, minPixels: minPixels) }
 
@@ -199,6 +231,7 @@ public struct Qwen3VLProcessorConfiguration: Codable, Sendable {
         case imageStd = "image_std"
         case _minPixels = "min_pixels"
         case _maxPixels = "max_pixels"
+        case _size = "size"
         case mergeSize = "merge_size"
         case patchSize = "patch_size"
         case temporalPatchSize = "temporal_patch_size"
@@ -1328,6 +1361,15 @@ enum Qwen3VLLanguage {
 
 extension Qwen3VLLanguage {
 
+    /// - Parameter positionOffset: the absolute M-RoPE position the first
+    ///   token should occupy. Zero (the default) starts the index at absolute
+    ///   zero — correct for a cold full prefill. A warm continuation that
+    ///   resumes a cached prefix passes the **Position Anchor** (cache offset +
+    ///   the rope delta accumulated by the cached images), so a *new* image in
+    ///   the remainder gets its diverging temporal/height/width positions
+    ///   computed *from* the anchor instead of resetting to zero. The returned
+    ///   delta is shifted with the positions, so it remains
+    ///   `maxPositionId + 1 − tokenCount` in the offset frame.
     static func getRopeIndex(
         inputIds: MLXArray,
         imageGridTHW: [THW]?,
@@ -1336,7 +1378,8 @@ extension Qwen3VLLanguage {
         imageTokenId: Int,
         videoTokenId: Int,
         visionStartTokenId: Int,
-        attentionMask: MLXArray? = nil
+        attentionMask: MLXArray? = nil,
+        positionOffset: Int = 0
     ) -> (MLXArray, MLXArray) {
 
         let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
@@ -1345,10 +1388,15 @@ extension Qwen3VLLanguage {
         positionIds = broadcast(positionIds[.newAxis, 0...], to: [batchSize, seqLength])
 
         guard inputIds.ndim > 0, imageGridTHW != nil || videoGridTHW != nil else {
-            let positionIds3D = broadcast(
+            var positionIds3D = broadcast(
                 positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
-            let zeros = MLXArray.zeros([batchSize], dtype: .int32)
-            return (positionIds3D, zeros)
+            if positionOffset != 0 {
+                positionIds3D = positionIds3D + MLXArray(Int32(positionOffset))
+            }
+            // Text-only positions are `arange + positionOffset`, so the delta
+            // (`maxPos + 1 − tokenCount`) collapses to `positionOffset`.
+            let deltas = MLXArray(Array(repeating: Int32(positionOffset), count: batchSize))
+            return (positionIds3D, deltas)
         }
 
         positionIds = ones(like: inputIds).asType(.int32)
@@ -1484,7 +1532,14 @@ extension Qwen3VLLanguage {
 
             // Concatenate all position IDs for this batch item
             if !llmPosIdsList.isEmpty {
-                let llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+                var llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+                // Shift the whole batch item into the anchor frame. Applied to
+                // `llmPositions` (not just the final array) so `maxPosId` below
+                // — and therefore the returned delta — is computed in the same
+                // offset frame the positions live in.
+                if positionOffset != 0 {
+                    llmPositions = llmPositions + MLXArray(Int32(positionOffset))
+                }
 
                 // Update position_ids for this batch
                 let expandedMask = broadcast(

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -270,7 +270,9 @@ public class YourModel: Module, VLMModel, KVCacheDimensionProvider {
         self._languageModel.wrappedValue = Language.LanguageModel(config.textConfiguration)
     }
 
-    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+    ) throws
         -> PrepareResult
     {
         // Merge image and text embeddings, then prefill the KV cache in

--- a/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 @testable import MLXVLM
 
-/// Unit tests for `Gemma4.prepare(_:cache:windowSize:)` chunked prefill.
+/// Unit tests for `Gemma4.prepare(_:cache:state:windowSize:)` chunked prefill.
 ///
 /// The core property under test is **chunk-size invariance**: prefilling the
 /// same prompt with a small `windowSize` (many chunks) and a `windowSize`
@@ -67,7 +67,7 @@ struct Gemma4ChunkedPrefillTests {
     ) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
         let cache = model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
-        let result = try model.prepare(input, cache: cache, windowSize: windowSize)
+        let result = try model.prepare(input, cache: cache, state: nil, windowSize: windowSize)
         guard case .logits(let output) = result else {
             Issue.record("Expected .logits from Gemma4.prepare, got .tokens")
             return (MLXArray(0), [])
@@ -123,7 +123,7 @@ struct Gemma4ChunkedPrefillTests {
 
         let cache = model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray(tokens))  // 1-D, no batch axis
-        let result = try model.prepare(input, cache: cache, windowSize: 6)
+        let result = try model.prepare(input, cache: cache, state: nil, windowSize: 6)
         guard case .logits(let output) = result else {
             Issue.record("Expected .logits from Gemma4.prepare")
             return

--- a/Tests/MLXLMTests/Gemma4UnifiedTests.swift
+++ b/Tests/MLXLMTests/Gemma4UnifiedTests.swift
@@ -113,7 +113,7 @@ struct Gemma4UnifiedTests {
         let input = LMInput(tokens: MLXArray([0, 2, 3, 4, 5, 1]).expandedDimensions(axis: 0))
 
         let result = try model.prepare(
-            input, cache: cache, windowSize: 2)
+            input, cache: cache, state: nil, windowSize: 2)
 
         guard case .logits(let output) = result else {
             Issue.record("Expected text-only Gemma4Unified.prepare to return logits")
@@ -131,7 +131,7 @@ struct Gemma4UnifiedTests {
 
         func prefill(windowSize: Int) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
             let cache = model.newCache(parameters: nil)
-            let result = try model.prepare(input, cache: cache, windowSize: windowSize)
+            let result = try model.prepare(input, cache: cache, state: nil, windowSize: windowSize)
             guard case .logits(let output) = result else {
                 Issue.record("Expected text-only Gemma4Unified.prepare to return logits")
                 return (MLXArray.zeros([1, 32]), [])
@@ -282,7 +282,7 @@ struct Gemma4UnifiedTests {
         )
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), windowSize: nil)
+            input, cache: model.newCache(parameters: nil), state: nil, windowSize: nil)
 
         guard case .logits(let output) = result else {
             Issue.record("Expected Gemma4Unified.prepare to return logits")

--- a/Tests/MLXLMTests/MTPDrafterModelTests.swift
+++ b/Tests/MLXLMTests/MTPDrafterModelTests.swift
@@ -83,7 +83,9 @@ func testMTPDrafterContainerPerform() async {
 private final class DummyLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
     var kvHeads: [Int] { [] }
 
-    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
+        throws -> PrepareResult
+    {
         .tokens(input.text)
     }
 

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 import MLX
-@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
+
+@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,10 +2,9 @@
 
 import Foundation
 import MLX
+@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
-
-@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 
@@ -69,7 +68,9 @@ private final class MockMainModel: Module, LanguageModel, KVCacheDimensionProvid
         super.init()
     }
 
-    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
+        throws -> PrepareResult
+    {
         // Return `.tokens(...)`; the iterator's `prepare` will follow up with
         // a one-position forward call that primes drafter state.
         .tokens(input.text)

--- a/Tests/MLXLMTests/Qwen35ContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen35ContinuationTests.swift
@@ -1,0 +1,284 @@
+// Copyright © 2026 Apple Inc.
+//
+// Equivalence tests for Qwen3.5 windowed prefill and warm (cached-prefix)
+// continuation, on a tiny random-weight model so they run in CI without
+// downloads. The invariant under test: however a prompt reaches the KV cache
+// — one shot, windowed chunks, or split across a warm continuation — the
+// next-token logits must match, because M-RoPE positions must be anchored at
+// the cache offset (plus the carried rope delta), never restarted at zero.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import XCTest
+
+final class Qwen35ContinuationTests: XCTestCase {
+
+    // MARK: - Tiny model
+
+    private func makeTinyModel() throws -> Qwen35 {
+        let json = """
+            {
+                "model_type": "qwen3_5_vl",
+                "image_token_id": 500,
+                "video_token_id": 501,
+                "vision_start_token_id": 502,
+                "vision_end_token_id": 503,
+                "vocab_size": 512,
+                "text_config": {
+                    "model_type": "qwen3_5",
+                    "hidden_size": 64,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 128,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "head_dim": 32,
+                    "vocab_size": 512,
+                    "full_attention_interval": 2,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 2,
+                    "linear_key_head_dim": 32,
+                    "linear_value_head_dim": 32,
+                    "linear_conv_kernel_dim": 4,
+                    "max_position_embeddings": 4096,
+                    "rope_parameters": {
+                        "type": "default",
+                        "mrope_section": [8, 4, 4],
+                        "rope_theta": 100000.0,
+                        "partial_rotary_factor": 1.0
+                    }
+                },
+                "vision_config": {
+                    "model_type": "qwen3_vl",
+                    "depth": 2,
+                    "hidden_size": 32,
+                    "intermediate_size": 64,
+                    "out_hidden_size": 64,
+                    "num_heads": 2,
+                    "patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2,
+                    "num_position_embeddings": 64
+                }
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Qwen35Configuration.self, from: Data(json.utf8))
+        return Qwen35(config)
+    }
+
+    /// Deterministic pseudo-random plain-text tokens, away from the special
+    /// ids (500...503).
+    private func textTokens(_ count: Int, seed: Int32 = 0) -> MLXArray {
+        var values: [Int32] = []
+        for i in 0 ..< count {
+            let value: Int = (i * 13 + 7 + Int(seed)) % 480
+            values.append(Int32(value))
+        }
+        let array = MLXArray(values)
+        return array.expandedDimensions(axis: 0)
+    }
+
+    private func lastLogits(_ result: PrepareResult) throws -> (MLXArray, LMOutput.State?) {
+        guard case .logits(let out) = result else {
+            throw XCTSkip("expected .logits from prepare")
+        }
+        return (out.logits[0..., -1, 0...], out.state)
+    }
+
+    private func maxAbsDiff(_ a: MLXArray, _ b: MLXArray) -> Float {
+        abs(a - b).max().item(Float.self)
+    }
+
+    // MARK: - Tests
+
+    /// A warm continuation (prefix already in the cache, remainder prefilled
+    /// on top — the ChatSession cross-turn / tool-restart flow) must produce
+    /// the same next-token logits as one cold prefill of the concatenation.
+    /// The decode path (token-by-token with state threaded) is the
+    /// offset-correct control that bounds the numerical noise floor.
+    func testWarmTextContinuationMatchesFullPrefill() throws {
+        MLXRandom.seed(7)
+        let model = try makeTinyModel()
+        let t1 = textTokens(40)
+        let t2 = textTokens(8, seed: 3)
+        let full = concatenated([t1, t2], axis: 1)
+
+        // Reference: one cold prefill of the whole sequence.
+        let cacheF = model.newCache(parameters: nil)
+        let (logitsF, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: full)), cache: cacheF, state: nil, windowSize: nil))
+
+        // Control: decode path, token by token, state threaded. Correct by
+        // construction; its divergence from F is the numerical noise floor.
+        let cacheD = model.newCache(parameters: nil)
+        let (_, s0) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1)), cache: cacheD, state: nil, windowSize: nil))
+        var state = s0
+        var logitsD = MLXArray(0)
+        for j in 0 ..< t2.dim(1) {
+            let out = model(
+                LMInput.Text(tokens: t2[0..., j ..< (j + 1)]), cache: cacheD, state: state)
+            state = out.state
+            logitsD = out.logits[0..., -1, 0...]
+        }
+        let noiseFloor = maxAbsDiff(logitsD, logitsF)
+
+        // Warm continuation via prepare, no carried state — the direct
+        // TokenIterator flow. The anchored windowed path must place the new
+        // tokens at the cache offset, not back at zero.
+        let cacheW = model.newCache(parameters: nil)
+        _ = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+        let (logitsW, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: nil, windowSize: nil))
+
+        let drift = maxAbsDiff(logitsW, logitsF)
+        XCTAssertLessThanOrEqual(
+            drift, max(noiseFloor * 10, 1e-3),
+            "warm continuation diverged from full prefill (noise floor \(noiseFloor))")
+    }
+
+    /// With an image in turn 1, the rope delta the image accumulated must be
+    /// carried into turn 2's prefill (the ChatSession cross-turn state
+    /// threading): two-turn with threaded state ≡ one-shot full prefill.
+    func testWarmImageContinuationMatchesFullPrefill() throws {
+        MLXRandom.seed(5)
+        let model = try makeTinyModel()
+
+        // One image: grid THW (1, 4, 4), merge 2 → 4 merged tokens in text.
+        // pixels: [t*h*w, channels * temporalPatch * patch * patch].
+        let pixels = MLXRandom.normal([16, 3 * 2 * 16 * 16])
+        let image = LMInput.ProcessedImage(pixels: pixels, frames: [THW(1, 4, 4)])
+
+        let visionStart = MLXArray([Int32(502)]).expandedDimensions(axis: 0)
+        let imageRun = MLXArray([Int32](repeating: 500, count: 4)).expandedDimensions(axis: 0)
+        let t1 = concatenated(
+            [textTokens(10), visionStart, imageRun, textTokens(8, seed: 5)], axis: 1)
+        let t2 = textTokens(8, seed: 9)
+        let full = concatenated([t1, t2], axis: 1)
+
+        // Reference: one cold prefill of the whole image-bearing sequence.
+        let cacheF = model.newCache(parameters: nil)
+        let (logitsF, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
+                windowSize: nil))
+
+        // Two turns with the prefill state threaded, as ChatSession does.
+        let cacheW = model.newCache(parameters: nil)
+        let (_, s1) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
+                windowSize: nil))
+        let (logitsW, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, windowSize: nil))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsW, logitsF), 1e-3,
+            "state-threaded warm continuation diverged from full prefill")
+    }
+
+    /// The full three-turn round trip: a warm continuation whose remainder
+    /// itself contains a new image must compute that image's positions from
+    /// the anchor AND hand back a resume state that positions the following
+    /// turn correctly — turn 3 reads back the delta turn 2 produced.
+    func testImageMidContinuationResumeState() throws {
+        MLXRandom.seed(3)
+        let model = try makeTinyModel()
+
+        let pixels = MLXRandom.normal([16, 3 * 2 * 16 * 16])
+        let image = LMInput.ProcessedImage(pixels: pixels, frames: [THW(1, 4, 4)])
+        let visionStart = MLXArray([Int32(502)]).expandedDimensions(axis: 0)
+        let imageRun = MLXArray([Int32](repeating: 500, count: 4)).expandedDimensions(axis: 0)
+
+        let t1 = textTokens(12)
+        let t2 = concatenated(
+            [textTokens(4, seed: 2), visionStart, imageRun, textTokens(6, seed: 4)], axis: 1)
+        let t3 = textTokens(8, seed: 6)
+        let full = concatenated([t1, t2, t3], axis: 1)
+
+        // Reference: everything cold in one shot.
+        let cacheF = model.newCache(parameters: nil)
+        let (logitsF, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
+                windowSize: nil))
+
+        // Three turns, state threaded turn-to-turn: text, then image, then text.
+        let cacheW = model.newCache(parameters: nil)
+        let (_, s1) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+        let (_, s2) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t2), image: image), cache: cacheW, state: s1,
+                windowSize: nil))
+        let (logitsW, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t3)), cache: cacheW, state: s2, windowSize: nil))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsW, logitsF), 1e-3,
+            "post-image resume state positioned the following turn wrong")
+    }
+
+    /// Windowed (chunked) prefill must produce the same first-token logits as
+    /// the single-shot forward — on plain text and on an image-bearing prompt
+    /// whose image straddles a window boundary.
+    func testWindowedPrefillMatchesSingleShot() throws {
+        MLXRandom.seed(11)
+        let model = try makeTinyModel()
+        let prompt = textTokens(40)
+
+        let cacheS = model.newCache(parameters: nil)
+        let (logitsS, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt)), cache: cacheS, state: nil, windowSize: nil))
+
+        let cacheC = model.newCache(parameters: nil)
+        let (logitsC, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt)), cache: cacheC, state: nil, windowSize: 8))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsC, logitsS), 1e-3,
+            "windowed prefill diverged from single-shot")
+    }
+
+    func testWindowedImagePrefillMatchesSingleShot() throws {
+        MLXRandom.seed(13)
+        let model = try makeTinyModel()
+
+        let pixels = MLXRandom.normal([16, 3 * 2 * 16 * 16])
+        let image = LMInput.ProcessedImage(pixels: pixels, frames: [THW(1, 4, 4)])
+        let visionStart = MLXArray([Int32(502)]).expandedDimensions(axis: 0)
+        let imageRun = MLXArray([Int32](repeating: 500, count: 4)).expandedDimensions(axis: 0)
+        // Image tokens sit at positions 10...14 — straddling the 8-token
+        // window boundary, the hard case for chunked slicing.
+        let prompt = concatenated(
+            [textTokens(10), visionStart, imageRun, textTokens(12, seed: 7)], axis: 1)
+
+        let cacheS = model.newCache(parameters: nil)
+        let (logitsS, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt), image: image), cache: cacheS, state: nil,
+                windowSize: nil))
+
+        let cacheC = model.newCache(parameters: nil)
+        let (logitsC, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt), image: image), cache: cacheC, state: nil,
+                windowSize: 8))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsC, logitsS), 1e-3,
+            "windowed image prefill diverged from single-shot")
+    }
+}

--- a/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
@@ -34,32 +34,38 @@ final class Qwen3VLProcessorConfigTests: XCTestCase {
 
     /// The real Qwen3.6/3.5 PARO shape: only new-style edges, no legacy keys.
     func testNewStyleEdgesDecodeToBudget() throws {
-        let cfg = try decode(config(
-            budget: #""size": { "longest_edge": 16777216, "shortest_edge": 65536 }"#))
+        let cfg = try decode(
+            config(
+                budget: #""size": { "longest_edge": 16777216, "shortest_edge": 65536 }"#))
         XCTAssertEqual(cfg.minPixels, 65536, "shortest_edge → minPixels")
         XCTAssertEqual(cfg.maxPixels, 16_777_216, "longest_edge → maxPixels")
     }
 
     /// Legacy top-level keys still win.
     func testLegacyTopLevelPixelsHonored() throws {
-        let cfg = try decode(config(
-            budget: #""min_pixels": 1024, "max_pixels": 200000"#))
+        let cfg = try decode(
+            config(
+                budget: #""min_pixels": 1024, "max_pixels": 200000"#))
         XCTAssertEqual(cfg.minPixels, 1024)
         XCTAssertEqual(cfg.maxPixels, 200_000)
     }
 
     /// Legacy keys nested inside `size` are honored.
     func testLegacySizePixelsHonored() throws {
-        let cfg = try decode(config(
-            budget: #""size": { "min_pixels": 2048, "max_pixels": 300000 }"#))
+        let cfg = try decode(
+            config(
+                budget: #""size": { "min_pixels": 2048, "max_pixels": 300000 }"#))
         XCTAssertEqual(cfg.minPixels, 2048)
         XCTAssertEqual(cfg.maxPixels, 300_000)
     }
 
     /// Top-level legacy keys take precedence over a `size` block.
     func testTopLevelPixelsBeatSizeEdges() throws {
-        let cfg = try decode(config(budget:
-            #""min_pixels": 100, "max_pixels": 999, "size": { "longest_edge": 5, "shortest_edge": 5 }"#))
+        let cfg = try decode(
+            config(
+                budget:
+                    #""min_pixels": 100, "max_pixels": 999, "size": { "longest_edge": 5, "shortest_edge": 5 }"#
+            ))
         XCTAssertEqual(cfg.minPixels, 100)
         XCTAssertEqual(cfg.maxPixels, 999)
     }

--- a/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
@@ -1,0 +1,73 @@
+// Copyright © 2026 Apple Inc.
+//
+// Verifies `Qwen3VLProcessorConfiguration` decodes the new-style
+// `size.{longest_edge, shortest_edge}` pixel-area budget that recent Qwen3-VL
+// configs (e.g. Qwen3.6-27B PARO) ship, in addition to the legacy
+// `min_pixels`/`max_pixels`. Pre-fix the new keys were ignored and the budget
+// silently fell back to the hardcoded defaults — wrong for every model on the
+// new config format.
+
+import Foundation
+import MLXVLM
+import XCTest
+
+final class Qwen3VLProcessorConfigTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> Qwen3VLProcessorConfiguration {
+        try JSONDecoder().decode(
+            Qwen3VLProcessorConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Common required fields; the budget block is appended per-case.
+    private func config(budget: String) -> String {
+        """
+        {
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+            "merge_size": 2,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "image_processor_type": "Qwen2VLImageProcessorFast"\(budget.isEmpty ? "" : ",\n    " + budget)
+        }
+        """
+    }
+
+    /// The real Qwen3.6/3.5 PARO shape: only new-style edges, no legacy keys.
+    func testNewStyleEdgesDecodeToBudget() throws {
+        let cfg = try decode(config(
+            budget: #""size": { "longest_edge": 16777216, "shortest_edge": 65536 }"#))
+        XCTAssertEqual(cfg.minPixels, 65536, "shortest_edge → minPixels")
+        XCTAssertEqual(cfg.maxPixels, 16_777_216, "longest_edge → maxPixels")
+    }
+
+    /// Legacy top-level keys still win.
+    func testLegacyTopLevelPixelsHonored() throws {
+        let cfg = try decode(config(
+            budget: #""min_pixels": 1024, "max_pixels": 200000"#))
+        XCTAssertEqual(cfg.minPixels, 1024)
+        XCTAssertEqual(cfg.maxPixels, 200_000)
+    }
+
+    /// Legacy keys nested inside `size` are honored.
+    func testLegacySizePixelsHonored() throws {
+        let cfg = try decode(config(
+            budget: #""size": { "min_pixels": 2048, "max_pixels": 300000 }"#))
+        XCTAssertEqual(cfg.minPixels, 2048)
+        XCTAssertEqual(cfg.maxPixels, 300_000)
+    }
+
+    /// Top-level legacy keys take precedence over a `size` block.
+    func testTopLevelPixelsBeatSizeEdges() throws {
+        let cfg = try decode(config(budget:
+            #""min_pixels": 100, "max_pixels": 999, "size": { "longest_edge": 5, "shortest_edge": 5 }"#))
+        XCTAssertEqual(cfg.minPixels, 100)
+        XCTAssertEqual(cfg.maxPixels, 999)
+    }
+
+    /// No budget at all falls back to the historical defaults.
+    func testAbsentBudgetFallsBackToDefaults() throws {
+        let cfg = try decode(config(budget: ""))
+        XCTAssertEqual(cfg.minPixels, 4 * 28 * 28)
+        XCTAssertEqual(cfg.maxPixels, 16384 * 28 * 28)
+    }
+}

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -231,7 +231,9 @@ private final class StableTransitionLanguageModel: Module, LanguageModel, KVCach
         super.init()
     }
 
-    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
+        throws -> PrepareResult
+    {
         .tokens(input.text)
     }
 


### PR DESCRIPTION
### Proposed changes

Three related changes, reshaped by the review (thanks @davidkoski, both
questions turned out to be the right ones):

1. **Windowed prefill for Qwen3.5/3.6** (the item deferred from #344).
   `prepare` drives the language model in chunks of `windowSize ?? 512`,
   same default and shape as Gemma3 and `LLMModel`. This bounds the
   full-attention scratch to `[heads, window, L]` instead of
   `[heads, L, L]`. The vision tower runs once; chunks slice the merged
   embeddings. Batched inputs keep the single-shot path.

2. **`prepare` now takes `state: LMOutput.State?`**, and the
   `WindowedVisionContinuation` protocol from earlier revisions is
   removed. `prepareContinuation` is private to `Qwen35` now.

   This fixes a live bug: `ChatSession` reuses the KV cache across turns,
   but the M-RoPE state died with each turn's `TokenIterator`, so Qwen3.5
   recomputed positions from zero on every warm continuation. On a tiny
   random-weight model the warm turn-2 logits diverge from a cold full
   prefill by 0.43 max-abs, against a 8.3e-07 decode-path noise floor.

   `TokenIterator` takes an optional seed state and exposes the
   post-prefill state, `ChatSession` carries it across turns and
   tool-call restarts, and every other model ignores the new parameter
   (one line each). Speculative/MTP iterators are untouched. Qwen2.5-VL
   and Qwen3-VL have the same cross-turn drop, filed as #420.

   Known limitation, out of scope here: `savePromptCache` doesn't persist
   `LMOutput.State`, so a disk-restored image prefix still needs the
   caller to hold the state. Happy to follow up on the file format if
   there's interest.

3. **Processor config: `size.{longest_edge, shortest_edge}`** decode
   support, unchanged from earlier revisions (newer Qwen3-VL configs only
   ship the new-style keys).

### Tests

`Qwen35ContinuationTests`: tiny random-weight model, in-process, no
downloads (pattern per `NemotronHTests`):

- warm text continuation matches full prefill (the drift regression, red
  before the fix)
- warm image continuation matches full prefill (the rope delta carry)
- three-turn resume: text, then an image arriving mid-continuation, then
  text again
- windowed matches single-shot, for text and for an image straddling a
  window boundary

Plus `Qwen3VLProcessorConfigTests` for (3). Full MLXLMTests suite green
locally.

### Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly (API doc comments + MLXVLM README example)
