### PR TITLE
Prepare tool-calling input through the model's processor (fixes #433)

### DIFF
--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -1064,7 +1064,7 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                         let allTools =
                             Array(request.enabledToolDefinitions) + [finalAnswerDef]
 
-                        // Re-tokenize using the model's native tool-aware chat
+                        // Re-render using the model's native tool-aware chat
                         // template (Qwen/Llama/Phi/Gemma all ship one in their
                         // tokenizer_config.json). This is what teaches the model
                         // *what* tools exist and how to decide between them; the
@@ -1072,8 +1072,6 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                         // whatever tool call it emits.
                         let toolSpecs = try ToolCallingConversions.makeToolSpecs(
                             from: allTools)
-                        let tokenizerMessages = DefaultMessageGenerator().generate(
-                            messages: messages)
 
                         // Think-then-call is gated to the enable_thinking
                         // family (Qwen3/QwQ): their template both renders the tool
@@ -1098,12 +1096,18 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                                 forThinkingEnabled: Self.thinkingEnabled(
                                     for: request.contextOptions.reasoningLevel))
                         }
-                        let toolAwareTokens = try context.tokenizer.applyChatTemplate(
-                            messages: tokenizerMessages,
-                            tools: toolSpecs,
-                            additionalContext: reasoningContext
-                        )
-                        let toolAwareInput = LMInput(tokens: MLXArray(toolAwareTokens))
+                        // Prepare through the model's UserInputProcessor (like the
+                        // unconstrained and guided paths) instead of hand-building
+                        // an LMInput from raw applyChatTemplate output: processors
+                        // produce the token rank their model family requires (LLM
+                        // processors emit [N]; VLM processors emit [1, N], and VLM
+                        // `prepare` fatally aborts on 1-D input), and they carry
+                        // image/video content through to the model.
+                        let toolAwareInput = try await context.processor.prepare(
+                            input: UserInput(
+                                chat: messages,
+                                tools: toolSpecs,
+                                additionalContext: reasoningContext))
 
                         let toolCallingGrammar =
                             try SchemaConverter.encodeToolCallingGrammar(
@@ -1195,8 +1199,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                         let phase2Input =
                             reasoningTokenIDs.isEmpty
                             ? toolAwareInput
-                            : LMInput(
-                                tokens: MLXArray(toolAwareTokens + reasoningTokenIDs))
+                            : Self.continuationInput(
+                                from: toolAwareInput, appending: reasoningTokenIDs)
                         // Shared budget (match the unconstrained path): the
                         // envelope continues under the remaining budget, floored
                         // at the completion reserve so it always has room to close
@@ -1680,6 +1684,28 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
         /// Decodes the rendered prompt's tail and asks whether it ends inside an
         /// open reasoning block (some model families prefill the opening
         /// delimiter).
+        /// Build the Phase-2 continuation input: the tool-aware prompt with the
+        /// completed reasoning token IDs appended along the sequence axis.
+        ///
+        /// The prompt tokens keep whatever rank the model's processor produced
+        /// ([N] from LLM processors, [1, N] from VLM processors — VLM `prepare`
+        /// requires the batched form), and processed image/video content is
+        /// carried through so a VLM's Phase-2 prefill still sees its pixels.
+        static func continuationInput(
+            from input: LMInput, appending tokenIDs: [Int]
+        ) -> LMInput {
+            let promptTokens = input.text.tokens
+            var appended = MLXArray(tokenIDs.map { Int32($0) })
+                .asType(promptTokens.dtype)
+            if promptTokens.ndim == 2 {
+                appended = appended[.newAxis, 0...]
+            }
+            return LMInput(
+                text: .init(tokens: concatenated([promptTokens, appended], axis: -1)),
+                image: input.image,
+                video: input.video)
+        }
+
         private static func reasoningPrimedInside(
             input: LMInput, config: ReasoningConfig, tokenizer: any Tokenizer
         ) -> Bool {

--- a/Tests/MLXFoundationModelsTests/ContinuationInputTests.swift
+++ b/Tests/MLXFoundationModelsTests/ContinuationInputTests.swift
@@ -1,0 +1,72 @@
+// Copyright © 2026 Apple Inc.
+
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
+
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXFoundationModels
+
+/// Unit tests for `MLXLanguageModel.Executor.continuationInput(from:appending:)`,
+/// the Phase-2 (think-then-call) input builder.
+///
+/// The prompt's token rank must be preserved: LLM processors produce 1-D
+/// `[N]` token arrays (the default `LLMModel.prepare` adds the batch axis
+/// itself), while VLM processors produce 2-D `[1, N]` (VLM `prepare`
+/// implementations index `dim(1)` and fatally abort on 1-D input — see
+/// ml-explore/mlx-swift-lm#433). Media must survive so a VLM's Phase-2
+/// prefill still sees its pixels.
+@Suite
+struct ContinuationInputTests {
+
+    @Test func appendsToRank1PromptKeepingRank() {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let prompt = LMInput(tokens: MLXArray([1, 2, 3].map { Int32($0) }))
+        let result = MLXLanguageModel.Executor.continuationInput(
+            from: prompt, appending: [7, 8])
+
+        #expect(result.text.tokens.ndim == 1)
+        #expect(result.text.tokens.asArray(Int.self) == [1, 2, 3, 7, 8])
+    }
+
+    @Test func appendsToRank2PromptKeepingRank() {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let tokens = MLXArray([1, 2, 3].map { Int32($0) }).expandedDimensions(axis: 0)
+        let prompt = LMInput(tokens: tokens)
+        let result = MLXLanguageModel.Executor.continuationInput(
+            from: prompt, appending: [7, 8])
+
+        #expect(result.text.tokens.shape == [1, 5])
+        #expect(result.text.tokens.asArray(Int.self) == [1, 2, 3, 7, 8])
+    }
+
+    @Test func preservesPromptTokenDType() {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let prompt = LMInput(tokens: MLXArray([1, 2, 3]))  // int64
+        let result = MLXLanguageModel.Executor.continuationInput(
+            from: prompt, appending: [7])
+
+        #expect(result.text.tokens.dtype == prompt.text.tokens.dtype)
+    }
+
+    @Test func carriesProcessedMediaThrough() {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let tokens = MLXArray([1, 2, 3].map { Int32($0) }).expandedDimensions(axis: 0)
+        let image = LMInput.ProcessedImage(
+            pixels: MLXArray.zeros([4, 4]), frames: [THW(1, 2, 2)])
+        let prompt = LMInput(text: .init(tokens: tokens), image: image)
+
+        let result = MLXLanguageModel.Executor.continuationInput(
+            from: prompt, appending: [7])
+
+        #expect(result.image != nil)
+        let frame = result.image?.frames?.first
+        #expect(frame?.t == 1)
+        #expect(frame?.h == 2)
+        #expect(frame?.w == 2)
+        #expect(result.video == nil)
+    }
+}
+
+#endif


### PR DESCRIPTION
Fixes #433.

## Root cause

The tool-calling path in `MLXFoundationModels` hand-built its model input from raw `applyChatTemplate` output:

```swift
let toolAwareInput = LMInput(tokens: MLXArray(toolAwareTokens))   // 1-D [N]
```

That 1-D token array happens to work for text models — the default `LLMModel.prepare` slices with `[.newAxis, ...]` and `GuidedGenerationLoop` batches the returned tokens — but every VLM `prepare` implementation consumes `input.text.tokens` as given and indexes `dim(1)` (e.g. `getRopeIndex` in Qwen3VL). On a 1-D array that call reaches `mlx_array_dim` → `shape.at(1)` → an uncatchable `SmallVector out of range` abort (`array.cpp:335` in mlx-swift 0.31.6 is the `mlx_error` call inside `mlx_array_dim`'s catch block, matching the reported crash line exactly).

The mechanism was confirmed in isolation: a random-weight micro `Qwen3VL` given `prepare` input shaped `[1, 8]` succeeds; the identical model given `[8]` reproduces the exact fatal from the issue. This also explains the issue's isolation matrix — the crash is per-model-family (VLM container), independent of whether an image is present, because it happens during prefill.

The same hand-built path had a second defect: it re-templated the transcript text-only, so any image/video content was silently dropped from tool-calling prompts.

## Fix

Route the tool-aware prompt through `context.processor.prepare(UserInput(chat:tools:additionalContext:))` — the same path the unconstrained and guided-generation flows already use. Each model family's processor then produces the token rank its `prepare` expects (LLM processors emit 1-D, VLM processors emit `[1, N]`), and vision content in the transcript reaches the model during tool calls.

The think-then-call Phase-2 continuation (tool-aware prompt + Phase-1 reasoning token IDs) is built by a new `continuationInput` helper that appends along the last axis, preserving the prompt's rank, dtype, and processed image/video — unit-tested in `ContinuationInputTests` (rank-1, rank-2, dtype preservation, media carry-through).

## Verification

- `MLXFoundationModelsTests`: green (17 suites, including the 4 new tests).
- Live repro from #433 (`mlx-community/Qwen3-VL-4B-Instruct-4bit`, `[.toolCalling]` and `[.vision, .toolCalling]`, with and without an image): previously 100%-fatal, now completes with the tool firing correctly; text-model tool calling unchanged.
- Production-shaped soak: 78 documents through a single session declaring `[.vision, .toolCalling, .guidedGeneration]` on the same VLM — zero crashes, and tool submissions carry verbatim image content (confirming the image-drop fix).
- Think-then-call Phase-2 exercised end-to-end on both ranks: Qwen3-8B (`[.toolCalling, .reasoning]`, rank-1) and Qwen3-VL-4B-Thinking (`[.toolCalling, .reasoning]`, rank-2) — reason → constrained tool call, correct results. The rank-2 shape was unreachable before this fix (fatal in prefill).

One note for reviewers: `VisionIntegrationTests` currently only declares `[.vision]`, so the VLM+toolCalling intersection has no upstream coverage; the new unit tests cover the input-construction contract, and I'm happy to add a device-only integration test for the intersection if you'd like it in this PR.

This investigation and fix were AI-assisted; every verification above was run on hardware (M4 Max, macOS 27.0 beta, Xcode 27 beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
