### PR TITLE
Hoist tool-schema $defs to the tool-calling envelope root (fixes #432)

### DIFF
--- a/Libraries/MLXFoundationModels/GuidedGeneration/SchemaConverter.swift
+++ b/Libraries/MLXFoundationModels/GuidedGeneration/SchemaConverter.swift
@@ -201,15 +201,10 @@ enum SchemaConverter {
             // can embed it as a nested object in the envelope we assemble via
             // JSONSerialization.data(withJSONObject:). Cheap: schemas are small.
             let paramsData = try encoder.encode(tool.parameters)
-            // Rewrite refs on the raw JSONEncoder output, where the
-            // "#/$defs/" prefix appears literally. (A JSONSerialization
-            // re-serialization escapes "/" as "\/", so the prefix would not
-            // match and the refs would silently survive unrewritten. Cover
-            // the escaped form too, defensively.)
-            let rewritten = String(data: paramsData, encoding: .utf8)!
-                .replacingOccurrences(of: "#/$defs/", with: "#/$defs/\(tool.name)__")
-                .replacingOccurrences(of: "#\\/$defs\\/", with: "#\\/$defs\\/\(tool.name)__")
-            var paramsAny = try JSONSerialization.jsonObject(with: Data(rewritten.utf8))
+            var paramsAny = rewriteDefsRefs(
+                in: try JSONSerialization.jsonObject(with: paramsData),
+                toolName: tool.name
+            )
             if var paramsObj = paramsAny as? [String: Any] {
                 if let defs = paramsObj.removeValue(forKey: "$defs") as? [String: Any] {
                     for (key, value) in defs {
@@ -233,6 +228,35 @@ enum SchemaConverter {
             envelope["$defs"] = hoistedDefs
         }
         return envelope
+    }
+
+    /// Rewrites every `"$ref": "#/$defs/<name>"` in a parsed schema tree to
+    /// the per-tool namespaced key (`#/$defs/<tool>__<name>`).
+    ///
+    /// The rewrite is structure-aware: only the string value directly under a
+    /// `$ref` key is touched, so other strings that merely mention the
+    /// pointer text — a `description`, `const`, `enum` entry, `default`, or
+    /// `pattern` containing "#/$defs/" — survive verbatim. Runs before the
+    /// `$defs` are hoisted out, and recurses through the whole tree because
+    /// refs can appear anywhere, including inside other `$defs` bodies.
+    private static func rewriteDefsRefs(in value: Any, toolName: String) -> Any {
+        switch value {
+        case let object as [String: Any]:
+            var result: [String: Any] = [:]
+            result.reserveCapacity(object.count)
+            for (key, nested) in object {
+                if key == "$ref", let ref = nested as? String, ref.hasPrefix("#/$defs/") {
+                    result[key] = "#/$defs/\(toolName)__" + ref.dropFirst("#/$defs/".count)
+                } else {
+                    result[key] = rewriteDefsRefs(in: nested, toolName: toolName)
+                }
+            }
+            return result
+        case let array as [Any]:
+            return array.map { rewriteDefsRefs(in: $0, toolName: toolName) }
+        default:
+            return value
+        }
     }
 
     enum SchemaConversionError: Error {

--- a/Libraries/MLXFoundationModels/GuidedGeneration/SchemaConverter.swift
+++ b/Libraries/MLXFoundationModels/GuidedGeneration/SchemaConverter.swift
@@ -48,9 +48,16 @@ enum SchemaConverter {
     ///       }
     ///     },
     ///     ...
-    ///   ]
+    ///   ],
+    ///   "$defs": { "<tool name>__<def name>": ... }
     /// }
     /// ```
+    ///
+    /// If a tool's parameters schema carries `$defs` (named sub-schemas such
+    /// as nested `@Generable` types), they are hoisted to the envelope root
+    /// under per-tool namespaced keys, with that tool's `$ref`s rewritten to
+    /// match — JSON Pointers resolve from the document root, so defs left
+    /// nested inside `arguments` would leave every ref dangling.
     ///
     /// This is the *inner* schema -- it describes one tool call JSON object.
     /// For end-to-end grammar generation that also encodes the model's native
@@ -176,12 +183,41 @@ enum SchemaConverter {
         }
 
         let encoder = JSONEncoder()
+        // `GenerationSchema` serializes named sub-schemas (e.g. a nested
+        // `@Generable` type, or a named `DynamicGenerationSchema`) as
+        // root-level `$defs` plus root-anchored `"$ref": "#/$defs/..."`
+        // pointers. Embedding a tool's schema as a nested object under
+        // `oneOf[i].properties.arguments` buries its `$defs` inside
+        // `arguments` while the refs stay anchored to the document root —
+        // and xgrammar resolves JSON Pointers from the document root, so
+        // every ref dangles and grammar compilation hard-fails
+        // ("Cannot find field $defs in {\"oneOf\": ...",
+        // json_schema_converter.cc). Hoist each tool's `$defs` to the
+        // envelope root instead, namespacing keys per tool
+        // (`<tool>__<def>`) so same-named defs across tools cannot collide.
+        var hoistedDefs: [String: Any] = [:]
         let oneOf: [[String: Any]] = try tools.map { tool in
             // Round-trip the tool's parameters through JSONSerialization so we
             // can embed it as a nested object in the envelope we assemble via
             // JSONSerialization.data(withJSONObject:). Cheap: schemas are small.
             let paramsData = try encoder.encode(tool.parameters)
-            let paramsAny = try JSONSerialization.jsonObject(with: paramsData)
+            // Rewrite refs on the raw JSONEncoder output, where the
+            // "#/$defs/" prefix appears literally. (A JSONSerialization
+            // re-serialization escapes "/" as "\/", so the prefix would not
+            // match and the refs would silently survive unrewritten. Cover
+            // the escaped form too, defensively.)
+            let rewritten = String(data: paramsData, encoding: .utf8)!
+                .replacingOccurrences(of: "#/$defs/", with: "#/$defs/\(tool.name)__")
+                .replacingOccurrences(of: "#\\/$defs\\/", with: "#\\/$defs\\/\(tool.name)__")
+            var paramsAny = try JSONSerialization.jsonObject(with: Data(rewritten.utf8))
+            if var paramsObj = paramsAny as? [String: Any] {
+                if let defs = paramsObj.removeValue(forKey: "$defs") as? [String: Any] {
+                    for (key, value) in defs {
+                        hoistedDefs["\(tool.name)__\(key)"] = value
+                    }
+                }
+                paramsAny = paramsObj
+            }
             return [
                 "type": "object",
                 "required": ["name", "arguments"],
@@ -192,7 +228,11 @@ enum SchemaConverter {
                 ],
             ]
         }
-        return ["oneOf": oneOf]
+        var envelope: [String: Any] = ["oneOf": oneOf]
+        if !hoistedDefs.isEmpty {
+            envelope["$defs"] = hoistedDefs
+        }
+        return envelope
     }
 
     enum SchemaConversionError: Error {

--- a/Tests/MLXFoundationModelsTests/ToolCallingSchemaTests.swift
+++ b/Tests/MLXFoundationModelsTests/ToolCallingSchemaTests.swift
@@ -28,11 +28,35 @@ private struct AddArgs {
 
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 @Generable
+private struct Passport {
+    @Guide(description: "Issuing country.")
+    var country: String
+    @Guide(description: "Passport number.")
+    var number: String
+}
+
+/// Contains a further nested `@Generable` type: `Traveler`'s own `$defs`
+/// body carries a `"$ref": "#/$defs/Passport"`, exercising refs that live
+/// inside other defs (not just under the schema root).
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@Generable
 private struct Traveler {
     @Guide(description: "Full name.")
     var name: String
     @Guide(description: "Age.")
     var age: Int
+    @Guide(description: "Travel document.")
+    var passport: Passport
+}
+
+/// No nested `@Generable` at all — but the description mentions the
+/// `#/$defs/` pointer text, which a naive string-level ref rewrite would
+/// mangle.
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@Generable
+private struct PointerDocArgs {
+    @Guide(description: "A JSON Pointer such as #/$defs/Foo to resolve.")
+    var pointer: String
 }
 
 /// Arguments containing a nested `@Generable` type: `GenerationSchema`
@@ -210,6 +234,8 @@ struct ToolCallingSchemaTests {
         let defs = parsed["$defs"] as? [String: Any] ?? [:]
         #expect(defs["book_trip__Traveler"] != nil)
         #expect(defs["cancel_trip__Traveler"] != nil)
+        #expect(defs["book_trip__Passport"] != nil)
+        #expect(defs["cancel_trip__Passport"] != nil)
 
         let refs = collectRefs(in: parsed)
         #expect(!refs.isEmpty, "nested @Generable arguments must produce $refs")
@@ -218,6 +244,26 @@ struct ToolCallingSchemaTests {
             let key = String(ref.dropFirst("#/$defs/".count))
             #expect(defs[key] != nil, "dangling $ref: \(ref)")
         }
+    }
+
+    @Test
+    func nonRefStringMentioningDefsPointerIsNotRewritten() throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        // The ref rewrite must only touch strings under a `$ref` key: a
+        // description (or const/enum/default/pattern) that merely mentions
+        // the "#/$defs/" pointer text has to survive verbatim.
+        let probe = Transcript.ToolDefinition(
+            name: "probe_tool",
+            description: "Resolves JSON Pointers",
+            parameters: PointerDocArgs.generationSchema
+        )
+        let json = try SchemaConverter.encodeToolCallingEnvelopeJSON(tools: [probe])
+        let strings = collectStringValues(in: try parseAsDictionary(json))
+
+        // The pointer text made it into the schema...
+        #expect(strings.contains { $0.contains("#/$defs/") })
+        // ...and came through untouched by the namespace rewrite.
+        #expect(strings.allSatisfy { !$0.contains("probe_tool__") })
     }
 
     @Test
@@ -373,6 +419,21 @@ struct ToolCallingSchemaTests {
             return [:]
         }
         return obj
+    }
+
+    /// Recursively collects every string value in a parsed JSON tree
+    /// (dictionary values and array elements, at any depth).
+    private func collectStringValues(in value: Any) -> [String] {
+        switch value {
+        case let string as String:
+            return [string]
+        case let object as [String: Any]:
+            return object.values.flatMap { collectStringValues(in: $0) }
+        case let array as [Any]:
+            return array.flatMap { collectStringValues(in: $0) }
+        default:
+            return []
+        }
     }
 
     /// Recursively collects every `"$ref"` string value in a parsed JSON tree.

--- a/Tests/MLXFoundationModelsTests/ToolCallingSchemaTests.swift
+++ b/Tests/MLXFoundationModelsTests/ToolCallingSchemaTests.swift
@@ -26,6 +26,29 @@ private struct AddArgs {
     var b: Int
 }
 
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@Generable
+private struct Traveler {
+    @Guide(description: "Full name.")
+    var name: String
+    @Guide(description: "Age.")
+    var age: Int
+}
+
+/// Arguments containing a nested `@Generable` type: `GenerationSchema`
+/// serializes `Traveler` as a root-level `$defs` entry referenced via a
+/// root-anchored `"$ref": "#/$defs/Traveler"` pointer.
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@Generable
+private struct BookTripArgs {
+    @Guide(description: "Origin city.")
+    var origin: String
+    @Guide(description: "Destination city.")
+    var destination: String
+    @Guide(description: "The traveler.")
+    var traveler: Traveler
+}
+
 /// Unit tests for the tool-calling schema and grammar builders.
 ///
 /// Covers both:
@@ -135,6 +158,115 @@ struct ToolCallingSchemaTests {
         #expect(names.contains(FinalAnswerTool.toolName))
     }
 
+    // MARK: - $defs Hoisting
+
+    @Test
+    func nestedGenerableDefsAreHoistedToEnvelopeRoot() throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let bookTrip = Transcript.ToolDefinition(
+            name: "book_trip",
+            description: "Books a trip",
+            parameters: BookTripArgs.generationSchema
+        )
+
+        let json = try SchemaConverter.encodeToolCallingEnvelopeJSON(tools: [bookTrip])
+        let parsed = try parseAsDictionary(json)
+
+        // The nested type's def must live at the envelope root, namespaced
+        // per tool, because xgrammar resolves JSON Pointers from the
+        // document root.
+        let defs = try #require(parsed["$defs"] as? [String: Any])
+        #expect(defs["book_trip__Traveler"] != nil)
+
+        // The embedded arguments schema must no longer carry its own $defs.
+        let oneOf = try #require(parsed["oneOf"] as? [[String: Any]])
+        let arguments = try #require(
+            (oneOf[0]["properties"] as? [String: Any])?["arguments"] as? [String: Any]
+        )
+        #expect(arguments["$defs"] == nil, "tool-local $defs must be hoisted, not duplicated")
+    }
+
+    @Test
+    func everyRefInEnvelopeResolvesWithinTheDocument() throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        // Two tools sharing a same-named nested type: hoisting must also
+        // namespace, so the defs cannot collide or shadow each other.
+        let tools = [
+            Transcript.ToolDefinition(
+                name: "book_trip",
+                description: "Books a trip",
+                parameters: BookTripArgs.generationSchema
+            ),
+            Transcript.ToolDefinition(
+                name: "cancel_trip",
+                description: "Cancels a trip",
+                parameters: BookTripArgs.generationSchema
+            ),
+        ]
+
+        let json = try SchemaConverter.encodeToolCallingEnvelopeJSON(tools: tools)
+        let parsed = try parseAsDictionary(json)
+
+        let defs = parsed["$defs"] as? [String: Any] ?? [:]
+        #expect(defs["book_trip__Traveler"] != nil)
+        #expect(defs["cancel_trip__Traveler"] != nil)
+
+        let refs = collectRefs(in: parsed)
+        #expect(!refs.isEmpty, "nested @Generable arguments must produce $refs")
+        for ref in refs {
+            #expect(ref.hasPrefix("#/$defs/"), "unexpected ref shape: \(ref)")
+            let key = String(ref.dropFirst("#/$defs/".count))
+            #expect(defs[key] != nil, "dangling $ref: \(ref)")
+        }
+    }
+
+    @Test
+    func nestedDefsEnvelopeCompilesWithXGrammar() throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        // End-to-end regression for the dangling-$refs failure: without
+        // hoisting, xgrammar rejects this envelope outright
+        // ("Cannot find field $defs in {\"oneOf\": ...").
+        let bookTrip = Transcript.ToolDefinition(
+            name: "book_trip",
+            description: "Books a trip",
+            parameters: BookTripArgs.generationSchema
+        )
+        let finalAnswer = FinalAnswerTool.makeToolDefinition(responseSchema: nil)
+
+        let json = try SchemaConverter.encodeToolCallingEnvelopeJSON(
+            tools: [bookTrip, finalAnswer]
+        )
+
+        let tokenizer = try makeByteTokenizer()
+        _ = try GrammarConstraint(tokenizer: tokenizer, jsonSchema: json, fastForward: false)
+    }
+
+    @Test
+    func grammarBuilderHoistsNestedDefsInBothArms() throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let bookTrip = Transcript.ToolDefinition(
+            name: "book_trip",
+            description: "Books a trip",
+            parameters: BookTripArgs.generationSchema
+        )
+
+        let grammar = try SchemaConverter.encodeToolCallingGrammar(tools: [bookTrip])
+        let parsed = try parseAsDictionary(grammar)
+
+        let format = try #require(parsed["format"] as? [String: Any])
+        let elements = try #require(format["elements"] as? [[String: Any]])
+        try #require(elements.count == 2)
+
+        let wrappedSchema = try #require(
+            (elements[0]["content"] as? [String: Any])?["json_schema"] as? [String: Any]
+        )
+        let bareSchema = try #require(elements[1]["json_schema"] as? [String: Any])
+        for schema in [wrappedSchema, bareSchema] {
+            let defs = try #require(schema["$defs"] as? [String: Any])
+            #expect(defs["book_trip__Traveler"] != nil)
+        }
+    }
+
     // MARK: - Grammar Compilation
 
     @Test
