### PR TITLE
Optimize Qwen3.5 interleaved M-RoPE

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -222,36 +222,28 @@ enum Qwen35Language {
 
     final class RotaryEmbedding {
         private let invFreq: MLXArray
-        private let mropeSection: [Int]
+        private let mropeIndices: MLXArray
 
         init(dim: Int, base: Float, mropeSection: [Int]) {
             let safeDim = max(1, dim)
             var freq = MLXArray(stride(from: 0, to: safeDim, by: 2)).asType(.float32)
             freq = freq / Float(safeDim)
             self.invFreq = 1.0 / pow(MLXArray(base), freq)
-            self.mropeSection =
-                mropeSection.count >= 3 ? mropeSection : [11, 11, 10]
+
+            let sections = mropeSection.count >= 3 ? mropeSection : [11, 11, 10]
+            var indices = [Int32](repeating: 0, count: freq.dim(0))
+            for (dimension, offset) in [(1, 1), (2, 2)] {
+                let end = min(sections[dimension] * 3, indices.count)
+                for index in stride(from: offset, to: end, by: 3) {
+                    indices[index] = Int32(dimension)
+                }
+            }
+            self.mropeIndices = MLXArray(indices)
         }
 
         private func applyInterleavedMRope(_ freqs: MLXArray) -> MLXArray {
-            let freqsT = freqs[0, 0..., 0..., 0...]
-            let dims = freqsT.dim(-1)
-            var slices: [MLXArray] = []
-            slices.reserveCapacity(dims)
-
-            for idx in 0 ..< dims {
-                var slice = freqsT[0..., 0..., idx]
-                for (dim, offset) in [(1, 1), (2, 2)] {
-                    let length = min(mropeSection[dim] * 3, dims)
-                    if idx >= offset && idx < length && ((idx - offset) % 3 == 0) {
-                        slice = freqs[dim, 0..., 0..., idx]
-                        break
-                    }
-                }
-                slices.append(slice)
-            }
-
-            return stacked(slices, axis: -1)
+            let indices = mropeIndices[.newAxis, .newAxis, .newAxis, 0...]
+            return takeAlong(freqs, indices, axis: 0).squeezed(axis: 0)
         }
 
         func callAsFunction(x: MLXArray, positionIds: MLXArray) -> (MLXArray, MLXArray) {

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -238,12 +238,11 @@ enum Qwen35Language {
                     indices[index] = Int32(dimension)
                 }
             }
-            self.mropeIndices = MLXArray(indices)
+            self.mropeIndices = MLXArray(indices).reshaped(1, 1, 1, -1)
         }
 
         private func applyInterleavedMRope(_ freqs: MLXArray) -> MLXArray {
-            let indices = mropeIndices[.newAxis, .newAxis, .newAxis, 0...]
-            return takeAlong(freqs, indices, axis: 0).squeezed(axis: 0)
+            takeAlong(freqs, mropeIndices, axis: 0).squeezed(axis: 0)
         }
 
         func callAsFunction(x: MLXArray, positionIds: MLXArray) -> (MLXArray, MLXArray) {

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -986,37 +986,26 @@ enum Qwen3VLLanguage {
     final class RotaryEmbedding {
 
         private let invFreq: MLXArray
-        private let mropeSection: [Int]
+        private let mropeIndices: MLXArray
 
         init(headDim: Int, base: Double, ropeScaling: Qwen3VLConfiguration.RoPEScaling?) {
             var freq = MLXArray(stride(from: 0, to: headDim, by: 2)).asType(.float32)
             freq = freq / Float(headDim)
             let baseArray = MLXArray(Float(base))
             self.invFreq = 1.0 / pow(baseArray, freq)
-            self.mropeSection = ropeScaling?.mropeSection ?? [24, 20, 20]
+            let sections = ropeScaling?.mropeSection ?? [24, 20, 20]
+            var indices = [Int32](repeating: 0, count: freq.dim(0))
+            for (dimension, offset) in [(1, 1), (2, 2)] {
+                let end = min(sections[dimension] * 3, indices.count)
+                for index in stride(from: offset, to: end, by: 3) {
+                    indices[index] = Int32(dimension)
+                }
+            }
+            self.mropeIndices = MLXArray(indices).reshaped(1, 1, 1, -1)
         }
 
         private func applyInterleavedMRope(_ freqs: MLXArray) -> MLXArray {
-            let freqs_t = freqs[0, 0..., 0..., 0...]  // (bs, seq_len, head_dim // 2)
-
-            let dims = freqs_t.dim(-1)
-            var slices: [MLXArray] = []
-
-            for idx in 0 ..< dims {
-                var slice = freqs_t[0..., 0..., idx]
-
-                for (dimIndex, offset) in [(1, 1), (2, 2)] {
-                    let end = min(mropeSection[dimIndex] * 3, dims)
-                    if idx >= offset && idx < end && (idx - offset) % 3 == 0 {
-                        slice = freqs[dimIndex, 0..., 0..., idx]
-                        break
-                    }
-                }
-
-                slices.append(slice)
-            }
-
-            return stacked(slices, axis: -1)
+            takeAlong(freqs, mropeIndices, axis: 0).squeezed(axis: 0)
         }
 
         func callAsFunction(positionIds: MLXArray, dtype: MLX.DType) -> (MLXArray, MLXArray) {

--- a/Tests/MLXLMTests/Qwen35MRoPETests.swift
+++ b/Tests/MLXLMTests/Qwen35MRoPETests.swift
@@ -1,0 +1,66 @@
+import MLX
+import XCTest
+
+@testable import MLXVLM
+
+final class Qwen35MRoPETests: XCTestCase {
+    func testDefaultSectionsMatchSliceReference() {
+        assertMatchesReference(dim: 64, sections: [11, 11, 10])
+    }
+
+    func testTruncatedSectionsMatchSliceReference() {
+        assertMatchesReference(dim: 16, sections: [2, 1, 1])
+    }
+
+    func testMissingSectionsUseDefaults() {
+        assertMatchesReference(dim: 64, sections: [])
+    }
+
+    private func assertMatchesReference(dim: Int, sections: [Int]) {
+        let embedding = Qwen35Language.RotaryEmbedding(
+            dim: dim, base: 100_000, mropeSection: sections)
+        let positionIds = MLXArray((0 ..< 24).map(Int32.init)).reshaped(3, 2, 4)
+        let x = MLXArray.zeros([1], dtype: .float32)
+
+        let actual = embedding(x: x, positionIds: positionIds)
+        let expected = reference(
+            dim: dim, base: 100_000, sections: sections, positionIds: positionIds)
+
+        eval(actual.0, actual.1, expected.0, expected.1)
+        XCTAssertTrue(allClose(actual.0, expected.0, atol: 1e-6).item(Bool.self))
+        XCTAssertTrue(allClose(actual.1, expected.1, atol: 1e-6).item(Bool.self))
+    }
+
+    private func reference(
+        dim: Int, base: Float, sections: [Int], positionIds: MLXArray
+    ) -> (MLXArray, MLXArray) {
+        let sections = sections.count >= 3 ? sections : [11, 11, 10]
+        let safeDim = max(1, dim)
+        var frequency = MLXArray(stride(from: 0, to: safeDim, by: 2)).asType(.float32)
+        frequency = frequency / Float(safeDim)
+        var inverseFrequency = 1.0 / pow(MLXArray(base), frequency)
+        inverseFrequency = inverseFrequency[.newAxis, .newAxis, .newAxis, 0...]
+
+        let positions = positionIds.asType(.float32)
+        let frequencies = positions[0..., 0..., 0..., .newAxis] * inverseFrequency
+        let temporal = frequencies[0, 0..., 0..., 0...]
+        var slices: [MLXArray] = []
+        slices.reserveCapacity(temporal.dim(-1))
+
+        for index in 0 ..< temporal.dim(-1) {
+            var slice = temporal[0..., 0..., index]
+            for (dimension, offset) in [(1, 1), (2, 2)] {
+                let end = min(sections[dimension] * 3, temporal.dim(-1))
+                if index >= offset && index < end && (index - offset) % 3 == 0 {
+                    slice = frequencies[dimension, 0..., 0..., index]
+                    break
+                }
+            }
+            slices.append(slice)
+        }
+
+        let interleaved = stacked(slices, axis: -1)
+        let embedding = concatenated([interleaved, interleaved], axis: -1)
+        return (cos(embedding), sin(embedding))
+    }
+}

--- a/Tests/MLXLMTests/Qwen35MRoPETests.swift
+++ b/Tests/MLXLMTests/Qwen35MRoPETests.swift
@@ -23,44 +23,74 @@ final class Qwen35MRoPETests: XCTestCase {
         let x = MLXArray.zeros([1], dtype: .float32)
 
         let actual = embedding(x: x, positionIds: positionIds)
-        let expected = reference(
-            dim: dim, base: 100_000, sections: sections, positionIds: positionIds)
+        let expected = referenceInterleavedMRope(
+            dim: dim, base: 100_000, sections: sections,
+            fallbackSections: [11, 11, 10], positionIds: positionIds)
 
         eval(actual.0, actual.1, expected.0, expected.1)
         XCTAssertTrue(allClose(actual.0, expected.0, atol: 1e-6).item(Bool.self))
         XCTAssertTrue(allClose(actual.1, expected.1, atol: 1e-6).item(Bool.self))
     }
 
-    private func reference(
-        dim: Int, base: Float, sections: [Int], positionIds: MLXArray
-    ) -> (MLXArray, MLXArray) {
-        let sections = sections.count >= 3 ? sections : [11, 11, 10]
-        let safeDim = max(1, dim)
-        var frequency = MLXArray(stride(from: 0, to: safeDim, by: 2)).asType(.float32)
-        frequency = frequency / Float(safeDim)
-        var inverseFrequency = 1.0 / pow(MLXArray(base), frequency)
-        inverseFrequency = inverseFrequency[.newAxis, .newAxis, .newAxis, 0...]
+}
 
-        let positions = positionIds.asType(.float32)
-        let frequencies = positions[0..., 0..., 0..., .newAxis] * inverseFrequency
-        let temporal = frequencies[0, 0..., 0..., 0...]
-        var slices: [MLXArray] = []
-        slices.reserveCapacity(temporal.dim(-1))
-
-        for index in 0 ..< temporal.dim(-1) {
-            var slice = temporal[0..., 0..., index]
-            for (dimension, offset) in [(1, 1), (2, 2)] {
-                let end = min(sections[dimension] * 3, temporal.dim(-1))
-                if index >= offset && index < end && (index - offset) % 3 == 0 {
-                    slice = frequencies[dimension, 0..., 0..., index]
-                    break
-                }
-            }
-            slices.append(slice)
-        }
-
-        let interleaved = stacked(slices, axis: -1)
-        let embedding = concatenated([interleaved, interleaved], axis: -1)
-        return (cos(embedding), sin(embedding))
+final class Qwen3VLMRoPETests: XCTestCase {
+    func testDefaultSectionsMatchSliceReference() {
+        assertMatchesReference(headDim: 128, sections: nil)
     }
+
+    func testCustomSectionsMatchSliceReference() {
+        assertMatchesReference(headDim: 16, sections: [2, 1, 1])
+    }
+
+    private func assertMatchesReference(headDim: Int, sections: [Int]?) {
+        let scaling = sections.map {
+            Qwen3VLConfiguration.RoPEScaling(mropeSection: $0)
+        }
+        let embedding = Qwen3VLLanguage.RotaryEmbedding(
+            headDim: headDim, base: 100_000, ropeScaling: scaling)
+        let positionIds = MLXArray((0 ..< 24).map(Int32.init)).reshaped(3, 2, 4)
+
+        let actual = embedding(positionIds: positionIds, dtype: .float32)
+        let expected = referenceInterleavedMRope(
+            dim: headDim, base: 100_000, sections: sections ?? [24, 20, 20],
+            fallbackSections: [24, 20, 20], positionIds: positionIds)
+
+        eval(actual.0, actual.1, expected.0, expected.1)
+        XCTAssertTrue(allClose(actual.0, expected.0, atol: 1e-6).item(Bool.self))
+        XCTAssertTrue(allClose(actual.1, expected.1, atol: 1e-6).item(Bool.self))
+    }
+}
+
+private func referenceInterleavedMRope(
+    dim: Int, base: Float, sections: [Int], fallbackSections: [Int], positionIds: MLXArray
+) -> (MLXArray, MLXArray) {
+    let sections = sections.count >= 3 ? sections : fallbackSections
+    let safeDim = max(1, dim)
+    var frequency = MLXArray(stride(from: 0, to: safeDim, by: 2)).asType(.float32)
+    frequency = frequency / Float(safeDim)
+    var inverseFrequency = 1.0 / pow(MLXArray(base), frequency)
+    inverseFrequency = inverseFrequency[.newAxis, .newAxis, .newAxis, 0...]
+
+    let positions = positionIds.asType(.float32)
+    let frequencies = positions[0..., 0..., 0..., .newAxis] * inverseFrequency
+    let temporal = frequencies[0, 0..., 0..., 0...]
+    var slices: [MLXArray] = []
+    slices.reserveCapacity(temporal.dim(-1))
+
+    for index in 0 ..< temporal.dim(-1) {
+        var slice = temporal[0..., 0..., index]
+        for (dimension, offset) in [(1, 1), (2, 2)] {
+            let end = min(sections[dimension] * 3, temporal.dim(-1))
+            if index >= offset && index < end && (index - offset) % 3 == 0 {
+                slice = frequencies[dimension, 0..., 0..., index]
+                break
+            }
+        }
+        slices.append(slice)
+    }
+
+    let interleaved = stacked(slices, axis: -1)
+    let embedding = concatenated([interleaved, interleaved], axis: -1)
+    return (cos(embedding), sin(embedding))
 }


### PR DESCRIPTION
## Proposed changes

In an Instruments profile of Qwen3.5 generation, `Qwen35Language.RotaryEmbedding.applyInterleavedMRope` accounted for approximately 1.84 billion cycles, or 11% of the generation worker’s CPU cycles. The implementation selected each frequency dimension using repeated `MLXArray` subscripting and then reconstructed the result with `stacked`, making `MLXArray.subscript` and `getItemND` significant hotspots.

This PR:

- Precomputes the M-RoPE modality indices once during `RotaryEmbedding` initialization.
- Replaces the per-dimension slicing loop and `stacked` operation with a single broadcasted `takeAlong` operation.
- Removes 32 individual frequency-column subscripts per invocation for the standard 64-dimensional Qwen3.5 configuration.
- Preserves the existing fallback behavior for missing M-RoPE section configuration.
- Adds regression tests comparing the optimized implementation against the previous slicing algorithm for standard, truncated, and fallback configurations.

The complete unit-test suite passes, including all existing Qwen3.5 continuation tests.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)