### PR TITLE
Make BaseKVCache.ropeOffset overridable

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -174,6 +174,10 @@ open class BaseKVCache: KVCache {
     public var offset: Int = 0
     public var maxSize: Int? { nil }
 
+    /// RoPE offset for this cache. `open` so subclasses can return a non-scalar
+    /// offset (e.g. a batched cache's per-row `.batch(...)`).
+    open var ropeOffset: RoPEOffset { .scalar(offset) }
+
     public func innerState() -> [MLXArray] { [] }
 
     open func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -753,3 +753,28 @@ func preservesScoreDtype() {
         #expect(out.asType(.float32).sum().item(Float.self).isFinite)  // no -inf → NaN
     }
 }
+
+// MARK: - ropeOffset overridability
+
+/// A `BaseKVCache` subclass reporting a per-row RoPE offset, as a batched cache does.
+private final class BatchOffsetProbeCache: BaseKVCache {
+    override var ropeOffset: RoPEOffset { .batch(MLXArray([10, 20])) }
+
+    override func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        (keys, values)
+    }
+}
+
+/// Models read `ropeOffset` through a `KVCache` reference, so a subclass override has to
+/// survive that dispatch. When `BaseKVCache` did not declare `ropeOffset`, the extension
+/// default was the witness and this resolved to `.scalar(0)`, silently ignoring the subclass.
+@Test func testSubclassRopeOffsetOverrideIsHonoredThroughKVCacheReference() {
+    let cache: any KVCache = BatchOffsetProbeCache()
+
+    guard case .batch(let offsets) = cache.ropeOffset else {
+        Issue.record(
+            "subclass ropeOffset override ignored — resolved to the .scalar extension default")
+        return
+    }
+    #expect(offsets.asArray(Int32.self) == [10, 20])
+}


### PR DESCRIPTION
## Proposed changes

`BaseKVCache` does not declare `ropeOffset`, so the `KVCache` extension default (`.scalar(offset)`) is bound as the protocol witness at its conformance. A subclass that declares a property of the same name only shadows it statically — every access through a `KVCache` reference still resolves to `.scalar(offset)` and silently ignores the subclass.

That reference is the normal access path: models read the offset off a `KVCache`, e.g.

```swift
let offset = cache?.ropeOffset
```

Nothing in the tree overrides `ropeOffset` today, so **this changes no current behavior**. But `BaseKVCache` is `open`, and this is a trap for any cache that needs a non-scalar offset: a batched cache returning a per-row `.batch(...)` compiles cleanly, is then ignored, and every row silently gets the same scalar offset. That is a wrong-numbers bug with no compile-time signal, and it is the kind of cache several in-flight PRs need (e.g. #263's batched caches, and custom caches along the lines of #232 / #329).

### Fix

Declare `ropeOffset` as an `open` class property on `BaseKVCache` with the same `.scalar(offset)` default, so it is the real witness and subclasses get a dynamically-dispatched override point.

This is the same reason `state`, `isTrimmable`, and `update(keys:values:)` are already declared on `BaseKVCache` rather than left to extension defaults.

### Test

The test subclasses `BaseKVCache`, overrides `ropeOffset` with a per-row `.batch(...)`, and reads it back through a `KVCache` reference — the path models actually use.

It discriminates in both directions:

- **without** this change it does not compile — `error: property does not override any property from its superclass`, which is precisely the defect being fixed (you cannot override it at all);
- **with** it, the override is honored through the protocol reference and the test passes.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed) — no doc changes needed; the new property is documented inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)