### PR TITLE
ChatSession: keep the cached transcript canonical on continuation turns

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -167,47 +167,54 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma3_1B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-1b-it-qat-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma3n_E4B_it_lm_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-3n-E4B-it-lm-bf16",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma3n_E2B_it_lm_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-3n-E2B-it-lm-bf16",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma3n_E4B_it_lm_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3n-E4B-it-lm-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma3n_E2B_it_lm_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3n-E2B-it-lm-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
         // https://ai.google.dev/gemma/docs/core/prompt-structure
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma4_e4b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<turn|>\n")
     )
 
     static public let gemma4_e2b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "What is the difference between a fruit and a vegetable?",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<turn|>\n")
     )
 
     static public let qwen205b4bit = ModelConfiguration(

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -163,32 +163,6 @@ public final class ChatSession {
     /// Speculative decoding configuration, nil if disabled.
     public let speculativeDecoding: SpeculativeDecodingConfig?
 
-    /// Text that closes a *truncated* previous model turn when a new turn is
-    /// appended to a non-empty KV cache (e.g. `"<turn|>\n"` for Gemma 4,
-    /// `"<end_of_turn>\n"` for Gemma 3).
-    ///
-    /// The KV cache stores prior turns as raw tokens. A normally completed
-    /// turn ends with its stop token already in the cache (the iterator feeds
-    /// each sampled token through the model before the generate loop
-    /// recognizes it as a stop), but a generation that was cancelled
-    /// mid-stream — or capped by `maxTokens` — leaves the cached turn dangling
-    /// mid-sentence. Chat templates only render the messages they are given,
-    /// so nothing ever closes that dangling turn: the continuation is appended
-    /// right after the truncated reply's last word, leaving the transcript
-    /// malformed (`…repl<|turn>user…`).
-    ///
-    /// When set, these tokens are prepended to the continuation prompt *only
-    /// when the previous generation did not finish with a stop token*, so the
-    /// cached transcript stays canonical (`…repl<turn|>\n<|turn>user…`)
-    /// without duplicating the terminator of completed turns. Off (nil) by
-    /// default.
-    public var continuationTurnClosure: String?
-
-    /// Chat templates that begin with `{{ bos_token }}` re-emit `<bos>` on
-    /// every render; on continuation turns that would inject a spurious BOS
-    /// mid-transcript, so it is stripped. On by default.
-    public var stripsContinuationBOS: Bool = true
-
     /// Stop reason of the most recent generation pass, kept across turns so
     /// continuation repair can tell a completed turn (stop token already in
     /// the KV cache) from a truncated one (cancelled or length-capped).
@@ -655,8 +629,6 @@ extension ChatSession {
         // and are only being sent to the inner async
         let inputMessages = SendableBox<[Chat.Message]>(messages)
 
-        let continuationTurnClosure = self.continuationTurnClosure
-        let stripsContinuationBOS = self.stripsContinuationBOS
         let task = Task {
             [
                 model,
@@ -715,6 +687,11 @@ extension ChatSession {
                     // prepare the input
                     messages.append(contentsOf: inputMessages.consume())
 
+                    // The model side owns the template-specific mechanics of
+                    // continuation repair; the session only determines the
+                    // semantics (continuation? truncated or completed?).
+                    let continuationPolicy = modelConfiguration.continuationPolicy
+
                     // loop can restart on tool calls
                     restart: while !messages.isEmpty {
                         // A continuation appends to a non-empty KV cache.
@@ -735,13 +712,16 @@ extension ChatSession {
                             processing: processing,
                             tools: tools, additionalContext: additionalContext)
                         let preparedInput = try await processor.prepare(input: userInput)
-                        let input =
-                            isContinuation
-                            ? repairContinuation(
+                        let input: LMInput
+                        if isContinuation, let continuationPolicy {
+                            input = repairContinuation(
                                 preparedInput, tokenizer: tokenizer,
-                                closure: previousTurnCompleted ? nil : continuationTurnClosure,
-                                stripBOS: stripsContinuationBOS)
-                            : preparedInput
+                                closure: previousTurnCompleted
+                                    ? nil : continuationPolicy.truncatedTurnClosure,
+                                stripBOS: continuationPolicy.stripsRepeatedBOS)
+                        } else {
+                            input = preparedInput
+                        }
                         // Pessimistic until this pass reports completion: a
                         // generation that dies mid-stream leaves a truncated
                         // turn behind.

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -163,25 +163,39 @@ public final class ChatSession {
     /// Speculative decoding configuration, nil if disabled.
     public let speculativeDecoding: SpeculativeDecodingConfig?
 
-    /// Text that closes the previous model turn when a new turn is appended to
-    /// a non-empty KV cache (e.g. `"<turn|>\n"` for Gemma 4, `"<end_of_turn>\n"`
-    /// for Gemma 3).
+    /// Text that closes a *truncated* previous model turn when a new turn is
+    /// appended to a non-empty KV cache (e.g. `"<turn|>\n"` for Gemma 4,
+    /// `"<end_of_turn>\n"` for Gemma 3).
     ///
-    /// The KV cache stores prior turns as raw tokens and always ends mid
-    /// model-turn: the stop token is *sampled* but never fed through the model,
-    /// and a cancelled generation stops anywhere. Chat templates only render
-    /// the messages they are given, so nothing ever closes that dangling turn —
-    /// every continuation turn is appended right after the previous reply's
-    /// last word, leaving the transcript malformed (`…reply<|turn>user…`).
-    /// When set, these tokens are prepended to each continuation prompt so the
-    /// cached transcript stays canonical (`…reply<turn|>\n<|turn>user…`), which
-    /// also heals turns truncated by cancellation. Off (nil) by default.
+    /// The KV cache stores prior turns as raw tokens. A normally completed
+    /// turn ends with its stop token already in the cache (the iterator feeds
+    /// each sampled token through the model before the generate loop
+    /// recognizes it as a stop), but a generation that was cancelled
+    /// mid-stream — or capped by `maxTokens` — leaves the cached turn dangling
+    /// mid-sentence. Chat templates only render the messages they are given,
+    /// so nothing ever closes that dangling turn: the continuation is appended
+    /// right after the truncated reply's last word, leaving the transcript
+    /// malformed (`…repl<|turn>user…`).
+    ///
+    /// When set, these tokens are prepended to the continuation prompt *only
+    /// when the previous generation did not finish with a stop token*, so the
+    /// cached transcript stays canonical (`…repl<turn|>\n<|turn>user…`)
+    /// without duplicating the terminator of completed turns. Off (nil) by
+    /// default.
     public var continuationTurnClosure: String?
 
     /// Chat templates that begin with `{{ bos_token }}` re-emit `<bos>` on
     /// every render; on continuation turns that would inject a spurious BOS
     /// mid-transcript, so it is stripped. On by default.
     public var stripsContinuationBOS: Bool = true
+
+    /// Stop reason of the most recent generation pass, kept across turns so
+    /// continuation repair can tell a completed turn (stop token already in
+    /// the KV cache) from a truncated one (cancelled or length-capped).
+    /// `nil` until a pass reports completion — and reset to `nil` at the
+    /// start of each pass, so a generation that dies without reporting is
+    /// treated as truncated.
+    private let lastStopReason = SerialAccessContainer<GenerateStopReason?>(nil)
 
     /// Initialize the `ChatSession`.
     ///
@@ -588,14 +602,21 @@ public final class ChatSession {
 
 /// Repairs a continuation prompt (appended to a non-empty KV cache) so the
 /// cached transcript stays canonical: strips the duplicate `<bos>` that
-/// templates re-emit on every render, and prepends `continuationTurnClosure`
-/// to close the previous model turn (whose stop token was sampled but never
-/// fed — or which was truncated by a cancelled generation).
-private func repairContinuation(
+/// templates re-emit on every render, and prepends `closure` to close the
+/// previous model turn when it was truncated (the caller passes `nil` for a
+/// turn that completed with its stop token, which is already in the cache).
+func repairContinuation(
     _ input: LMInput, tokenizer: any Tokenizer,
     closure: String?, stripBOS: Bool
 ) -> LMInput {
     var tokens = input.text.tokens
+    // Text-only processors produce rank-1 `[N]` tokens; VLM processors
+    // produce rank-2 `[1, N]`. Normalize to `[1, N]` and restore on the way
+    // out.
+    let wasRank1 = tokens.ndim == 1
+    if wasRank1 {
+        tokens = tokens.expandedDimensions(axis: 0)
+    }
     guard tokens.ndim == 2, tokens.dim(1) > 0 else { return input }
     var changed = false
     if stripBOS, let bos = tokenizer.bosTokenId, tokens.dim(1) > 1,
@@ -614,8 +635,12 @@ private func repairContinuation(
         }
     }
     guard changed else { return input }
+    let mask = input.text.mask == nil ? nil : ones(like: tokens).asType(.int8)
+    if wasRank1 {
+        tokens = tokens.squeezed(axis: 0)
+    }
     return LMInput(
-        text: .init(tokens: tokens, mask: ones(like: tokens).asType(.int8)),
+        text: .init(tokens: tokens, mask: mask),
         image: input.image, video: input.video, audio: input.audio)
 }
 
@@ -636,7 +661,8 @@ extension ChatSession {
             [
                 model,
                 instructions, processing, tools, toolDispatch,
-                additionalContext, cache, loadedDraftModel, generateParameters, speculativeDecoding
+                additionalContext, cache, loadedDraftModel, generateParameters,
+                speculativeDecoding, lastStopReason
             ] in
             do {
                 try await cache.update { cache in
@@ -670,7 +696,6 @@ extension ChatSession {
 
                     var kvCache: [KVCache]
                     var draftKVCache: [KVCache]?
-                    var isContinuation = false
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
@@ -679,7 +704,6 @@ extension ChatSession {
                     case .kvcache(let array, let storedDraftCache):
                         kvCache = array
                         draftKVCache = storedDraftCache
-                        isContinuation = kvCache.first.map { $0.offset > 0 } ?? false
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
@@ -693,6 +717,19 @@ extension ChatSession {
 
                     // loop can restart on tool calls
                     restart: while !messages.isEmpty {
+                        // A continuation appends to a non-empty KV cache.
+                        // Derived from the live cache offset each pass, so
+                        // the tool-dispatch restart (same cache, new prompt)
+                        // is repaired too.
+                        let isContinuation = (kvCache.first?.offset ?? 0) > 0
+                        // A turn that finished with a stop token is already
+                        // closed in the cache — prepending the closure again
+                        // would duplicate the terminator. Only truncated
+                        // turns (cancelled, length-capped, or never
+                        // reported) need closing.
+                        let previousTurnCompleted = await lastStopReason.read {
+                            if case .stop = $0 { true } else { false }
+                        }
                         let userInput = UserInput(
                             chat: messages,
                             processing: processing,
@@ -702,10 +739,13 @@ extension ChatSession {
                             isContinuation
                             ? repairContinuation(
                                 preparedInput, tokenizer: tokenizer,
-                                closure: continuationTurnClosure,
+                                closure: previousTurnCompleted ? nil : continuationTurnClosure,
                                 stripBOS: stripsContinuationBOS)
                             : preparedInput
-                        isContinuation = false
+                        // Pessimistic until this pass reports completion: a
+                        // generation that dies mid-stream leaves a truncated
+                        // turn behind.
+                        await lastStopReason.update { $0 = nil }
                         messages.removeAll()
 
                         // Select the token iterator based on speculative decoding configuration.
@@ -820,8 +860,17 @@ extension ChatSession {
                         }
 
                         var pendingToolCalls: [ToolCall] = []
+                        var passStopReason: GenerateStopReason? = nil
+                        var consumerTerminated = false
 
                         for await item in genStream {
+                            // record how the pass ended even after the
+                            // consumer went away — the next continuation
+                            // needs it to decide whether the turn is closed
+                            if let info = item.info {
+                                passStopReason = info.stopReason
+                            }
+                            if consumerTerminated { continue }
                             // collect tool calls for dispatch; if no
                             // toolDispatch the caller handles them via
                             // the transform (streamDetails path)
@@ -829,15 +878,18 @@ extension ChatSession {
                                 pendingToolCalls.append(toolCall)
                             } else if let value = transform(item) {
                                 if case .terminated = continuation.yield(value) {
-                                    break
+                                    consumerTerminated = true
                                 }
                             }
                         }
 
                         // wait for the task to complete -- this is important in
-                        // the case where we broke the loop early as the generation
-                        // work may continue (briefly) and use the KVCache
+                        // the case where the consumer terminated early as the
+                        // generation work may continue (briefly) and use the KVCache
                         await genTask.value
+
+                        let finalStopReason = passStopReason
+                        await lastStopReason.update { $0 = finalStopReason }
 
                         // dispatch all tool calls from this generation pass
                         if let toolDispatch, !pendingToolCalls.isEmpty,

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -163,6 +163,26 @@ public final class ChatSession {
     /// Speculative decoding configuration, nil if disabled.
     public let speculativeDecoding: SpeculativeDecodingConfig?
 
+    /// Text that closes the previous model turn when a new turn is appended to
+    /// a non-empty KV cache (e.g. `"<turn|>\n"` for Gemma 4, `"<end_of_turn>\n"`
+    /// for Gemma 3).
+    ///
+    /// The KV cache stores prior turns as raw tokens and always ends mid
+    /// model-turn: the stop token is *sampled* but never fed through the model,
+    /// and a cancelled generation stops anywhere. Chat templates only render
+    /// the messages they are given, so nothing ever closes that dangling turn —
+    /// every continuation turn is appended right after the previous reply's
+    /// last word, leaving the transcript malformed (`…reply<|turn>user…`).
+    /// When set, these tokens are prepended to each continuation prompt so the
+    /// cached transcript stays canonical (`…reply<turn|>\n<|turn>user…`), which
+    /// also heals turns truncated by cancellation. Off (nil) by default.
+    public var continuationTurnClosure: String?
+
+    /// Chat templates that begin with `{{ bos_token }}` re-emit `<bos>` on
+    /// every render; on continuation turns that would inject a spurious BOS
+    /// mid-transcript, so it is stripped. On by default.
+    public var stripsContinuationBOS: Bool = true
+
     /// Initialize the `ChatSession`.
     ///
     /// - Parameters:
@@ -564,6 +584,42 @@ public final class ChatSession {
         )
     }
 
+}
+
+/// Repairs a continuation prompt (appended to a non-empty KV cache) so the
+/// cached transcript stays canonical: strips the duplicate `<bos>` that
+/// templates re-emit on every render, and prepends `continuationTurnClosure`
+/// to close the previous model turn (whose stop token was sampled but never
+/// fed — or which was truncated by a cancelled generation).
+private func repairContinuation(
+    _ input: LMInput, tokenizer: any Tokenizer,
+    closure: String?, stripBOS: Bool
+) -> LMInput {
+    var tokens = input.text.tokens
+    guard tokens.ndim == 2, tokens.dim(1) > 0 else { return input }
+    var changed = false
+    if stripBOS, let bos = tokenizer.bosTokenId, tokens.dim(1) > 1,
+        tokens[0, 0].item(Int.self) == bos
+    {
+        tokens = tokens[0..., 1...]
+        changed = true
+    }
+    if let closure, !closure.isEmpty {
+        let ids = tokenizer.encode(text: closure, addSpecialTokens: false)
+        if !ids.isEmpty {
+            tokens = concatenated(
+                [MLXArray(ids.map { Int32($0) }).expandedDimensions(axis: 0), tokens],
+                axis: 1)
+            changed = true
+        }
+    }
+    guard changed else { return input }
+    return LMInput(
+        text: .init(tokens: tokens, mask: ones(like: tokens).asType(.int8)),
+        image: input.image, video: input.video, audio: input.audio)
+}
+
+extension ChatSession {
     private func streamMap<R: Sendable>(
         messages: consuming [Chat.Message],
         transform: @Sendable @escaping (Generation) -> R?
@@ -574,6 +630,8 @@ public final class ChatSession {
         // and are only being sent to the inner async
         let inputMessages = SendableBox<[Chat.Message]>(messages)
 
+        let continuationTurnClosure = self.continuationTurnClosure
+        let stripsContinuationBOS = self.stripsContinuationBOS
         let task = Task {
             [
                 model,
@@ -612,6 +670,7 @@ public final class ChatSession {
 
                     var kvCache: [KVCache]
                     var draftKVCache: [KVCache]?
+                    var isContinuation = false
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
@@ -620,6 +679,7 @@ public final class ChatSession {
                     case .kvcache(let array, let storedDraftCache):
                         kvCache = array
                         draftKVCache = storedDraftCache
+                        isContinuation = kvCache.first.map { $0.offset > 0 } ?? false
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
@@ -637,7 +697,15 @@ public final class ChatSession {
                             chat: messages,
                             processing: processing,
                             tools: tools, additionalContext: additionalContext)
-                        let input = try await processor.prepare(input: userInput)
+                        let preparedInput = try await processor.prepare(input: userInput)
+                        let input =
+                            isContinuation
+                            ? repairContinuation(
+                                preparedInput, tokenizer: tokenizer,
+                                closure: continuationTurnClosure,
+                                stripBOS: stripsContinuationBOS)
+                            : preparedInput
+                        isContinuation = false
                         messages.removeAll()
 
                         // Select the token iterator based on speculative decoding configuration.

--- a/Libraries/MLXLMCommon/ModelConfiguration.swift
+++ b/Libraries/MLXLMCommon/ModelConfiguration.swift
@@ -118,6 +118,13 @@ public struct ModelConfiguration: Sendable {
     /// Tool call format for this model (nil = default JSON format)
     public var toolCallFormat: ToolCallFormat?
 
+    /// Model-specific policy for keeping a cached chat transcript canonical
+    /// across ``ChatSession`` continuation turns. `nil` (the default)
+    /// disables continuation repair. Like ``extraEOSTokens`` and
+    /// ``toolCallFormat``, this captures chat-template knowledge on the
+    /// model side so callers never handle template-specific token framing.
+    public var continuationPolicy: ContinuationPolicy?
+
     public init(
         id: String, revision: String = "main",
         tokenizerSource: TokenizerSource? = nil,
@@ -125,7 +132,8 @@ public struct ModelConfiguration: Sendable {
         extraEOSTokens: Set<String> = [],
         stopStrings: Set<String>? = nil,
         eosTokenIds: Set<Int> = [],
-        toolCallFormat: ToolCallFormat? = nil
+        toolCallFormat: ToolCallFormat? = nil,
+        continuationPolicy: ContinuationPolicy? = nil
     ) {
         self.id = .id(id, revision: revision)
         self.tokenizerSource = tokenizerSource
@@ -134,6 +142,7 @@ public struct ModelConfiguration: Sendable {
         self.stopStrings = stopStrings
         self.eosTokenIds = eosTokenIds
         self.toolCallFormat = toolCallFormat
+        self.continuationPolicy = continuationPolicy
     }
 
     public init(
@@ -143,7 +152,8 @@ public struct ModelConfiguration: Sendable {
         extraEOSTokens: Set<String> = [],
         stopStrings: Set<String>? = nil,
         eosTokenIds: Set<Int> = [],
-        toolCallFormat: ToolCallFormat? = nil
+        toolCallFormat: ToolCallFormat? = nil,
+        continuationPolicy: ContinuationPolicy? = nil
     ) {
         self.id = .directory(directory)
         self.tokenizerSource = tokenizerSource
@@ -152,6 +162,34 @@ public struct ModelConfiguration: Sendable {
         self.stopStrings = stopStrings
         self.eosTokenIds = eosTokenIds
         self.toolCallFormat = toolCallFormat
+        self.continuationPolicy = continuationPolicy
+    }
+
+    /// Model-specific knowledge for repairing a continuation prompt that is
+    /// appended to a non-empty KV cache.
+    ///
+    /// ``ChatSession`` determines the *semantics* (is this a continuation?
+    /// was the previous model turn truncated or completed?) and this policy
+    /// supplies the template-specific mechanics, keeping the session API
+    /// model-agnostic.
+    public struct ContinuationPolicy: Sendable, Equatable {
+
+        /// Text that closes a *truncated* model turn (e.g. `"<turn|>\n"` for
+        /// Gemma 4, `"<end_of_turn>\n"` for Gemma 3). Applied only when the
+        /// previous generation did not finish with a stop token — a
+        /// completed turn already has its terminator in the cache.
+        public let truncatedTurnClosure: String?
+
+        /// Whether the model's chat template begins with `{{ bos_token }}`
+        /// and therefore re-emits `<bos>` on every render; the duplicate is
+        /// stripped from continuation prompts. The strip only triggers when
+        /// the first prompt token actually equals the tokenizer's BOS.
+        public let stripsRepeatedBOS: Bool
+
+        public init(truncatedTurnClosure: String? = nil, stripsRepeatedBOS: Bool = true) {
+            self.truncatedTurnClosure = truncatedTurnClosure
+            self.stripsRepeatedBOS = stripsRepeatedBOS
+        }
     }
 
     /// Maps this configuration's behavioral properties into a

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -29,6 +29,11 @@ extension Tokenizer {
         decode(tokenIds: tokenIds, skipSpecialTokens: false)
     }
 
+    public var bosTokenId: Int? {
+        guard let bosToken else { return nil }
+        return convertTokenToId(bosToken)
+    }
+
     public var eosTokenId: Int? {
         guard let eosToken else { return nil }
         return convertTokenToId(eosToken)

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -206,43 +206,50 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
     static public let gemma3_4B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-4b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma3_12B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-12b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma3_27B_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-3-27b-it-qat-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<end_of_turn>"]
+        extraEOSTokens: ["<end_of_turn>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<end_of_turn>\n")
     )
 
     static public let gemma4_E2B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e2b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<turn|>\n")
     )
 
     static public let gemma4_E4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-e4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<turn|>\n")
     )
 
     static public let gemma4_31B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-31b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<turn|>\n")
     )
 
     static public let gemma4_26BA4B_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-26b-a4b-it-4bit",
         defaultPrompt: "Describe the image in English",
-        extraEOSTokens: ["<turn|>"]
+        extraEOSTokens: ["<turn|>"],
+        continuationPolicy: .init(truncatedTurnClosure: "<turn|>\n")
     )
 
     static public let smolvlm = ModelConfiguration(

--- a/Tests/MLXLMTests/ContinuationRepairTests.swift
+++ b/Tests/MLXLMTests/ContinuationRepairTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import MLX
+import MLXLLM
 import XCTest
 
 @testable import MLXLMCommon
@@ -112,6 +113,23 @@ public class ContinuationRepairTests: XCTestCase {
         XCTAssertEqual(repaired.text.tokens.ndim, 2)
         XCTAssertEqual(repaired.text.tokens.dim(0), 1)
         XCTAssertEqual(tokenList(repaired.text.tokens.squeezed(axis: 0)), [77, 78, 10, 11])
+    }
+
+    // MARK: - ContinuationPolicy plumbing
+
+    func testDefaultConfigurationHasNoContinuationPolicy() {
+        // No policy ⇒ ChatSession performs no repair: zero behavior change
+        // for models that don't declare one.
+        XCTAssertNil(ModelConfiguration(id: "test").continuationPolicy)
+    }
+
+    func testGemmaRegistrationsCarryContinuationPolicy() throws {
+        let gemma4 = try XCTUnwrap(LLMRegistry.gemma4_e4b_it_4bit.continuationPolicy)
+        XCTAssertEqual(gemma4.truncatedTurnClosure, "<turn|>\n")
+        XCTAssertTrue(gemma4.stripsRepeatedBOS)
+
+        let gemma3 = try XCTUnwrap(LLMRegistry.gemma3_1B_qat_4bit.continuationPolicy)
+        XCTAssertEqual(gemma3.truncatedTurnClosure, "<end_of_turn>\n")
     }
 
     // MARK: - mask handling

--- a/Tests/MLXLMTests/ContinuationRepairTests.swift
+++ b/Tests/MLXLMTests/ContinuationRepairTests.swift
@@ -1,0 +1,141 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+
+/// Deterministic tokenizer for `repairContinuation` tests: known BOS id and
+/// a fixed encoding for the turn-closure text.
+private struct RepairTestTokenizer: MLXLMCommon.Tokenizer {
+
+    static let bosId = 2
+    static let closureText = "<turn|>\n"
+    static let closureIds = [77, 78]
+
+    var bosToken: String? = "<bos>"
+    var eosToken: String? = nil
+    var unknownToken: String? = nil
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        text == Self.closureText ? Self.closureIds : [9]
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        token == bosToken ? Self.bosId : nil
+    }
+
+    func convertIdToToken(_ id: Int) -> String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        [Self.bosId, 10, 11]
+    }
+}
+
+public class ContinuationRepairTests: XCTestCase {
+
+    private let tokenizer = RepairTestTokenizer()
+
+    private func tokenList(_ tokens: MLXArray) -> [Int] {
+        tokens.asArray(Int.self)
+    }
+
+    // MARK: - rank-1 (default text-only LLMUserInputProcessor shape)
+
+    func testStripsBOSFromRank1Tokens() {
+        let input = LMInput(tokens: MLXArray([2, 10, 11]))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer, closure: nil, stripBOS: true)
+
+        XCTAssertEqual(repaired.text.tokens.ndim, 1)
+        XCTAssertEqual(tokenList(repaired.text.tokens), [10, 11])
+        XCTAssertNil(repaired.text.mask)
+    }
+
+    func testPrependsClosureToRank1Tokens() {
+        let input = LMInput(tokens: MLXArray([2, 10, 11]))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer,
+            closure: RepairTestTokenizer.closureText, stripBOS: true)
+
+        XCTAssertEqual(repaired.text.tokens.ndim, 1)
+        XCTAssertEqual(tokenList(repaired.text.tokens), [77, 78, 10, 11])
+    }
+
+    func testNilClosureAndDisabledStripReturnInputUnchanged() {
+        let input = LMInput(tokens: MLXArray([2, 10, 11]))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer, closure: nil, stripBOS: false)
+
+        XCTAssertEqual(tokenList(repaired.text.tokens), [2, 10, 11])
+    }
+
+    func testLoneBOSTokenIsNotStripped() {
+        // A single-token prompt equal to BOS must survive (dim(1) > 1 guard).
+        let input = LMInput(tokens: MLXArray([2]))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer, closure: nil, stripBOS: true)
+
+        XCTAssertEqual(tokenList(repaired.text.tokens), [2])
+    }
+
+    func testNonBOSFirstTokenIsNotStripped() {
+        let input = LMInput(tokens: MLXArray([10, 11]))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer, closure: nil, stripBOS: true)
+
+        XCTAssertEqual(tokenList(repaired.text.tokens), [10, 11])
+    }
+
+    // MARK: - rank-2 (VLM processor shape)
+
+    func testRepairsRank2TokensPreservingRank() {
+        let input = LMInput(
+            text: .init(tokens: MLXArray([2, 10, 11]).expandedDimensions(axis: 0)))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer,
+            closure: RepairTestTokenizer.closureText, stripBOS: true)
+
+        XCTAssertEqual(repaired.text.tokens.ndim, 2)
+        XCTAssertEqual(repaired.text.tokens.dim(0), 1)
+        XCTAssertEqual(tokenList(repaired.text.tokens.squeezed(axis: 0)), [77, 78, 10, 11])
+    }
+
+    // MARK: - mask handling
+
+    func testNilMaskStaysNil() {
+        let input = LMInput(
+            text: .init(tokens: MLXArray([2, 10, 11]).expandedDimensions(axis: 0), mask: nil))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer, closure: nil, stripBOS: true)
+
+        XCTAssertNil(repaired.text.mask)
+    }
+
+    func testExistingMaskIsRebuiltToNewLength() throws {
+        let tokens = MLXArray([2, 10, 11]).expandedDimensions(axis: 0)
+        let input = LMInput(
+            text: .init(tokens: tokens, mask: ones(like: tokens).asType(.int8)))
+
+        let repaired = repairContinuation(
+            input, tokenizer: tokenizer,
+            closure: RepairTestTokenizer.closureText, stripBOS: true)
+
+        let mask = try XCTUnwrap(repaired.text.mask)
+        XCTAssertEqual(mask.dim(-1), repaired.text.tokens.dim(-1))
+    }
+}


### PR DESCRIPTION
### Problem

`ChatSession` keeps prior turns in the KV cache as raw tokens, and two behaviors interact so that **continuation turns can append to a malformed transcript**:

1. **A truncated generation leaves a dangling model turn in the cache.** A caller that stops consuming mid-stream (e.g. voice barge-in) — or a generation capped by `maxTokens` — leaves the cached turn cut off mid-sentence, with no turn terminator. (A normally completed turn is fine: the sampled stop token is fed through the model before the generate loop recognizes it, so it is already in the cache.)
2. **Templates that begin with `{{ bos_token }}` re-emit `<bos>` on every render** (Gemma's chat template does), so every continuation prompt injects a spurious `<bos>` mid-transcript.

Chat templates only render the messages they are given, so nothing ever repairs this: after an interruption the effective transcript the model sees is

```
…truncated repl<bos><|turn>user
next message…
```

instead of the canonical

```
…truncated repl<turn|>
<|turn>user
next message…
```

In practice the duplicate `<bos>` alone is often invisible on short text-only chats, but after an interruption the malformed transcript can push Gemma 4 into emitting its `<|channel>thought` channel or degenerate output (reproduced with `mlx-community/gemma-4-12B-it-4bit`). With the repair in place, post-interruption turns stay clean — validated on-device in a voice-assistant app with real barge-in.

### Fix

The split follows the layering @aleroot suggested in review: **the session determines the semantics, the model side owns the template mechanics.** Callers never see or set template syntax.

- New `ModelConfiguration.ContinuationPolicy` (`truncatedTurnClosure`, `stripsRepeatedBOS`) — model-side knowledge, declared alongside the template knowledge that already lives there (`extraEOSTokens`, `toolCallFormat`). The Gemma 3 / Gemma 4 registrations declare it (`"<end_of_turn>\n"` / `"<turn|>\n"`).
- `ChatSession` only determines: is this pass a continuation (live KV-cache offset, so the tool-dispatch restart is covered), and did the previous turn complete or truncate (tracked `GenerateStopReason`, pessimistically reset at pass start). It then applies the model's policy: the turn closure **only for truncated turns** (completed turns already carry their terminator in the cache), the BOS strip only when the first prompt token equals the tokenizer's BOS.
- **No policy ⇒ no repair**: models that don't declare a `ContinuationPolicy` get zero behavior change, which also resolves the earlier concern about the BOS-strip default.
- `Tokenizer.bosTokenId` convenience, mirroring the existing `eosTokenId`.

The token-level repair itself runs in one place (`repairContinuation`), after `processor.prepare`, handling both token-tensor shapes (rank-1 text / rank-2 VLM) and preserving a `nil` mask.

### Testing

- Deterministic unit tests for `repairContinuation` (rank-1/rank-2, BOS edge cases, closure prepending, mask handling) plus policy-plumbing tests (default configuration has no policy; Gemma registrations carry the right closures).
- `xcodebuild build-for-testing` + `MLXLMTests` via `xcrun xctest` (same as CI) pass on this branch.
- Deterministic A/B at temperature 0 on Gemma 4 12B: without repair, continuation turns show `<bos>` duplication and post-interruption thought-channel leakage; with repair, transcripts are canonical and the leakage disappears. Validated on-device (iPad, voice barge-in scenario).