### PR TITLE
Generation: honor suppress_tokens and mask multimodal placeholder tokens

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -585,6 +585,11 @@ public final class LLMModelFactory: GenericModelFactory {
             eosTokenIds = Set(genEosIds)  // Override per Python mlx-lm behavior
         }
 
+        // Honor `suppress_tokens` from generation_config.json (transformers'
+        // SuppressTokensLogitsProcessor): merge into the model's suppressed
+        // token IDs so the token iterators mask them during sampling.
+        mergeGenerationConfigSuppressedTokens(generationConfig, into: model)
+
         // Build a ModelConfiguration with loaded EOS token IDs and tool call format
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -711,6 +711,11 @@ public final class LLMModelFactory: GenericModelFactory {
             eosTokenIds = Set(genEosIds)  // Override per Python mlx-lm behavior
         }
 
+        // Honor `suppress_tokens` from generation_config.json (transformers'
+        // SuppressTokensLogitsProcessor): merge into the model's suppressed
+        // token IDs so the token iterators mask them during sampling.
+        mergeGenerationConfigSuppressedTokens(generationConfig, into: model)
+
         // Build a ModelConfiguration with loaded EOS token IDs and tool call format
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -590,7 +590,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.y = .init(tokens: prompt)
         self.cache = cache ?? model.newCache(parameters: parameters)
 
-        self.processor = parameters.processor()
+        self.processor = makeLogitProcessor(parameters: parameters, model: model)
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
 
@@ -624,7 +624,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.y = input.text
         self.cache = cache ?? model.newCache(parameters: parameters)
 
-        self.processor = parameters.processor()
+        self.processor = makeLogitProcessor(parameters: parameters, model: model)
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
 
@@ -834,7 +834,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         self.sampler = parameters.sampler()
-        self.processor = parameters.processor()
+        self.processor = makeLogitProcessor(parameters: parameters, model: mainModel)
 
         self.maxTokens = parameters.maxTokens
         self.numDraftTokens = numDraftTokens

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -797,7 +797,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.cacheStorage = cacheStorage
 
         try components.validate(parameters: parameters)
-        self.processor = components.logitProcessor(parameters: parameters)
+        self.processor = components.logitProcessor(parameters: parameters, model: model)
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
 
@@ -1114,7 +1114,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.sampler = parameters.sampler()
         try components.validate(parameters: parameters)
-        self.processor = components.logitProcessor(parameters: parameters)
+        self.processor = components.logitProcessor(parameters: parameters, model: mainModel)
 
         self.maxTokens = parameters.maxTokens
         self.numDraftTokens = numDraftTokens

--- a/Libraries/MLXLMCommon/GenerationComponents.swift
+++ b/Libraries/MLXLMCommon/GenerationComponents.swift
@@ -123,7 +123,8 @@ public struct GenerationComponents: Sendable {
     }
 
     /// As ``logitProcessor(parameters:)``, additionally masking the token ids
-    /// the model declares through ``SuppressedTokensProviding``.
+    /// the model suppresses -- declared through ``SuppressedTokensProviding``
+    /// or read from its `generation_config.json`.
     ///
     /// Suppression runs last so that no processor composed before it can
     /// reintroduce a masked id -- for multimodal placeholder tokens, emitting
@@ -132,9 +133,7 @@ public struct GenerationComponents: Sendable {
         parameters: GenerateParameters, model: any LanguageModel
     ) -> LogitProcessor? {
         let base = logitProcessor(parameters: parameters)
-        guard let provider = model as? SuppressedTokensProviding,
-            let suppressor = SuppressTokensProcessor(tokenIds: provider.suppressedTokenIds)
-        else {
+        guard let suppressor = makeSuppressTokensProcessor(model: model) else {
             return base
         }
         guard let base else { return suppressor }

--- a/Libraries/MLXLMCommon/GenerationComponents.swift
+++ b/Libraries/MLXLMCommon/GenerationComponents.swift
@@ -121,4 +121,23 @@ public struct GenerationComponents: Sendable {
             return ChainedLogitProcessor(processors: [penalty, custom])
         }
     }
+
+    /// As ``logitProcessor(parameters:)``, additionally masking the token ids
+    /// the model declares through ``SuppressedTokensProviding``.
+    ///
+    /// Suppression runs last so that no processor composed before it can
+    /// reintroduce a masked id -- for multimodal placeholder tokens, emitting
+    /// one is never valid output.
+    public func logitProcessor(
+        parameters: GenerateParameters, model: any LanguageModel
+    ) -> LogitProcessor? {
+        let base = logitProcessor(parameters: parameters)
+        guard let provider = model as? SuppressedTokensProviding,
+            let suppressor = SuppressTokensProcessor(tokenIds: provider.suppressedTokenIds)
+        else {
+            return base
+        }
+        guard let base else { return suppressor }
+        return ChainedLogitProcessor(processors: [base, suppressor])
+    }
 }

--- a/Libraries/MLXLMCommon/GenerationConfigFile.swift
+++ b/Libraries/MLXLMCommon/GenerationConfigFile.swift
@@ -7,24 +7,36 @@ import Foundation
 /// This file can override values from `config.json`, particularly `eos_token_id`.
 /// Following mlx-lm Python behavior, if `generation_config.json` exists and contains
 /// `eos_token_id`, it takes precedence over the value in `config.json`.
+///
+/// It can also declare `suppress_tokens`: token IDs that must never be sampled
+/// during generation (see `SuppressTokensLogitsProcessor` in Hugging Face
+/// transformers). Model factories merge these into the model's
+/// ``SuppressedTokensProviding/suppressedTokenIds``.
 public struct GenerationConfigFile: Codable, Sendable {
     public var eosTokenIds: IntOrIntArray?
     public var stopStrings: Set<String>
+    public var suppressTokens: IntOrIntArray?
 
     enum CodingKeys: String, CodingKey {
         case eosTokenIds = "eos_token_id"
         case stopStrings = "stop_strings"
         case stop
+        case suppressTokens = "suppress_tokens"
     }
 
-    public init(eosTokenIds: IntOrIntArray? = nil, stopStrings: Set<String> = []) {
+    public init(
+        eosTokenIds: IntOrIntArray? = nil, stopStrings: Set<String> = [],
+        suppressTokens: IntOrIntArray? = nil
+    ) {
         self.eosTokenIds = eosTokenIds
         self.stopStrings = stopStrings
+        self.suppressTokens = suppressTokens
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         eosTokenIds = try container.decodeIfPresent(IntOrIntArray.self, forKey: .eosTokenIds)
+        suppressTokens = try container.decodeIfPresent(IntOrIntArray.self, forKey: .suppressTokens)
 
         stopStrings = []
         stopStrings.formUnion(Self.decodeStringSet(from: container, forKey: .stopStrings))
@@ -34,6 +46,7 @@ public struct GenerationConfigFile: Codable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(eosTokenIds, forKey: .eosTokenIds)
+        try container.encodeIfPresent(suppressTokens, forKey: .suppressTokens)
         if !stopStrings.isEmpty {
             try container.encode(stopStrings.sorted(), forKey: .stopStrings)
         }

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -118,7 +118,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         self.sampler = parameters.sampler()
-        self.processor = parameters.processor()
+        self.processor = makeLogitProcessor(parameters: parameters, model: mainModel)
 
         self.maxTokens = parameters.maxTokens
         self.blockSize = blockSize

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -44,6 +44,13 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     var processor: LogitProcessor?
     let sampler: LogitSampler
 
+    /// Sampler handed to ``MTPDrafterModel/draftBlock``: the base sampler,
+    /// wrapped to mask suppressed token IDs when the target has any.
+    /// `draftBlock` receives no ``LogitProcessor``, and an unsuppressed
+    /// draft of a suppressed token would always be rejected by the
+    /// verifier, wasting draft slots.
+    let draftSampler: LogitSampler
+
     public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
     /// Total tokens proposed per round (`blockSize - 1` drafted, plus the
@@ -119,6 +126,11 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.sampler = parameters.sampler()
         self.processor = makeLogitProcessor(parameters: parameters, model: mainModel)
+        if let suppressor = makeSuppressTokensProcessor(model: mainModel) {
+            self.draftSampler = SuppressTokensSampler(base: self.sampler, suppressor: suppressor)
+        } else {
+            self.draftSampler = self.sampler
+        }
 
         self.maxTokens = parameters.maxTokens
         self.blockSize = blockSize
@@ -275,7 +287,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             sharedKV: sharedKV,
             queryOffset: cacheOffset,
             blockSize: numDraft + 1,  // total round size: bonus + numDraft
-            sampler: sampler
+            sampler: draftSampler
         )
         // draftTokens shape [B, numDraft] -> flatten to [numDraft].
         let flatDraftTokens = draftTokens.flattened()

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -49,6 +49,13 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     var processor: LogitProcessor?
     let sampler: LogitSampler
 
+    /// Sampler handed to ``MTPDrafterModel/draftBlock``: the base sampler,
+    /// wrapped to mask suppressed token IDs when the target has any.
+    /// `draftBlock` receives no ``LogitProcessor``, and an unsuppressed
+    /// draft of a suppressed token would always be rejected by the
+    /// verifier, wasting draft slots.
+    let draftSampler: LogitSampler
+
     public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
     /// Total tokens proposed per round (`blockSize - 1` drafted, plus the
@@ -130,6 +137,14 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         self.sampler = parameters.sampler()
         try components.validate(parameters: parameters)
         self.processor = components.logitProcessor(parameters: parameters, model: mainModel)
+        // Draft proposals bypass the iterator's processor chain, so suppressed
+        // ids have to be masked at the drafter's own sampler: a proposal the
+        // verifier will always reject is a wasted speculation slot.
+        if let suppressor = makeSuppressTokensProcessor(model: mainModel) {
+            self.draftSampler = SuppressTokensSampler(base: self.sampler, suppressor: suppressor)
+        } else {
+            self.draftSampler = self.sampler
+        }
 
         self.maxTokens = parameters.maxTokens
         // A round presents `blockSize` positions at once, and a sliding layer can only show a
@@ -466,7 +481,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
                 queryOffset: queryOffset,
                 blockSize: numDraft + 1,  // total round size: bonus + numDraft
                 state: &currentDrafterState,
-                sampler: sampler
+                sampler: draftSampler
             )
             drafterState = currentDrafterState
         } else {
@@ -478,7 +493,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
                 positionDeltas: state[mtpPositionDeltasKey],
                 queryOffset: queryOffset,
                 blockSize: numDraft + 1,  // total round size: bonus + numDraft
-                sampler: sampler
+                sampler: draftSampler
             )
         }
         // draftTokens shape [B, numDraft] -> flatten to [numDraft].

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -129,7 +129,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.sampler = parameters.sampler()
         try components.validate(parameters: parameters)
