### PR TITLE
Add cross-request LRU prompt cache (PromptTrie + byte-bounded eviction)

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -62,6 +62,14 @@ public protocol KVCache: Evaluatable {
     /// get/set metadata state as string array for serialization
     var metaState: [String] { get set }
 
+    /// Approximate number of bytes held by this cache's allocated buffers.
+    ///
+    /// The basis is the *allocated* (step-rounded) buffers returned by
+    /// `innerState()`, not the offset-sliced ``state`` — matching Python
+    /// `mlx_lm`'s `KVCache.nbytes`, which counts the step-over-allocated arrays.
+    /// Used by ``LRUPromptCache`` for byte-budget accounting.
+    var nbytes: Int { get }
+
     /// whether this cache can be trimmed
     var isTrimmable: Bool { get }
 
@@ -106,6 +114,14 @@ extension KVCache {
     public func prepare(lengths: MLXArray?) {}
 
     public func finalize() {}
+
+    /// Default ``nbytes`` for conformers that are not ``BaseKVCache`` subclasses:
+    /// sum the allocated buffers from `innerState()`. `BaseKVCache` overrides
+    /// this with an `open var` so its subclasses get a dynamically-dispatched
+    /// override point.
+    public var nbytes: Int {
+        innerState().reduce(0) { $0 + $1.nbytes }
+    }
 }
 
 public func withPreparedCache<Result>(
@@ -200,6 +216,15 @@ open class BaseKVCache: KVCache {
                 fatalError("This cache has no meta_state but a meta_state was set.")
             }
         }
+    }
+
+    /// Allocated-buffer byte size. Declared `open` (not left to the `KVCache`
+    /// extension default) so subclasses have a dynamically-dispatched override
+    /// point that survives being called through the protocol.
+    /// The default sums `innerState()`; no subclass needs to override it,
+    /// since each already reports its allocated buffers there.
+    open var nbytes: Int {
+        innerState().reduce(0) { $0 + $1.nbytes }
     }
 
     open var isTrimmable: Bool { false }

