### PR TITLE
CI: fix mac_build_and_test for mlx-swift >= 0.31.5 (skip package plugin validation) + swift-format 603 conformance

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,7 +88,7 @@ jobs:
           xcodebuild -version
           swift --version
           rm -rf ~/Library/Developer/Xcode/DerivedData/*
-          xcodebuild build-for-testing -scheme mlx-swift-lm-Package -destination 'platform=macOS'
+          xcodebuild build-for-testing -skipPackagePluginValidation -scheme mlx-swift-lm-Package -destination 'platform=macOS'
 
       - name: Verify documentation
         run: scripts/verify-docs.sh

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 import MLX
-@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
+
+@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 


### PR DESCRIPTION
## Proposed changes

CI has been red for every PR since 2026-06-30. This PR fixes both causes; no library code is changed.

### 1. `mac_build_and_test`: package plugin validation failure

Every run now fails during **Prepare packages**, before any project code compiles:

```
Validate plug-in "CudaBuild" in package "mlx-swift"
** TEST BUILD FAILED **
```

**Diagnosis.** [mlx-swift 0.31.5](https://github.com/ml-explore/mlx-swift/releases/tag/0.31.5) (via ml-explore/mlx-swift#413) attached the new `CudaBuild` build-tool plugin to the Cmlx target. Xcode treats SwiftPM build-tool plugins as arbitrary build-time code and requires a one-time interactive trust approval per plugin ("Trust & Enable" in the GUI). Non-interactive `xcodebuild` cannot grant it, so validation fails. Because this repo pins `.upToNextMinor(from: "0.31.4")` with no committed `Package.resolved`, CI resolves the newest 0.31.x fresh each run — 0.31.5 flowed in with no commit here to blame. The timeline is airtight: the last green run ([28461282349](https://github.com/ml-explore/mlx-swift-lm/actions/runs/28461282349)) resolved `mlx-swift @ 0.31.4` and finished at 17:08 UTC on 6/30; 0.31.5 was published at 17:33 UTC, 25 minutes later. Every subsequent run fails identically.

**Fix.** Add `-skipPackagePluginValidation` to the `xcodebuild build-for-testing` invocation — per `xcodebuild -help`, "Skip validation of package plugins"; it is the standard way to build a plugin-bearing SwiftPM graph on CI (see [Swift Forums on programmatic plugin trust for CI](https://forums.swift.org/t/how-do-i-get-xcode-to-programmatically-trust-a-specific-build-tool-plugin-for-ci/61331)).

**Why this is safe here:**
- The flag only suppresses the first-run trust prompt for this invocation. Dependency resolution, package signature validation, code signing, and test behavior are untouched.
- The `CudaBuild` plugin is a no-op on macOS: its `isCudaEnabled()` is `#if os(Linux)`-gated, so on the Mac runner it returns zero build commands. SwiftPM plugins also run sandboxed (write access only to their work directory).
- The job already checks out, builds, and runs test code from PR branches, and the plugin ships in `ml-explore/mlx-swift` itself — a first-party dependency — so the prompt adds no protection in this context.
- Alternative rejected: pre-approving the fingerprint (or `defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation`) on the runner works but is unversioned, invisible to contributors, and silently re-breaks on a runner rebuild. The workflow flag is auditable in the repo.

### 2. `lint`: swift-format 603.0.0 import ordering

The lint job builds the **latest** swift-format release on each run. 603.0.0 (current) orders attributed imports (`@_spi(Testing) @testable import …`) after plain imports, so `Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift` — clean under the previous release — now fails `pre-commit run --all` on every PR's merge ref, which gates `mac_build_and_test` behind a failure unrelated to any PR. The second commit applies exactly the diff swift-format 603.0.0 emits (verified locally with swift-format 603.0.0 over the whole tree; this is the only file affected). A longer-term option is pinning the swift-format version in the workflow instead of always building the latest release — happy to do that here or in a follow-up if preferred.

Since `pull_request` workflows run from the PR merge ref, this PR's own CI run demonstrates both fixes.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works (CI-only change — this PR's own green run is the test)
- [ ] I have updated the necessary documentation (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)