### PR TITLE
fix: Honor safetensors index when loading weights

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -4,10 +4,38 @@ import Foundation
 import MLX
 import MLXNN
 
+private struct SafetensorsIndex: Decodable {
+    let weightMap: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case weightMap = "weight_map"
+    }
+}
+
+package func safetensorWeightURLs(in modelDirectory: URL) throws -> [URL] {
+    let indexURL = modelDirectory.appendingPathComponent("model.safetensors.index.json")
+    if FileManager.default.fileExists(atPath: indexURL.path) {
+        let data = try Data(contentsOf: indexURL)
+        let index = try JSONDecoder().decode(SafetensorsIndex.self, from: data)
+        return Set(index.weightMap.values)
+            .sorted()
+            .map { modelDirectory.appendingPathComponent($0) }
+    }
+
+    let enumerator = FileManager.default.enumerator(
+        at: modelDirectory, includingPropertiesForKeys: nil)!
+    return enumerator.compactMap { item -> URL? in
+        guard let url = item as? URL, url.pathExtension == "safetensors" else {
+            return nil
+        }
+        return url
+    }
+}
+
 /// Load model weights.
 ///
 /// This is typically called via ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:)``.
-/// This function loads all `safetensor` files in the given `modelDirectory`,
+/// This function loads model weight `safetensor` files in the given `modelDirectory`,
 /// calls ``BaseLanguageModel/sanitize(weights:metadata:)`` to allow per-model preprocessing,
 /// applies optional quantization, and
 /// updates the model with the weights.
@@ -19,17 +47,13 @@ public func loadWeights(
     // load the weights and collect metadata from the first safetensor file
     var weights = [String: MLXArray]()
     var metadata = [String: String]()
-    let enumerator = FileManager.default.enumerator(
-        at: modelDirectory, includingPropertiesForKeys: nil)!
-    for case let url as URL in enumerator {
-        if url.pathExtension == "safetensors" {
-            let (w, m) = try loadArraysAndMetadata(url: url)
-            for (key, value) in w {
-                weights[key] = value
-            }
-            if metadata.isEmpty {
-                metadata = m
-            }
+    for url in try safetensorWeightURLs(in: modelDirectory) {
+        let (w, m) = try loadArraysAndMetadata(url: url)
+        for (key, value) in w {
+            weights[key] = value
+        }
+        if metadata.isEmpty {
+            metadata = m
         }
     }
 

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -1,0 +1,42 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLXLMCommon
+
+final class LoadWeightsTests: XCTestCase {
+
+    func testLoadWeightsUsesSafetensorsIndexWeightMapWhenPresent() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try writeEmptyFile("model.safetensors", in: directory)
+        try writeEmptyFile("mtp.safetensors", in: directory)
+        try writeEmptyFile("optiq_vision.safetensors", in: directory)
+        try """
+        {
+          "metadata": { "total_size": 1 },
+          "weight_map": {
+            "model.norm.weight": "model.safetensors"
+          }
+        }
+        """.data(using: .utf8)!.write(
+            to: directory.appendingPathComponent("model.safetensors.index.json"))
+
+        let names = try safetensorWeightURLs(in: directory).map(\.lastPathComponent)
+
+        XCTAssertEqual(names, ["model.safetensors"])
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LoadWeightsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeEmptyFile(_ name: String, in directory: URL) throws {
+        try Data().write(to: directory.appendingPathComponent(name))
+    }
+}

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 import MLX
-@_spi(Testing) @testable import MLXLMCommon
 import MLXNN
 import Testing
+
+@_spi(Testing) @testable import MLXLMCommon
 
 // MARK: - Synthetic mocks for iterator plumbing
 


### PR DESCRIPTION
## Proposed changes

`loadWeights` currently loads every `.safetensors` file found in the model directory. This can break checkpoints such as [`mlx-community/Qwen3.5-4B-OptiQ-4bit`](https://huggingface.co/mlx-community/Qwen3.5-4B-OptiQ-4bit/tree/main), whose directory contains the primary `model.safetensors` plus auxiliary safetensors files, while `model.safetensors.index.json` maps the model weights only to `model.safetensors`.

Loading the auxiliary files into the main model weight dictionary can pass unrelated tensors through model sanitization and corrupt generation. In the Qwen3.5 OptiQ case, this shows up as incoherent text generation even though the same checkpoint loads correctly through Python `mlx-lm`.

This PR treats `model.safetensors.index.json` as authoritative when it is present. In that case, `loadWeights` loads only the unique safetensors files referenced by `weight_map`. If no index file is present, the existing behavior is preserved: all `.safetensors` files in the directory are loaded.

A regression test covers the indexed case with extra safetensors in the same directory, ensuring only the indexed model weight file is selected.

Tested with:

- `xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -only-testing:MLXLMTests/LoadWeightsTests -skipPackagePluginValidation`
- `swift test --filter LoadWeightsTests`
- `swift format lint Libraries/MLXLMCommon/Load.swift Tests/MLXLMTests/LoadWeightsTests.swift`
- Local smoke test with `mlx-community/Qwen3.5-4B-OptiQ-4bit`: generation produces coherent Chinese text after the loader change.

## Test plan

- [x] `xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -only-testing:MLXLMTests/LoadWeightsTests -skipPackagePluginValidation`
- [x] `swift test --filter LoadWeightsTests`
- [x] `swift format lint Libraries/MLXLMCommon/Load.swift Tests/MLXLMTests/LoadWeightsTests.swift`
- [x] Local smoke test with `mlx-community/Qwen3.5-4B-OptiQ-4bit`: generation produces coherent Chinese text after the loader change.


## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