@@ -241,6 +373,23 @@ struct ToolCallingSchemaTests {
             return [:]
         }
         return obj
+    }
+
+    /// Recursively collects every `"$ref"` string value in a parsed JSON tree.
+    private func collectRefs(in value: Any) -> [String] {
+        switch value {
+        case let object as [String: Any]:
+            return object.flatMap { key, nested -> [String] in
+                if key == "$ref", let ref = nested as? String {
+                    return [ref]
+                }
+                return collectRefs(in: nested)
+            }
+        case let array as [Any]:
+            return array.flatMap { collectRefs(in: $0) }
+        default:
+            return []
+        }
     }
 
     private func makeByteTokenizer() throws -> GrammarTokenizer {


### PR DESCRIPTION
## Proposed changes

Fixes #432.

`GenerationSchema` serializes named sub-schemas (nested `@Generable` types, named `DynamicGenerationSchema` nodes) as root-level `$defs` with root-anchored `"$ref": "#/$defs/..."` pointers. `SchemaConverter.toolCallingEnvelopeObject` embeds each tool's parameters schema as a nested object under `oneOf[i].properties.arguments`, which buries the tool's `$defs` inside `arguments` while the refs stay anchored to the (defs-less) envelope root. xgrammar resolves JSON Pointers from the document root, so any tool with a non-flat argument schema fails grammar compilation with `constraintCompilationFailed("... Cannot find field $defs in {\"oneOf\": ...")` at the first tool-calling turn. Flat, primitive-only tools don't emit `$defs`, which is why small demos pass.

This PR hoists each tool's `$defs` into the envelope root, namespaced per tool (`<tool>__<def>`, so same-named defs across tools can't collide), and rewrites that tool's `$ref`s to match. The change is in `toolCallingEnvelopeObject` — the single composition point shared by both `encodeToolCallingEnvelopeJSON` and the structural-tag `encodeToolCallingGrammar`, so both encoders are covered.

