### PR TITLE
Make DeepseekV3Model.init public

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -421,7 +421,7 @@ public class DeepseekV3Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
     public var model: DeepseekV3ModelInner
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 
-    init(_ args: DeepseekV3Configuration) {
+    public init(_ args: DeepseekV3Configuration) {
         self.args = args
         self.model = DeepseekV3ModelInner(config: args)
         self._lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabSize, bias: false)


### PR DESCRIPTION
`DeepseekV3Model` and everything needed to use it are already public — the class, `callAsFunction`, `sanitize`, `kvHeads`, `model`, and `loraLayers`. The initializer is the one exception, so another module can't actually construct one.

This widens just the initializer to `public`. The signature parameter (`DeepseekV3Configuration`) is already public, so this is a pure access-modifier change with no effect on existing call sites.

`GLM4MoEModel.init(_:)` is already public, which is the precedent — it's what lets you wrap that architecture from another module. I'd like to do the same for DeepSeek V3: a thin wrapper (for a model whose text tower is exactly `DeepseekV3Model`) that holds one and forwards `callAsFunction` / `kvHeads` / `loraLayers` and composes `sanitize`, rather than reimplementing the ~1000-line core to get around one access modifier.

Resolves #417.