### PR TITLE
Fix Qwen3.5 VLM garbage output: gate the RMSNorm weight shift in sanitize

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1071,6 +1071,19 @@ public class Qwen35: Module, VLMModel {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Whether the checkpoint stores RMSNorm weights in the raw (un-shifted)
+        // convention that needs the `+1` offset. Mirrors the MLXLLM Qwen35 gate
+        // so the VLM and text paths agree: a pre-converted MLX checkpoint
+        // (conv1d already sanitized, no MTP tensors) has already been shifted at
+        // conversion time and must NOT be shifted again — doing so double-shifts
+        // every layernorm and produces garbage tokens. Computed on the incoming
+        // weights, before the `mtp.` filter below.
+        let hasMTPWeights = weights.keys.contains { $0.contains("mtp.") }
+        let hasUnsanitizedConv1d = weights.contains { key, value in
+            key.contains("conv1d.weight") && value.dim(-1) != 1
+        }
+        let shouldShiftNormWeights = hasMTPWeights || hasUnsanitizedConv1d
+
         var weights = weights.filter { !$0.key.contains("mtp.") }
 
         if config.textConfiguration.tieWordEmbeddings {
@@ -1111,7 +1124,9 @@ public class Qwen35: Module, VLMModel {
             if key.contains("conv1d.weight") && value.dim(-1) != 1 {
                 value = value.movedAxis(source: 2, destination: 1)
             }
-            if normKeys.contains(where: { key.hasSuffix($0) }) && value.ndim == 1 {
+            if shouldShiftNormWeights
+                && normKeys.contains(where: { key.hasSuffix($0) }) && value.ndim == 1
+            {
                 value = value + MLXArray(1, dtype: value.dtype)
             }
 

--- a/Tests/MLXLMTests/Qwen35SanitizeTests.swift
+++ b/Tests/MLXLMTests/Qwen35SanitizeTests.swift
@@ -102,4 +102,49 @@ final class Qwen35SanitizeTests: XCTestCase {
                 "bare model.* key leaked through sanitize: \(key)")
         }
     }
+
+    /// A pre-converted MLX checkpoint (conv1d already sanitized, trailing dim
+    /// == 1, no MTP tensors) already stores RMSNorm weights in the shifted
+    /// convention. Sanitize must NOT add the `+1` again: double-shifting every
+    /// layernorm decoheres the whole model and produces garbage tokens. This is
+    /// the VLM/LLM sanitize divergence — the LLM path gated the shift, the VLM
+    /// path did not.
+    func testPreConvertedNormWeightsAreNotShifted() throws {
+        let config = try makeMinimalConfig()
+        let model = Qwen35(config)
+
+        let weights: [String: MLXArray] = [
+            // Sanitized conv1d (trailing dim == 1) marks an already-converted
+            // checkpoint, so the norm shift must be suppressed.
+            "language_model.model.layers.0.linear_attn.conv1d.weight": MLXArray.zeros([8, 4, 1]),
+            "language_model.model.norm.weight": MLXArray.zeros([8]),
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        let norm = try XCTUnwrap(sanitized["language_model.model.norm.weight"])
+        XCTAssertEqual(
+            norm.sum().item(Float.self), 0.0, accuracy: 1e-6,
+            "pre-converted norm weight must not be +1 shifted (double-shift => garbage)")
+    }
+
+    /// A raw HF checkpoint (unsanitized conv1d, trailing dim != 1) stores
+    /// RMSNorm weights un-shifted, so sanitize must add the `+1`.
+    func testRawCheckpointNormWeightsAreShifted() throws {
+        let config = try makeMinimalConfig()
+        let model = Qwen35(config)
+
+        let weights: [String: MLXArray] = [
+            // Unsanitized conv1d (trailing dim != 1) marks a raw checkpoint.
+            "language_model.model.layers.0.linear_attn.conv1d.weight": MLXArray.zeros([8, 1, 4]),
+            "language_model.model.norm.weight": MLXArray.zeros([8]),
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        let norm = try XCTUnwrap(sanitized["language_model.model.norm.weight"])
+        XCTAssertEqual(
+            norm.sum().item(Float.self), 8.0, accuracy: 1e-6,
+            "raw-checkpoint norm weight must be +1 shifted (8 zeros => sum 8)")
+    }
 }


### PR DESCRIPTION
## Proposed changes

`MLXVLM/Models/Qwen35.sanitize` applies the RMSNorm `+1` weight offset **unconditionally**, whereas `MLXLLM/Models/Qwen35.sanitize` gates it behind `hasMTPWeights || hasUnsanitizedConv1d`.

On an already-converted MLX checkpoint (conv1d weights already sanitized to a trailing dim of 1, no MTP tensors), the norm weights have already been shifted at conversion time. The VLM path shifts them a **second** time, doubling every `input_layernorm` / `post_attention_layernorm` / `q_norm` / `k_norm` / `model.norm`. That decoheres the model and produces garbage tokens.

The same weights loaded through the `MLXLLM` `Qwen35` path (which gates the shift) decode correctly — which isolates the divergence to `sanitize`, not the model math or the shared gated-delta kernel. Because Qwen3.5 is natively multimodal, every Qwen3.5 checkpoint routes through `VLMModelFactory` → the affected path, so all Qwen3.5 generation (text and multimodal) is broken on pre-converted checkpoints.

### Fix

Mirror the `MLXLLM` gate in the VLM `sanitize`: compute `shouldShiftNormWeights = hasMTPWeights || hasUnsanitizedConv1d` from the incoming weights and apply the `+1` only when true. This makes the VLM path reproduce the `MLXLLM` numerics.

### Reproduction

- Load a pre-converted Qwen3.5 VLM checkpoint via `VLMModelFactory` and greedily decode a trivial prompt → garbage before, coherent after.
- The same weights with `vision_config` removed route to `LLMModelFactory` and were already coherent (the control).

### Tests

Adds two `Qwen35SanitizeTests` cases: a pre-converted checkpoint (conv1d already sanitized) must **not** shift the norm weights; a raw checkpoint (unsanitized conv1d) must. Verified end-to-end on the previously-failing checkpoint (garbage → coherent).

```
xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' \
  -only-testing:MLXLMTests/Qwen35SanitizeTests
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (not needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
