### PR TITLE
Fix Gemma4 VLM load of QAT checkpoints: wire kvSharedOnly through the backbone

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1112,8 +1112,11 @@ final class Gemma4TextBackbone: Module {
 
         self._embedTokens.wrappedValue = Embedding(
             embeddingCount: config.vocabularySize, dimensions: config.hiddenSize)
+        let firstKVSharedLayer = config.hiddenLayers - config.numKVSharedLayers
         self._layers.wrappedValue = (0 ..< config.hiddenLayers).map {
-            Gemma4TextDecoderLayer(config: config, layerIdx: $0)
+            Gemma4TextDecoderLayer(
+                config: config, layerIdx: $0,
+                kvSharedOnly: firstKVSharedLayer > 0 && $0 >= firstKVSharedLayer)
         }
         self._norm.wrappedValue = Gemma4RMSNormZeroShift(
             dimensions: config.hiddenSize, eps: config.rmsNormEps)


### PR DESCRIPTION
`Gemma4TextAttention` / `Gemma4TextDecoderLayer` accept `kvSharedOnly` to skip building `k_proj`/`v_proj`/`k_norm`/`v_norm` on KV-shared layers — #330's sanitize drop relies on those module slots not existing — but `Gemma4TextBackbone` constructs every layer with the default (`false`). Checkpoints that omit the redundant tensors (e.g. `mlx-community/gemma-4-e2b-it-4bit`) fail to load:

```
keyNotFound(path: ["language_model", "model", "layers", "15", "self_attn", "k_proj", "weight"], …)
```

This passes `kvSharedOnly` for layers `>= hiddenLayers - numKVSharedLayers`, the same boundary the attention/MLP/cache-map already use.

Verified with `gemma-4-e2b-it-4bit` (35 layers, 20 shared): loads, generates text, and describes images correctly via the VLM processor.