--- a/Libraries/MLXLMCommon/PromptCache/LRUPromptCache.swift
+++ b/Libraries/MLXLMCommon/PromptCache/LRUPromptCache.swift
@@ -1,0 +1,219 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+
+/// Cross-request LRU prompt cache: keeps recently-used KV caches keyed by
+/// `(model, tokens)` and, for a new prompt, returns the nearest reusable cache
+/// plus the token remainder still to be processed.
+///
+/// Direct port of Python `mlx_lm`'s `LRUPromptCache` (`mlx_lm/models/cache.py`).
+/// It also carries fixes for two bugs still open in the Python implementation,
+/// reported in ml-explore/mlx-lm#1495 and fixed there by ml-explore/mlx-lm#1496:
+///
+/// - a value stored at a single-token prefix is now returned
+///   (``PromptTrie/search(model:tokens:)`` uses `lastIndex >= 0`).
+/// - fetching a cache refreshes its LRU recency, so the store is truly
+///   least-recently-*used* rather than FIFO. See ``fetchNearestCache(model:tokens:)``.
+///
+/// Eviction is type-aware: entries are ordered `assistant` → `user` → `system`,
+/// and the eviction policy sheds the most-populous higher-churn class first, so
+/// system prompts survive longest.
+///
+/// This is a plain non-`Sendable` `final class`, mirroring Python's
+/// single-server-thread assumption. Cross-task consumers must wrap an instance
+/// in a `SerialAccessContainer` (see `Utilities/SerialAccessContainer.swift`).
+public final class LRUPromptCache<Model: Hashable> {
+
+    /// One stored cache plus its byte size and type.
+    public struct CacheEntry {
+        public var promptCache: [KVCache]
+        public var nbytes: Int
+        public var cacheType: String
+    }
+
+    /// Per-type sequence statistics returned by ``statsByType()``.
+    public struct TypeStats {
+        public let sequences: Int
+        public let bytes: Int
+    }
+
+    /// Type-partitioned recency lists. Newest is appended; oldest is `first`.
+    private final class CacheOrder {
+        let ordering: [String]
+        var lrus: [String: [(Model, [Int])]]
+
+        init(ordering: [String] = ["assistant", "user", "system"]) {
+            self.ordering = ordering
+            self.lrus = Dictionary(uniqueKeysWithValues: ordering.map { ($0, []) })
+        }
+
+        var count: Int { lrus.values.reduce(0) { $0 + $1.count } }
+
+        func count(ofType cacheType: String) -> Int { lrus[cacheType]?.count ?? 0 }
+
+        func push(model: Model, tokens: [Int], cacheType: String = "assistant") {
+            lrus[cacheType, default: []].append((model, tokens))
+        }
+
+        func remove(model: Model, tokens: [Int]) {
+            for cacheType in ordering {
+                if let idx = lrus[cacheType]!.firstIndex(where: {
+                    $0.0 == model && $0.1 == tokens
+                }) {
+                    lrus[cacheType]!.remove(at: idx)
+                    return
+                }
+            }
+        }
+
+        /// Evict the least-recently-used entry from the most-populous
+        /// higher-churn class (assistant before user before system).
+        func pop() -> (Model, [Int]) {
+            var i = 0
+            while i + 1 < ordering.count {
+                let a = lrus[ordering[i]]!
+                let b = lrus[ordering[i + 1]]!
+                if !a.isEmpty && a.count >= b.count {
+                    return lrus[ordering[i]]!.removeFirst()
+                }
+                i += 1
+            }
+            return lrus[ordering[i]]!.removeFirst()
+        }
+    }
+
+    public let maxSize: Int
+    public let maxBytes: Int
+
+    private let trie = PromptTrie<Model, CacheEntry>()
+    private let lru = CacheOrder()
+    private var totalBytes = 0
+    private var bytesByType: [String: Int]
+
+    public init(maxSize: Int = 10, maxBytes: Int = Int.max) {
+        self.maxSize = maxSize
+        self.maxBytes = maxBytes
+        self.bytesByType = Dictionary(uniqueKeysWithValues: lru.ordering.map { ($0, 0) })
+    }
+
+    /// Number of stored sequences.
+    public var count: Int { lru.count }
+
+    /// Total bytes held across all stored caches.
+    public var nbytes: Int { totalBytes }
+
+    /// Fetch the nearest reusable cache for `tokens`, returning a deep copy plus
+    /// the token remainder the caller still needs to process. Returns `(nil,
+    /// tokens)` on a total miss.
+    ///
+    /// Every hit refreshes the matched entry's LRU recency (upstream fix ml-explore/mlx-lm#1496).
+    public func fetchNearestCache(model: Model, tokens: [Int]) -> (
+        cache: [KVCache]?, remainder: [Int]
+    ) {
+        let result = trie.search(model: model, tokens: tokens)
+
+        if let exact = result.exact {
+            let entry = trie.get(model: result.model, tokens: exact)
+            refreshRecency(model: result.model, tokens: exact, cacheType: entry.cacheType)
+            return (entry.promptCache.map { $0.copy() }, [])
+        }
+
+        let shortLength = result.shorter?.count ?? 0
+        if let longer = result.longer, result.commonPrefix > shortLength {
+            let entry = trie.get(model: result.model, tokens: longer)
+            if canTrimPromptCache(entry.promptCache) {
+                let cache = entry.promptCache.map { $0.copy() }
+                let prefix = min(tokens.count - 1, result.commonPrefix)
+                let numToTrim = longer.count - prefix
+                trimPromptCache(cache, numTokens: numToTrim)
+                refreshRecency(model: result.model, tokens: longer, cacheType: entry.cacheType)
+                return (cache, Array(tokens[prefix...]))
+            }
+        }
+
+        if shortLength > 0, let shorter = result.shorter {
+            let entry = trie.get(model: result.model, tokens: shorter)
+            refreshRecency(model: result.model, tokens: shorter, cacheType: entry.cacheType)
+            return (entry.promptCache.map { $0.copy() }, Array(tokens[shortLength...]))
+        }
+
+        return (nil, tokens)
+    }
+
+    /// Insert `cache` at `tokens` for `model`, updating byte accounting, purging
+    /// now-redundant prefixes of a trimmable cache, and evicting to satisfy the
+    /// size/byte limits.
+    public func insertCache(
+        model: Model, tokens: [Int], cache: [KVCache], cacheType: String = "assistant"
+    ) {
+        let entry = CacheEntry(
+            promptCache: cache,
+            nbytes: cache.reduce(0) { $0 + $1.nbytes },
+            cacheType: cacheType)
+
+        totalBytes += entry.nbytes
+        bytesByType[cacheType, default: 0] += entry.nbytes
+        if let prev = trie.add(model: model, tokens: tokens, value: entry) {
+            totalBytes -= prev.nbytes
+            bytesByType[prev.cacheType, default: 0] -= prev.nbytes
+            lru.remove(model: model, tokens: tokens)
+        }
+        lru.push(model: model, tokens: tokens, cacheType: cacheType)
+
+        // A trimmable cache subsumes its own prefixes, so those just take space.
+        if canTrimPromptCache(cache) {
+            for (prefixLen, purged) in trie.popPrefixes(model: model, tokens: tokens) {
+                totalBytes -= purged.nbytes
+                bytesByType[purged.cacheType, default: 0] -= purged.nbytes
+                lru.remove(model: model, tokens: Array(tokens[0 ..< prefixLen]))
+            }
+        }
+
+        // One insert adds at most one net entry, so a single size-eviction restores it.
+        if lru.count > maxSize {
+            evictOne()
+        }
+        while totalBytes > maxBytes {
+            evictOne()
+        }
+    }
+
+    /// Trim down to at most `sequences` entries and/or `bytes` total bytes.
+    /// A `nil` bound means "unbounded" for that dimension.
+    public func trimTo(sequences: Int? = nil, bytes: Int? = nil) {
+        let nSequences = sequences.map { max(0, $0) } ?? Int.max
+        let nBytes = bytes.map { max(0, $0) } ?? Int.max
+        while lru.count > nSequences {
+            evictOne()
+        }
+        while totalBytes > nBytes {
+            evictOne()
+        }
+    }
+
+    /// Per-type `(sequences, bytes)` breakdown.
+    public func statsByType() -> [String: TypeStats] {
+        var result: [String: TypeStats] = [:]
+        for cacheType in lru.ordering {
+            result[cacheType] = TypeStats(
+                sequences: lru.count(ofType: cacheType),
+                bytes: bytesByType[cacheType] ?? 0)
+        }
+        return result
+    }
+
+    private func refreshRecency(model: Model, tokens: [Int], cacheType: String) {
+        lru.remove(model: model, tokens: tokens)
+        lru.push(model: model, tokens: tokens, cacheType: cacheType)
+    }
+
+    /// Evict a single least-recently-used entry and update byte accounting.
+    @discardableResult
+    private func evictOne() -> CacheEntry {
+        let (model, tokens) = lru.pop()
+        let popped = trie.pop(model: model, tokens: tokens)
+        totalBytes -= popped.nbytes
+        bytesByType[popped.cacheType, default: 0] -= popped.nbytes
+        return popped
+    }
+}

