### PR TITLE
Fix prefill LMOutput.State being dropped on TokenIterator's .logits path

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -649,6 +649,8 @@ public struct TokenIterator: TokenIteratorProtocol {
             asyncEval(y.tokens)
 
         case .logits(let result):
+            // carry the prefill state into decode, as step(previous:) does for later steps
+            self.state = result.state
             y = .init(tokens: convertToToken(logits: result.logits))
             asyncEval(y.tokens)
 


### PR DESCRIPTION
## Proposed changes

Qwen2.5-VL seeds its MROPE `positionIds`/`ropeDeltas` into the per-call `LMOutput.State` during prefill (the #283 pattern), but `TokenIterator.prepare(...)`'s `.logits` branch never carries `result.state` into `self.state`, so the first decode step runs without them — positions drift by the image-token count and greedy decode emits an empty ` ``` ` fence instead of the JSON body.

Reproducible with `mlx-community/Qwen2.5-VL-7B-Instruct-4bit` on any dense full-page screenshot (e.g. a 1280×900 capture of a Wikipedia article) with a standard `bbox_2d` grounding prompt at temperature 0: `main` returns a lone fence; with the state carried, the same input grounds correctly.

The `.tokens` branch already gets the carry via `step(previous:)`, and the speculative iterator's `.logits` branch does `mainState = result.state`; this makes the standard path consistent with both. +2 lines, one function.

Follows the Qwen2.5-VL fixes in #238 / #239 / #242 / #243 — #239 moved the MROPE state onto per-call `LMOutput.State`; this restores its prefill→decode handoff on the `.logits` path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works — no new test; the repro above exercises the path end-to-end
- [ ] I have updated the necessary documentation (if needed) — not needed
