### PR TITLE
Silence Metal compiler warning noise in integration test runs

### DIFF
--- a/IntegrationTesting/IntegrationTesting.xcodeproj/xcshareddata/xcschemes/IntegrationTesting.xcscheme
+++ b/IntegrationTesting/IntegrationTesting.xcodeproj/xcshareddata/xcschemes/IntegrationTesting.xcscheme
@@ -39,6 +39,13 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"


### PR DESCRIPTION
## Proposed changes

Set OS_ACTIVITY_MODE=disable on the IntegrationTesting scheme TestAction to suppress log spam from MLX runtime shader JIT compilation, e.g.:

  [Metal Compiler Warning] Warning: Compilation succeeded with:
  mlx/backend/metal/kernels/defines.h:10:32: warning: unused variable
  MAX_REDUCE_SPECIALIZED_DIMS [-Wunused-const-variable]
  static MTL_CONST constexpr int MAX_REDUCE_SPECIALIZED_DIMS = 4;
                                  ^
  (and similarly for REDUCE_N_READS, REDUCE_N_WRITES, SOFTMAX_N_READS,
  RMS_N_READS, RMS_LOOPED_LIMIT)

These come from mlx-swift vendored MLX C++/Metal sources, not this repo.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