--- a/Libraries/MLXLMCommon/PromptCache/PromptTrie.swift
+++ b/Libraries/MLXLMCommon/PromptCache/PromptTrie.swift
@@ -1,0 +1,184 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+
+/// Result of a ``PromptTrie/search(model:tokens:)``.
+///
+/// Ported from the Python `mlx_lm` `PromptTrieResult` dataclass
+/// (`mlx_lm/models/cache.py`). Exactly one of `exact`/`shorter`/`longer` is the
+/// useful hit for a given query; `commonPrefix` is the length of the longest
+/// path shared with any stored sequence.
+public struct PromptTrieResult<Model: Hashable> {
+    public let model: Model
+    /// The queried tokens, when an exact stored sequence matches them.
+    public let exact: [Int]?
+    /// The longest stored *prefix* of the queried tokens that carries a value.
+    public let shorter: [Int]?
+    /// The shortest stored sequence that *extends beyond* the queried tokens.
+    public let longer: [Int]?
+    /// Length of the common prefix walked into the trie.
+    public let commonPrefix: Int
+}
+
+/// A prefix trie keyed by integer tokens, storing an arbitrary `Value` at any
+/// node reached by a token sequence.
+///
+/// Direct port of Python `mlx_lm`'s `PromptTrie` (`mlx_lm/models/cache.py`),
+/// generalised over the value type. Used by ``LRUPromptCache`` to find the
+/// nearest reusable KV-cache for an incoming prompt.
+///
+/// Not thread-safe (mirrors the Python single-server-thread assumption); wrap in
+/// a `SerialAccessContainer` for concurrent use.
+public final class PromptTrie<Model: Hashable, Value> {
+
+    private final class Node {
+        var children: [Int: Node] = [:]
+        var value: Value?
+
+        /// A node is prunable once it holds neither a value nor any children —
+        /// the Swift analogue of Python's `len(node) > 0` dict check.
+        var isEmpty: Bool { value == nil && children.isEmpty }
+    }
+
+    private var roots: [Model: Node] = [:]
+
+    public init() {}
+
+    /// Insert `value` at `tokens` for `model`, returning the previous value (if any).
+    @discardableResult
+    public func add(model: Model, tokens: [Int], value: Value) -> Value? {
+        let root: Node
+        if let existing = roots[model] {
+            root = existing
+        } else {
+            root = Node()
+            roots[model] = root
+        }
+        var current = root
+        for tok in tokens {
+            if let next = current.children[tok] {
+                current = next
+            } else {
+                let next = Node()
+                current.children[tok] = next
+                current = next
+            }
+        }
+        let prev = current.value
+        current.value = value
+        return prev
+    }
+
+    /// Fetch the value stored at exactly `tokens`. The caller must know the path
+    /// exists (mirrors Python's `KeyError`-on-miss contract) — it is only called
+    /// with a sequence a prior ``search(model:tokens:)`` returned.
+    public func get(model: Model, tokens: [Int]) -> Value {
+        var current = roots[model]!
+        for tok in tokens {
+            current = current.children[tok]!
+        }
+        return current.value!
+    }
+
+    /// Remove and return the value at `tokens`, pruning any nodes left empty.
+    @discardableResult
+    public func pop(model: Model, tokens: [Int]) -> Value {
+        let root = roots[model]!
+        var path: [Node] = [root]
+        for tok in tokens {
+            path.append(path[path.count - 1].children[tok]!)
+        }
+        let value = path[path.count - 1].value!
+        path[path.count - 1].value = nil
+        var i = tokens.count
+        while i > 0 {
+            let node = path[i]
+            let parent = path[i - 1]
+            let tok = tokens[i - 1]
+            if !node.isEmpty { break }
+            parent.children[tok] = nil
+            i -= 1
+        }
+        return value
+    }
+
+    /// Remove and return every value stored at a *proper* prefix of `tokens`,
+    /// as `(prefixLength, value)` pairs. Used when inserting a trimmable cache:
+    /// its prefixes are redundant and just take space.
+    @discardableResult
+    public func popPrefixes(model: Model, tokens: [Int]) -> [(Int, Value)] {
+        var values: [(Int, Value)] = []
+        guard var current = roots[model] else { return values }
+        for (i, tok) in tokens.enumerated() {
+            if let v = current.value {
+                values.append((i, v))
+                current.value = nil
+            }
+            guard let next = current.children[tok] else { break }
+            current = next
+        }
+        return values
+    }
+
+    /// Find the nearest stored sequence to `tokens`.
+    ///
+    /// Baked-in upstream fix (mlx-lm #1495): the shorter-prefix guard is
+    /// `lastIndex >= 0` (Python shipped `last_index > 0`), so a value stored at a
+    /// single-token prefix — reached at `lastIndex == 0` — is actually returned.
+    public func search(model: Model, tokens: [Int]) -> PromptTrieResult<Model> {
+        guard let root = roots[model] else {
+            return PromptTrieResult(
+                model: model, exact: nil, shorter: nil, longer: nil, commonPrefix: 0)
+        }
+
+        var current = root
+        if tokens.isEmpty && current.value != nil {
+            return PromptTrieResult(
+                model: model, exact: [], shorter: nil, longer: nil, commonPrefix: 0)
+        }
+
+        // Walk the tokens as far as the trie allows.
+        var lastIndex = -1
+        var index = 0
+        while index < tokens.count, let next = current.children[tokens[index]] {
+            current = next
+            if current.value != nil { lastIndex = index }
+            index += 1
+        }
+
+        // Exact match.
+        if lastIndex == tokens.count - 1 && lastIndex >= 0 {
+            return PromptTrieResult(
+                model: model, exact: tokens, shorter: nil, longer: nil, commonPrefix: 0)
+        }
+
+        // Longest stored prefix carrying a value. (mlx-lm#1495 fix: `>= 0`, not `> 0`.)
+        var shorter: [Int]? = nil
+        if lastIndex >= 0 {
+            shorter = Array(tokens[0 ..< (lastIndex + 1)])
+        }
+
+        // Shortest stored sequence extending beyond the queried tokens.
+        var longer: [Int]? = nil
+        let commonPrefix = index
+        if index > 0 {
+            var best: [Int]? = nil
+            var stack: [(Node, [Int])] = [(current, [])]
+            while let (node, extra) = stack.popLast() {
+                if node.value != nil {
+                    if best == nil || extra.count < best!.count { best = extra }
+                } else if best == nil || extra.count < best!.count {
+                    for (tok, child) in node.children {
+                        stack.append((child, extra + [tok]))
+                    }
+                }
+            }
+            if let best {
+                longer = Array(tokens[0 ..< index]) + best
+            }
+        }
+
+        return PromptTrieResult(
+            model: model, exact: nil, shorter: shorter, longer: longer, commonPrefix: commonPrefix)
+    }
+}

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -778,3 +778,54 @@ private final class BatchOffsetProbeCache: BaseKVCache {
     }
     #expect(offsets.asArray(Int32.self) == [10, 20])
 }