-        self.processor = components.logitProcessor(parameters: parameters)
+        self.processor = components.logitProcessor(parameters: parameters, model: mainModel)
 
         self.maxTokens = parameters.maxTokens
         // A round presents `blockSize` positions at once, and a sliding layer can only show a

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -395,6 +395,10 @@ public func loadParoQuantModel<T: LanguageModel>(
         eosTokenIds = Set(genEos)
     }
 
+    // Honor `suppress_tokens` from generation_config.json: merge into the
+    // model's suppressed token IDs so they are masked during sampling.
+    mergeGenerationConfigSuppressedTokens(genConfig, into: model)
+
     var config = ModelConfiguration(
         directory: directory, stopStrings: genConfig?.stopStrings,
         toolCallFormat: toolCallFormat)

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -625,6 +625,10 @@ public func loadParoQuantModel<T: LanguageModel>(
         eosTokenIds = Set(genEos)
     }
 
+    // Honor `suppress_tokens` from generation_config.json: merge into the
+    // model's suppressed token IDs so they are masked during sampling.
+    mergeGenerationConfigSuppressedTokens(genConfig, into: model)
+
     var config = ModelConfiguration(
         directory: directory, stopStrings: genConfig?.stopStrings,
         toolCallFormat: toolCallFormat)

--- a/Libraries/MLXLMCommon/SuppressTokens.swift
+++ b/Libraries/MLXLMCommon/SuppressTokens.swift
@@ -31,8 +31,16 @@ public protocol SuppressedTokensProviding: AnyObject {
 /// which is driven by `suppress_tokens` in `generation_config.json`.
 public struct SuppressTokensProcessor: LogitProcessor {
 
+    /// Suppressed vocabulary indices, sorted ascending. IDs at or beyond the
+    /// logits vocabulary size are dropped at ``process(logits:)`` time, so a
+    /// configuration that inherits placeholder defaults larger than the
+    /// model's vocabulary (e.g. tiny test configs) degrades to a no-op
+    /// instead of indexing out of range.
+    private let sortedIds: [Int]
+
     /// Suppressed vocabulary indices, shaped `[1, N]` for broadcasting
-    /// against `[B, vocab]` logits.
+    /// against `[B, vocab]` logits. Fast path used when every ID fits the
+    /// logits vocabulary.
     private let broadcastIndices: MLXArray
 
     /// `-inf` fill values, shaped `[1, N]` to match `broadcastIndices`.
@@ -40,11 +48,13 @@ public struct SuppressTokensProcessor: LogitProcessor {
 
     /// Create a processor masking the given token IDs.
     ///
-    /// Returns `nil` when `tokenIds` is empty (nothing to suppress).
+    /// Negative IDs are ignored. Returns `nil` when no valid IDs remain
+    /// (nothing to suppress).
     public init?(tokenIds: Set<Int>) {
-        guard !tokenIds.isEmpty else { return nil }
-        let sorted = tokenIds.sorted().map { UInt32($0) }
-        self.broadcastIndices = MLXArray(sorted)[.newAxis, 0...]
+        let sorted = tokenIds.filter { $0 >= 0 }.sorted()
+        guard !sorted.isEmpty else { return nil }
+        self.sortedIds = sorted
+        self.broadcastIndices = MLXArray(sorted.map { UInt32($0) })[.newAxis, 0...]
         self.negInfValues =
             MLXArray([Float](repeating: -Float.infinity, count: sorted.count))[
                 .newAxis, 0...]
@@ -55,8 +65,19 @@ public struct SuppressTokensProcessor: LogitProcessor {
     }
 
     public func process(logits: MLXArray) -> MLXArray {
-        putAlong(
-            logits, broadcastIndices, values: negInfValues.asType(logits.dtype), axis: -1)
+        let vocabularySize = logits.dim(-1)
+        if sortedIds.last! < vocabularySize {
+            return putAlong(
+                logits, broadcastIndices, values: negInfValues.asType(logits.dtype), axis: -1)
+        }
+        // Slow path: some IDs exceed this model's vocabulary — mask only the
+        // in-range subset.
+        let valid = sortedIds.prefix { $0 < vocabularySize }
+        guard !valid.isEmpty else { return logits }
+        let indices = MLXArray(valid.map { UInt32($0) })[.newAxis, 0...]
+        let values = MLXArray([Float](repeating: -Float.infinity, count: valid.count))[
+            .newAxis, 0...]
+        return putAlong(logits, indices, values: values.asType(logits.dtype), axis: -1)
     }
 
     public mutating func didSample(token: MLXArray) {
@@ -90,31 +111,99 @@ public struct ChainedLogitProcessor: LogitProcessor {
     }
 }
 
-/// Merge `suppress_tokens` from `generation_config.json` into the model's
-/// ``SuppressedTokensProviding/suppressedTokenIds``.
+/// Side table associating suppressed token IDs with models that do not
+/// conform to ``SuppressedTokensProviding``.
 ///
-/// No-op when the configuration declares no suppressed tokens or the model
-/// does not conform to ``SuppressedTokensProviding``. Called by the model
-/// factories after the model is created.
+/// `suppress_tokens` from `generation_config.json` must be honored for every
+/// model, not only those that adopt the protocol; this registry provides the
+/// storage for the rest. Keys are held weakly, so entries disappear with
+/// their model.
+private final class SuppressedTokensRegistry: @unchecked Sendable {
+
+    static let shared = SuppressedTokensRegistry()
+
+    private let lock = NSLock()
+    private let table = NSMapTable<AnyObject, NSSet>.weakToStrongObjects()
+
+    func union(_ tokenIds: Set<Int>, for model: AnyObject) {
+        guard !tokenIds.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        let existing = (table.object(forKey: model) as? Set<Int>) ?? []
+        table.setObject(existing.union(tokenIds) as NSSet, forKey: model)
+    }
+
+    func tokenIds(for model: AnyObject) -> Set<Int> {
+        lock.lock()
+        defer { lock.unlock() }
+        return (table.object(forKey: model) as? Set<Int>) ?? []
+    }
+}
+
+/// Merge `suppress_tokens` from `generation_config.json` into the model's
+/// suppressed-token set.
+///
+/// Models conforming to ``SuppressedTokensProviding`` receive the IDs in
+/// ``SuppressedTokensProviding/suppressedTokenIds``; every other model is
+/// tracked in a weak side table, so `generation_config.json` is honored
+/// regardless of conformance. No-op when the configuration declares no
+/// suppressed tokens. Called by the model factories after the model is
+/// created.
 public func mergeGenerationConfigSuppressedTokens(
     _ generationConfig: GenerationConfigFile?, into model: any LanguageModel
 ) {
     guard let suppressTokens = generationConfig?.suppressTokens?.values else { return }
-    (model as? SuppressedTokensProviding)?.suppressedTokenIds.formUnion(suppressTokens)
+    if let provider = model as? SuppressedTokensProviding {
+        provider.suppressedTokenIds.formUnion(suppressTokens)
+    } else {
+        SuppressedTokensRegistry.shared.union(Set(suppressTokens), for: model)
+    }
+}
+
+/// The full suppressed-token set for a model: protocol-advertised IDs plus
+/// any `generation_config.json` IDs tracked in the side table.
+func suppressedTokenIds(for model: any LanguageModel) -> Set<Int> {
+    var ids = (model as? SuppressedTokensProviding)?.suppressedTokenIds ?? []
+    ids.formUnion(SuppressedTokensRegistry.shared.tokenIds(for: model))
+    return ids
+}
+
+/// Build the ``SuppressTokensProcessor`` for a model, or `nil` when it has
+/// no suppressed tokens.
+func makeSuppressTokensProcessor(model: any LanguageModel) -> SuppressTokensProcessor? {
+    SuppressTokensProcessor(tokenIds: suppressedTokenIds(for: model))
 }
 
 /// Build the ``LogitProcessor`` for a generation run: the parameter-derived
 /// penalty processor chained with a ``SuppressTokensProcessor`` when the
-/// model advertises suppressed token IDs via ``SuppressedTokensProviding``.
+/// model has suppressed token IDs (via ``SuppressedTokensProviding`` or
+/// `generation_config.json`).
 func makeLogitProcessor(
     parameters: GenerateParameters, model: any LanguageModel
 ) -> LogitProcessor? {
     let base = parameters.processor()
-    guard let provider = model as? SuppressedTokensProviding,
-        let suppressor = SuppressTokensProcessor(tokenIds: provider.suppressedTokenIds)
-    else {
+    guard let suppressor = makeSuppressTokensProcessor(model: model) else {
         return base
     }
     guard let base else { return suppressor }
     return ChainedLogitProcessor(processors: [base, suppressor])
+}
+
+/// A ``LogitSampler`` that masks suppressed token IDs before delegating to a
+/// base sampler.
+///
+/// Used for draft-token sampling paths that receive a sampler but not the
+/// iterator's ``LogitProcessor`` chain (e.g.
+/// ``MTPDrafterModel/draftBlock(target:lastToken:lastHidden:sharedKV:queryOffset:blockSize:sampler:)``).
+/// Draft proposals of suppressed tokens would always be rejected by the
+/// verifier — masking them at the source keeps speculative acceptance high.
+/// ``SuppressTokensProcessor`` is stateless, so wrapping is safe.
+struct SuppressTokensSampler: LogitSampler {
+
+    let base: LogitSampler
+    let suppressor: SuppressTokensProcessor
+
+    func sample(logits: MLXArray) -> MLXArray {
+        base.sample(logits: suppressor.process(logits: logits))
+    }
 }

--- a/Libraries/MLXLMCommon/SuppressTokens.swift
+++ b/Libraries/MLXLMCommon/SuppressTokens.swift
@@ -1,0 +1,120 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// A language model that exposes token IDs that must never be sampled
+/// during generation.
+///
+/// Multimodal models seed this set with the placeholder token IDs from their
+/// configuration (image / audio / video soft tokens and their begin/end
+/// markers). Those tokens are prompt-side markers that carry no meaning as
+/// generated text, but they can occasionally be sampled if left unmasked and
+/// then leak into the output verbatim (e.g. `<audio|>` read aloud by TTS).
+/// Model factories additionally merge `suppress_tokens` from
+/// `generation_config.json` into this set after the model is created.
+///
+/// Token iterators consult this set at initialization and chain a
+/// ``SuppressTokensProcessor`` after the parameter-derived processor, masking
+/// the corresponding logits to `-inf` before sampling. Only generated tokens
+/// are affected; prompt tokens are never modified.
+public protocol SuppressedTokensProviding: AnyObject {
+
+    /// Token IDs whose logits are masked to `-inf` before sampling.
+    var suppressedTokenIds: Set<Int> { get set }
+}
+
+/// Processor that masks a fixed set of token IDs to `-inf` so they can never
+/// be sampled.
+///
+/// Port of `SuppressTokensLogitsProcessor` from Hugging Face `transformers`,
+/// which is driven by `suppress_tokens` in `generation_config.json`.
+public struct SuppressTokensProcessor: LogitProcessor {
+
+    /// Suppressed vocabulary indices, shaped `[1, N]` for broadcasting
+    /// against `[B, vocab]` logits.
+    private let broadcastIndices: MLXArray
+
+    /// `-inf` fill values, shaped `[1, N]` to match `broadcastIndices`.
+    private let negInfValues: MLXArray
+
+    /// Create a processor masking the given token IDs.
+    ///
+    /// Returns `nil` when `tokenIds` is empty (nothing to suppress).
+    public init?(tokenIds: Set<Int>) {
+        guard !tokenIds.isEmpty else { return nil }
+        let sorted = tokenIds.sorted().map { UInt32($0) }
+        self.broadcastIndices = MLXArray(sorted)[.newAxis, 0...]
+        self.negInfValues =
+            MLXArray([Float](repeating: -Float.infinity, count: sorted.count))[
+                .newAxis, 0...]
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        // Stateless: suppression does not depend on the prompt.
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        putAlong(
+            logits, broadcastIndices, values: negInfValues.asType(logits.dtype), axis: -1)
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        // Stateless: nothing to track.
+    }
+}
+
+/// Processor that applies multiple ``LogitProcessor``s in order.
+public struct ChainedLogitProcessor: LogitProcessor {
+
+    private var processors: [any LogitProcessor]
+
+    public init(processors: [any LogitProcessor]) {
+        self.processors = processors
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        for index in processors.indices {
+            processors[index].prompt(prompt)
+        }
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        processors.reduce(logits) { $1.process(logits: $0) }
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        for index in processors.indices {
+            processors[index].didSample(token: token)
+        }
+    }
+}
+
+/// Merge `suppress_tokens` from `generation_config.json` into the model's
+/// ``SuppressedTokensProviding/suppressedTokenIds``.
+///
+/// No-op when the configuration declares no suppressed tokens or the model
+/// does not conform to ``SuppressedTokensProviding``. Called by the model
+/// factories after the model is created.
+public func mergeGenerationConfigSuppressedTokens(
+    _ generationConfig: GenerationConfigFile?, into model: any LanguageModel
+) {
+    guard let suppressTokens = generationConfig?.suppressTokens?.values else { return }
+    (model as? SuppressedTokensProviding)?.suppressedTokenIds.formUnion(suppressTokens)
+}
+
+/// Build the ``LogitProcessor`` for a generation run: the parameter-derived
+/// penalty processor chained with a ``SuppressTokensProcessor`` when the
+/// model advertises suppressed token IDs via ``SuppressedTokensProviding``.
+func makeLogitProcessor(
+    parameters: GenerateParameters, model: any LanguageModel
+) -> LogitProcessor? {
+    let base = parameters.processor()
+    guard let provider = model as? SuppressedTokensProviding,
+        let suppressor = SuppressTokensProcessor(tokenIds: provider.suppressedTokenIds)
+    else {
+        return base
+    }
+    guard let base else { return suppressor }
+    return ChainedLogitProcessor(processors: [base, suppressor])
+}

--- a/Libraries/MLXLMCommon/SuppressTokens.swift
+++ b/Libraries/MLXLMCommon/SuppressTokens.swift
@@ -1,0 +1,78 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// A language model that exposes token IDs that must never be sampled
+/// during generation.
+///
+/// Multimodal models seed this set with the placeholder token IDs from their
+/// configuration (image / audio / video soft tokens and their begin/end
+/// markers). Those tokens are prompt-side markers that carry no meaning as
+/// generated text, but they can occasionally be sampled if left unmasked and
+/// then leak into the output verbatim (e.g. `<audio|>` read aloud by TTS).
+/// Model factories additionally merge `suppress_tokens` from
+/// `generation_config.json` into this set after the model is created.
+///
+/// Token iterators consult this set at initialization and chain a
+/// ``SuppressTokensProcessor`` after the parameter-derived processor, masking
+/// the corresponding logits to `-inf` before sampling. Only generated tokens
+/// are affected; prompt tokens are never modified.
+public protocol SuppressedTokensProviding: AnyObject {
+
+    /// Token IDs whose logits are masked to `-inf` before sampling.
+    var suppressedTokenIds: Set<Int> { get set }
+}
+
+/// Processor that masks a fixed set of token IDs to `-inf` so they can never
+/// be sampled.
+///
+/// Port of `SuppressTokensLogitsProcessor` from Hugging Face `transformers`,
+/// which is driven by `suppress_tokens` in `generation_config.json`.
+public struct SuppressTokensProcessor: LogitProcessor {
+
+    /// Suppressed vocabulary indices, shaped `[1, N]` for broadcasting
+    /// against `[B, vocab]` logits.
+    private let broadcastIndices: MLXArray
+
+    /// `-inf` fill values, shaped `[1, N]` to match `broadcastIndices`.
+    private let negInfValues: MLXArray
+
+    /// Create a processor masking the given token IDs.
+    ///
+    /// Returns `nil` when `tokenIds` is empty (nothing to suppress).
+    public init?(tokenIds: Set<Int>) {
+        guard !tokenIds.isEmpty else { return nil }
+        let sorted = tokenIds.sorted().map { UInt32($0) }
+        self.broadcastIndices = MLXArray(sorted)[.newAxis, 0...]
+        self.negInfValues =
+            MLXArray([Float](repeating: -Float.infinity, count: sorted.count))[
+                .newAxis, 0...]
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        // Stateless: suppression does not depend on the prompt.
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        putAlong(
+            logits, broadcastIndices, values: negInfValues.asType(logits.dtype), axis: -1)
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        // Stateless: nothing to track.
+    }
+}
+
+/// Merge `suppress_tokens` from `generation_config.json` into the model's
+/// ``SuppressedTokensProviding/suppressedTokenIds``.
+///
+/// No-op when the configuration declares no suppressed tokens or the model
+/// does not conform to ``SuppressedTokensProviding``. Called by the model
+/// factories after the model is created.
+public func mergeGenerationConfigSuppressedTokens(
+    _ generationConfig: GenerationConfigFile?, into model: any LanguageModel
+) {
+    guard let suppressTokens = generationConfig?.suppressTokens?.values else { return }
+    (model as? SuppressedTokensProviding)?.suppressedTokenIds.formUnion(suppressTokens)
+}

--- a/Libraries/MLXLMCommon/SuppressTokens.swift
+++ b/Libraries/MLXLMCommon/SuppressTokens.swift
@@ -31,8 +31,16 @@ public protocol SuppressedTokensProviding: AnyObject {
 /// which is driven by `suppress_tokens` in `generation_config.json`.
 public struct SuppressTokensProcessor: LogitProcessor {
 
+    /// Suppressed vocabulary indices, sorted ascending. IDs at or beyond the
+    /// logits vocabulary size are dropped at ``process(logits:)`` time, so a
+    /// configuration that inherits placeholder defaults larger than the
+    /// model's vocabulary (e.g. tiny test configs) degrades to a no-op
+    /// instead of indexing out of range.
+    private let sortedIds: [Int]
+
     /// Suppressed vocabulary indices, shaped `[1, N]` for broadcasting
-    /// against `[B, vocab]` logits.
+    /// against `[B, vocab]` logits. Fast path used when every ID fits the
+    /// logits vocabulary.
     private let broadcastIndices: MLXArray
 
     /// `-inf` fill values, shaped `[1, N]` to match `broadcastIndices`.
@@ -40,11 +48,13 @@ public struct SuppressTokensProcessor: LogitProcessor {
 
     /// Create a processor masking the given token IDs.
     ///
-    /// Returns `nil` when `tokenIds` is empty (nothing to suppress).
+    /// Negative IDs are ignored. Returns `nil` when no valid IDs remain
+    /// (nothing to suppress).
     public init?(tokenIds: Set<Int>) {
-        guard !tokenIds.isEmpty else { return nil }
-        let sorted = tokenIds.sorted().map { UInt32($0) }
-        self.broadcastIndices = MLXArray(sorted)[.newAxis, 0...]
+        let sorted = tokenIds.filter { $0 >= 0 }.sorted()
+        guard !sorted.isEmpty else { return nil }
+        self.sortedIds = sorted
+        self.broadcastIndices = MLXArray(sorted.map { UInt32($0) })[.newAxis, 0...]
         self.negInfValues =
             MLXArray([Float](repeating: -Float.infinity, count: sorted.count))[
                 .newAxis, 0...]
@@ -55,8 +65,19 @@ public struct SuppressTokensProcessor: LogitProcessor {
     }
 
     public func process(logits: MLXArray) -> MLXArray {
-        putAlong(
-            logits, broadcastIndices, values: negInfValues.asType(logits.dtype), axis: -1)
+        let vocabularySize = logits.dim(-1)
+        if sortedIds.last! < vocabularySize {
+            return putAlong(
+                logits, broadcastIndices, values: negInfValues.asType(logits.dtype), axis: -1)
+        }
+        // Slow path: some IDs exceed this model's vocabulary — mask only the
+        // in-range subset.
+        let valid = sortedIds.prefix { $0 < vocabularySize }
+        guard !valid.isEmpty else { return logits }
+        let indices = MLXArray(valid.map { UInt32($0) })[.newAxis, 0...]
+        let values = MLXArray([Float](repeating: -Float.infinity, count: valid.count))[
+            .newAxis, 0...]
+        return putAlong(logits, indices, values: values.asType(logits.dtype), axis: -1)
     }
 
     public mutating func didSample(token: MLXArray) {
@@ -64,15 +85,84 @@ public struct SuppressTokensProcessor: LogitProcessor {
     }
 }
 
-/// Merge `suppress_tokens` from `generation_config.json` into the model's
-/// ``SuppressedTokensProviding/suppressedTokenIds``.
+/// Side table associating suppressed token IDs with models that do not
+/// conform to ``SuppressedTokensProviding``.
 ///
-/// No-op when the configuration declares no suppressed tokens or the model
-/// does not conform to ``SuppressedTokensProviding``. Called by the model
-/// factories after the model is created.
+/// `suppress_tokens` from `generation_config.json` must be honored for every
+/// model, not only those that adopt the protocol; this registry provides the
+/// storage for the rest. Keys are held weakly, so entries disappear with
+/// their model.
+private final class SuppressedTokensRegistry: @unchecked Sendable {
+
+    static let shared = SuppressedTokensRegistry()
+
+    private let lock = NSLock()
+    private let table = NSMapTable<AnyObject, NSSet>.weakToStrongObjects()
+
+    func union(_ tokenIds: Set<Int>, for model: AnyObject) {
+        guard !tokenIds.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        let existing = (table.object(forKey: model) as? Set<Int>) ?? []
+        table.setObject(existing.union(tokenIds) as NSSet, forKey: model)
+    }
+
+    func tokenIds(for model: AnyObject) -> Set<Int> {
+        lock.lock()
+        defer { lock.unlock() }
+        return (table.object(forKey: model) as? Set<Int>) ?? []
+    }
+}
+
+/// Merge `suppress_tokens` from `generation_config.json` into the model's
+/// suppressed-token set.
+///
+/// Models conforming to ``SuppressedTokensProviding`` receive the IDs in
+/// ``SuppressedTokensProviding/suppressedTokenIds``; every other model is
+/// tracked in a weak side table, so `generation_config.json` is honored
+/// regardless of conformance. No-op when the configuration declares no
+/// suppressed tokens. Called by the model factories after the model is
+/// created.
 public func mergeGenerationConfigSuppressedTokens(
     _ generationConfig: GenerationConfigFile?, into model: any LanguageModel
 ) {
     guard let suppressTokens = generationConfig?.suppressTokens?.values else { return }
-    (model as? SuppressedTokensProviding)?.suppressedTokenIds.formUnion(suppressTokens)
+    if let provider = model as? SuppressedTokensProviding {
+        provider.suppressedTokenIds.formUnion(suppressTokens)
+    } else {
+        SuppressedTokensRegistry.shared.union(Set(suppressTokens), for: model)
+    }
+}
+
+/// The full suppressed-token set for a model: protocol-advertised IDs plus
+/// any `generation_config.json` IDs tracked in the side table.
+func suppressedTokenIds(for model: any LanguageModel) -> Set<Int> {
+    var ids = (model as? SuppressedTokensProviding)?.suppressedTokenIds ?? []
+    ids.formUnion(SuppressedTokensRegistry.shared.tokenIds(for: model))
+    return ids
+}
+
+/// Build the ``SuppressTokensProcessor`` for a model, or `nil` when it has
+/// no suppressed tokens.
+func makeSuppressTokensProcessor(model: any LanguageModel) -> SuppressTokensProcessor? {
+    SuppressTokensProcessor(tokenIds: suppressedTokenIds(for: model))
+}
+
+/// A ``LogitSampler`` that masks suppressed token IDs before delegating to a
+/// base sampler.
+///
+/// Used for draft-token sampling paths that receive a sampler but not the
+/// iterator's ``LogitProcessor`` chain (e.g.
+/// ``MTPDrafterModel/draftBlock(target:lastToken:lastHidden:sharedKV:queryOffset:blockSize:sampler:)``).
+/// Draft proposals of suppressed tokens would always be rejected by the
+/// verifier — masking them at the source keeps speculative acceptance high.
+/// ``SuppressTokensProcessor`` is stateless, so wrapping is safe.
+struct SuppressTokensSampler: LogitSampler {
+
+    let base: LogitSampler
+    let suppressor: SuppressTokensProcessor
+
+    func sample(logits: MLXArray) -> MLXArray {
+        base.sample(logits: suppressor.process(logits: logits))
+    }
 }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1995,7 +1995,7 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider, Suppresse
     /// Multimodal placeholder token IDs that must never be sampled as text.
     /// Seeded from the model configuration; the model factory merges
     /// `suppress_tokens` from `generation_config.json` on top.
-    /// See ``SuppressedTokensProviding``.
+    /// See `SuppressedTokensProviding` in MLXLMCommon.
     public var suppressedTokenIds: Set<Int>
 
     public init(_ config: Gemma4Configuration) {
@@ -2377,7 +2377,7 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider,
     /// Multimodal placeholder token IDs that must never be sampled as text.
     /// Seeded from the model configuration; the model factory merges
     /// `suppress_tokens` from `generation_config.json` on top.
-    /// See ``SuppressedTokensProviding``.
+    /// See `SuppressedTokensProviding` in MLXLMCommon.
     public var suppressedTokenIds: Set<Int>
 
     public init(_ config: Gemma4UnifiedConfiguration) {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1978,7 +1978,7 @@ private final class Gemma4MultimodalEmbedder: Module, UnaryLayer {
 
 // MARK: - Model
 
-public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
+public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider, SuppressedTokensProviding {
     @ModuleInfo(key: "vision_tower") private var visionTower: Gemma4VisionModel
     /// Module-internal — also reached by `Gemma4Assistant.swift` (drafter `bind()`
     /// walks here to cache the target's input embeddings, embed scale, and
@@ -1992,8 +1992,19 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
     public var loraLayers: [Module] { languageModel.model.layers }
 
+    /// Multimodal placeholder token IDs that must never be sampled as text.
+    /// Seeded from the model configuration; the model factory merges
+    /// `suppress_tokens` from `generation_config.json` on top.
+    /// See ``SuppressedTokensProviding``.
+    public var suppressedTokenIds: Set<Int>
+
     public init(_ config: Gemma4Configuration) {
         self.config = config
+        self.suppressedTokenIds = Set(
+            [
+                config.imageTokenId, config.audioTokenId,
+                config.boiTokenId, config.eoiTokenId,
+            ].compactMap { $0 })
         self._visionTower.wrappedValue = Gemma4VisionModel(config: config.visionConfiguration)
         self._languageModel.wrappedValue = Gemma4TextLanguageModel(config.textConfiguration)
         self._embedVision.wrappedValue = Gemma4MultimodalEmbedder(
@@ -2349,7 +2360,9 @@ private final class Gemma4UnifiedVisionEmbedder: Module {
     }
 }
 
-public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
+public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider,
+    SuppressedTokensProviding
+{
     @ModuleInfo(key: "language_model") private var languageModel: Gemma4TextLanguageModel
     @ModuleInfo(key: "vision_embedder") private var visionEmbedder: Gemma4UnifiedVisionEmbedder?
     @ModuleInfo(key: "embed_vision") private var embedVision: Gemma4MultimodalEmbedder?
@@ -2361,8 +2374,19 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
     public var loraLayers: [Module] { languageModel.model.layers }
 
+    /// Multimodal placeholder token IDs that must never be sampled as text.
+    /// Seeded from the model configuration; the model factory merges
+    /// `suppress_tokens` from `generation_config.json` on top.
+    /// See ``SuppressedTokensProviding``.
+    public var suppressedTokenIds: Set<Int>
+
     public init(_ config: Gemma4UnifiedConfiguration) {
         self.config = config
+        self.suppressedTokenIds = Set(
+            [
+                config.imageTokenId, config.audioTokenId, config.videoTokenId,
+                config.boiTokenId, config.eoiTokenId, config.boaTokenId, config.eoaTokenId,
+            ].compactMap { $0 })
         self._languageModel.wrappedValue = Gemma4TextLanguageModel(config.textConfiguration)
         if let visionConfiguration = config.visionConfiguration {
             self._visionEmbedder.wrappedValue = Gemma4UnifiedVisionEmbedder(

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1972,7 +1972,7 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider, Suppresse
     /// Multimodal placeholder token IDs that must never be sampled as text.
     /// Seeded from the model configuration; the model factory merges
     /// `suppress_tokens` from `generation_config.json` on top.
-    /// See ``SuppressedTokensProviding``.
+    /// See `SuppressedTokensProviding` in MLXLMCommon.
     public var suppressedTokenIds: Set<Int>
 
     public init(_ config: Gemma4Configuration) {
@@ -2426,7 +2426,7 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider,
     /// Multimodal placeholder token IDs that must never be sampled as text.
     /// Seeded from the model configuration; the model factory merges
     /// `suppress_tokens` from `generation_config.json` on top.
-    /// See ``SuppressedTokensProviding``.
+    /// See `SuppressedTokensProviding` in MLXLMCommon.
     public var suppressedTokenIds: Set<Int>
 
     public init(_ config: Gemma4UnifiedConfiguration) {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1955,7 +1955,7 @@ private final class Gemma4MultimodalEmbedder: Module, UnaryLayer {
 
 // MARK: - Model
 
-public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
+public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider, SuppressedTokensProviding {
     @ModuleInfo(key: "vision_tower") private var visionTower: Gemma4VisionModel
     /// Module-internal — also reached by `Gemma4Assistant.swift` (drafter `bind()`
     /// walks here to cache the target's input embeddings, embed scale, and
@@ -1969,8 +1969,19 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
     public var loraLayers: [Module] { languageModel.model.layers }
 
+    /// Multimodal placeholder token IDs that must never be sampled as text.
+    /// Seeded from the model configuration; the model factory merges
+    /// `suppress_tokens` from `generation_config.json` on top.
+    /// See ``SuppressedTokensProviding``.
+    public var suppressedTokenIds: Set<Int>
+
     public init(_ config: Gemma4Configuration) {
         self.config = config
+        self.suppressedTokenIds = Set(
+            [
+                config.imageTokenId, config.audioTokenId,
+                config.boiTokenId, config.eoiTokenId,
+            ].compactMap { $0 })
         self._visionTower.wrappedValue = Gemma4VisionModel(config: config.visionConfiguration)
         self._languageModel.wrappedValue = Gemma4TextLanguageModel(config.textConfiguration)
         self._embedVision.wrappedValue = Gemma4MultimodalEmbedder(
@@ -2398,7 +2409,9 @@ private final class Gemma4UnifiedVisionEmbedder: Module {
     }
 }
 
-public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
+public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider,
+    SuppressedTokensProviding
+{
     @ModuleInfo(key: "language_model") private var languageModel: Gemma4TextLanguageModel
     @ModuleInfo(key: "vision_embedder") private var visionEmbedder: Gemma4UnifiedVisionEmbedder?
     @ModuleInfo(key: "embed_vision") private var embedVision: Gemma4MultimodalEmbedder?
@@ -2410,8 +2423,19 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
     public var loraLayers: [Module] { languageModel.model.layers }
 
+    /// Multimodal placeholder token IDs that must never be sampled as text.
+    /// Seeded from the model configuration; the model factory merges
+    /// `suppress_tokens` from `generation_config.json` on top.
+    /// See ``SuppressedTokensProviding``.
+    public var suppressedTokenIds: Set<Int>
+
     public init(_ config: Gemma4UnifiedConfiguration) {
         self.config = config
+        self.suppressedTokenIds = Set(
+            [
+                config.imageTokenId, config.audioTokenId, config.videoTokenId,
+                config.boiTokenId, config.eoiTokenId, config.boaTokenId, config.eoaTokenId,
+            ].compactMap { $0 })
         self._languageModel.wrappedValue = Gemma4TextLanguageModel(config.textConfiguration)
         if let visionConfiguration = config.visionConfiguration {
             self._visionEmbedder.wrappedValue = Gemma4UnifiedVisionEmbedder(

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -377,6 +377,11 @@ public final class VLMModelFactory: GenericModelFactory {
             eosTokenIds = Set(genEosIds)  // Override per Python mlx-lm behavior
         }
 
+        // Honor `suppress_tokens` from generation_config.json (transformers'
+        // SuppressTokensLogitsProcessor): merge into the model's suppressed
+        // token IDs so the token iterators mask them during sampling.
+        mergeGenerationConfigSuppressedTokens(generationConfig, into: model)
+
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -412,6 +412,11 @@ public final class VLMModelFactory: GenericModelFactory {
             eosTokenIds = Set(genEosIds)  // Override per Python mlx-lm behavior
         }
 
+        // Honor `suppress_tokens` from generation_config.json (transformers'
+        // SuppressTokensLogitsProcessor): merge into the model's suppressed
+        // token IDs so the token iterators mask them during sampling.
+        mergeGenerationConfigSuppressedTokens(generationConfig, into: model)
+
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])

--- a/Tests/MLXLMTests/SuppressTokensTests.swift
+++ b/Tests/MLXLMTests/SuppressTokensTests.swift
@@ -1,0 +1,225 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXVLM
+
+/// Minimal `LanguageModel` whose logits always peak at `peakToken` with
+/// `runnerUpToken` in second place. Conforms to `SuppressedTokensProviding`
+/// so tests can verify that suppressed tokens are never sampled.
+private final class SuppressingMockModel: Module, LanguageModel, KVCacheDimensionProvider,
+    SuppressedTokensProviding
+{
+    var kvHeads: [Int] { [1] }
+    var suppressedTokenIds: Set<Int>
+
+    let vocabularySize = 16
+    let peakToken: Int
+    let runnerUpToken: Int
+
+    init(peakToken: Int, runnerUpToken: Int, suppressedTokenIds: Set<Int>) {
+        self.peakToken = peakToken
+        self.runnerUpToken = runnerUpToken
+        self.suppressedTokenIds = suppressedTokenIds
+        super.init()
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let positions = inputs.dim(-1)
+        var data = [Float](repeating: 0, count: positions * vocabularySize)
+        for position in 0 ..< positions {
+            data[position * vocabularySize + peakToken] = 10
+            data[position * vocabularySize + runnerUpToken] = 5
+        }
+        return MLXArray(data, [1, positions, vocabularySize])
+    }
+}
+
+public class SuppressTokensTests: XCTestCase {
+
+    // MARK: - generation_config.json parsing
+
+    func testGenerationConfigDecodesSuppressTokensArray() throws {
+        // Mirrors mlx-community/gemma-4-12B-it-4bit's generation_config.json
+        let json = """
+            {"eos_token_id": [1, 106], "suppress_tokens": [258883, 258882]}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertEqual(config.suppressTokens?.values, [258883, 258882])
+    }
+
+    func testGenerationConfigDecodesSuppressTokensSingleInt() throws {
+        let json = """
+            {"suppress_tokens": 258882}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertEqual(config.suppressTokens?.values, [258882])
+    }
+
+    func testGenerationConfigMissingSuppressTokensIsNil() throws {
+        let json = """
+            {"eos_token_id": 106}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertNil(config.suppressTokens)
+    }
+
+    func testGenerationConfigNullSuppressTokensIsNil() throws {
+        let json = """
+            {"suppress_tokens": null}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertNil(config.suppressTokens)
+    }
+
+    // MARK: - SuppressTokensProcessor
+
+    func testSuppressTokensProcessorMasksOnlyGivenIds() throws {
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [1, 3]))
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = processor.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 3].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 0].item(Float.self), 0.5)
+        XCTAssertEqual(processed[0, 2].item(Float.self), 1.0)
+        XCTAssertEqual(processed[0, 4].item(Float.self), 2.0)
+    }
+
+    func testSuppressTokensProcessorEmptySetIsNil() {
+        XCTAssertNil(SuppressTokensProcessor(tokenIds: []))
+    }
+
+    func testSuppressedTokenIsNeverArgMax() throws {
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [3]))
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let token = ArgMaxSampler().sample(logits: processor.process(logits: logits))
+
+        XCTAssertEqual(token.item(Int.self), 1)
+    }
+
+    // MARK: - ChainedLogitProcessor
+
+    func testChainedLogitProcessorAppliesAllProcessors() throws {
+        let first = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [1]))
+        let second = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [3]))
+        let chained = ChainedLogitProcessor(processors: [first, second])
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = chained.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 3].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 4].item(Float.self), 2.0)
+    }
+
+    // MARK: - TokenIterator integration
+
+    private func generate(model: SuppressingMockModel, parameters: GenerateParameters) throws
+        -> [Int]
+    {
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+        var iterator = try TokenIterator(input: input, model: model, parameters: parameters)
+        var tokens = [Int]()
+        while let token = iterator.next() {
+            tokens.append(token)
+        }
+        return tokens
+    }
+
+    func testTokenIteratorNeverSamplesSuppressedToken() throws {
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [5])
+        let parameters = GenerateParameters(maxTokens: 5, temperature: 0)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    func testTokenIteratorWithoutSuppressionSamplesPeakToken() throws {
+        // Control: with nothing suppressed, the argmax token is the peak.
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [])
+        let parameters = GenerateParameters(maxTokens: 5, temperature: 0)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertEqual(tokens, [5, 5, 5, 5, 5])
+    }
+
+    func testTokenIteratorSuppressionChainsWithPenaltyProcessor() throws {
+        // With a repetition penalty active, suppression is chained after the
+        // penalty processor and must still mask the suppressed token.
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [5])
+        let parameters = GenerateParameters(
+            maxTokens: 5, temperature: 0, repetitionPenalty: 1.5, repetitionContextSize: 4)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertFalse(tokens.contains(5))
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    // MARK: - Gemma4Unified config-derived suppressed tokens
+
+    func testGemma4UnifiedSeedsSuppressedTokenIdsFromConfig() throws {
+        let config = try JSONDecoder.json5().decode(
+            Gemma4UnifiedConfiguration.self,
+            from: Data(
+                """
+                {
+                  "model_type": "gemma4_unified",
+                  "vocab_size": 32,
+                  "image_token_id": 31,
+                  "audio_token_id": 30,
+                  "video_token_id": 29,
+                  "text_config": {
+                    "model_type": "gemma4_unified_text",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 8,
+                    "global_head_dim": 8,
+                    "vocab_size": 32,
+                    "vocab_size_per_layer_input": 32,
+                    "num_kv_shared_layers": 0,
+                    "hidden_size_per_layer_input": 0,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "attention_k_eq_v": true,
+                    "use_double_wide_mlp": false,
+                    "layer_types": ["full_attention"],
+                    "tie_word_embeddings": true
+                  },
+                  "vision_config": null,
+                  "audio_config": null
+                }
+                """.utf8))
+
+        let model = Gemma4Unified(config)
+
+        // image / audio / video placeholder tokens from the config, plus the
+        // boi / eoi / boa defaults for gemma4_unified.
+        XCTAssertTrue(model.suppressedTokenIds.isSuperset(of: [31, 30, 29]))
+        XCTAssertTrue(model.suppressedTokenIds.contains(config.boiTokenId))
+        XCTAssertTrue(model.suppressedTokenIds.contains(config.boaTokenId))
+        if let eoiTokenId = config.eoiTokenId {
+            XCTAssertTrue(model.suppressedTokenIds.contains(eoiTokenId))
+        }
+    }
+}

--- a/Tests/MLXLMTests/SuppressTokensTests.swift
+++ b/Tests/MLXLMTests/SuppressTokensTests.swift
@@ -43,6 +43,37 @@ private final class SuppressingMockModel: Module, LanguageModel, KVCacheDimensio
     }
 }
 
+/// Like `SuppressingMockModel`, but does NOT conform to
+/// `SuppressedTokensProviding` — used to verify that `suppress_tokens` from
+/// `generation_config.json` is honored for models without the conformance.
+private final class PlainMockModel: Module, LanguageModel, KVCacheDimensionProvider {
+    var kvHeads: [Int] { [1] }
+
+    let vocabularySize = 16
+    let peakToken: Int
+    let runnerUpToken: Int
+
+    init(peakToken: Int, runnerUpToken: Int) {
+        self.peakToken = peakToken
+        self.runnerUpToken = runnerUpToken
+        super.init()
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let positions = inputs.dim(-1)
+        var data = [Float](repeating: 0, count: positions * vocabularySize)
+        for position in 0 ..< positions {
+            data[position * vocabularySize + peakToken] = 10
+            data[position * vocabularySize + runnerUpToken] = 5
+        }
+        return MLXArray(data, [1, positions, vocabularySize])
+    }
+}
+
 public class SuppressTokensTests: XCTestCase {
 
     // MARK: - generation_config.json parsing
@@ -108,6 +139,34 @@ public class SuppressTokensTests: XCTestCase {
         XCTAssertEqual(token.item(Int.self), 1)
     }
 
+    func testSuppressTokensProcessorIgnoresOutOfRangeIds() throws {
+        // IDs beyond the logits vocabulary (e.g. a tiny test config
+        // inheriting 255k-range boi/boa defaults) must be dropped, not
+        // passed to putAlong.
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [1, 258882, 258883]))
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = processor.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 3].item(Float.self), 9.0)
+    }
+
+    func testSuppressTokensProcessorAllOutOfRangeIsNoOp() throws {
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [258882, 258883]))
+        let logits = MLXArray([0.5, 5.0, 1.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = processor.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), 5.0)
+    }
+
+    func testSuppressTokensProcessorIgnoresNegativeIds() {
+        // Negative IDs are dropped at init; all-negative means nothing to
+        // suppress.
+        XCTAssertNil(SuppressTokensProcessor(tokenIds: [-1, -106]))
+    }
+
     // MARK: - ChainedLogitProcessor
 
     func testChainedLogitProcessorAppliesAllProcessors() throws {
@@ -169,6 +228,42 @@ public class SuppressTokensTests: XCTestCase {
         let tokens = try generate(model: model, parameters: parameters)
 
         XCTAssertFalse(tokens.contains(5))
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    func testTokenIteratorWithOutOfVocabularySuppressedIdsDoesNotCrash() throws {
+        // Regression: a model whose suppressed set mixes in-range and
+        // out-of-vocabulary IDs (tiny vocab + inherited 255k-range
+        // placeholder defaults) must generate normally, suppressing only
+        // the in-range IDs.
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [5, 258882, 258883])
+        let parameters = GenerateParameters(maxTokens: 5, temperature: 0)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    // MARK: - generation_config.json suppression without protocol conformance
+
+    func testGenerationConfigSuppressionAppliesToNonConformingModel() throws {
+        // suppress_tokens from generation_config.json must be honored even
+        // when the model does not adopt SuppressedTokensProviding.
+        let model = PlainMockModel(peakToken: 5, runnerUpToken: 7)
+        let generationConfig = GenerationConfigFile(suppressTokens: IntOrIntArray([5]))
+
+        mergeGenerationConfigSuppressedTokens(generationConfig, into: model)
+
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+        var iterator = try TokenIterator(
+            input: input, model: model,
+            parameters: GenerateParameters(maxTokens: 5, temperature: 0))
+        var tokens = [Int]()
+        while let token = iterator.next() {
+            tokens.append(token)
+        }
+
         XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
     }
 

--- a/Tests/MLXLMTests/SuppressTokensTests.swift
+++ b/Tests/MLXLMTests/SuppressTokensTests.swift
@@ -46,6 +46,40 @@ private final class SuppressingMockModel: Module, LanguageModel, KVCacheDimensio
     }
 }
 
+/// Like `SuppressingMockModel`, but does NOT conform to
+/// `SuppressedTokensProviding` — used to verify that `suppress_tokens` from
+/// `generation_config.json` is honored for models without the conformance.
+private final class PlainMockModel: Module, LanguageModel, KVCacheDimensionProvider {
+    var kvHeads: [Int] { [1] }
+
+    let vocabularySize = 16
+    let peakToken: Int
+    let runnerUpToken: Int
+
+    init(peakToken: Int, runnerUpToken: Int) {
+        self.peakToken = peakToken
+        self.runnerUpToken = runnerUpToken
+        super.init()
+    }
+
+    func prepare(
+        _ input: LMInput, cache _: [KVCache], state _: LMOutput.State?,
+        prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let positions = inputs.dim(-1)
+        var data = [Float](repeating: 0, count: positions * vocabularySize)
+        for position in 0 ..< positions {
+            data[position * vocabularySize + peakToken] = 10
+            data[position * vocabularySize + runnerUpToken] = 5
+        }
+        return MLXArray(data, [1, positions, vocabularySize])
+    }
+}
+
 public class SuppressTokensTests: XCTestCase {
 
     // MARK: - generation_config.json parsing
@@ -111,6 +145,34 @@ public class SuppressTokensTests: XCTestCase {
         XCTAssertEqual(token.item(Int.self), 1)
     }
 
+    func testSuppressTokensProcessorIgnoresOutOfRangeIds() throws {
+        // IDs beyond the logits vocabulary (e.g. a tiny test config
+        // inheriting 255k-range boi/boa defaults) must be dropped, not
+        // passed to putAlong.
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [1, 258882, 258883]))
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = processor.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 3].item(Float.self), 9.0)
+    }
+
+    func testSuppressTokensProcessorAllOutOfRangeIsNoOp() throws {
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [258882, 258883]))
+        let logits = MLXArray([0.5, 5.0, 1.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = processor.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), 5.0)
+    }
+
+    func testSuppressTokensProcessorIgnoresNegativeIds() {
+        // Negative IDs are dropped at init; all-negative means nothing to
+        // suppress.
+        XCTAssertNil(SuppressTokensProcessor(tokenIds: [-1, -106]))
+    }
+
     // MARK: - ChainedLogitProcessor
 
     func testChainedLogitProcessorAppliesAllProcessors() throws {
@@ -172,6 +234,42 @@ public class SuppressTokensTests: XCTestCase {
         let tokens = try generate(model: model, parameters: parameters)
 
         XCTAssertFalse(tokens.contains(5))
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    func testTokenIteratorWithOutOfVocabularySuppressedIdsDoesNotCrash() throws {
+        // Regression: a model whose suppressed set mixes in-range and
+        // out-of-vocabulary IDs (tiny vocab + inherited 255k-range
+        // placeholder defaults) must generate normally, suppressing only
+        // the in-range IDs.
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [5, 258882, 258883])
+        let parameters = GenerateParameters(maxTokens: 5, temperature: 0)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    // MARK: - generation_config.json suppression without protocol conformance
+
+    func testGenerationConfigSuppressionAppliesToNonConformingModel() throws {
+        // suppress_tokens from generation_config.json must be honored even
+        // when the model does not adopt SuppressedTokensProviding.
+        let model = PlainMockModel(peakToken: 5, runnerUpToken: 7)
+        let generationConfig = GenerationConfigFile(suppressTokens: IntOrIntArray([5]))
+
+        mergeGenerationConfigSuppressedTokens(generationConfig, into: model)
+
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+        var iterator = try TokenIterator(
+            input: input, model: model,
+            parameters: GenerateParameters(maxTokens: 5, temperature: 0))
+        var tokens = [Int]()
+        while let token = iterator.next() {
+            tokens.append(token)
+        }
+
         XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
     }
 

--- a/Tests/MLXLMTests/SuppressTokensTests.swift
+++ b/Tests/MLXLMTests/SuppressTokensTests.swift
@@ -1,0 +1,228 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXVLM
+
+/// Minimal `LanguageModel` whose logits always peak at `peakToken` with
+/// `runnerUpToken` in second place. Conforms to `SuppressedTokensProviding`
+/// so tests can verify that suppressed tokens are never sampled.
+private final class SuppressingMockModel: Module, LanguageModel, KVCacheDimensionProvider,
+    SuppressedTokensProviding
+{
+    var kvHeads: [Int] { [1] }
+    var suppressedTokenIds: Set<Int>
+
+    let vocabularySize = 16
+    let peakToken: Int
+    let runnerUpToken: Int
+
+    init(peakToken: Int, runnerUpToken: Int, suppressedTokenIds: Set<Int>) {
+        self.peakToken = peakToken
+        self.runnerUpToken = runnerUpToken
+        self.suppressedTokenIds = suppressedTokenIds
+        super.init()
+    }
+
+    func prepare(
+        _ input: LMInput, cache _: [KVCache], state _: LMOutput.State?,
+        prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let positions = inputs.dim(-1)
+        var data = [Float](repeating: 0, count: positions * vocabularySize)
+        for position in 0 ..< positions {
+            data[position * vocabularySize + peakToken] = 10
+            data[position * vocabularySize + runnerUpToken] = 5
+        }
+        return MLXArray(data, [1, positions, vocabularySize])
+    }
+}
+
+public class SuppressTokensTests: XCTestCase {
+
+    // MARK: - generation_config.json parsing
+
+    func testGenerationConfigDecodesSuppressTokensArray() throws {
+        // Mirrors mlx-community/gemma-4-12B-it-4bit's generation_config.json
+        let json = """
+            {"eos_token_id": [1, 106], "suppress_tokens": [258883, 258882]}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertEqual(config.suppressTokens?.values, [258883, 258882])
+    }
+
+    func testGenerationConfigDecodesSuppressTokensSingleInt() throws {
+        let json = """
+            {"suppress_tokens": 258882}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertEqual(config.suppressTokens?.values, [258882])
+    }
+
+    func testGenerationConfigMissingSuppressTokensIsNil() throws {
+        let json = """
+            {"eos_token_id": 106}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertNil(config.suppressTokens)
+    }
+
+    func testGenerationConfigNullSuppressTokensIsNil() throws {
+        let json = """
+            {"suppress_tokens": null}
+            """
+        let config = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(json.utf8))
+        XCTAssertNil(config.suppressTokens)
+    }
+
+    // MARK: - SuppressTokensProcessor
+
+    func testSuppressTokensProcessorMasksOnlyGivenIds() throws {
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [1, 3]))
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = processor.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 3].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 0].item(Float.self), 0.5)
+        XCTAssertEqual(processed[0, 2].item(Float.self), 1.0)
+        XCTAssertEqual(processed[0, 4].item(Float.self), 2.0)
+    }
+
+    func testSuppressTokensProcessorEmptySetIsNil() {
+        XCTAssertNil(SuppressTokensProcessor(tokenIds: []))
+    }
+
+    func testSuppressedTokenIsNeverArgMax() throws {
+        let processor = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [3]))
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let token = ArgMaxSampler().sample(logits: processor.process(logits: logits))
+
+        XCTAssertEqual(token.item(Int.self), 1)
+    }
+
+    // MARK: - ChainedLogitProcessor
+
+    func testChainedLogitProcessorAppliesAllProcessors() throws {
+        let first = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [1]))
+        let second = try XCTUnwrap(SuppressTokensProcessor(tokenIds: [3]))
+        let chained = ChainedLogitProcessor(processors: [first, second])
+        let logits = MLXArray([0.5, 5.0, 1.0, 9.0, 2.0] as [Float])[.newAxis, .ellipsis]
+
+        let processed = chained.process(logits: logits)
+
+        XCTAssertEqual(processed[0, 1].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 3].item(Float.self), -Float.infinity)
+        XCTAssertEqual(processed[0, 4].item(Float.self), 2.0)
+    }
+
+    // MARK: - TokenIterator integration
+
+    private func generate(model: SuppressingMockModel, parameters: GenerateParameters) throws
+        -> [Int]
+    {
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+        var iterator = try TokenIterator(input: input, model: model, parameters: parameters)
+        var tokens = [Int]()
+        while let token = iterator.next() {
+            tokens.append(token)
+        }
+        return tokens
+    }
+
+    func testTokenIteratorNeverSamplesSuppressedToken() throws {
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [5])
+        let parameters = GenerateParameters(maxTokens: 5, temperature: 0)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    func testTokenIteratorWithoutSuppressionSamplesPeakToken() throws {
+        // Control: with nothing suppressed, the argmax token is the peak.
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [])
+        let parameters = GenerateParameters(maxTokens: 5, temperature: 0)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertEqual(tokens, [5, 5, 5, 5, 5])
+    }
+
+    func testTokenIteratorSuppressionChainsWithPenaltyProcessor() throws {
+        // With a repetition penalty active, suppression is chained after the
+        // penalty processor and must still mask the suppressed token.
+        let model = SuppressingMockModel(
+            peakToken: 5, runnerUpToken: 7, suppressedTokenIds: [5])
+        let parameters = GenerateParameters(
+            maxTokens: 5, temperature: 0, repetitionPenalty: 1.5, repetitionContextSize: 4)
+
+        let tokens = try generate(model: model, parameters: parameters)
+
+        XCTAssertFalse(tokens.contains(5))
+        XCTAssertEqual(tokens, [7, 7, 7, 7, 7])
+    }
+
+    // MARK: - Gemma4Unified config-derived suppressed tokens
+
+    func testGemma4UnifiedSeedsSuppressedTokenIdsFromConfig() throws {
+        let config = try JSONDecoder.json5().decode(
+            Gemma4UnifiedConfiguration.self,
+            from: Data(
+                """
+                {
+                  "model_type": "gemma4_unified",
+                  "vocab_size": 32,
+                  "image_token_id": 31,
+                  "audio_token_id": 30,
+                  "video_token_id": 29,
+                  "text_config": {
+                    "model_type": "gemma4_unified_text",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 8,
+                    "global_head_dim": 8,
+                    "vocab_size": 32,
+                    "vocab_size_per_layer_input": 32,
+                    "num_kv_shared_layers": 0,
+                    "hidden_size_per_layer_input": 0,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "attention_k_eq_v": true,
+                    "use_double_wide_mlp": false,
+                    "layer_types": ["full_attention"],
+                    "tie_word_embeddings": true
+                  },
+                  "vision_config": null,
+                  "audio_config": null
+                }
+                """.utf8))
+
+        let model = Gemma4Unified(config)
+
+        // image / audio / video placeholder tokens from the config, plus the
+        // boi / eoi / boa defaults for gemma4_unified.
+        XCTAssertTrue(model.suppressedTokenIds.isSuperset(of: [31, 30, 29]))
+        XCTAssertTrue(model.suppressedTokenIds.contains(config.boiTokenId))
+        XCTAssertTrue(model.suppressedTokenIds.contains(config.boaTokenId))
+        if let eoiTokenId = config.eoiTokenId {
+            XCTAssertTrue(model.suppressedTokenIds.contains(eoiTokenId))
+        }
+    }
+}


### PR DESCRIPTION

### Problem

Two related gaps in the sampling path:

1. **`suppress_tokens` from `generation_config.json` was silently ignored** — `GenerationConfigFile` never parsed the field, so checkpoints that declare tokens which must never be sampled got no masking at all.
2. **Multimodal placeholder tokens were sampled as text.** Nothing masks the placeholder IDs of multimodal models (image/audio/video soft tokens and their begin/end markers), so they occasionally leak verbatim into generated text. On `gemma4_unified` (e.g. `mlx-community/gemma-4-12B-it-4bit`) we saw `<audio|>` (258882) show up in text-only replies — nasty for downstream consumers (imagine a TTS reading it aloud). The same symptom was reported independently against the same checkpoint family in another runtime: jundot/omlx#1670. The shipped `generation_config.json` only suppresses 258883/258882 on some checkpoints, and even that was ignored (gap 1).

### Fix

Mirrors the `transformers` design (`SuppressTokensLogitsProcessor`, driven by `generation_config.suppress_tokens`):

- `GenerationConfigFile`: parse `suppress_tokens`.
- New `SuppressedTokensProviding` protocol: models advertise token IDs that must never be sampled; the LLM/VLM model factories merge `generation_config.json`'s `suppress_tokens` into that set after the model is created.
- New `SuppressTokensProcessor` (port of the transformers processor): masks those IDs to `-inf` before sampling, chained after the parameter-derived penalty processor in `TokenIterator`, `SpeculativeTokenIterator` and `MTPSpeculativeTokenIterator` via a small `ChainedLogitProcessor`.
- `Gemma4` / `Gemma4Unified`: seed the set from the config placeholder IDs (image/audio/video soft tokens plus boi/eoi/boa/eoa markers).

Only sampled tokens are affected; prompt tokens are untouched, so multimodal *inputs* keep working unchanged.

### Testing

- 12 new tests in `Tests/MLXLMTests/SuppressTokensTests.swift` (config parsing, processor masking/broadcasting, chaining, factory merge, Gemma 4 seeding).
- `xcodebuild build-for-testing -scheme mlx-swift-lm-Package -destination 'platform=macOS'` + `xcrun xctest …/MLXLMTests.xctest` (same as CI) pass on this branch.
- Smoke-tested with `mlx-community/gemma-4-12B-it-4bit`: the placeholder leakage disappears; generation output otherwise unchanged.




### Planned follow-up (separate PR)

App-driven per-generation suppression via a `suppressedTokens` field on `GenerateParameters`, merged into the same `makeLogitProcessor` union (and reaching the MTP draft sampler through the same path). This PR intentionally keeps checkpoint-level semantics only — `generation_config.json` and model-adopted sets — mirroring how `transformers` scopes `suppress_tokens`; the per-generation field is for app decisions (e.g. suppressing a model's thinking-channel delimiters for a voice reply while another session of the same loaded model leaves them free).