### PR TITLE
Enable MTP speculative decoding for Gemma 4 12B (gemma4_unified target + gemma4_unified_assistant drafter)

### DIFF
--- a/Libraries/MLXVLM/Gemma4AssistantRegistration.swift
+++ b/Libraries/MLXVLM/Gemma4AssistantRegistration.swift
@@ -25,13 +25,21 @@ import MLXLMCommon
 /// ```
 public enum Gemma4AssistantRegistration {
     public static func register() async {
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "gemma4_assistant",
-            creator: { data in
-                let config = try JSONDecoder().decode(
-                    Gemma4AssistantConfiguration.self, from: data)
-                return Gemma4AssistantDraftModel(config)
-            }
-        )
+        // `gemma4_assistant` (E-series, 26B-A4B, 31B drafters) and
+        // `gemma4_unified_assistant` (the 12B drafter, whose target is the
+        // `gemma4_unified` VLM) share the drafter implementation: the unified
+        // variant differs only in its `text_config` (`gemma4_unified_text`,
+        // `attention_k_eq_v`, `num_global_key_value_heads`), which
+        // `Gemma4TextConfiguration` already decodes.
+        for modelType in ["gemma4_assistant", "gemma4_unified_assistant"] {
+            await MTPDrafterTypeRegistry.shared.registerModelType(
+                modelType,
+                creator: { data in
+                    let config = try JSONDecoder().decode(
+                        Gemma4AssistantConfiguration.self, from: data)
+                    return Gemma4AssistantDraftModel(config)
+                }
+            )
+        }
     }
 }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2350,9 +2350,7 @@ private final class Gemma4UnifiedVisionEmbedder: Module {
 }
 
 public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
-    // Module-internal (not `private`) — the MTP drafter in `Gemma4Assistant.swift`
-    // reaches `embed_tokens` / `embed_scale` through this, mirroring `Gemma4`.
-    @ModuleInfo(key: "language_model") var languageModel: Gemma4TextLanguageModel
+    @ModuleInfo(key: "language_model") private var languageModel: Gemma4TextLanguageModel
     @ModuleInfo(key: "vision_embedder") private var visionEmbedder: Gemma4UnifiedVisionEmbedder?
     @ModuleInfo(key: "embed_vision") private var embedVision: Gemma4MultimodalEmbedder?
     @ModuleInfo(key: "embed_audio") private var embedAudio: Gemma4MultimodalEmbedder?
@@ -2594,6 +2592,30 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
         }
         return languageModel.sanitize(weights: filtered)
     }
+}
+
+// MARK: - MTP drafter target access
+
+/// A Gemma 4 - family VLM whose text stack is the shared
+/// `Gemma4TextBackbone`. The MTP drafter
+/// (`Gemma4AssistantDraftModel.draftBlock`) casts its `target` to this
+/// protocol instead of dispatching on concrete classes, so it stays agnostic
+/// of which Gemma 4 variant wraps the backbone.
+///
+/// Declared in this file so the conformances can reach the classes' private
+/// `languageModel` without widening its visibility.
+protocol Gemma4BackboneProviding {
+    /// The text backbone whose `embedTokens` / `embedScale` the drafter
+    /// shares with the target.
+    var textBackbone: Gemma4TextBackbone { get }
+}
+
+extension Gemma4: Gemma4BackboneProviding {
+    var textBackbone: Gemma4TextBackbone { languageModel.model }
+}
+
+extension Gemma4Unified: Gemma4BackboneProviding {
+    var textBackbone: Gemma4TextBackbone { languageModel.model }
 }
 
 // MARK: - Processor

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2350,7 +2350,9 @@ private final class Gemma4UnifiedVisionEmbedder: Module {
 }
 
 public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "language_model") private var languageModel: Gemma4TextLanguageModel
+    // Module-internal (not `private`) — the MTP drafter in `Gemma4Assistant.swift`
+    // reaches `embed_tokens` / `embed_scale` through this, mirroring `Gemma4`.
+    @ModuleInfo(key: "language_model") var languageModel: Gemma4TextLanguageModel
     @ModuleInfo(key: "vision_embedder") private var visionEmbedder: Gemma4UnifiedVisionEmbedder?
     @ModuleInfo(key: "embed_vision") private var embedVision: Gemma4MultimodalEmbedder?
     @ModuleInfo(key: "embed_audio") private var embedAudio: Gemma4MultimodalEmbedder?
