### PR TITLE
Add cooperative cancellation check to the prompt prefill loop

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -26,12 +26,20 @@ extension LLMModel {
         let prefillStepSize = windowSize ?? 512
         var y = input.text
 
-        withPreparedCache(cache, lengths: y.sequenceLengths) {
+        try withPreparedCache(cache, lengths: y.sequenceLengths) {
             // Prepare the prompt in chunks if larger than the prefill size.
             // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
             // chunk N.
             var state: LMOutput.State? = state
             while y.tokens.size > prefillStepSize {
+                // Cooperative cancellation between prefill windows. On iOS, GPU work
+                // submitted after the app moves to the background is rejected by the
+                // system ("Insufficient Permission"), and the resulting command-buffer
+                // error is thrown from a Metal completion handler where it cannot be
+                // caught, aborting the process. Without this check a long prompt's
+                // prefill cannot be interrupted, so apps cannot stop GPU submissions
+                // in time when entering the background. See ml-explore/mlx-swift-examples#230.
+                try Task.checkCancellation()
                 let input = y[.newAxis, ..<prefillStepSize]
                 let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
                 state = output.state


### PR DESCRIPTION
## Problem

Token generation already checks `Task.isCancelled` between tokens, but the prompt prefill loop in `LLMModel.prepare` does not. For long prompts, prefill runs for multiple seconds as an uninterruptible sequence of GPU submissions.

On iOS this is fatal: GPU work submitted while an app is in the background is rejected by the system ("Insufficient Permission (to submit GPU work in background)"), and the resulting Metal command-buffer error is thrown as a C++ exception from a completion handler where Swift cannot catch it, aborting the process. Apps cancel generation on `UIApplication.willResignActiveNotification`, but if the model is mid-prefill the cancellation has no effect until prefill finishes — by which time the app is already backgrounded and the process is killed. See #230 (mlx-swift-examples) for the original report of this class of crash.

## Fix

Check `Task.checkCancellation()` between prefill windows. `prepare` is already `throws`, and `TokenIterator`/`generate` already propagate errors, so cancelling the surrounding task now stops further GPU submissions within one `prefillStepSize` window (~hundreds of ms with small window sizes) instead of after the full prompt.

Verified on device (iPhone, iOS 26): an app that cancels in-flight generation on resign-active previously aborted reliably when backgrounded during prefill of a ~800-token prompt; with this change it survives repeated background/foreground cycles with generation in flight (8/8 in our stress test, previously 0/8).