Implementation note: the ref rewrite runs on the raw `JSONEncoder` output, where the `#/$defs/` prefix appears literally. Rewriting a `JSONSerialization` re-serialization does not work — it escapes `/` as `\/`, the prefix never matches, and the refs silently survive unrewritten while the defs get hoisted under prefixed keys.

Tests added to `ToolCallingSchemaTests` (model-free, in the existing unit target):
- a nested-`@Generable` fixture's def is hoisted to the envelope root and removed from the embedded `arguments` schema;
- with two tools sharing a same-named nested type, every `$ref` in the envelope resolves within the document and the namespaced defs don't collide;
- the nested-defs envelope compiles end-to-end with xgrammar (`GrammarConstraint`) — this is the direct regression test: it fails on `main` with the "Cannot find field $defs" check failure;
- the structural-tag grammar embeds the hoisted `$defs` in both the wrapped and bare arms.

Beyond unit tests, this patch has run several hundred tool-calling generations in our downstream harness (macOS 27.0 beta 26A5378n, M4 Max) without a grammar-compilation failure.

Local verification note: this beta seed names `GenerationOptions.SamplingMode.Kind` cases `randomTopK`/`randomProbabilityThreshold`, where `main` matches `.top`/`.nucleus` from a newer seed — local builds needed that 2-line rename as a scratch commit, which is **not** part of this PR. CI on the newer seed should compile unmodified.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