@@ -2555,6 +2557,22 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
     public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
         let logits = languageModel(inputs, cache: cache?.map { $0 })
         return logits.logits
+    }
+
+    /// MTP-aware `LanguageModel` entry point. Reads `mtpEmitFlagKey` from
+    /// the incoming `state` and threads it through to `Gemma4TextLanguageModel`;
+    /// the returned `LMOutput` carries `mtpLastHiddenStatesKey` and
+    /// `mtpSharedKVStatesKey` populated when the flag is set, empty otherwise.
+    /// Overrides the protocol-extension default at `LanguageModel` which
+    /// would discard `state`. Mirrors `Gemma4.callAsFunction(_:cache:state:)`.
+    public func callAsFunction(
+        _ input: LMInput.Text, cache: [any KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        let emit = state?[mtpEmitFlagKey] ?? false
+        return languageModel(
+            input.tokens, cache: cache?.map { $0 },
+            emitDrafterState: emit
+        )
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXVLM/Models/Gemma4Assistant.swift
+++ b/Libraries/MLXVLM/Models/Gemma4Assistant.swift
@@ -182,14 +182,21 @@ public final class Gemma4AssistantDraftModel: Module, MTPDrafterModel {
         // walk (gemma4_assistant.py:79-101): for Gemma 4 the input embedding
         // lives under `.language_model.model.embed_tokens`. `Gemma4Text‐
         // LanguageModel` is not itself a `LanguageModel`, so only the
-        // top-level `Gemma4` is accepted here. Stateless wrt target by
-        // construction (no ivars retain anything derived from `target`).
-        guard let g4 = target as? Gemma4 else {
+        // top-level VLM classes are accepted here — `Gemma4` (`gemma4`:
+        // E-series, 26B-A4B, 31B) and `Gemma4Unified` (`gemma4_unified`: 12B),
+        // which wrap the same `Gemma4TextLanguageModel`. Stateless wrt target
+        // by construction (no ivars retain anything derived from `target`).
+        let backbone: Gemma4TextBackbone
+        switch target {
+        case let g4 as Gemma4:
+            backbone = g4.languageModel.model
+        case let g4u as Gemma4Unified:
+            backbone = g4u.languageModel.model
+        default:
             fatalError(
                 "Gemma4AssistantDraftModel.draftBlock: target is not a Gemma 4 VLM "
                     + "(got \(type(of: target)))")
         }
-        let backbone = g4.languageModel.model
         let inputEmbed = backbone.embedTokens
         let embedScale = backbone.embedScale
 

--- a/Libraries/MLXVLM/Models/Gemma4Assistant.swift
+++ b/Libraries/MLXVLM/Models/Gemma4Assistant.swift
@@ -180,23 +180,17 @@ public final class Gemma4AssistantDraftModel: Module, MTPDrafterModel {
 
         // Derive target-bound constants inline per round. Mirrors mlx-vlm's
         // walk (gemma4_assistant.py:79-101): for Gemma 4 the input embedding
-        // lives under `.language_model.model.embed_tokens`. `Gemma4Text‐
-        // LanguageModel` is not itself a `LanguageModel`, so only the
-        // top-level VLM classes are accepted here — `Gemma4` (`gemma4`:
-        // E-series, 26B-A4B, 31B) and `Gemma4Unified` (`gemma4_unified`: 12B),
-        // which wrap the same `Gemma4TextLanguageModel`. Stateless wrt target
-        // by construction (no ivars retain anything derived from `target`).
-        let backbone: Gemma4TextBackbone
-        switch target {
-        case let g4 as Gemma4:
-            backbone = g4.languageModel.model
-        case let g4u as Gemma4Unified:
-            backbone = g4u.languageModel.model
-        default:
+        // lives under `.language_model.model.embed_tokens`. The target is
+        // any Gemma 4 - family VLM that exposes the shared text backbone via
+        // `Gemma4BackboneProviding` (`Gemma4`: E-series, 26B-A4B, 31B;
+        // `Gemma4Unified`: 12B). Stateless wrt target by construction (no
+        // ivars retain anything derived from `target`).
+        guard let provider = target as? Gemma4BackboneProviding else {
             fatalError(
                 "Gemma4AssistantDraftModel.draftBlock: target is not a Gemma 4 VLM "
                     + "(got \(type(of: target)))")
         }
+        let backbone = provider.textBackbone
         let inputEmbed = backbone.embedTokens
         let embedScale = backbone.embedScale
 

--- a/Tests/MLXLMTests/Gemma4AssistantDraftModelTests.swift
+++ b/Tests/MLXLMTests/Gemma4AssistantDraftModelTests.swift
@@ -149,3 +149,164 @@ private func syntheticConfig(tieWordEmbeddings: Bool) -> Gemma4AssistantConfigur
     return try! JSONDecoder().decode(
         Gemma4AssistantConfiguration.self, from: Data(json.utf8))
 }
+
+// MARK: - gemma4_unified_assistant (the 12B drafter)
+
+/// Decode pin for the unified-assistant config shape: mirrors
+/// `mlx-community/gemma-4-12B-it-assistant-4bit`'s `config.json`
+/// (`model_type: gemma4_unified_assistant`, `text_config.model_type:
+/// gemma4_unified_text`, `attention_k_eq_v`, `num_global_key_value_heads`).
+@Test
+func testGemma4UnifiedAssistantConfigurationDecodes() throws {
+    let json = """
+        {
+          "model_type": "gemma4_unified_assistant",
+          "backbone_hidden_size": 3840,
+          "tie_word_embeddings": true,
+          "use_ordered_embeddings": false,
+          "num_centroids": 2048,
+          "centroid_intermediate_top_k": 32,
+          "text_config": {
+            "model_type": "gemma4_unified_text",
+            "hidden_size": 1024,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "num_global_key_value_heads": 1,
+            "head_dim": 256,
+            "global_head_dim": 512,
+            "vocab_size": 262144,
+            "num_kv_shared_layers": 4,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 1024,
+            "max_position_embeddings": 262144,
+            "rms_norm_eps": 1e-6,
+            "attention_k_eq_v": true,
+            "intermediate_size": 8192,
+            "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"],
+            "rope_parameters": {},
+            "tie_word_embeddings": true
+          }
+        }
+        """
+    let cfg = try JSONDecoder().decode(
+        Gemma4AssistantConfiguration.self, from: Data(json.utf8))
+    #expect(cfg.modelType == "gemma4_unified_assistant")
+    #expect(cfg.backboneHiddenSize == 3840)
+    #expect(cfg.useOrderedEmbeddings == false)
+    #expect(cfg.textConfiguration.modelType == "gemma4_unified_text")
+    #expect(cfg.textConfiguration.attentionKEqV == true)
+    #expect(cfg.textConfiguration.globalKVHeads == 1)
+    #expect(cfg.textConfiguration.hiddenSize == 1024)
+
+    // Instantiation must succeed with the unified text config.
+    let model = Gemma4AssistantDraftModel(cfg)
+    #expect(model.config.modelType == "gemma4_unified_assistant")
+}
+
+/// End-to-end synthetic pin for the `gemma4_unified` target path: a tiny
+/// `Gemma4Unified` (a) emits drafter state through the MTP-aware
+/// `callAsFunction(_:cache:state:)` entry point, and (b) is accepted by
+/// `draftBlock` as the target (the pre-fix guard only recognized `Gemma4`
+/// and trapped on `Gemma4Unified`, which the iterator surfaced as sticky
+/// passthrough — MTP silently disabled for the 12B).
+@Test
+func testDraftBlockAcceptsGemma4UnifiedTarget() throws {
+    let unifiedJSON = """
+        {
+          "model_type": "gemma4_unified",
+          "vocab_size": 32,
+          "image_token_id": 31,
+          "text_config": {
+            "model_type": "gemma4_unified_text",
+            "hidden_size": 8,
+            "num_hidden_layers": 2,
+            "intermediate_size": 16,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "num_global_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "num_kv_shared_layers": 0,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 8,
+            "attention_k_eq_v": true,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "rope_parameters": {},
+            "tie_word_embeddings": true
+          },
+          "vision_config": null,
+          "audio_config": null
+        }
+        """
+    let targetConfig = try JSONDecoder.json5().decode(
+        Gemma4UnifiedConfiguration.self, from: Data(unifiedJSON.utf8))
+    let target = Gemma4Unified(targetConfig)
+
+    // Prime drafter state through the MTP entry point (what the iterator does).
+    let cache = target.newCache(parameters: nil)
+    var emitState = LMOutput.State()
+    emitState[mtpEmitFlagKey] = true
+    let tokens = MLXArray((0 ..< 8).map { Int32($0 % 32) }).reshaped([1, 8])
+    let out = target(LMInput.Text(tokens: tokens), cache: cache, state: emitState)
+    eval(out.logits)
+
+    #expect(out.state != nil, "Gemma4Unified must emit drafter state when the flag is set")
+    guard let state = out.state,
+        let lastHidden = state[mtpLastHiddenStatesKey],
+        let sharedKV = state[mtpSharedKVStatesKey]
+    else {
+        Issue.record("missing drafter state keys on Gemma4Unified LMOutput")
+        return
+    }
+    #expect(Set(sharedKV.keys) == ["full_attention", "sliding_attention"])
+
+    // Tiny drafter with geometry matching the target's KV (cross-attention
+    // consumes the target's sharedKV pool) and backbone hidden size.
+    let drafterJSON = """
+        {
+          "model_type": "gemma4_unified_assistant",
+          "backbone_hidden_size": 8,
+          "tie_word_embeddings": true,
+          "use_ordered_embeddings": false,
+          "num_centroids": 2,
+          "centroid_intermediate_top_k": 1,
+          "text_config": {
+            "model_type": "gemma4_unified_text",
+            "hidden_size": 8,
+            "num_hidden_layers": 2,
+            "intermediate_size": 16,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "num_global_key_value_heads": 1,
+            "head_dim": 8,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "num_kv_shared_layers": 2,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 8,
+            "attention_k_eq_v": true,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "rope_parameters": {},
+            "tie_word_embeddings": true
+          }
+        }
+        """
+    let drafterConfig = try JSONDecoder().decode(
+        Gemma4AssistantConfiguration.self, from: Data(drafterJSON.utf8))
+    let drafter = Gemma4AssistantDraftModel(drafterConfig)
+
+    let lastHiddenSlice = lastHidden[0..., (-1)..., 0...]
+    let proposed = drafter.draftBlock(
+        target: target,
+        lastToken: MLXArray([Int32(3)]),
+        lastHidden: lastHiddenSlice,
+        sharedKV: sharedKV,
+        queryOffset: cache.first?.offset ?? 8,
+        blockSize: 3,
+        sampler: ArgMaxSampler()
+    )
+    eval(proposed)
+    #expect(proposed.shape == [1, 2])
+}


### PR DESCRIPTION
### Problem

The 12B Gemma 4 (`model_type: gemma4_unified`, class `Gemma4Unified`) cannot use MTP speculative decoding, for three stacked reasons:

1. Its drafter (`google/gemma-4-12B-it-assistant` and the mlx-community conversions) ships `model_type: gemma4_unified_assistant`, which is not registered with `MTPDrafterTypeRegistry`.
2. `Gemma4Unified` does not override `callAsFunction(_:cache:state:)`, so the `mtpEmitFlagKey` opt-in is discarded by the protocol-extension default and the target never emits drafter state — the MTP iterator **silently falls back to single-token passthrough** (no error, just no speedup).
3. `Gemma4AssistantDraftModel.draftBlock` only accepted a `Gemma4` target and trapped on `Gemma4Unified`.

### Fix

- Register `gemma4_unified_assistant` with the same creator — the drafter implementation is shared; the unified variant differs only in its `text_config`, which `Gemma4TextConfiguration` already decodes.
- Add the MTP-aware state entry point to `Gemma4Unified`, mirroring `Gemma4`.
- Make `draftBlock` target-agnostic: instead of dispatching on concrete classes, the target is cast to a new internal `Gemma4BackboneProviding` protocol exposing the shared text backbone. `Gemma4` and `Gemma4Unified` adopt it in `Gemma4.swift`, where the conformances can reach the private `languageModel` without widening its visibility.
- For a non-Gemma-4 target, `draftBlock` keeps the existing trap semantics (`fatalError` with the offending type); happy to convert that to a thrown error if you'd prefer.

### Testing

- Config-decode pin mirroring the published 12B assistant config, and a synthetic end-to-end pin: `Gemma4Unified` emits state through the MTP entry point, and `draftBlock` accepts the unified target and returns `[1, blockSize-1]`.
- `xcodebuild build-for-testing` + `MLXLMTests` via `xcrun xctest` (same as CI): 184 tests pass on this branch.
- Validated on-device that the wiring works end-to-end: ~62% draft acceptance on predictable text with the 12B target + assistant drafter.