+
+// MARK: - nbytes (allocated-buffer basis, Python-parity)
+
+private func innerStateBytes(_ cache: any KVCache) -> Int {
+    cache.innerState().reduce(0) { $0 + $1.nbytes }
+}
+
+/// An empty cache holds no allocated buffers.
+@Test func testEmptyCacheNbytesIsZero() {
+    #expect(KVCacheSimple().nbytes == 0)
+    #expect(RotatingKVCache(maxSize: 32).nbytes == 0)
+}
+
+/// `nbytes` counts the step-rounded *allocated* buffers (`innerState()`), not
+/// the offset-sliced `state`. A single-token update allocates a 256-step buffer,
+/// so `nbytes` must exceed the 1-token slice — matching Python `mlx_lm`.
+@Test func testNbytesCountsAllocatedBuffersNotOffsetSlice() {
+    let cache = KVCacheSimple()
+    let keys = MLXArray.ones([1, 2, 1, 64], dtype: .float32)
+    _ = cache.update(keys: keys, values: keys)
+    let stateBytes = cache.state.reduce(0) { $0 + $1.nbytes }
+    #expect(cache.nbytes == innerStateBytes(cache))
+    #expect(cache.nbytes > stateBytes)
+}
+
+/// `nbytes` sums `innerState()` for every cache type; `CacheList` sums children.
+@Test func testNbytesSumsInnerStateForEachCacheType() {
+    let keys = MLXArray.ones([1, 4, 8, 64], dtype: .float32)
+
+    let simple = KVCacheSimple()
+    _ = simple.update(keys: keys, values: keys)
+    #expect(simple.nbytes == innerStateBytes(simple))
+    #expect(simple.nbytes > 0)
+
+    let rotating = RotatingKVCache(maxSize: 32)
+    _ = rotating.update(keys: keys, values: keys)
+    #expect(rotating.nbytes == innerStateBytes(rotating))
+    #expect(rotating.nbytes > 0)
+
+    let quantized = simple.toQuantized(groupSize: 64, bits: 4)
+    #expect(quantized.nbytes == innerStateBytes(quantized))
+    #expect(quantized.nbytes > 0)
+
+    let sub1 = KVCacheSimple()
+    _ = sub1.update(keys: keys, values: keys)
+    let sub2 = RotatingKVCache(maxSize: 32)
+    _ = sub2.update(keys: keys, values: keys)
+    let list = CacheList(sub1, sub2)
+    #expect(list.nbytes == innerStateBytes(list))
+    #expect(list.nbytes == sub1.nbytes + sub2.nbytes)
+}

