### PR TITLE
Gemma4Unified (12B): audio and video input in the processor

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2599,6 +2599,9 @@ public struct Gemma4MessageGenerator: MessageGenerator {
                     + message.videos.map { _ in
                         ["type": "video"]
                     }
+                    + message.audios.map { _ in
+                        ["type": "audio"]
+                    }
                     + [
                         ["type": "text", "text": message.content]
                     ],
@@ -2763,6 +2766,12 @@ public struct Gemma4UnifiedProcessorConfiguration: Decodable, Sendable {
     public let videoTokenId: Int?
     public let boiTokenId: Int
     public let eoiTokenId: Int?
+    public let boaTokenId: Int
+    public let eoaTokenId: Int
+    public let audioSampleRate: Int
+    public let audioSamplesPerToken: Int
+    public let videoSoftTokensPerFrame: Int
+    public let videoMaxFrames: Int
 
     private struct ImageProcessorConfiguration: Decodable, Sendable {
         let doResize: Bool?
@@ -2794,9 +2803,35 @@ public struct Gemma4UnifiedProcessorConfiguration: Decodable, Sendable {
         }
     }
 
+    /// `processor_config.json` nests the audio extractor params under
+    /// `feature_extractor`. The mel-related keys in there are vestigial
+    /// (written by mlx-vlm's `save_pretrained` fallback) — the unified
+    /// extractor only uses `sampling_rate` and `audio_samples_per_token`.
+    private struct FeatureExtractorConfiguration: Decodable, Sendable {
+        let samplingRate: Int?
+        let audioSamplesPerToken: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case samplingRate = "sampling_rate"
+            case audioSamplesPerToken = "audio_samples_per_token"
+        }
+    }
+
+    private struct VideoProcessorConfiguration: Decodable, Sendable {
+        let maxSoftTokens: Int?
+        let numFrames: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case maxSoftTokens = "max_soft_tokens"
+            case numFrames = "num_frames"
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case processorClass = "processor_class"
         case imageProcessor = "image_processor"
+        case featureExtractor = "feature_extractor"
+        case videoProcessor = "video_processor"
         case doResize = "do_resize"
         case doRescale = "do_rescale"
         case rescaleFactor = "rescale_factor"
@@ -2817,12 +2852,24 @@ public struct Gemma4UnifiedProcessorConfiguration: Decodable, Sendable {
         case videoTokenId = "video_token_id"
         case boiTokenId = "boi_token_id"
         case eoiTokenId = "eoi_token_id"
+        case boaTokenId = "boa_token_id"
+        case eoaTokenId = "eoa_token_id"
+        case eoaTokenIndex = "eoa_token_index"
+        case audioSampleRate = "audio_sampling_rate"
+        case audioSamplesPerToken = "audio_samples_per_token"
+        case videoSoftTokensPerFrame = "video_soft_tokens_per_frame"
+        case visionSoftTokensPerVideoFrame = "vision_soft_tokens_per_video_frame"
+        case videoMaxFrames = "video_max_frames"
     }
 
     public init(from decoder: any Swift.Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         let imageProcessor = try c.decodeIfPresent(
             ImageProcessorConfiguration.self, forKey: CodingKeys.imageProcessor)
+        let featureExtractor = try c.decodeIfPresent(
+            FeatureExtractorConfiguration.self, forKey: CodingKeys.featureExtractor)
+        let videoProcessor = try c.decodeIfPresent(
+            VideoProcessorConfiguration.self, forKey: CodingKeys.videoProcessor)
 
         processorClass =
             try c.decodeIfPresent(String.self, forKey: CodingKeys.processorClass)
@@ -2884,6 +2931,28 @@ public struct Gemma4UnifiedProcessorConfiguration: Decodable, Sendable {
         videoTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoTokenId) ?? 258_884
         boiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boiTokenId) ?? 255_999
         eoiTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoiTokenId) ?? 258_882
+        boaTokenId = try c.decodeIfPresent(Int.self, forKey: CodingKeys.boaTokenId) ?? 256_000
+        eoaTokenId =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.eoaTokenId)
+            ?? c.decodeIfPresent(Int.self, forKey: CodingKeys.eoaTokenIndex)
+            ?? 258_883
+        audioSampleRate =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioSampleRate)
+            ?? featureExtractor?.samplingRate
+            ?? 16_000
+        audioSamplesPerToken =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.audioSamplesPerToken)
+            ?? featureExtractor?.audioSamplesPerToken
+            ?? 640
+        videoSoftTokensPerFrame =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoSoftTokensPerFrame)
+            ?? c.decodeIfPresent(Int.self, forKey: CodingKeys.visionSoftTokensPerVideoFrame)
+            ?? videoProcessor?.maxSoftTokens
+            ?? 70
+        videoMaxFrames =
+            try c.decodeIfPresent(Int.self, forKey: CodingKeys.videoMaxFrames)
+            ?? videoProcessor?.numFrames
+            ?? 32
     }
 
     public var imageMeanTuple: (CGFloat, CGFloat, CGFloat) {
@@ -2901,10 +2970,16 @@ public struct Gemma4UnifiedProcessorConfiguration: Decodable, Sendable {
     }
 
     public func aspectRatioPreservingSize(for imageSize: CGSize) throws -> CGSize {
+        try aspectRatioPreservingSize(for: imageSize, maxTokens: maxSoftTokens)
+    }
+
+    public func aspectRatioPreservingSize(for imageSize: CGSize, maxTokens budget: Int) throws
+        -> CGSize
+    {
         let width = max(1, Int(ceil(imageSize.width)))
         let height = max(1, Int(ceil(imageSize.height)))
         let sideMultiple = max(1, patchSize * poolingKernelSize)
-        let maxTokens = max(1, maxSoftTokens)
+        let maxTokens = max(1, budget)
 
         let targetPixels = Double(maxTokens * sideMultiple * sideMultiple)
         let resizeFactor = sqrt(targetPixels / Double(width * height))
@@ -2945,13 +3020,13 @@ public struct Gemma4UnifiedProcessor: UserInputProcessor {
         self.tokenizer = tokenizer
     }
 
-    private func patchify(_ pixelValues: MLXArray) -> (MLXArray, MLXArray, Int, THW) {
+    private func patchify(_ pixelValues: MLXArray, budget: Int) -> (MLXArray, MLXArray, Int, THW) {
         let channels = pixelValues.dim(1)
         let height = pixelValues.dim(2)
         let width = pixelValues.dim(3)
         let patchHeight = height / config.modelPatchSize
         let patchWidth = width / config.modelPatchSize
-        let realCount = min(patchHeight * patchWidth, config.maxSoftTokens)
+        let realCount = min(patchHeight * patchWidth, budget)
         let patchDim = config.modelPatchSize * config.modelPatchSize * channels
 
         var patches = pixelValues.reshaped(
@@ -2961,12 +3036,12 @@ public struct Gemma4UnifiedProcessor: UserInputProcessor {
         if realCount < patches.dim(0) {
             patches = patches[..<realCount, 0...]
         }
-        if realCount < config.maxSoftTokens {
-            patches = padded(patches, widths: [.init((0, config.maxSoftTokens - realCount)), 0])
+        if realCount < budget {
+            patches = padded(patches, widths: [.init((0, budget - realCount)), 0])
         }
 
         var positionValues: [Int32] = []
-        positionValues.reserveCapacity(config.maxSoftTokens * 2)
+        positionValues.reserveCapacity(budget * 2)
         var emitted = 0
         for y in 0 ..< patchHeight {
             for x in 0 ..< patchWidth where emitted < realCount {
@@ -2975,13 +3050,51 @@ public struct Gemma4UnifiedProcessor: UserInputProcessor {
                 emitted += 1
             }
         }
-        while emitted < config.maxSoftTokens {
+        while emitted < budget {
             positionValues.append(-1)
             positionValues.append(-1)
             emitted += 1
         }
-        let positions = MLXArray(positionValues, [config.maxSoftTokens, 2])
+        let positions = MLXArray(positionValues, [budget, 2])
         return (patches, positions, realCount, THW(1, height, width))
+    }
+
+    /// Shared image/video-frame pipeline: user processing → sRGB tone curve →
+    /// aspect-preserving resize into `budget` model patches → rescale/normalize →
+    /// patchify. Images use `config.maxSoftTokens`; video frames use the smaller
+    /// `config.videoSoftTokensPerFrame` budget.
+    private func processFrame(
+        _ image: CIImage, processing: UserInput.Processing?, budget: Int
+    ) throws -> (patches: MLXArray, positions: MLXArray, tokenCount: Int, frame: THW) {
+        let processedImage = MediaProcessing.apply(image, processing: processing)
+        let srgbImage = MediaProcessing.inSRGBToneCurveSpace(processedImage)
+        let resizedImage =
+            if config.doResize {
+                try MediaProcessing.resampleBicubic(
+                    srgbImage,
+                    to: config.aspectRatioPreservingSize(
+                        for: srgbImage.extent.size, maxTokens: budget))
+            } else {
+                srgbImage
+            }
+
+        var pixelValues = MediaProcessing.asMLXArray(resizedImage)
+        let rescaleMultiplier = Float(config.doRescale ? config.rescaleFactor * 255 : 255)
+        if rescaleMultiplier != 1 {
+            pixelValues = pixelValues * MLXArray(rescaleMultiplier, dtype: pixelValues.dtype)
+        }
+        if config.doNormalize {
+            let mean = MLXArray(
+                config.imageMean.map { Float($0) }, [1, config.imageMean.count, 1, 1]
+            )
+            .asType(pixelValues.dtype)
+            let std = MLXArray(
+                config.imageStd.map { Float($0) }, [1, config.imageStd.count, 1, 1]
+            )
+            .asType(pixelValues.dtype)
+            pixelValues = (pixelValues - mean) / std
+        }
+        return patchify(pixelValues, budget: budget)
     }
 
     public func preprocess(images: [CIImage], processing: UserInput.Processing?) throws -> (
@@ -2993,34 +3106,8 @@ public struct Gemma4UnifiedProcessor: UserInputProcessor {
         var frames: [THW] = []
 
         for image in images {
-            let processedImage = MediaProcessing.apply(image, processing: processing)
-            let srgbImage = MediaProcessing.inSRGBToneCurveSpace(processedImage)
-            let resizedImage =
-                if config.doResize {
-                    try MediaProcessing.resampleBicubic(
-                        srgbImage,
-                        to: config.aspectRatioPreservingSize(for: srgbImage.extent.size))
-                } else {
-                    srgbImage
-                }
-
-            var pixelValues = MediaProcessing.asMLXArray(resizedImage)
-            let rescaleMultiplier = Float(config.doRescale ? config.rescaleFactor * 255 : 255)
-            if rescaleMultiplier != 1 {
-                pixelValues = pixelValues * MLXArray(rescaleMultiplier, dtype: pixelValues.dtype)
-            }
-            if config.doNormalize {
-                let mean = MLXArray(
-                    config.imageMean.map { Float($0) }, [1, config.imageMean.count, 1, 1]
-                )
-                .asType(pixelValues.dtype)
-                let std = MLXArray(
-                    config.imageStd.map { Float($0) }, [1, config.imageStd.count, 1, 1]
-                )
-                .asType(pixelValues.dtype)
-                pixelValues = (pixelValues - mean) / std
-            }
-            let (patches, positions, tokenCount, frame) = patchify(pixelValues)
+            let (patches, positions, tokenCount, frame) = try processFrame(
+                image, processing: processing, budget: config.maxSoftTokens)
             patchRows.append(patches)
             positionRows.append(positions)
             tokenCounts.append(tokenCount)
@@ -3032,6 +3119,142 @@ public struct Gemma4UnifiedProcessor: UserInputProcessor {
             positionIds: stacked(positionRows, axis: 0),
             tokenCounts: tokenCounts,
             frames: frames
+        )
+    }
+
+    /// Sample up to `config.videoMaxFrames` frames (~1 fps) from each video and
+    /// patchify each frame like an image, but with the per-frame
+    /// `config.videoSoftTokensPerFrame` budget. Returns stacked patches and
+    /// positions with one row per frame (all videos concatenated), plus per-video
+    /// per-frame soft-token counts and timestamps (seconds) for the `mm:ss`
+    /// prompt prefixes.
+    public func processVideos(_ videos: [UserInput.Video], processing: UserInput.Processing?)
+        async throws -> (
+            pixels: MLXArray, positionIds: MLXArray,
+            tokenCounts: [[Int]], timestamps: [[Double]]
+        )
+    {
+        var patchRows: [MLXArray] = []
+        var positionRows: [MLXArray] = []
+        var tokenCounts: [[Int]] = []
+        var timestamps: [[Double]] = []
+
+        for video in videos {
+            let sequence = try await MediaProcessing.asProcessedSequence(
+                video, targetFPS: { _ in 1.0 }, maxFrames: config.videoMaxFrames
+            ) { frame in
+                let processedImage = MediaProcessing.apply(frame.frame, processing: processing)
+                let srgbImage = MediaProcessing.inSRGBToneCurveSpace(processedImage)
+                let resizedImage =
+                    if config.doResize {
+                        try MediaProcessing.resampleBicubic(
+                            srgbImage,
+                            to: config.aspectRatioPreservingSize(
+                                for: srgbImage.extent.size,
+                                maxTokens: config.videoSoftTokensPerFrame))
+                    } else {
+                        srgbImage
+                    }
+                return VideoFrame(frame: resizedImage, timeStamp: frame.timeStamp)
+            }
+
+            var videoTokenCounts: [Int] = []
+            for frame in sequence.frames {
+                var pixelValues = frame
+                let rescaleMultiplier = Float(
+                    config.doRescale ? config.rescaleFactor * 255 : 255)
+                if rescaleMultiplier != 1 {
+                    pixelValues =
+                        pixelValues * MLXArray(rescaleMultiplier, dtype: pixelValues.dtype)
+                }
+                if config.doNormalize {
+                    let mean = MLXArray(
+                        config.imageMean.map { Float($0) }, [1, config.imageMean.count, 1, 1]
+                    )
+                    .asType(pixelValues.dtype)
+                    let std = MLXArray(
+                        config.imageStd.map { Float($0) }, [1, config.imageStd.count, 1, 1]
+                    )
+                    .asType(pixelValues.dtype)
+                    pixelValues = (pixelValues - mean) / std
+                }
+                let (patches, positions, tokenCount, _) = patchify(
+                    pixelValues, budget: config.videoSoftTokensPerFrame)
+                patchRows.append(patches)
+                positionRows.append(positions)
+                videoTokenCounts.append(tokenCount)
+            }
+            tokenCounts.append(videoTokenCounts)
+            timestamps.append(sequence.timestamps.map { $0.seconds })
+        }
+
+        return (
+            pixels: stacked(patchRows, axis: 0),
+            positionIds: stacked(positionRows, axis: 0),
+            tokenCounts: tokenCounts,
+            timestamps: timestamps
+        )
+    }
+
+    /// Encoder-free audio features: the raw 16 kHz waveform is zero-padded to a
+    /// multiple of `audioSamplesPerToken` (640 = 40 ms) and reshaped into
+    /// `[1, tokens, samplesPerToken]` frames — each frame IS the feature vector
+    /// projected by the model's `embed_audio`, one soft token per frame. Clips
+    /// are truncated to `audioSeqLength` tokens (750 = 30 s) so the placeholder
+    /// count always matches the scattered feature rows. Mask is true on valid
+    /// frames (false only on cross-clip batch padding).
+    private func prepareAudio(
+        _ audios: [UserInput.Audio]
+    ) async throws -> (LMInput.ProcessedAudio, [Int]) {
+        var processing = UserInput.AudioProcessing()
+        processing.sampleRate = Double(config.audioSampleRate)
+        let samplesPerToken = max(1, config.audioSamplesPerToken)
+        let maxSamples = config.audioSeqLength * samplesPerToken
+
+        var featureRows: [MLXArray] = []
+        var maskRows: [MLXArray] = []
+        var tokenCounts: [Int] = []
+        for audio in audios {
+            var waveform = try await audio.asMLXArray(processing: processing)
+                .flattened().asType(.float32)
+            if waveform.dim(0) > maxSamples {
+                waveform = waveform[..<maxSamples]
+            }
+            guard waveform.dim(0) > 0 else {
+                throw VLMError.processing("Audio input contains no samples.")
+            }
+            let tokens = (waveform.dim(0) + samplesPerToken - 1) / samplesPerToken
+            let padLength = tokens * samplesPerToken - waveform.dim(0)
+            if padLength > 0 {
+                waveform = padded(waveform, widths: [IntOrPair((0, padLength))])
+            }
+            featureRows.append(waveform.reshaped(1, tokens, samplesPerToken))
+            maskRows.append(MLXArray.ones([1, tokens], dtype: .bool))
+            tokenCounts.append(tokens)
+        }
+
+        let maxFrames = featureRows.map { $0.dim(1) }.max() ?? 0
+        var paddedFeatures: [MLXArray] = []
+        var paddedMasks: [MLXArray] = []
+        for (features, mask) in zip(featureRows, maskRows) {
+            let t = features.dim(1)
+            if t < maxFrames {
+                paddedFeatures.append(
+                    padded(features, widths: [0, IntOrPair((0, maxFrames - t)), 0]))
+                paddedMasks.append(
+                    padded(mask.asType(.int32), widths: [0, IntOrPair((0, maxFrames - t))])
+                        .asType(.bool))
+            } else {
+                paddedFeatures.append(features)
+                paddedMasks.append(mask)
+            }
+        }
+
+        return (
+            LMInput.ProcessedAudio(
+                features: concatenated(paddedFeatures, axis: 0),
+                mask: concatenated(paddedMasks, axis: 0)),
+            tokenCounts
         )
     }
 
@@ -3078,8 +3301,90 @@ public struct Gemma4UnifiedProcessor: UserInputProcessor {
             promptTokens = expandedTokens
         }
 
+        var processedVideo: LMInput.ProcessedVideo?
+        if !input.videos.isEmpty, let videoTokenId = config.videoTokenId {
+            let videoData = try await processVideos(input.videos, processing: input.processing)
+            processedVideo = LMInput.ProcessedVideo(
+                pixels: videoData.pixels, positionIds: videoData.positionIds)
+
+            // Expand the i-th `<video>` placeholder into one block per sampled
+            // frame — `mm:ss BOI + video_token×N + EOI`, blocks joined by a
+            // space — matching the HF/mlx-vlm processors. The timestamp text is
+            // tokenized in isolation, so merges across the text/special-token
+            // boundary can differ slightly from tokenizing the fully expanded
+            // prompt string; both sides of each timestamp are special tokens in
+            // the original too, so only the leading edge is affected.
+            var expandedTokens: [Int] = []
+            var videoIndex = 0
+            for token in promptTokens {
+                if token == videoTokenId {
+                    let frameTokenCounts =
+                        videoIndex < videoData.tokenCounts.count
+                        ? videoData.tokenCounts[videoIndex] : []
+                    let frameTimestamps =
+                        videoIndex < videoData.timestamps.count
+                        ? videoData.timestamps[videoIndex] : []
+                    for (frameIndex, count) in frameTokenCounts.enumerated() {
+                        let seconds =
+                            frameIndex < frameTimestamps.count ? frameTimestamps[frameIndex] : 0
+                        let timestampText =
+                            (frameIndex == 0 ? "" : " ")
+                            + gemma4VideoTimestampText(seconds: seconds) + " "
+                        expandedTokens.append(
+                            contentsOf: tokenizer.encode(
+                                text: timestampText, addSpecialTokens: false))
+                        expandedTokens.append(config.boiTokenId)
+                        expandedTokens.append(
+                            contentsOf: Array(repeating: videoTokenId, count: count))
+                        if let eoiTokenId = config.eoiTokenId {
+                            expandedTokens.append(eoiTokenId)
+                        }
+                    }
+                    videoIndex += 1
+                } else {
+                    expandedTokens.append(token)
+                }
+            }
+            promptTokens = expandedTokens
+        }
+
+        var processedAudio: LMInput.ProcessedAudio?
+        if !input.audios.isEmpty {
+            let (audio, tokenCounts) = try await prepareAudio(input.audios)
+            processedAudio = audio
+
+            // Expand each audio placeholder into `boa + audio_token×N + eoa`,
+            // N = the clip's frame count (= feature rows the model scatters).
+            var expandedTokens: [Int] = []
+            var audioIndex = 0
+            for token in promptTokens {
+                if token == config.audioTokenId {
+                    let count =
+                        audioIndex < tokenCounts.count
+                        ? tokenCounts[audioIndex] : config.audioSeqLength
+                    expandedTokens.append(config.boaTokenId)
+                    expandedTokens.append(
+                        contentsOf: Array(repeating: config.audioTokenId, count: count))
+                    expandedTokens.append(config.eoaTokenId)
+                    audioIndex += 1
+                } else {
+                    expandedTokens.append(token)
+                }
+            }
+            promptTokens = expandedTokens
+        }
+
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
         let mask = ones(like: promptArray).asType(.int8)
-        return LMInput(text: .init(tokens: promptArray, mask: mask), image: processedImage)
+        return LMInput(
+            text: .init(tokens: promptArray, mask: mask),
+            image: processedImage, video: processedVideo, audio: processedAudio)
     }
+}
+
+/// `mm:ss` prefix for a sampled video frame, matching the reference processors
+/// (`f"{int(secs // 60):02d}:{int(secs % 60):02d}"`).
+func gemma4VideoTimestampText(seconds: Double) -> String {
+    let total = max(0, Int(seconds))
+    return String(format: "%02d:%02d", total / 60, total % 60)
 }

--- a/Tests/MLXLMTests/Gemma4UnifiedAudioVideoTests.swift
+++ b/Tests/MLXLMTests/Gemma4UnifiedAudioVideoTests.swift
@@ -1,0 +1,390 @@
+// Copyright © 2026 Apple Inc.
+
+import CoreImage
+import CoreMedia
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXVLM
+
+// MARK: - Audio + video for the encoder-free Gemma 4 Unified (12B)
+
+/// Tokenizer for the unified processor tests. `applyChatTemplate` returns a
+/// fixed prompt with modality placeholders; `encode` returns a single marker
+/// token (9) so tests can assert where video timestamp text was spliced.
+private struct UnifiedAVTestTokenizer: Tokenizer {
+    var template: [Int] = [3, 30, 2]
+
+    let vocabularySize: Int = 32
+    let bosToken: String? = nil
+    let eosToken: String? = nil
+    let eosTokenId: Int? = 1
+    let unknownToken: String? = nil
+    let unknownTokenId: Int? = 0
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        [9]
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.map(String.init).joined(separator: " ")
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        Int(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        String(id)
+    }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        template
+    }
+}
+
+struct Gemma4UnifiedAudioVideoTests {
+
+    private func decodeProcessorConfig(_ json: String) throws
+        -> Gemma4UnifiedProcessorConfiguration
+    {
+        try JSONDecoder.json5().decode(
+            Gemma4UnifiedProcessorConfiguration.self, from: Data(json.utf8))
+    }
+
+    private func decodeModelConfig(_ json: String) throws -> Gemma4UnifiedConfiguration {
+        try JSONDecoder.json5().decode(Gemma4UnifiedConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Processor config with the tiny ids used across these tests:
+    /// audio 30, boa 27, eoa 26, video 29, boi 28, eoi 31, image 25.
+    private func tinyProcessorConfig(extraLines: String = "") throws
+        -> Gemma4UnifiedProcessorConfiguration
+    {
+        try decodeProcessorConfig(
+            """
+            {
+              "processor_class": "Gemma4UnifiedProcessor",
+              "image_token_id": 25,
+              "audio_token_id": 30,
+              "video_token_id": 29,
+              "boi_token_id": 28,
+              "eoi_token_id": 31,
+              "boa_token_id": 27,
+              "eoa_token_id": 26,
+              "video_soft_tokens_per_frame": 4,
+              \(extraLines)
+              "image_processor": {
+                "patch_size": 2,
+                "pooling_kernel_size": 2,
+                "model_patch_size": 4,
+                "max_soft_tokens": 4,
+                "size": { "height": 8, "width": 8 }
+              }
+            }
+            """)
+    }
+
+    // MARK: - Configuration decoding
+
+    @Test("Unified processor config decodes audio and video keys from processor_config.json")
+    func configDecodesAudioVideoKeys() throws {
+        // Mirrors the real mlx-community/gemma-4-12B-it-4bit processor_config.json:
+        // audio params nested under `feature_extractor` (with vestigial mel keys),
+        // eoa id spelled `eoa_token_index`, no explicit boa/video keys.
+        let config = try decodeProcessorConfig(
+            """
+            {
+              "processor_class": "Gemma4UnifiedProcessor",
+              "audio_ms_per_token": 40,
+              "eoa_token_index": 258883,
+              "feature_extractor": {
+                "feature_extractor_type": "Gemma4UnifiedAudioFeatureExtractor",
+                "sampling_rate": 16000,
+                "num_mel_filters": 128,
+                "fft_length": 512,
+                "hop_length": 160,
+                "chunk_duration": 8.0,
+                "overlap_duration": 1.0
+              },
+              "image_processor": {
+                "max_soft_tokens": 280,
+                "patch_size": 16,
+                "pooling_kernel_size": 3,
+                "model_patch_size": 48
+              }
+            }
+            """)
+
+        #expect(config.audioTokenId == 258_881)
+        #expect(config.boaTokenId == 256_000)
+        #expect(config.eoaTokenId == 258_883)
+        #expect(config.audioSampleRate == 16_000)
+        #expect(config.audioSamplesPerToken == 640)
+        #expect(config.audioSeqLength == 750)
+        #expect(config.audioMsPerToken == 40)
+        #expect(config.videoTokenId == 258_884)
+        #expect(config.videoSoftTokensPerFrame == 70)
+        #expect(config.videoMaxFrames == 32)
+    }
+
+    // MARK: - Audio
+
+    @Test("Unified audio features are raw waveform frames (reference framing parity)")
+    func audioFramingMatchesReference() async throws {
+        let config = try tinyProcessorConfig()
+        let processor = Gemma4UnifiedProcessor(config, tokenizer: UnifiedAVTestTokenizer())
+
+        // 1600 samples = 2.5 frames of 640 → 3 tokens, tail zero-padded.
+        let samples = (0 ..< 1600).map { Float($0) * 1e-3 }
+        let input = try await processor.prepare(
+            input: UserInput(prompt: "transcribe", audios: [.array(MLXArray(samples))]))
+
+        let audio = try #require(input.audio)
+        #expect(audio.features.shape == [1, 3, 640])
+        #expect(audio.mask?.shape == [1, 3])
+        #expect(audio.mask?.asType(.int32).sum().item(Int.self) == 3)
+
+        // Frame contents must be the exact reshaped waveform (no windowing, no
+        // normalization): frame 0 = samples[0..<640], frame 2 tail = zeros.
+        let features = audio.features.asArray(Float.self)
+        #expect(features[0] == samples[0])
+        #expect(features[639] == samples[639])
+        #expect(features[640] == samples[640])
+        #expect(features[2 * 640 + 319] == samples[1599])
+        #expect(features[(2 * 640 + 320) ..< (3 * 640)].allSatisfy { $0 == 0 })
+
+        // Template [3, <audio>, 2] → 3, boa, audio×3, eoa, 2.
+        #expect(input.text.tokens.asArray(Int32.self) == [3, 27, 30, 30, 30, 26, 2])
+    }
+
+    @Test("Unified audio truncates to audio_seq_length tokens (30s cap)")
+    func audioTruncatesToSeqLength() async throws {
+        let config = try tinyProcessorConfig(extraLines: "\"audio_seq_length\": 2,")
+        let processor = Gemma4UnifiedProcessor(config, tokenizer: UnifiedAVTestTokenizer())
+
+        let samples = [Float](repeating: 0.25, count: 5 * 640)
+        let input = try await processor.prepare(
+            input: UserInput(prompt: "transcribe", audios: [.array(MLXArray(samples))]))
+
+        let audio = try #require(input.audio)
+        #expect(audio.features.shape == [1, 2, 640])
+        #expect(input.text.tokens.asArray(Int32.self) == [3, 27, 30, 30, 26, 2])
+    }
+
+    @Test("Unified audio batches clips with padding masked out")
+    func multipleAudiosArePaddedAndMasked() async throws {
+        let config = try tinyProcessorConfig()
+        var tokenizer = UnifiedAVTestTokenizer()
+        tokenizer.template = [3, 30, 4, 30, 2]
+        let processor = Gemma4UnifiedProcessor(config, tokenizer: tokenizer)
+
+        let short = [Float](repeating: 0.5, count: 640)
+        let long = [Float](repeating: -0.5, count: 1600)
+        let input = try await processor.prepare(
+            input: UserInput(
+                prompt: "compare",
+                audios: [.array(MLXArray(short)), .array(MLXArray(long))]))
+
+        let audio = try #require(input.audio)
+        #expect(audio.features.shape == [2, 3, 640])
+        let maskCounts = try #require(audio.mask?.asType(.int32).sum(axis: -1))
+        #expect(maskCounts.asArray(Int.self) == [1, 3])
+        #expect(
+            input.text.tokens.asArray(Int32.self)
+                == [3, 27, 30, 26, 4, 27, 30, 30, 30, 26, 2])
+    }
+
+    @Test("Unified audio processor → model round trip (scatter counts match)")
+    func audioProcessorModelRoundTrip() async throws {
+        let config = try tinyProcessorConfig()
+        let processor = Gemma4UnifiedProcessor(config, tokenizer: UnifiedAVTestTokenizer())
+        let model = Gemma4Unified(
+            try decodeModelConfig(
+                """
+                {
+                  "model_type": "gemma4_unified",
+                  "vocab_size": 32,
+                  "image_token_id": 25,
+                  "audio_token_id": 30,
+                  "video_token_id": 29,
+                  "text_config": {
+                    "model_type": "gemma4_unified_text",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 8,
+                    "global_head_dim": 8,
+                    "vocab_size": 32,
+                    "vocab_size_per_layer_input": 32,
+                    "num_kv_shared_layers": 0,
+                    "hidden_size_per_layer_input": 0,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "attention_k_eq_v": true,
+                    "use_double_wide_mlp": false,
+                    "layer_types": ["full_attention"],
+                    "tie_word_embeddings": true
+                  },
+                  "vision_config": null,
+                  "audio_config": {
+                    "model_type": "gemma4_unified_audio",
+                    "audio_samples_per_token": 640,
+                    "audio_embed_dim": 640,
+                    "hidden_size": 640,
+                    "output_proj_dims": 640
+                  }
+                }
+                """))
+
+        let samples = (0 ..< 1600).map { Float($0) * 1e-3 }
+        let input = try await processor.prepare(
+            input: UserInput(prompt: "transcribe", audios: [.array(MLXArray(samples))]))
+
+        let result = try model.prepare(
+            input, cache: model.newCache(parameters: nil), windowSize: nil)
+
+        guard case .logits(let output) = result else {
+            Issue.record("Expected Gemma4Unified.prepare to return logits")
+            return
+        }
+        // Prompt expands to [3, boa, audio×3, eoa, 2] = 7 tokens; a count
+        // mismatch between placeholders and feature rows would have thrown.
+        #expect(output.logits.shape == [1, 7, 32])
+    }
+
+    // MARK: - Video
+
+    @Test("Unified processor expands video placeholders per frame with timestamps")
+    func videoExpansionPerFrame() async throws {
+        let config = try tinyProcessorConfig()
+        var tokenizer = UnifiedAVTestTokenizer()
+        tokenizer.template = [3, 29, 2]
+        let processor = Gemma4UnifiedProcessor(config, tokenizer: tokenizer)
+
+        let frame = CIImage(color: .gray).cropped(to: CGRect(x: 0, y: 0, width: 8, height: 8))
+        let video = UserInput.Video.frames([
+            .init(frame: frame, timeStamp: CMTime(seconds: 0, preferredTimescale: 600)),
+            .init(frame: frame, timeStamp: CMTime(seconds: 2, preferredTimescale: 600)),
+        ])
+
+        let input = try await processor.prepare(
+            input: UserInput(prompt: "describe", videos: [video]))
+
+        let videoInput = try #require(input.video)
+        // 8×8 frame / 4px model patches = 4 patches per frame, budget 4 → no padding.
+        #expect(videoInput.pixels.shape == [2, 4, 48])
+        #expect(videoInput.positionIds?.shape == [2, 4, 2])
+
+        // Per frame: timestamp marker (9) + boi + video×4 + eoi.
+        #expect(
+            input.text.tokens.asArray(Int32.self)
+                == [3, 9, 28, 29, 29, 29, 29, 31, 9, 28, 29, 29, 29, 29, 31, 2])
+    }
+
+    @Test("Unified video frames use the per-frame soft-token budget, padded with -1 positions")
+    func videoFramesUsePerFrameBudget() async throws {
+        // Frame budget 4 but a 8×4 frame only yields 2 real patches → padding.
+        let config = try tinyProcessorConfig(extraLines: "\"do_resize\": false,")
+        let processor = Gemma4UnifiedProcessor(config, tokenizer: UnifiedAVTestTokenizer())
+
+        let frame = CIImage(color: .gray).cropped(to: CGRect(x: 0, y: 0, width: 8, height: 4))
+        let videoData = try await processor.processVideos(
+            [.frames([.init(frame: frame, timeStamp: .zero)])], processing: nil)
+
+        #expect(videoData.pixels.shape == [1, 4, 48])
+        #expect(videoData.positionIds.shape == [1, 4, 2])
+        #expect(videoData.tokenCounts == [[2]])
+        let positions = videoData.positionIds.asArray(Int32.self)
+        #expect(Array(positions[0 ..< 4]) == [0, 0, 1, 0])
+        #expect(Array(positions[4 ..< 8]) == [-1, -1, -1, -1])
+    }
+
+    @Test("Unified video timestamp text formats mm:ss like the reference")
+    func videoTimestampFormatting() {
+        #expect(gemma4VideoTimestampText(seconds: 0) == "00:00")
+        #expect(gemma4VideoTimestampText(seconds: 2.4) == "00:02")
+        #expect(gemma4VideoTimestampText(seconds: 61.9) == "01:01")
+        #expect(gemma4VideoTimestampText(seconds: 600) == "10:00")
+    }
+
+    @Test("Unified model scatters video features through the vision embedder")
+    func videoEndToEndTinyModel() throws {
+        let model = Gemma4Unified(
+            try decodeModelConfig(
+                """
+                {
+                  "model_type": "gemma4_unified",
+                  "vocab_size": 32,
+                  "image_token_id": 25,
+                  "audio_token_id": 30,
+                  "video_token_id": 29,
+                  "text_config": {
+                    "model_type": "gemma4_unified_text",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 8,
+                    "global_head_dim": 8,
+                    "vocab_size": 32,
+                    "vocab_size_per_layer_input": 32,
+                    "num_kv_shared_layers": 0,
+                    "hidden_size_per_layer_input": 0,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "attention_k_eq_v": true,
+                    "use_double_wide_mlp": false,
+                    "layer_types": ["full_attention"],
+                    "tie_word_embeddings": true
+                  },
+                  "vision_config": {
+                    "model_type": "gemma4_unified_vision",
+                    "patch_size": 2,
+                    "pooling_kernel_size": 2,
+                    "model_patch_size": 4,
+                    "mm_embed_dim": 8,
+                    "mm_posemb_size": 4,
+                    "num_soft_tokens": 4,
+                    "output_proj_dims": 8
+                  },
+                  "audio_config": null
+                }
+                """))
+
+        // Two frames × 3 real patches (1 padded with -1 positions) = 6 video tokens.
+        let inputIds = MLXArray([0, 29, 29, 29, 29, 29, 29, 1]).reshaped(1, 8)
+        let pixels = MLXArray.zeros([2, 4, 48], dtype: .float32)
+        var positionValues = [Int32](repeating: 0, count: 2 * 4 * 2)
+        positionValues[6] = -1
+        positionValues[7] = -1
+        positionValues[14] = -1
+        positionValues[15] = -1
+        let positionIds = MLXArray(positionValues, [2, 4, 2])
+
+        let input = LMInput(
+            text: .init(tokens: inputIds),
+            video: .init(pixels: pixels, positionIds: positionIds)
+        )
+
+        let result = try model.prepare(
+            input, cache: model.newCache(parameters: nil), windowSize: nil)
+
+        guard case .logits(let output) = result else {
+            Issue.record("Expected Gemma4Unified.prepare to return logits")
+            return
+        }
+        #expect(output.logits.shape == [1, 8, 32])
+    }
+}


### PR DESCRIPTION
## What

Completes multimodal input for the encoder-free `gemma4_unified` (12B) models. The `Gemma4Unified` model class already projects and scatters audio/video features (`embed_audio`, `getInputEmbeddings` handle `input.audio` / `input.video`), but `Gemma4UnifiedProcessor` only produced image inputs, so audio and video never reached the model. This is the follow-up noted in #391 ("the encoder-free Gemma4Unified (12B) processor video block"), plus the audio path.

## Audio (encoder-free — no mel, no conformer)

Unlike the `gemma4` E-series (whose audio tower is ported in #392), the unified models project raw waveform frames directly into the LLM embedding space:

- The 16 kHz waveform is zero-padded to a multiple of `audio_samples_per_token` (640 = 40 ms) and reshaped into `[1, T, 640]` frames — each frame is the feature vector, one soft token per frame (25 tokens/s).
- Clips are truncated to `audio_seq_length` tokens (750 = 30 s) so the placeholder count always matches the feature rows the model scatters. (The Python processor caps placeholders but does not truncate features; truncating the waveform keeps the two consistent.)
- Each `<|audio|>` placeholder expands to `boa + <|audio|> × N + eoa`, `N = ceil(samples / 640)` capped at 750.
- Multiple clips are batched to the longest with the validity mask false on padding (mask semantics: true = valid, used as-is — the unified path does not invert it like the conformer path).

Matches HF `Gemma4UnifiedAudioFeatureExtractor` / `Gemma4UnifiedProcessor` and mlx-vlm `gemma4_unified` (algorithm cross-checked against both, plus the `mlx-community/gemma-4-12B-it-4bit` checkpoint config/tokenizer files).

## Video

- Samples up to `video_max_frames` frames (~1 fps via `MediaProcessing.asProcessedSequence`, matching the `gemma4` processor in #391).
- Each frame goes through the same aspect-preserving resize + patchify pipeline as images, but with the per-frame `vision_soft_tokens_per_video_frame` budget (70) instead of 280; per-frame padding uses `-1` position ids, which the model already strips before scattering.
- Each `<|video|>` placeholder expands into per-frame `mm:ss {boi}{<|video|> × N}{eoi}` blocks joined by spaces, matching the HF/mlx-vlm processors (timestamps from the actual frame times). The timestamp text is tokenized in isolation, so token merges at the leading text boundary can differ slightly from tokenizing the fully expanded prompt string.

## Config

`Gemma4UnifiedProcessorConfiguration` now decodes: `boa_token_id` / `eoa_token_id` (including the `eoa_token_index` spelling used by the released checkpoints), audio sampling rate and samples-per-token from the nested `feature_extractor` block of `processor_config.json` (whose mel-related keys are vestigial and ignored, as in the Python implementations), and the video budget/frame-count keys.

`Gemma4MessageGenerator` additionally emits `{"type": "audio"}` content parts (3 lines, also part of #392 — trivial to resolve whichever lands first).

## Tests

9 new tests in `Gemma4UnifiedAudioVideoTests`: config decoding against the real `processor_config.json` shape, audio framing parity with the reference algorithm (exact values incl. tail zero-padding), the 30 s cap, batch padding/masking, a processor→model round trip that would throw on any placeholder/feature count mismatch, per-frame video budget + `-1` position padding, `mm:ss` formatting, and an end-to-end tiny-model video scatter. `xcodebuild test` on this branch passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)