### PR TITLE
Fix FoundationModels API drift and the integration tests that no longer compiled

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GenerableRoundTripTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GenerableRoundTripTests.swift
@@ -33,10 +33,8 @@ struct GenerableRoundTripTests {
         let stream = try await executeResponse(executor, request: request, model: model)
         var text = ""
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text += chunk
             }
         }
         return text

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationIntegrationTests.swift
@@ -53,28 +53,20 @@ struct GuidedGenerationIntegrationTests {
 
         let stream = try await executeResponse(executor, request: request, model: model)
 
-        var events: [LanguageModelExecutorGenerationChannel.Event] = []
+        var events: [MLXLanguageModel.Executor.GenerationEvent] = []
         for try await event in stream {
             events.append(event)
         }
 
         #expect(events.count >= 2, "Should produce metadata and text events")
 
-        guard
-            let firstResponse = events.first
-                as? LanguageModelExecutorGenerationChannel.Response,
-            case .updateMetadata = firstResponse.action
-        else {
+        guard case .updateMetadata = events.first else {
             Issue.record("First event should be metadataUpdate")
             return
         }
 
         let hasText = events.contains { event in
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
-                return true
-            }
+            if case .appendText(_, _, .response) = event { return true }
             return false
         }
         #expect(hasText, "Should produce text deltas")
@@ -100,9 +92,7 @@ struct GuidedGenerationIntegrationTests {
 
         var hasText = false
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
+            if case .appendText(_, _, .response) = event {
                 hasText = true
                 break
             }
@@ -139,10 +129,8 @@ struct GuidedGenerationIntegrationTests {
         let stream1 = try await executeResponse(executor, request: request1, model: model)
         var text1 = ""
         for try await event in stream1 {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text1 += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text1 += chunk
             }
         }
         #expect(!text1.isEmpty, "Turn 1 (unconstrained) should produce text")
@@ -159,10 +147,8 @@ struct GuidedGenerationIntegrationTests {
         let stream2 = try await executeResponse(executor, request: request2, model: model)
         var text2 = ""
         for try await event in stream2 {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text2 += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text2 += chunk
             }
         }
         let trimmed2 = text2.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -187,10 +173,8 @@ struct GuidedGenerationIntegrationTests {
         let stream3 = try await executeResponse(executor, request: request3, model: model)
         var text3 = ""
         for try await event in stream3 {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text3 += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text3 += chunk
             }
         }
         #expect(!text3.isEmpty, "Turn 3 (unconstrained) should produce text")
@@ -220,10 +204,8 @@ struct GuidedGenerationIntegrationTests {
                 let stream = try await executeResponse(executor, request: request, model: model)
                 var text = ""
                 for try await event in stream {
-                    if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                        case .appendText(let delta) = response.action
-                    {
-                        text += delta.content
+                    if case .appendText(let chunk, _, .response) = event {
+                        text += chunk
                     }
                 }
                 return text
@@ -244,10 +226,8 @@ struct GuidedGenerationIntegrationTests {
                 let stream = try await executeResponse(executor, request: request, model: model)
                 var text = ""
                 for try await event in stream {
-                    if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                        case .appendText(let delta) = response.action
-                    {
-                        text += delta.content
+                    if case .appendText(let chunk, _, .response) = event {
+                        text += chunk
                     }
                 }
                 return text
@@ -286,16 +266,14 @@ struct GuidedGenerationIntegrationTests {
 
         let stream = try await executeResponse(executor, request: request, model: model)
 
-        var events: [LanguageModelExecutorGenerationChannel.Event] = []
+        var events: [MLXLanguageModel.Executor.GenerationEvent] = []
         for try await event in stream {
             events.append(event)
         }
 
         let incompleteIdx = events.firstIndex { event in
-            guard let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .updateMetadata(let metadata) = response.action
-            else { return false }
-            return (metadata.values["incompleteOutput"] as? Bool) == true
+            guard case .updateMetadata(let metadata, _) = event else { return false }
+            return (metadata["incompleteOutput"] as? Bool) == true
         }
         #expect(
             incompleteIdx != nil,
@@ -304,9 +282,7 @@ struct GuidedGenerationIntegrationTests {
 
         if let incompleteIdx,
             let lastTextIdx = events.lastIndex(where: {
-                if let response = $0 as? LanguageModelExecutorGenerationChannel.Response,
-                    case .appendText = response.action
-                {
+                if case .appendText(_, _, .response) = $0 {
                     return true
                 } else {
                     return false

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationUsageTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationUsageTests.swift
@@ -185,10 +185,8 @@ struct GuidedGenerationUsageTests {
         let stream = try await executeResponse(executor, request: request, model: model)
         var text = ""
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text += chunk
             }
         }
         return text

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/MaxTokenTruncationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/MaxTokenTruncationTests.swift
@@ -101,10 +101,8 @@ struct MaxTokenTruncationTests {
 
         var fullText = ""
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                fullText += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                fullText += chunk
             }
         }
 

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/MultiModelGuidedGenerationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/MultiModelGuidedGenerationTests.swift
@@ -402,10 +402,8 @@ struct MultiModelGuidedGenerationTests {
         let stream = try await executeResponse(executor, request: request, model: model)
         var text = ""
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text += chunk
             }
         }
         return text

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/PrewarmGrammarTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/PrewarmGrammarTests.swift
@@ -45,9 +45,7 @@ struct PrewarmGrammarTests {
 
         var hasText = false
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
+            if case .appendText(_, _, .response) = event {
                 hasText = true
                 break
             }
@@ -78,9 +76,7 @@ struct PrewarmGrammarTests {
 
         var hasText = false
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
+            if case .appendText(_, _, .response) = event {
                 hasText = true
                 break
             }

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Reasoning/ConfigurationResolverRoutingTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Reasoning/ConfigurationResolverRoutingTests.swift
@@ -47,14 +47,10 @@ struct ConfigurationResolverRoutingTests {
         var reasoning = ""
         var response = ""
         for try await event in stream {
-            if let r = event as? LanguageModelExecutorGenerationChannel.Reasoning,
-                case .appendText(let fragment) = r.action
-            {
-                reasoning += fragment.content
-            } else if let r = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let fragment) = r.action
-            {
-                response += fragment.content
+            if case .appendText(let chunk, _, .reasoning) = event {
+                reasoning += chunk
+            } else if case .appendText(let chunk, _, .response) = event {
+                response += chunk
             }
         }
         return (reasoning, response)

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Reasoning/ReasoningCapabilityGateTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Reasoning/ReasoningCapabilityGateTests.swift
@@ -67,14 +67,10 @@ struct ReasoningCapabilityGateTests {
         var response = ""
         var reasoning = ""
         for try await event in stream {
-            if let r = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let fragment) = r.action
-            {
-                response += fragment.content
-            } else if let r = event as? LanguageModelExecutorGenerationChannel.Reasoning,
-                case .appendText(let fragment) = r.action
-            {
-                reasoning += fragment.content
+            if case .appendText(let chunk, _, .response) = event {
+                response += chunk
+            } else if case .appendText(let chunk, _, .reasoning) = event {
+                reasoning += chunk
             }
         }
         // No <think> leak.

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Reasoning/ReasoningIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Reasoning/ReasoningIntegrationTests.swift
@@ -53,14 +53,10 @@ struct ReasoningIntegrationTests {
         var reasoning = ""
         var response = ""
         for try await event in stream {
-            if let r = event as? LanguageModelExecutorGenerationChannel.Reasoning,
-                case .appendText(let fragment) = r.action
-            {
-                reasoning += fragment.content
-            } else if let r = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let fragment) = r.action
-            {
-                response += fragment.content
+            if case .appendText(let chunk, _, .reasoning) = event {
+                reasoning += chunk
+            } else if case .appendText(let chunk, _, .response) = event {
+                response += chunk
             }
         }
         return (reasoning, response)

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
@@ -183,8 +183,10 @@ func makeExecutorRequest(
 /// public `finish()`. In production the framework closes the channel after
 /// respond returns; tests bypass the framework, so iterating the channel
 /// directly hangs forever. We relay events into an `AsyncThrowingStream`
-/// that we own. A producer task runs `respond()`, then cancels a collector
-/// task (which relays channel events into our stream). Our stream's
+/// that we own. A producer task attaches an observer that yields readable
+/// `GenerationEvent`s into our stream, then runs `respond()` and cancels a
+/// collector task that drains and discards the channel's opaque events (just
+/// enough to keep `respond()`'s sends from stalling). Our stream's
 /// continuation is finished once both tasks settle, so `for try await`
 /// terminates naturally. Early break from iteration cancels both tasks via
 /// `deinit`, so tests that stop reading mid-generation don't waste GPU

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
@@ -191,7 +191,7 @@ func makeExecutorRequest(
 /// compute on tokens nobody wants.
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
 final class TestResponseStream: AsyncSequence, @unchecked Sendable {
-    typealias Element = LanguageModelExecutorGenerationChannel.Event
+    typealias Element = MLXLanguageModel.Executor.GenerationEvent
     typealias AsyncIterator = AsyncThrowingStream<Element, Error>.AsyncIterator
 
     private let stream: AsyncThrowingStream<Element, Error>
@@ -207,27 +207,35 @@ final class TestResponseStream: AsyncSequence, @unchecked Sendable {
         let (stream, continuation) = AsyncThrowingStream<Element, Error>.makeStream()
         self.stream = stream
 
-        // Collector: relay events from the framework channel into our stream.
+        // The SDK's channel events are opaque, so we read generated content via
+        // the executor's observation hook instead. We still must drain the
+        // channel: respond() sends into it, and without a consumer those sends
+        // would stall. The drained events are discarded; content comes from the
+        // observer below.
         let collector = Task<Void, Never> {
             do {
-                for try await event in channel {
-                    continuation.yield(event)
-                }
+                for try await _ in channel {}
             } catch {
                 // Including CancellationError; we don't depend on cancellation here.
             }
         }
         self.collectorTask = collector
 
-        // Producer: run respond(), then finish our stream so the test's
-        // iteration terminates.
+        // Producer: attach the observer (task-local, so it also reaches the
+        // guided-path forwarder child task), run respond(), then finish our
+        // stream so the test's iteration terminates.
         self.producerTask = Task<Void, Never> {
             defer { collector.cancel() }
-            do {
-                try await executor.respond(to: request, model: model, streamingInto: channel)
-                continuation.finish()
-            } catch {
-                continuation.finish(throwing: error)
+            await MLXLanguageModel.Executor.$generationObserver.withValue({ event in
+                continuation.yield(event)
+            }) {
+                do {
+                    try await executor.respond(
+                        to: request, model: model, streamingInto: channel)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
             }
         }
     }

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/IntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/IntegrationTests.swift
@@ -89,31 +89,23 @@ struct IntegrationTests {
             contextOptions: ContextOptions(),
             metadata: [:]
         )
-        let channel = LanguageModelExecutorGenerationChannel()
-        let respondTask = Task {
-            try await executor.respond(to: request, model: model, streamingInto: channel)
-        }
-
-        var events: [LanguageModelExecutorGenerationChannel.Event] = []
-        for try await event in channel {
+        let stream = try await executeResponse(executor, request: request, model: model)
+        var events: [MLXLanguageModel.Executor.GenerationEvent] = []
+        for try await event in stream {
             events.append(event)
             if events.count >= 3 {  // Get a few events
                 break
             }
         }
-        respondTask.cancel()
-        try? await respondTask.value
 
         // First event should be metadata
-        guard let response = events.first as? LanguageModelExecutorGenerationChannel.Response,
-            case .updateMetadata(let metadata) = response.action
-        else {
+        guard case .updateMetadata(let metadata, _) = events.first else {
             Issue.record("First event should be metadataUpdate")
             return
         }
 
         #expect(
-            metadata.values["modelID"] != nil,
+            metadata["modelID"] != nil,
             "Metadata should contain model identifier"
         )
     }
@@ -306,16 +298,11 @@ struct IntegrationTests {
             contextOptions: ContextOptions(),
             metadata: [:]
         )
-        let channel = LanguageModelExecutorGenerationChannel()
-        let respondTask = Task {
-            try await executor.respond(to: request, model: model, streamingInto: channel)
-        }
+        let stream = try await executeResponse(executor, request: request, model: model)
 
         var tokenCount = 0
-        for try await event in channel {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
+        for try await event in stream {
+            if case .appendText(_, _, .response) = event {
                 tokenCount += 1
             }
             // Cancel early after a few tokens
@@ -323,8 +310,6 @@ struct IntegrationTests {
                 break
             }
         }
-        // Cancel the respond task since we broke out early
-        respondTask.cancel()
 
         #expect(tokenCount >= 5, "Should have received at least 5 tokens before cancellation")
     }

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/PlainChatGenerationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/PlainChatGenerationTests.swift
@@ -37,9 +37,7 @@ struct PlainChatGenerationTests {
         let stream = try await executeResponse(executor, request: request, model: model)
         var sawTextDelta = false
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
+            if case .appendText(_, _, .response) = event {
                 sawTextDelta = true
             }
         }

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/SamplingModeBehaviorTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/SamplingModeBehaviorTests.swift
@@ -43,10 +43,8 @@ struct SamplingModeBehaviorTests {
     private func responseText(_ stream: TestResponseStream) async throws -> String {
         var response = ""
         for try await event in stream {
-            if let r = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let fragment) = r.action
-            {
-                response += fragment.content
+            if case .appendText(let chunk, _, .response) = event {
+                response += chunk
             }
         }
         return response

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/StreamingDeltaTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/StreamingDeltaTests.swift
@@ -30,9 +30,7 @@ struct StreamingDeltaTests {
         let stream = try await executeResponse(executor, request: request, model: model)
         var deltaCount = 0
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText = response.action
-            {
+            if case .appendText(_, _, .response) = event {
                 deltaCount += 1
             }
         }
@@ -56,10 +54,8 @@ struct StreamingDeltaTests {
         let stream = try await executeResponse(executor, request: request, model: model)
         var text = ""
         for try await event in stream {
-            if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                text += delta.content
+            if case .appendText(let chunk, _, .response) = event {
+                text += chunk
             }
         }
 

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/UpdateUsageEmissionTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/UpdateUsageEmissionTests.swift
@@ -135,10 +135,8 @@ private func collectFinalUsage(
 ) async throws -> (input: Int, output: Int) {
     var lastUsage: (input: Int, output: Int)?
     for try await event in stream {
-        if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-            case .updateUsage(let usage) = response.action
-        {
-            lastUsage = (usage.input.totalTokenCount, usage.output.totalTokenCount)
+        if case .updateUsage(let input, let output, _) = event {
+            lastUsage = (input.totalTokenCount, output.totalTokenCount)
         }
     }
     return try #require(

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/FoundationModelsToolCallingTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/FoundationModelsToolCallingTests.swift
@@ -69,23 +69,18 @@ struct FoundationModelsToolCallingTests {
         var textContent = ""
 
         for try await event in stream {
-            if let toolCalls = event as? LanguageModelExecutorGenerationChannel.ToolCalls,
-                case .toolCall(let toolCall) = toolCalls.action,
-                case .appendArguments(let argsDelta) = toolCall.action
-            {
-                if toolCall.name == "get_weather" {
+            if case .toolCall(_, let name, let arguments) = event {
+                if name == "get_weather" {
                     sawWeatherToolCall = true
-                    let data = Data(argsDelta.content.utf8)
+                    let data = Data(arguments.utf8)
                     let parsed = try? JSONSerialization.jsonObject(with: data)
                     #expect(
                         parsed != nil,
-                        "Tool call arguments should be valid JSON: \(argsDelta.content)")
+                        "Tool call arguments should be valid JSON: \(arguments)")
                 }
-            } else if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
+            } else if case .appendText(let chunk, _, .response) = event {
                 sawText = true
-                textContent += delta.content
+                textContent += chunk
             }
         }
 
@@ -148,16 +143,11 @@ struct FoundationModelsToolCallingTests {
         var textContent = ""
 
         for try await event in stream {
-            if let toolCalls = event as? LanguageModelExecutorGenerationChannel.ToolCalls,
-                case .toolCall(let toolCall) = toolCalls.action,
-                case .appendArguments(let argsDelta) = toolCall.action
-            {
-                toolCallName = toolCall.name
-                toolCallArguments = argsDelta.content
-            } else if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                textContent += delta.content
+            if case .toolCall(_, let name, let arguments) = event {
+                toolCallName = name
+                toolCallArguments = arguments
+            } else if case .appendText(let chunk, _, .response) = event {
+                textContent += chunk
             }
         }
 

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallingReasoningCharacterizationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallingReasoningCharacterizationTests.swift
@@ -82,16 +82,11 @@ struct ToolCallingReasoningCharacterizationTests {
         var toolCallName: String? = nil
         var toolArgs = ""
         for try await event in stream {
-            if let toolCalls = event as? LanguageModelExecutorGenerationChannel.ToolCalls,
-                case .toolCall(let toolCall) = toolCalls.action,
-                case .appendArguments(let argsDelta) = toolCall.action
-            {
-                toolCallName = toolCall.name
-                toolArgs += argsDelta.content
-            } else if let response = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let delta) = response.action
-            {
-                responseText += delta.content
+            if case .toolCall(_, let name, let arguments) = event {
+                toolCallName = name
+                toolArgs += arguments
+            } else if case .appendText(let chunk, _, .response) = event {
+                responseText += chunk
             }
         }
 

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallingReasoningTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallingReasoningTests.swift
@@ -79,23 +79,16 @@ struct ToolCallingReasoningTests {
     private func collect(_ stream: TestResponseStream) async throws -> Collected {
         var c = Collected()
         for try await event in stream {
-            if let r = event as? LanguageModelExecutorGenerationChannel.Reasoning,
-                case .appendText(let fragment) = r.action
-            {
-                c.reasoning += fragment.content
-            } else if let t = event as? LanguageModelExecutorGenerationChannel.ToolCalls,
-                case .toolCall(let toolCall) = t.action,
-                case .appendArguments(let argsDelta) = toolCall.action
-            {
+            if case .appendText(let chunk, _, .reasoning) = event {
+                c.reasoning += chunk
+            } else if case .toolCall(_, let name, let arguments) = event {
                 if c.toolCallName == nil {
-                    c.toolCallName = toolCall.name
+                    c.toolCallName = name
                     c.reasoningBeforeToolCall = !c.reasoning.isEmpty
                 }
-                c.toolArgs += argsDelta.content
-            } else if let r = event as? LanguageModelExecutorGenerationChannel.Response,
-                case .appendText(let fragment) = r.action
-            {
-                c.response += fragment.content
+                c.toolArgs += arguments
+            } else if case .appendText(let chunk, _, .response) = event {
+                c.response += chunk
             }
         }
         return c

--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -665,6 +665,83 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
     /// Executes inference requests for the model.
     public struct Executor: LanguageModelExecutor, Sendable {
 
+        // MARK: - Test observation hook
+        //
+        // The macOS 27 FoundationModels SDK made the generation-channel event
+        // and action types opaque: a consumer can no longer read back what was
+        // streamed. Tests need to read it, and the only place the content is
+        // available is here, right before it enters the channel. These emit
+        // helpers are the sole send sites for each event kind; each notifies an
+        // optional observer with a readable mirror. The observer is nil in
+        // shipping builds (only tests attach one via the task-local), so the
+        // arguments handed to `channel.send` are identical to before and
+        // behavior is unchanged.
+
+        /// Readable, internal-only mirror of the events this executor streams
+        /// into the opaque FoundationModels channel.
+        enum GenerationEvent: Sendable {
+            enum Destination: Sendable { case response, reasoning }
+            case appendText(String, entryID: String?, destination: Destination)
+            case toolCall(id: String, name: String, arguments: String)
+            case updateMetadata([String: any Sendable & Codable & Equatable], entryID: String?)
+            case updateUsage(
+                input: LanguageModelExecutorGenerationChannel.Usage.Input,
+                output: LanguageModelExecutorGenerationChannel.Usage.Output,
+                entryID: String?)
+        }
+
+        /// Attached only by tests (via `$generationObserver.withValue`); nil in
+        /// shipping. Task-local so it reaches child tasks that also emit (e.g.
+        /// the guided-generation text forwarder).
+        @TaskLocal static var generationObserver: (@Sendable (GenerationEvent) -> Void)?
+
+        static func emit(
+            text: String, entryID: String?, destination: GenerationEvent.Destination,
+            into channel: LanguageModelExecutorGenerationChannel
+        ) async {
+            generationObserver?(.appendText(text, entryID: entryID, destination: destination))
+            switch destination {
+            case .response:
+                await channel.send(
+                    .response(entryID: entryID, action: .appendText(text, tokenCount: 1)))
+            case .reasoning:
+                await channel.send(
+                    .reasoning(entryID: entryID, action: .appendText(text, tokenCount: 1)))
+            }
+        }
+
+        static func emitMetadata(
+            _ values: [String: any Sendable & Codable & Equatable], entryID: String?,
+            into channel: LanguageModelExecutorGenerationChannel
+        ) async {
+            generationObserver?(.updateMetadata(values, entryID: entryID))
+            await channel.send(.response(entryID: entryID, action: .updateMetadata(values)))
+        }
+
+        static func emitUsage(
+            input: LanguageModelExecutorGenerationChannel.Usage.Input,
+            output: LanguageModelExecutorGenerationChannel.Usage.Output,
+            entryID: String?,
+            into channel: LanguageModelExecutorGenerationChannel
+        ) async {
+            generationObserver?(.updateUsage(input: input, output: output, entryID: entryID))
+            await channel.send(
+                .response(entryID: entryID, action: .updateUsage(input: input, output: output)))
+        }
+
+        static func emitToolCall(
+            id: String, name: String, arguments: String, entryID: String,
+            into channel: LanguageModelExecutorGenerationChannel
+        ) async {
+            generationObserver?(.toolCall(id: id, name: name, arguments: arguments))
+            await channel.send(
+                .toolCalls(
+                    entryID: entryID,
+                    action: .toolCall(
+                        id: id, name: name,
+                        action: .appendArguments(arguments, tokenCount: 1))))
+        }
+
         /// Default `maxTokens` when the caller doesn't set
         /// `GenerationOptions.maximumResponseTokens`. Applied uniformly
         /// across guided-JSON, tool-calling, and unconstrained generation
@@ -895,13 +972,9 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
 
             do {
                 // Send metadata first
-                await channel.send(
-                    .response(
-                        entryID: entryID,
-                        action: .updateMetadata([
-                            "modelID": modelID,
-                            "requestID": request.id.uuidString,
-                        ])))
+                await Self.emitMetadata(
+                    ["modelID": modelID, "requestID": request.id.uuidString],
+                    entryID: entryID, into: channel)
 
                 // Generate tokens inside actor isolation. `messages` carries
                 // non-Sendable `Chat.Message` instances (UserInput.Image and
@@ -1179,12 +1252,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                                 // `</think>`). Don't prefill a truncated thought
                                 // into the grammar — signal and finish. Phase 1
                                 // already synchronized the GPU on its way out.
-                                await channel.send(
-                                    .response(
-                                        entryID: entryID,
-                                        action: .updateMetadata([
-                                            "incompleteOutput": true
-                                        ])))
+                                await Self.emitMetadata(
+                                    ["incompleteOutput": true], entryID: entryID, into: channel)
                                 return
                             }
                         }
@@ -1244,30 +1313,19 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                             // clamped ≤ total.
                             let reasoningCount = reasoningTokenIDs.count
                             let totalOutput = generatedTokenCount + reasoningCount
-                            await channel.send(
-                                .response(
-                                    entryID: entryID,
-                                    action: .updateUsage(
-                                        input: .init(
-                                            totalTokenCount: toolAwareInput.text.tokens
-                                                .size,
-                                            cachedTokenCount: 0
-                                        ),
-                                        output: .init(
-                                            totalTokenCount: totalOutput,
-                                            reasoningTokenCount: Swift.min(
-                                                reasoningCount, totalOutput)
-                                        )
-                                    )
-                                ))
+                            await Self.emitUsage(
+                                input: .init(
+                                    totalTokenCount: toolAwareInput.text.tokens.size,
+                                    cachedTokenCount: 0),
+                                output: .init(
+                                    totalTokenCount: totalOutput,
+                                    reasoningTokenCount: Swift.min(reasoningCount, totalOutput)),
+                                entryID: entryID, into: channel)
                         }
 
                         if incomplete {
-                            await channel.send(
-                                .response(
-                                    entryID: entryID,
-                                    action: .updateMetadata(["incompleteOutput": true]))
-                            )
+                            await Self.emitMetadata(
+                                ["incompleteOutput": true], entryID: entryID, into: channel)
                         }
                     } else if let schemaJSON {
                         // Guided generation: stream text deltas as they arrive.
@@ -1322,11 +1380,9 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                             .makeStream()
                         async let forwarder: Void = {
                             for await text in textStream {
-                                await channel.send(
-                                    .response(
-                                        entryID: entryID,
-                                        action: .appendText(text, tokenCount: 1)
-                                    ))
+                                await Self.emit(
+                                    text: text, entryID: entryID, destination: .response,
+                                    into: channel)
                             }
                         }()
 
@@ -1357,28 +1413,17 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                         await forwarder
 
                         if let generatedTokenCount {
-                            await channel.send(
-                                .response(
-                                    entryID: entryID,
-                                    action: .updateUsage(
-                                        input: .init(
-                                            totalTokenCount: input.text.tokens.size,
-                                            cachedTokenCount: 0
-                                        ),
-                                        output: .init(
-                                            totalTokenCount: generatedTokenCount,
-                                            reasoningTokenCount: 0
-                                        )
-                                    )
-                                ))
+                            await Self.emitUsage(
+                                input: .init(
+                                    totalTokenCount: input.text.tokens.size, cachedTokenCount: 0),
+                                output: .init(
+                                    totalTokenCount: generatedTokenCount, reasoningTokenCount: 0),
+                                entryID: entryID, into: channel)
                         }
 
                         if incomplete {
-                            await channel.send(
-                                .response(
-                                    entryID: entryID,
-                                    action: .updateMetadata(["incompleteOutput": true]))
-                            )
+                            await Self.emitMetadata(
+                                ["incompleteOutput": true], entryID: entryID, into: channel)
                         }
                     } else {
                         try await runTextGeneration(
@@ -1441,31 +1486,19 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                 try Task.checkCancellation()
                 switch generation {
                 case .chunk(let text):
-                    await channel.send(
-                        .response(
-                            entryID: entryID,
-                            action: .appendText(text, tokenCount: 1)
-                        ))
+                    await Self.emit(
+                        text: text, entryID: entryID, destination: .response, into: channel)
                 case .info(let info):
                     // MLX-LM emits one .info event at end-of-generation with
                     // authoritative scalar token counts (`promptTokenCount`
                     // is the prompt; `generationTokenCount` is the
                     // model-generated completion -- see Evaluate.swift's
                     // `GenerateCompletionInfo` definition).
-                    await channel.send(
-                        .response(
-                            entryID: entryID,
-                            action: .updateUsage(
-                                input: .init(
-                                    totalTokenCount: info.promptTokenCount,
-                                    cachedTokenCount: 0
-                                ),
-                                output: .init(
-                                    totalTokenCount: info.generationTokenCount,
-                                    reasoningTokenCount: 0
-                                )
-                            )
-                        ))
+                    await Self.emitUsage(
+                        input: .init(totalTokenCount: info.promptTokenCount, cachedTokenCount: 0),
+                        output: .init(
+                            totalTokenCount: info.generationTokenCount, reasoningTokenCount: 0),
+                        entryID: entryID, into: channel)
                 case .toolCall(_):
                     break
                 }
@@ -1582,10 +1615,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             // empty or partial answer for the model's chosen response — mirrors
             // the guided path's `incompleteOutput` convention.
             if emitter.isInsideReasoning {
-                await channel.send(
-                    .response(
-                        entryID: responseEntryID,
-                        action: .updateMetadata(["incompleteOutput": true])))
+                await Self.emitMetadata(
+                    ["incompleteOutput": true], entryID: responseEntryID, into: channel)
             }
 
             if let info = completionInfo {
@@ -1593,21 +1624,12 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                 // `.updateUsage` (the framework's aggregator replaces wholesale,
                 // so we must not also rely on per-delta auto-summing). The
                 // reasoning count is clamped to never exceed the total.
-                await channel.send(
-                    .response(
-                        entryID: responseEntryID,
-                        action: .updateUsage(
-                            input: .init(
-                                totalTokenCount: info.promptTokenCount,
-                                cachedTokenCount: 0
-                            ),
-                            output: .init(
-                                totalTokenCount: info.generationTokenCount,
-                                reasoningTokenCount: min(
-                                    reasoningTokenCount, info.generationTokenCount)
-                            )
-                        )
-                    ))
+                await Self.emitUsage(
+                    input: .init(totalTokenCount: info.promptTokenCount, cachedTokenCount: 0),
+                    output: .init(
+                        totalTokenCount: info.generationTokenCount,
+                        reasoningTokenCount: min(reasoningTokenCount, info.generationTokenCount)),
+                    entryID: responseEntryID, into: channel)
             }
         }
 
@@ -1620,15 +1642,11 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
         ) async {
             switch segment {
             case .reasoning(let text):
-                await channel.send(
-                    .reasoning(
-                        entryID: reasoningEntryID,
-                        action: .appendText(text, tokenCount: 1)))
+                await Self.emit(
+                    text: text, entryID: reasoningEntryID, destination: .reasoning, into: channel)
             case .response(let text):
-                await channel.send(
-                    .response(
-                        entryID: responseEntryID,
-                        action: .appendText(text, tokenCount: 1)))
+                await Self.emit(
+                    text: text, entryID: responseEntryID, destination: .response, into: channel)
             }
         }
 
@@ -1803,11 +1821,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             else {
                 // Malformed output. The grammar should have prevented this;
                 // emit the raw buffer as text so failures surface loudly.
-                await channel.send(
-                    .response(
-                        entryID: entryID,
-                        action: .appendText(outputBuffer, tokenCount: 1)
-                    ))
+                await Self.emit(
+                    text: outputBuffer, entryID: entryID, destination: .response, into: channel)
                 return
             }
 
@@ -1824,11 +1839,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                 } else {
                     text = ""
                 }
-                await channel.send(
-                    .response(
-                        entryID: entryID,
-                        action: .appendText(text, tokenCount: 1)
-                    ))
+                await Self.emit(
+                    text: text, entryID: entryID, destination: .response, into: channel)
             } else {
                 guard
                     let args = obj["arguments"],
@@ -1837,15 +1849,9 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                 else {
                     return
                 }
-                await channel.send(
-                    .toolCalls(
-                        entryID: toolCallsEntryID,
-                        action: .toolCall(
-                            id: UUID().uuidString,
-                            name: name,
-                            action: .appendArguments(argsStr, tokenCount: 1)
-                        )
-                    ))
+                await Self.emitToolCall(
+                    id: UUID().uuidString, name: name, arguments: argsStr,
+                    entryID: toolCallsEntryID, into: channel)
             }
         }
 

--- a/Tests/MLXFoundationModelsTests/GenerationEventObserverTests.swift
+++ b/Tests/MLXFoundationModelsTests/GenerationEventObserverTests.swift
@@ -1,0 +1,98 @@
+// Copyright © 2026 Apple Inc.
+
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
+
+import Foundation
+import FoundationModels
+import Testing
+
+@testable import MLXFoundationModels
+
+/// Proves the behavior-neutral observation hook: when an observer is attached
+/// via the task-local, each emit helper both sends to the channel (drained and
+/// discarded here) and hands the observer a readable GenerationEvent mirror.
+@Suite("GenerationEvent observer")
+struct GenerationEventObserverTests {
+
+    /// Runs `body` with an attached observer and a drained channel, returning
+    /// every mirrored event the observer received.
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    private func capture(
+        _ body: (LanguageModelExecutorGenerationChannel) async -> Void
+    ) async -> [MLXLanguageModel.Executor.GenerationEvent] {
+        let channel = LanguageModelExecutorGenerationChannel()
+        let drain = Task<Void, Never> {
+            do { for try await _ in channel {} } catch {}
+        }
+        let box = EventBox()
+        await MLXLanguageModel.Executor.$generationObserver.withValue({ box.append($0) }) {
+            await body(channel)
+        }
+        drain.cancel()
+        return box.events
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    private final class EventBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [MLXLanguageModel.Executor.GenerationEvent] = []
+        func append(_ e: MLXLanguageModel.Executor.GenerationEvent) {
+            lock.lock()
+            storage.append(e)
+            lock.unlock()
+        }
+        var events: [MLXLanguageModel.Executor.GenerationEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    @Test("appendText is mirrored with destination and entryID")
+    func mirrorsText() async {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let events = await capture { channel in
+            await MLXLanguageModel.Executor.emit(
+                text: "hi", entryID: "e1", destination: .response, into: channel)
+        }
+        #expect(events.count == 1)
+        guard case .appendText(let text, "e1", .response) = events.first else {
+            Issue.record("expected .appendText mirror, got \(String(describing: events.first))")
+            return
+        }
+        #expect(text == "hi")
+    }
+
+    @Test("toolCall is mirrored with name and arguments")
+    func mirrorsToolCall() async {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let events = await capture { channel in
+            await MLXLanguageModel.Executor.emitToolCall(
+                id: "id1", name: "get_weather", arguments: "{\"a\":1}",
+                entryID: "tc1", into: channel)
+        }
+        guard case .toolCall(_, let name, let arguments) = events.first else {
+            Issue.record("expected .toolCall mirror, got \(String(describing: events.first))")
+            return
+        }
+        #expect(name == "get_weather")
+        #expect(arguments == "{\"a\":1}")
+    }
+
+    @Test("no observer attached means no crash and events are simply sent")
+    func noObserverIsSafe() async {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        // Not inside withValue: generationObserver is nil (shipping behavior).
+        let channel = LanguageModelExecutorGenerationChannel()
+        let drain = Task<Void, Never> { do { for try await _ in channel {} } catch {} }
+        await MLXLanguageModel.Executor.emit(
+            text: "x", entryID: nil, destination: .reasoning, into: channel)
+        drain.cancel()
+        // Reaching here without trapping is the assertion.
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

The current FoundationModels SDK (macOS, iOS, and visionOS 27) changed its generation API. Our MLXFoundationModels integration tests were written against the older API and no longer compiled against it. This change finishes adapting to the new API and gets the integration tests building and running again, without changing how the model behaves in a shipping app.

## Background

Two parts of the FoundationModels generation API moved:

- Some type and case names were renamed. The cherry-picked groundwork this branch builds on (see below) already started tracking those.
- The values the framework uses to stream a response (generated text, tool calls, usage, and metadata) became opaque. Code that receives them can see that something was produced but can no longer read what it was.

The integration tests depended on the old names and on reading those streamed values directly. After the API moved, they failed to compile, and even once the names were fixed they had no way left to check the actual generated content.

## What this changes

1. A test-only way to observe generation. Every point where the model sends an event to the framework now goes through one of a few shared helpers. Each helper does two things: it sends to the framework exactly as before, and, if a test has asked to observe, it also hands over a plain, readable copy of the same event. Nothing observes in a normal build, so the framework receives the identical calls it always did and runtime behavior is unchanged.

2. The test stream now hands tests these readable events. It also quietly reads and discards the framework's opaque events, which is still necessary so that sending into the framework does not stall.

3. The integration test suites (text generation, reasoning, tool calling, and guided generation) now build against the new API and read these readable events instead of the framework's opaque values.

4. A stale documentation comment is corrected.

## Effect on shipping code

None. Nothing observes generation unless a test opts in, and the calls made to the framework are unchanged. This is test-only support: it makes the existing tests compile and run again on the current SDK, and does not alter how the model generates for real users.

## Dependency on an earlier PR, and rebasing

~~This work builds directly on Charlie Le's PR #431, which begins adapting to the drifted FoundationModels API (notably the renamed SamplingMode case names). I cherry-picked its three commits at the start of this work, so everything here is stacked on top of them.~~

~~PR #431 has not yet merged. Until it does, this branch should be reviewed and merged relative to #431, not main. Once #431 lands, this branch will most likely need to be rebased onto main before it can go in.~~

Given that #431 was just merged, I've since rebased. This should be good-to-go.

## Testing

I ran the MLXFoundationModels integration suites locally to validate.