--- a/Tests/MLXLMTests/LRUPromptCacheTests.swift
+++ b/Tests/MLXLMTests/LRUPromptCacheTests.swift
@@ -1,0 +1,228 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+/// Swift analogue of the Python `MockCache` in `mlx_lm`'s `test_server.py`:
+/// a `BaseKVCache` whose `nbytes` is the value length and whose `copy()`
+/// preserves the value (so a fetched copy compares equal). Overriding `nbytes`
+/// exercises the `open var` dispatch path added on `BaseKVCache`.
+private final class MockCache: BaseKVCache {
+    let value: String
+    private let trimmable: Bool
+
+    init(_ value: String, isTrimmable: Bool = true) {
+        self.value = value
+        self.trimmable = isTrimmable
+        super.init()
+    }
+
+    override var nbytes: Int { value.utf8.count }
+    override var isTrimmable: Bool { trimmable }
+
+    @discardableResult
+    override func trim(_ n: Int) -> Int { n }
+
+    override func copy() -> any KVCache { MockCache(value, isTrimmable: trimmable) }
+}
+
+@Suite("LRUPromptCache")
+struct LRUPromptCacheTests {
+
+    private func mockValue(_ c: [KVCache]?) -> String? {
+        (c?.first as? MockCache)?.value
+    }
+
+    private func flattenEqualsInts(_ a: MLXArray, _ expected: [Int]) -> Bool {
+        let flat = a.reshaped([-1]).asType(.int32)
+        guard flat.size == expected.count else { return false }
+        let e = MLXArray(expected.map { Int32($0) })
+        return (flat .== e).all().item(Bool.self)
+    }
+
+    // MARK: - test_caching (real KV caches)
+
+    @Test func caching() {
+        let cache = LRUPromptCache<String>(maxSize: 10)
+
+        func getKV(_ n: Int) -> (MLXArray, MLXArray) {
+            let keys = MLXArray((0 ..< n).map { Int32($0) }).reshaped([1, 1, n, 1])
+            return (keys, keys)
+        }
+
+        let model = "test"
+        var tokens = Array(repeating: 10, count: 24)
+
+        let (c0, t0) = cache.fetchNearestCache(model: model, tokens: tokens)
+        #expect(c0 == nil)
+        #expect(t0 == tokens)
+
+        let c = KVCacheSimple()
+        let kv24 = getKV(24)
+        _ = c.update(keys: kv24.0, values: kv24.1)
+        cache.insertCache(model: model, tokens: t0, cache: [c])
+
+        // Fetching a strict prefix does not evict it.
+        tokens = tokens + Array(repeating: 20, count: 5)
+        let (c1, t1) = cache.fetchNearestCache(model: model, tokens: tokens)
+        let s1 = c1![0].state
+        #expect(flattenEqualsInts(s1[0], Array(0 ..< 24)))
+        #expect(t1 == Array(repeating: 20, count: 5))
+        #expect(cache.count == 1)
+
+        // Inserting a trimmable cache with a shared prefix purges the prefix.
+        tokens = tokens + Array(repeating: 30, count: 3)
+        let kv8a = getKV(8)
+        _ = c1![0].update(keys: kv8a.0, values: kv8a.1)
+        cache.insertCache(model: model, tokens: tokens, cache: c1!)
+        #expect(cache.count == 1)
+
+        // Fetching a shared-prefix (diverging) query returns a trimmed copy.
+        tokens = Array(tokens[0 ..< 26]) + Array(repeating: 40, count: 8)
+        let (c2, t2) = cache.fetchNearestCache(model: model, tokens: tokens)
+        let s2 = c2![0].state
+        #expect(flattenEqualsInts(s2[0], Array(0 ..< 24) + [0, 1]))
+        #expect(t2 == Array(repeating: 40, count: 8))
+        #expect(cache.count == 1)
+
+        // Inserting a diverged cache creates a second entry.
+        let kv8b = getKV(8)
+        _ = c2![0].update(keys: kv8b.0, values: kv8b.1)
+        cache.insertCache(model: model, tokens: tokens, cache: c2!)
+        #expect(cache.count == 2)
+    }
+
+    // MARK: - test_lru (type-aware eviction)
+
+    @Test func lru() {
+        let cache = LRUPromptCache<String>(maxSize: 2)
+        let model = "test"
+        cache.insertCache(model: model, tokens: [1, 2], cache: [MockCache("test1")])
+        cache.insertCache(model: model, tokens: [2, 3], cache: [MockCache("test2")])
+
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [1, 2]).cache) == "test1")
+        #expect(cache.fetchNearestCache(model: model, tokens: [1, 2]).remainder == [])
+
+        var r = cache.fetchNearestCache(model: model, tokens: [1])
+        #expect(mockValue(r.cache) == "test1")
+        #expect(r.remainder == [1])
+
+        r = cache.fetchNearestCache(model: model, tokens: [1, 3, 4])
+        #expect(mockValue(r.cache) == "test1")
+        #expect(r.remainder == [3, 4])
+
+        r = cache.fetchNearestCache(model: model, tokens: [2, 3, 4])
+        #expect(mockValue(r.cache) == "test2")
+        #expect(r.remainder == [4])
+
+        r = cache.fetchNearestCache(model: model, tokens: [2, 4, 5])
+        #expect(mockValue(r.cache) == "test2")
+        #expect(r.remainder == [4, 5])
+
+        cache.insertCache(model: model, tokens: [1, 2], cache: [MockCache("test1")])
+        cache.insertCache(model: model, tokens: [2, 3], cache: [MockCache("test2")])
+        cache.insertCache(model: model, tokens: [3, 4], cache: [MockCache("test3")])
+
+        #expect(cache.fetchNearestCache(model: model, tokens: [1, 2]).cache == nil)
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [2, 3]).cache) == "test2")
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [3, 4]).cache) == "test3")
+
+        cache.insertCache(
+            model: model, tokens: [4, 5], cache: [MockCache("test4")], cacheType: "user")
+        #expect(cache.fetchNearestCache(model: model, tokens: [2, 3]).cache == nil)
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [3, 4]).cache) == "test3")
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [4, 5]).cache) == "test4")
+
+        cache.insertCache(model: model, tokens: [5, 6], cache: [MockCache("test5")])
+        cache.insertCache(model: model, tokens: [6, 7], cache: [MockCache("test6")])
+        #expect(cache.fetchNearestCache(model: model, tokens: [5, 6]).cache == nil)
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [6, 7]).cache) == "test6")
+        // The `user`-typed entry survives longest.
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [4, 5]).cache) == "test4")
+    }
+
+    // MARK: - prefix / empty-token behaviors
+
+    @Test func insertTrimmableCacheRemovesImmediatePrefix() {
+        let cache = LRUPromptCache<String>(maxSize: 10)
+        let model = "test"
+
+        cache.insertCache(model: model, tokens: [1, 2], cache: [MockCache("ab")])
+        #expect(cache.count == 1)
+        #expect(cache.nbytes == 2)
+
+        cache.insertCache(model: model, tokens: [1, 2, 3], cache: [MockCache("abc")])
+        #expect(cache.count == 1)
+        #expect(cache.nbytes == 3)
+    }
+
+    @Test func insertEmptyTokensDoesNotSelfDestruct() {
+        let cache = LRUPromptCache<String>(maxSize: 10)
+        let model = "test"
+
+        cache.insertCache(model: model, tokens: [], cache: [MockCache("root")])
+        #expect(cache.count == 1)
+        #expect(cache.nbytes == 4)
+
+        let (c, t) = cache.fetchNearestCache(model: model, tokens: [])
+        #expect(c != nil)
+        #expect(t == [])
+    }
+
+    @Test func fetchEmptyTokensAfterRootEviction() {
+        let cache = LRUPromptCache<String>(maxSize: 10)
+        let model = "test"
+
+        cache.insertCache(model: model, tokens: [], cache: [MockCache("root")])
+        cache.insertCache(model: model, tokens: [1], cache: [MockCache("a")])
+
+        let (c, t) = cache.fetchNearestCache(model: model, tokens: [])
+        #expect(c == nil)
+        #expect(t == [])
+    }
+
+    @Test func lruBytes() {
+        let cache = LRUPromptCache<String>(maxSize: 100, maxBytes: 10)
+        let model = "test"
+
+        cache.insertCache(model: model, tokens: [1, 2], cache: [MockCache("aaa")])
+        cache.insertCache(model: model, tokens: [3, 4], cache: [MockCache("bbb")])
+        cache.insertCache(model: model, tokens: [4, 5], cache: [MockCache("ccc")])
+        cache.insertCache(model: model, tokens: [6, 7], cache: [MockCache("ddd")])
+
+        #expect(cache.count == 3)
+        #expect(cache.nbytes == 9)
+
+        cache.trimTo(bytes: 7)
+        #expect(cache.count == 2)
+        #expect(cache.nbytes == 6)
+
+        #expect(cache.fetchNearestCache(model: model, tokens: [1, 2]).cache == nil)
+        #expect(cache.fetchNearestCache(model: model, tokens: [3, 4]).cache == nil)
+    }
+
+    // MARK: - Regression: upstream mlx-lm #1496
+
+    /// Fetching a cache must refresh its LRU recency (upstream ships FIFO). With
+    /// A, B inserted then A fetched, inserting C past `maxSize` must evict B (the
+    /// truly least-recently-used) and keep A. Reverting the recency refresh in
+    /// `fetchNearestCache` evicts A instead, failing the first expectation.
+    @Test func regressionFetchRefreshesRecency_1496() {
+        let cache = LRUPromptCache<String>(maxSize: 2)
+        let model = "m"
+        cache.insertCache(model: model, tokens: [1, 1], cache: [MockCache("A")])
+        cache.insertCache(model: model, tokens: [2, 2], cache: [MockCache("B")])
+
+        // Touch A so it becomes most-recently-used.
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [1, 1]).cache) == "A")
+
+        cache.insertCache(model: model, tokens: [3, 3], cache: [MockCache("C")])
+
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [1, 1]).cache) == "A")
+        #expect(cache.fetchNearestCache(model: model, tokens: [2, 2]).cache == nil)
+        #expect(mockValue(cache.fetchNearestCache(model: model, tokens: [3, 3]).cache) == "C")
+    }
+}

