### PR TITLE
ChatSession: cancel the generation task when the consumer goes away

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -761,9 +761,22 @@ public final class ChatSession {
                                 pendingToolCalls.append(toolCall)
                             } else if let value = transform(item) {
                                 if case .terminated = continuation.yield(value) {
+                                    genTask.cancel()
                                     break
                                 }
                             }
+                        }
+
+                        // The generation task is unstructured, so cancellation of
+                        // this task (stream onTermination) does not propagate to
+                        // it. Without an explicit cancel, `await genTask.value`
+                        // would wait for the FULL generation while holding the
+                        // cache lock — deadlocking the session's next call (e.g.
+                        // a caller that cancels mid-stream and immediately asks
+                        // again). The generate loop checks Task.isCancelled per
+                        // token, so this stops it promptly.
+                        if Task.isCancelled {
+                            genTask.cancel()
                         }
 
                         // wait for the task to complete -- this is important in


### PR DESCRIPTION

### Problem

The generation task returned by `generateTask()` is **unstructured**, so cancelling `streamMap`'s task (via the stream's `onTermination`) never propagates to it. A caller that stops consuming mid-stream and immediately issues the next request effectively deadlocks the session:

1. Consumer cancels the stream (e.g. voice barge-in: the user talks over the reply).
2. `streamMap`'s task is cancelled, but the generation task keeps generating the FULL reply.
3. The next `respond`/`streamResponse` call blocks on the session's serial cache lock, which is held until `await genTask.value` returns — i.e. until the abandoned generation finishes every remaining token.

On a 12B model on device that's many seconds of dead air per interruption (we hit this in a voice-assistant barge-in flow; it looks like a hang).

### Fix

Cancel the generation task explicitly at the two places the consumer goes away: when `continuation.yield` reports `.terminated`, and when the surrounding task itself is cancelled. The generate loop already checks `Task.isCancelled` per token, so it stops promptly, `await genTask.value` returns, and the cache lock is released. The existing "wait for the task to complete" semantics are preserved — we still await the task so the KV cache is never used concurrently.

### Testing

- `xcodebuild build-for-testing` + `MLXLMTests` via `xcrun xctest` (same as CI) pass on this branch.
- Reproduced the stall and verified the fix on-device (iPad, Gemma 4 12B): cancel mid-generation + immediate next request now responds promptly instead of waiting out the abandoned generation.


