### PR TITLE
fix(MLXFoundationModels): stop respond() crashing when emitting usage on the FM-27 SDK

### DIFF
--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -725,8 +725,39 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             into channel: LanguageModelExecutorGenerationChannel
         ) async {
             generationObserver?(.updateUsage(input: input, output: output, entryID: entryID))
-            await channel.send(
-                .response(entryID: entryID, action: .updateUsage(input: input, output: output)))
+
+            // TODO: papering over an FM-27 SDK symbol drift -- restore
+            // the channel usage send (the commented-out call at the end of this
+            // block) once the shipping dylib matches its own interface.
+            //
+            // Usage is intentionally NOT forwarded to the FoundationModels
+            // channel on this SDK. The FM-27 beta `.swiftinterface` declares
+            //   Response.Action.updateUsage(input:output:metadata: = [:])
+            // (three parameters), but the shipping FoundationModels dylib only
+            // exports the older two-parameter
+            //   Response.Action.updateUsage(input:output:)
+            // Because our call relies on the `metadata:` default, the compiler
+            // resolves it to the three-parameter symbol, which does not exist
+            // at runtime. dyld cannot bind it: under chained-fixups linking
+            // (the arm64 default) the reference aborts the process the moment
+            // the image loads, and under lazy binding it faults through null
+            // (SIGSEGV at 0x0) the instant this send executes -- crashing every
+            // `respond()` path right after generation completes.
+            //
+            // A runtime `dlsym` guard cannot save this: the compiled reference
+            // to the missing symbol is enough to abort at launch regardless of
+            // any surrounding check. The only safe option is to not reference
+            // the symbol at all, so no `channel.send(.updateUsage(...))` here.
+            //
+            // Effect: the framework does not receive our per-response usage
+            // event, so consumer-visible usage for these responses may be
+            // absent or zero. Tests still observe usage through
+            // `generationObserver` above. When a later SDK ships a dylib that
+            // matches its interface, restore the send:
+            //   await channel.send(
+            //       .response(
+            //           entryID: entryID,
+            //           action: .updateUsage(input: input, output: output)))
         }
 
         static func emitToolCall(


### PR DESCRIPTION
## What

PR #438 fixed the compile-time FoundationModels API drift so the integration target builds against the FM-27 event-action structs. This fixes a runtime drift in the same SDK that those now-compiling tests hit the moment they run on-device: every respond() call crashes with a SIGSEGV right after generation, inside Executor.emitUsage.

## Root cause

The FM-27 beta .swiftinterface we compile against declares:

```
LanguageModelExecutorGenerationChannel.Response.Action.updateUsage(input:output:metadata: = [:])
```

but the shipping FoundationModels dylib exports only the older two-parameter form `updateUsage(input:output:)`. Because emitUsage called `.updateUsage(input:output:)` and relied on the `metadata:` default, the compiler resolved the call to the three-parameter symbol, which does not exist at runtime. dyld cannot bind it, so the call jumps through null (`KERN_INVALID_ADDRESS at 0x0`).

Confirmed with `dyld_info -exports` (only the 2-arg symbol is present) and a standalone reproducer that aborts with `Symbol not found: ...updateUsage...metadata...`.

This is latent on main because the integration tests that exercise it don't run on-device in CI. `appendText` / `toolCall` / `updateMetadata` are unaffected: their full symbols do exist in the dylib.

## Fix

Remove the `channel.send(.updateUsage(...))` call, the only reference to the missing symbol. A runtime dlsym/availability guard cannot help here: under chained-fixups linking (the arm64 default) the compiled reference alone aborts the process at load, before any guard executes. Not referencing the symbol is the only safe option.

The `generationObserver` notification is preserved, so usage remains observable (tests and consumers of the observer are unaffected). The channel send is documented inline for one-line restoration once a later SDK ships a dylib that matches its own interface.

## Verification

- Standalone reproducer against the real SDK: crashes with the missing 3-arg symbol; runs clean with the send removed.
- `MLXFoundationModels` builds clean; formatter applied.
- On-device integration: `UpdateUsageEmissionTests` passes on all three `respond()` paths (unconstrained, guided, tool-calling) — 3/3, no crash report.