### PR TITLE
Qwen3 embedder: honor attentionMask instead of silently ignoring it

### DIFF
--- a/Libraries/MLXEmbedders/Models/Qwen3.swift
+++ b/Libraries/MLXEmbedders/Models/Qwen3.swift
@@ -262,14 +262,27 @@ private class Qwen3ModelInner: Module {
     /// - Parameters:
     ///   - inputs: An `MLXArray` of token IDs with shape `[Batch, Length]`.
     ///   - cache: An optional array of `KVCache` objects, one for each layer.
+    ///   - attentionMask: Optional `[Batch, Length]` key-padding mask
+    ///     (nonzero = attend, zero = padding). Folded into the causal mask so
+    ///     padded positions are excluded as attention keys — required for
+    ///     correct batched embedding with left padding, where pads *precede*
+    ///     the tokens that must not see them.
     /// - Returns: The final hidden states of shape `[Batch, Length, HiddenSize]`.
-    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+    public func callAsFunction(
+        _ inputs: MLXArray, cache: [KVCache]? = nil, attentionMask: MLXArray? = nil
+    ) -> MLXArray {
         // Step 1: Token Embedding lookup
         var h = embedTokens(inputs)
 
         // Step 2: Create the Attention Mask
         // Uses MLXFast utility to determine if a causal or additive mask is needed
-        let mask = createAttentionMask(h: h, cache: cache?.first)
+        var mask = createAttentionMask(h: h, cache: cache?.first)
+        if let attentionMask, inputs.dim(1) > 1 {
+            // Causal ∧ key-not-padding, broadcast to [Batch, 1, L, L].
+            let causal = createCausalMask(n: inputs.dim(1), offset: cache?.first?.offset ?? 0)
+            let keep = attentionMask.asType(.bool)[0..., .newAxis, .newAxis, 0...]
+            mask = .array(causal & keep)
+        }
 
         // Step 3: Sequential processing through Transformer Layers
         for (i, layer) in layers.enumerated() {
@@ -321,7 +334,11 @@ public class Qwen3Model: Module, EmbeddingModel {
     ///   - inputIds: Tensor of token indices.
     ///   - positionIds: Optional indices for positional information.
     ///   - tokenTypeIds: Optional indices for segment-based tasks.
-    ///   - attentionMask: Optional mask for specific attention patterns.
+    ///   - attentionMask: Optional `[Batch, Length]` key-padding mask
+    ///     (nonzero = attend). Honored, not decorative: without it a padded
+    ///     batch lets real tokens attend to padding keys whenever padding
+    ///     precedes them (left padding, the Hugging Face default for this
+    ///     model family).
     /// - Returns: An `EmbeddingModelOutput` containing the final hidden states.
     public func callAsFunction(
         _ inputIds: MLXArray,
@@ -330,7 +347,7 @@ public class Qwen3Model: Module, EmbeddingModel {
         attentionMask: MLXArray? = nil
     ) -> EmbeddingModelOutput {
         // Pass the input through the inner model backbone
-        let out = model(inputIds, cache: nil)
+        let out = model(inputIds, cache: nil, attentionMask: attentionMask)
 
         return EmbeddingModelOutput(
             hiddenStates: out,


### PR DESCRIPTION
## What

`Qwen3Model.callAsFunction` (MLXEmbedders) accepts an `attentionMask` parameter and silently discards it — the backbone always runs with a plain causal mask, so padding tokens participate as attention **keys** for any position that comes after them.

## Why it matters

Qwen3-Embedding is a last-token-pooling model, and its Hugging Face reference tokenizes with `padding_side='left'`. Under left padding, *every real token* attends to the pads that precede it, corrupting the hidden state at the exact position pooling reads. Callers who pass a mask today reasonably believe they are protected; the parameter is an API promise the implementation doesn't keep.

We found this in production: combined with maskless pooling on our side, short texts embedded to a shared content-free direction ("I love cats." vs "He is from Europe." at cosine 0.96), and semantic recall over a personal memory store returned confidently-ranked noise.

## Fix

When a caller provides a `[B, L]` mask, fold it into the causal mask — `causal ∧ key-not-padding`, broadcast to `[B, 1, L, L]` — via the existing `createCausalMask` helper. No mask provided → behavior unchanged.

Right-padded causal batches are unaffected by construction (pads sit after the real tokens, which causality already hides) — verified: our embedding regression suite produces identical vectors before and after this change for right-padded batches.

`swift build --target MLXEmbedders` passes.