### PR TITLE
Qwen3VL: apply the sRGB tone curve in the image preprocess path

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -52,7 +52,18 @@ public struct Qwen3VLProcessor: UserInputProcessor {
 
         let targetSize = CGSize(width: resizedWidth, height: resizedHeight)
 
-        let resampled = processed.map { MediaProcessing.resampleBicubic($0, to: targetSize) }
+        // The sRGB tone-curve step must precede resample/normalize: CoreImage
+        // filters run in a *linear-light* working space and `asMLXArray`
+        // renders with a nil colorSpace (raw working-space values), so without
+        // it the model receives linearized values instead of the gamma-encoded
+        // bytes the HF reference preprocesses — crushing dark-region contrast
+        // ~12× (near-black text becomes invisible to the model). The sibling
+        // Qwen25VL/Qwen2VL image paths and this file's own video path apply
+        // the same step.
+        let resampled = processed.map {
+            MediaProcessing.resampleBicubic(
+                MediaProcessing.inSRGBToneCurveSpace($0), to: targetSize)
+        }
 
         let normalized =
             resampled

--- a/Tests/MLXLMTests/Qwen3VLToneCurveTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLToneCurveTests.swift
@@ -1,0 +1,79 @@
+// Copyright © 2026 Apple Inc.
+
+import CoreGraphics
+import CoreImage
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MLXVLM
+
+/// The Qwen3VL image path must hand the model gamma-encoded sRGB values —
+/// the byte values the HF reference preprocesses — not CoreImage's
+/// linear-light working-space values. Without the tone-curve step, near-black
+/// content (e.g. dark-theme text at luminance 23/255 on a 6/255 background)
+/// reaches the ViT with ~12x less contrast than the reference and becomes
+/// unreadable, while bright content is barely affected.
+final class Qwen3VLToneCurveTests: XCTestCase {
+
+    private func makeProcessor() throws -> Qwen3VLProcessor {
+        let json = """
+            {
+              "image_mean": [0.5, 0.5, 0.5],
+              "image_std": [0.5, 0.5, 0.5],
+              "merge_size": 2,
+              "patch_size": 16,
+              "temporal_patch_size": 2,
+              "image_processor_type": "Qwen2VLImageProcessor"
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Qwen3VLProcessorConfiguration.self, from: Data(json.utf8))
+        return Qwen3VLProcessor(config, tokenizer: TestTokenizer())
+    }
+
+    /// A 64x64 sRGB image: background gray level 6 with a centered 32x32
+    /// block at gray level 23 — the luminances of a dark-theme screenshot's
+    /// background and a faint headline.
+    private func faintBlockImage() throws -> CIImage {
+        let side = 64
+        let block = 16 ..< 48
+        var pixels = [UInt8](repeating: 0, count: side * side * 4)
+        for y in 0 ..< side {
+            for x in 0 ..< side {
+                let level: UInt8 = block.contains(x) && block.contains(y) ? 23 : 6
+                let offset = (y * side + x) * 4
+                pixels[offset] = level
+                pixels[offset + 1] = level
+                pixels[offset + 2] = level
+                pixels[offset + 3] = 255
+            }
+        }
+        let provider = try XCTUnwrap(CGDataProvider(data: Data(pixels) as CFData))
+        let cgImage = try XCTUnwrap(
+            CGImage(
+                width: side, height: side, bitsPerComponent: 8, bitsPerPixel: 32,
+                bytesPerRow: side * 4,
+                space: try XCTUnwrap(CGColorSpace(name: CGColorSpace.sRGB)),
+                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue),
+                provider: provider, decode: nil, shouldInterpolate: false,
+                intent: .defaultIntent))
+        return CIImage(cgImage: cgImage)
+    }
+
+    func testDarkContentKeepsGammaEncodedContrast() throws {
+        let processor = try makeProcessor()
+        let (pixels, _) = try processor.preprocess(
+            images: [faintBlockImage()], processing: nil)
+
+        // Patchify rearranges layout but preserves values, so global extrema
+        // are layout-independent. Reference (HF byte-value preprocessing with
+        // mean/std 0.5): block = (23/255 - 0.5)/0.5 ≈ -0.820, background =
+        // (6/255 - 0.5)/0.5 ≈ -0.953. The linear-space failure mode produced
+        // ≈ -0.984 / -0.996 — far outside these tolerances.
+        let maxValue = pixels.max().item(Float.self)
+        let minValue = pixels.min().item(Float.self)
+        XCTAssertEqual(maxValue, -0.820, accuracy: 0.05)
+        XCTAssertEqual(minValue, -0.953, accuracy: 0.05)
+    }
+}


### PR DESCRIPTION
Fixes #410.

The Qwen3VL **image** path hands the model CoreImage's linear-light working-space values instead of the gamma-encoded sRGB values the HF reference preprocesses: CoreImage filters run in linear light and `MediaProcessing.asMLXArray` renders with a nil colorSpace. The sibling `Qwen25VL`/`Qwen2VL` image paths and this file's own **video** path all apply the linear→sRGB tone-curve step; the Qwen3VL port dropped it in the image path.

Bright content survives the error; dark content does not — near-black text (luminance 23/255 on a 6/255 background) reaches the ViT with ~12× less contrast than reference and is unreadable. Measured on the incident screenshot (text-vs-background signal after mean/std-0.5 normalization): **0.011** without the step, **0.126** with it, HF reference **0.133**. Before/after screenshots in #410.

The change is the one-line `inSRGBToneCurveSpace` wrap at the resample site, plus a regression test (`Qwen3VLToneCurveTests`) that runs a synthetic faint dark-theme fixture through `preprocess` and pins the model-side extrema to the gamma-encoded reference values — the linear-space failure mode lands far outside the tolerances.

Note: textually adjacent to #398 (both touch the resample site); whichever lands second is a trivial rebase.