--- a/Tests/MLXLMTests/PromptTrieTests.swift
+++ b/Tests/MLXLMTests/PromptTrieTests.swift
@@ -1,0 +1,113 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("PromptTrie")
+struct PromptTrieTests {
+
+    @Test func addGetReturnsStoredValue() {
+        let trie = PromptTrie<String, Int>()
+        #expect(trie.add(model: "m", tokens: [1, 2, 3], value: 42) == nil)
+        #expect(trie.get(model: "m", tokens: [1, 2, 3]) == 42)
+    }
+
+    @Test func addReturnsDisplacedValue() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1, 2], value: 1)
+        #expect(trie.add(model: "m", tokens: [1, 2], value: 2) == 1)
+        #expect(trie.get(model: "m", tokens: [1, 2]) == 2)
+    }
+
+    @Test func exactMatch() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1, 2, 3], value: 1)
+        let r = trie.search(model: "m", tokens: [1, 2, 3])
+        #expect(r.exact == [1, 2, 3])
+        #expect(r.shorter == nil)
+        #expect(r.longer == nil)
+    }
+
+    @Test func longerMatchIsShortestExtension() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1, 2, 3, 4], value: 1)
+        _ = trie.add(model: "m", tokens: [1, 2, 3, 4, 5, 6], value: 2)
+        // Query [1,2] is a strict prefix of both stored sequences; the shortest
+        // extension is [1,2,3,4].
+        let r = trie.search(model: "m", tokens: [1, 2])
+        #expect(r.exact == nil)
+        #expect(r.longer == [1, 2, 3, 4])
+        #expect(r.commonPrefix == 2)
+    }
+
+    @Test func shorterMatchIsLongestStoredPrefix() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1, 2], value: 1)
+        // Query [1,2,9] has stored prefix [1,2] and then diverges.
+        let r = trie.search(model: "m", tokens: [1, 2, 9])
+        #expect(r.shorter == [1, 2])
+        #expect(r.exact == nil)
+        #expect(r.commonPrefix == 2)
+        // Parity quirk with Python `mlx_lm`: `search` also reports the prefix
+        // itself as `longer` here, but `fetchNearestCache` ignores it because
+        // `commonPrefix (2) > shortLength (2)` is false, so the shorter hit wins.
+        #expect(r.longer == [1, 2])
+    }
+
+    @Test func missingModelReturnsEmptyResult() {
+        let trie = PromptTrie<String, Int>()
+        let r = trie.search(model: "absent", tokens: [1, 2])
+        #expect(r.exact == nil)
+        #expect(r.shorter == nil)
+        #expect(r.longer == nil)
+        #expect(r.commonPrefix == 0)
+    }
+
+    @Test func popPrunesEmptyNodes() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1, 2, 3], value: 1)
+        #expect(trie.pop(model: "m", tokens: [1, 2, 3]) == 1)
+        // Fully pruned: the sequence no longer matches anything.
+        let r = trie.search(model: "m", tokens: [1, 2, 3])
+        #expect(r.exact == nil)
+        #expect(r.shorter == nil)
+        #expect(r.longer == nil)
+    }
+
+    @Test func popKeepsSiblingBranches() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1, 2], value: 1)
+        _ = trie.add(model: "m", tokens: [1, 3], value: 2)
+        _ = trie.pop(model: "m", tokens: [1, 2])
+        #expect(trie.get(model: "m", tokens: [1, 3]) == 2)
+    }
+
+    @Test func popPrefixesRemovesOnlyProperPrefixes() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [1], value: 1)
+        _ = trie.add(model: "m", tokens: [1, 2], value: 2)
+        _ = trie.add(model: "m", tokens: [1, 2, 3], value: 3)
+        let popped = trie.popPrefixes(model: "m", tokens: [1, 2, 3])
+        // Proper prefixes [1] (len 1) and [1,2] (len 2) are popped; the full
+        // path [1,2,3] is not.
+        #expect(popped.map { $0.0 } == [1, 2])
+        #expect(popped.map { $0.1 } == [1, 2])
+        #expect(trie.get(model: "m", tokens: [1, 2, 3]) == 3)
+    }
+
+    // MARK: - Regression: upstream mlx-lm #1495
+
+    /// A value stored at a single-token prefix must be returned as `shorter`.
+    /// Buggy upstream code guards with `last_index > 0`, which drops the
+    /// `last_index == 0` case; the fix is `>= 0`. Reverting the guard in
+    /// `PromptTrie.search` makes this fail.
+    @Test func regressionSingleTokenPrefixIsFound_1495() {
+        let trie = PromptTrie<String, Int>()
+        _ = trie.add(model: "m", tokens: [5], value: 1)
+        let r = trie.search(model: "m", tokens: [5, 9])
+        #expect(r.shorter == [5])
+        #expect(r.exact == nil)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Swift only reuses a KV cache within a single `ChatSession`. A new request whose prompt shares a prefix with an earlier one re-processes that prefix from scratch. Python `mlx_lm` has had a cross-request store for exactly this — `PromptTrie` + `LRUPromptCache` in `mlx_lm/models/cache.py`, used by `server.py` — and this ports it to Swift.

### What's added

- **`KVCache.nbytes`** (`Libraries/MLXLMCommon/KVCache.swift`) — byte accounting, the prerequisite for any byte-bounded policy. Every Python cache implements `nbytes`; no Swift cache did. The basis is the *allocated* (step-rounded) buffers from `innerState()`, not the offset-sliced `state`, matching Python's `KVCache.nbytes`.

  It is declared as an `open var` on `BaseKVCache` rather than left to the protocol-extension default, so subclasses get a dynamically-dispatched override point. (A protocol-extension default becomes the witness at `BaseKVCache`'s conformance and a subclass property would only shadow it statically.)
- **`PromptTrie`** — prefix trie returning the nearest stored sequence: `exact` / `shorter` / `longer`, plus the common-prefix length.
- **`LRUPromptCache`** — the store itself: `fetchNearestCache` (returns a deep copy plus the token remainder still to process), prefix trim-reuse, `maxSize` / `maxBytes` eviction, type-aware eviction ordering (`assistant` → `user` → `system`, so system prompts survive longest), and `statsByType()`.

### Two Python bugs fixed at port time

The port deliberately does not inherit two bugs still open in the Python implementation — reported in ml-explore/mlx-lm#1495 and fixed there by ml-explore/mlx-lm#1496:

1. A value stored at a single-token prefix never matched (`search` used `> 0` where `>= 0` is correct).
2. Eviction ignored fetch recency, making the store FIFO rather than truly LRU.

Both are pinned by regression tests (`PromptTrieTests`, `LRUPromptCacheTests`).

### Scope / notes

- **No existing behavior changes.** This adds new types plus one protocol requirement that ships with a default implementation. Nothing is wired into `ChatSession` / `Evaluate` — that is deliberate, to keep this reviewable on its own and to stay out of the way of #370, which approaches prefix reuse at the `ChatSession` level. The two are complementary rather than competing: #370 adds `supportsStaticPrefixReuse` and this adds `nbytes`; both touch only the `KVCache` protocol block, so they should merge cleanly in either order.
- `LRUPromptCache` is a non-`Sendable` `final class`, mirroring Python's single-server-thread assumption. Cross-task consumers wrap it in `SerialAccessContainer`, as `ChatSession` already does elsewhere.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)