### PR TITLE
Document -skipPackagePluginValidation for local test runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Unit tests run without any special hardware and do not download models.
 Note: `swift test` [does not work yet](https://github.com/ml-explore/mlx-swift?tab=readme-ov-file#xcodebuild) — use `xcodebuild` instead:
 
 ```bash
-xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS'
+xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -skipPackagePluginValidation
 ```
 
 Integration tests verify end-to-end model loading and generation. They require
@@ -40,13 +40,15 @@ test target (`Cmd+U` or via the Test Navigator), or use `xcodebuild`:
 xcodebuild test \
   -project IntegrationTesting/IntegrationTesting.xcodeproj \
   -scheme IntegrationTesting \
-  -destination 'platform=macOS'
+  -destination 'platform=macOS' \
+  -skipPackagePluginValidation
 
 # Run a single test
 xcodebuild test \
   -project IntegrationTesting/IntegrationTesting.xcodeproj \
   -scheme IntegrationTesting \
   -destination 'platform=macOS' \
+  -skipPackagePluginValidation \
   -only-testing:IntegrationTestingTests/ToolCallIntegrationTests/qwen35FormatAutoDetection\(\)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,13 @@ xcodebuild test \
 
 See [Libraries/IntegrationTestHelpers/README.md](Libraries/IntegrationTestHelpers/README.md) for more details.
 
+CI also verifies that DocC documentation builds without warnings for every
+library target. Run the same check locally with:
+
+```bash
+scripts/verify-docs.sh
+```
+
 ## Issues
 
 We use GitHub issues to track public bugs. Please ensure your description is


### PR DESCRIPTION
## Proposed changes

mlx-swift 0.31.5 added the CudaBuild build-tool plugin, which xcodebuild refuses to run non-interactively without this flag; PR #404 added it to CI. CONTRIBUTING.md's documented test commands weren't updated, so contributors following them locally still hit the plugin trust error.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
