### PR TITLE
Qwen2.5-VL / Qwen2-VL: windowed prefill + state-threaded warm continuation (wires #420)

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -931,62 +931,8 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         self._languageModel.wrappedValue = Language.LanguageModel(config.textConfiguration)
     }
 
-    /// Builds the multimodal input embedding for one prefill step.
-    ///
-    /// Returns the embeddings paired with the prefill-only MROPE state
-    /// (positionIds + ropeDeltas) — both nil on the no-image path. The
-    /// caller seeds `LMOutput.State` with these so subsequent decode
-    /// steps can reconstruct positions from `ropeDeltas + cacheOffset`
-    /// without mutating the model.
-    private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)
-        -> (embeds: MLXArray, positionIds: MLXArray?, ropeDeltas: MLXArray?)
-    {
-        guard let pixelValues, let frames else {
-            return (
-                languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis]),
-                nil, nil
-            )
-        }
-
-        // Get the input embeddings from the language model
-        let inputEmbeds = languageModel.model.embedTokens(inputIds)
-
-        // Get the output hidden states from the vision model
-        var hiddenStates = self.visionModel(pixelValues, frames: frames)
-
-        if hiddenStates.ndim == 2 {
-            hiddenStates = hiddenStates[.newAxis, 0..., 0...]
-        }
-
-        // Insert special image tokens in the input_ids
-        let mergedEmbeds = QwenVL.mergeInputIdsWithImageFeatures(
-            inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
-            imageTokenId: config.baseConfiguration.imageTokenId,
-            videoTokenId: config.baseConfiguration.videoTokenId)
-
-        // Compute MROPE 3D position IDs for spatial awareness
-        let spatialMergeSize = config.visionConfiguration.spatialMergeSize
-        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
-        let (positionIds, ropeDeltas) = Qwen25VL.getRopeIndex(
-            inputIds: inputIds2D,
-            imageGridTHW: frames,
-            videoGridTHW: nil,
-            spatialMergeSize: spatialMergeSize,
-            imageTokenId: config.baseConfiguration.imageTokenId,
-            videoTokenId: config.baseConfiguration.videoTokenId,
-            visionStartTokenId: config.baseConfiguration.visionStartTokenId)
-
-        return (mergedEmbeds, positionIds, ropeDeltas)
-    }
-
-    public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
-    ) throws
-        -> PrepareResult
-    {
+    private func gatherVisionInputs(_ input: LMInput) -> (pixels: MLXArray?, frames: [THW]?) {
         let dtype = visionModel.patchEmbed.proj.weight.dtype
-
-        // Process both images and videos together
         var allPixels: MLXArray?
         var allFrames: [THW] = []
 
@@ -994,7 +940,6 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             allPixels = imagePixels.asType(dtype)
             allFrames.append(contentsOf: imageFrames)
         }
-
         if let videoPixels = input.video?.pixels, let videoFrames = input.video?.frames {
             if allPixels == nil {
                 allPixels = videoPixels.asType(dtype)
@@ -1004,26 +949,125 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: videoFrames)
         }
 
-        let (embeds, positionIds, ropeDeltas) = self.inputEmbeddings(
-            inputIds: input.text.tokens, pixelValues: allPixels,
-            frames: allFrames.isEmpty ? nil : allFrames)
+        return (allPixels, allFrames.isEmpty ? nil : allFrames)
+    }
 
-        // Seed per-call decoder state with the prefill-only MROPE
-        // positions + ropeDeltas (both nil on the no-image path). The
-        // LMOutput's `state` returned by this call is what subsequent
-        // decode steps consume via `callAsFunction(_:cache:state:)`.
-        var state = LMOutput.State()
-        if let positionIds {
-            state[positionIdsKey] = positionIds
+    private func mergedVisionEmbeds(inputIds: MLXArray, pixelValues: MLXArray, frames: [THW])
+        -> MLXArray
+    {
+        let inputEmbeds = languageModel.model.embedTokens(inputIds)
+        var hiddenStates = self.visionModel(pixelValues, frames: frames)
+        if hiddenStates.ndim == 2 {
+            hiddenStates = hiddenStates[.newAxis, 0..., 0...]
         }
-        if let ropeDeltas {
+        return QwenVL.mergeInputIdsWithImageFeatures(
+            inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId)
+    }
+
+    private func faCacheOffset(_ cache: [any KVCache]) -> Int {
+        cache.first?.offset ?? 0
+    }
+
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int?
+    ) throws
+        -> PrepareResult
+    {
+        let inputIds = input.text.tokens
+
+        let window = windowSize ?? 512
+        if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
+            faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
+        {
+            return try prepareContinuation(input, cache: cache, state: state, windowSize: window)
+        }
+
+        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
+        let (pixels, frames) = gatherVisionInputs(input)
+
+        var state = LMOutput.State()
+        var embeds: MLXArray?
+        if let pixels, let frames {
+            embeds = mergedVisionEmbeds(inputIds: inputIds2D, pixelValues: pixels, frames: frames)
+            let (positionIds, ropeDeltas) = Qwen25VL.getRopeIndex(
+                inputIds: inputIds2D,
+                imageGridTHW: frames,
+                videoGridTHW: nil,
+                spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+                imageTokenId: config.baseConfiguration.imageTokenId,
+                videoTokenId: config.baseConfiguration.videoTokenId,
+                visionStartTokenId: config.baseConfiguration.visionStartTokenId)
+            state[positionIdsKey] = positionIds
             state[ropeDeltasKey] = ropeDeltas
         }
 
         let result = languageModel(
-            nil, cache: cache, state: state, inputEmbedding: embeds)
+            embeds == nil ? inputIds2D : nil, cache: cache, state: state, inputEmbedding: embeds)
 
         return .logits(result)
+    }
+
+    private func prepareContinuation(
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int
+    ) throws -> PrepareResult {
+        let inputIds = input.text.tokens
+        let remainderLength = inputIds.dim(-1)
+        precondition(remainderLength > 0, "prepareContinuation needs a non-empty remainder")
+
+        let cacheOffset = faCacheOffset(cache)
+        var anchorRopeDelta = 0
+        if let seeded = state?[ropeDeltasKey] {
+            anchorRopeDelta = seeded.asType(.int32).item(Int.self)
+        }
+        let positionOffset = cacheOffset + anchorRopeDelta
+
+        let (pixels, frames) = gatherVisionInputs(input)
+        var embeds: MLXArray?
+        if let pixels, let frames {
+            embeds = mergedVisionEmbeds(inputIds: inputIds, pixelValues: pixels, frames: frames)
+        }
+
+        let (positionIds, ropeDeltas) = Qwen25VL.getRopeIndex(
+            inputIds: inputIds,
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            visionStartTokenId: config.baseConfiguration.visionStartTokenId,
+            positionOffset: positionOffset)
+
+        let step = max(1, windowSize)
+        var lastLogits = MLXArray(0)
+        var start = 0
+        repeat {
+            try Task.checkCancellation()
+            let end = min(start + step, remainderLength)
+            let chunkPositions = positionIds[0..., 0..., start ..< end]
+            let output: LMOutput
+            if let embeds {
+                let chunkEmbeds = embeds[0..., start ..< end, 0...]
+                output = languageModel(
+                    nil, cache: cache, state: nil, inputEmbedding: chunkEmbeds,
+                    positionIds: chunkPositions)
+            } else {
+                let chunkInputs = inputIds[0..., start ..< end]
+                output = languageModel(
+                    chunkInputs, cache: cache, state: nil, inputEmbedding: nil,
+                    positionIds: chunkPositions)
+            }
+            lastLogits = output.logits
+            asyncEval(cache)
+            start = end
+        } while start < remainderLength
+        eval(cache)
+
+        var resumeState = LMOutput.State()
+        resumeState[ropeDeltasKey] = ropeDeltas - MLXArray(Int32(cacheOffset))
+
+        return .logits(LMOutput(logits: lastLogits, state: resumeState))
     }
 
     static func getRopeIndex(
@@ -1034,7 +1078,8 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         imageTokenId: Int,
         videoTokenId: Int,
         visionStartTokenId: Int,
-        attentionMask: MLXArray? = nil
+        attentionMask: MLXArray? = nil,
+        positionOffset: Int = 0
     ) -> (MLXArray, MLXArray) {
 
         let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
@@ -1042,10 +1087,13 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         guard inputIds.ndim > 0, imageGridTHW != nil || videoGridTHW != nil else {
             var positionIds = MLXArray(0 ..< seqLength).asType(.int32)
             positionIds = broadcast(positionIds[.newAxis, 0...], to: [batchSize, seqLength])
-            let positionIds3D = broadcast(
+            var positionIds3D = broadcast(
                 positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
-            let zeros = MLXArray.zeros([batchSize], dtype: .int32)
-            return (positionIds3D, zeros)
+            if positionOffset != 0 {
+                positionIds3D = positionIds3D + MLXArray(Int32(positionOffset))
+            }
+            let deltas = MLXArray(Array(repeating: Int32(positionOffset), count: batchSize))
+            return (positionIds3D, deltas)
         }
 
         var positionIds = ones(like: inputIds).asType(.int32)
@@ -1158,7 +1206,10 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             }
 
             if !llmPosIdsList.isEmpty {
-                let llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+                var llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+                if positionOffset != 0 {
+                    llmPositions = llmPositions + MLXArray(Int32(positionOffset))
+                }
 
                 let expandedMask = broadcast(
                     mask[batchIdx, 0...][.newAxis, .newAxis, 0...], to: [3, 1, seqLength])

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -349,7 +349,8 @@ private enum Language {
         spatialMergeSize: Int,
         imageTokenId: Int,
         videoTokenId: Int,
-        attentionMask: MLXArray? = nil
+        attentionMask: MLXArray? = nil,
+        positionOffset: Int = 0
     ) -> (MLXArray, MLXArray) {
 
         let (batchSize, seqLength) = (inputIds.dim(0), inputIds.dim(1))
@@ -357,10 +358,13 @@ private enum Language {
         guard inputIds.ndim > 0, imageGridTHW != nil || videoGridTHW != nil else {
             var positionIds = MLXArray(0 ..< seqLength).asType(.int32)
             positionIds = broadcast(positionIds[.newAxis, 0...], to: [batchSize, seqLength])
-            let positionIds3D = broadcast(
+            var positionIds3D = broadcast(
                 positionIds[.newAxis, 0..., 0...], to: [3, batchSize, seqLength])
-            let zeros = MLXArray.zeros([batchSize], dtype: .int32)
-            return (positionIds3D, zeros)
+            if positionOffset != 0 {
+                positionIds3D = positionIds3D + MLXArray(Int32(positionOffset))
+            }
+            let deltas = MLXArray(Array(repeating: Int32(positionOffset), count: batchSize))
+            return (positionIds3D, deltas)
         }
 
         var positionIds = ones(like: inputIds).asType(.int32)
@@ -473,7 +477,10 @@ private enum Language {
             }
 
             if !llmPosIdsList.isEmpty {
-                let llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+                var llmPositions = concatenated(llmPosIdsList, axis: 1)  // [3, seq]
+                if positionOffset != 0 {
+                    llmPositions = llmPositions + MLXArray(Int32(positionOffset))
+                }
 
                 let expandedMask = broadcast(
                     mask[batchIdx, 0...][.newAxis, .newAxis, 0...], to: [3, 1, seqLength])
@@ -931,58 +938,8 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
         self._languageModel.wrappedValue = Language.LanguageModel(config.textConfiguration)
     }
 
-    /// Builds the multimodal input embedding for one prefill step.
-    ///
-    /// Returns the embeddings paired with the prefill-only MROPE state
-    /// (positionIds + ropeDeltas) — both nil on the no-image path. The
-    /// caller seeds `LMOutput.State` with these so subsequent decode steps
-    /// reconstruct positions from `ropeDeltas + cacheOffset` without
-    /// mutating the model.
-    private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)
-        -> (embeds: MLXArray, positionIds: MLXArray?, ropeDeltas: MLXArray?)
-    {
-        guard let pixelValues, let frames else {
-            return (languageModel.model.embedTokens(inputIds[.newAxis, .ellipsis]), nil, nil)
-        }
-
-        // Get the input embeddings from the language model
-        let inputEmbeds = languageModel.model.embedTokens(inputIds)
-
-        // Get the ouptut hidden states from the vision model
-        var hiddenStates = self.visionModel(pixelValues, frames: frames)
-
-        if hiddenStates.ndim == 2 {
-            hiddenStates = hiddenStates[.newAxis, 0..., 0...]
-        }
-
-        // Insert special image tokens in the input_ids
-        let merged = QwenVL.mergeInputIdsWithImageFeatures(
-            inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
-            imageTokenId: config.baseConfiguration.imageTokenId,
-            videoTokenId: config.baseConfiguration.videoTokenId)
-
-        // Compute MROPE 3D position IDs for spatial awareness
-        // #239: Qwen25VL.swift inputEmbeddings (:941)
-        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
-        let (positionIds, ropeDeltas) = Language.getRopeIndex(
-            inputIds: inputIds2D,
-            imageGridTHW: frames,
-            videoGridTHW: nil,
-            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
-            imageTokenId: config.baseConfiguration.imageTokenId,
-            videoTokenId: config.baseConfiguration.videoTokenId)
-
-        return (merged, positionIds, ropeDeltas)
-    }
-
-    public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
-    ) throws
-        -> PrepareResult
-    {
+    private func gatherVisionInputs(_ input: LMInput) -> (pixels: MLXArray?, frames: [THW]?) {
         let dtype = visionModel.patchEmbed.proj.weight.dtype
-
-        // Process both images and videos together
         var allPixels: MLXArray?
         var allFrames: [THW] = []
 
@@ -990,7 +947,6 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             allPixels = imagePixels.asType(dtype)
             allFrames.append(contentsOf: imageFrames)
         }
-
         if let videoPixels = input.video?.pixels, let videoFrames = input.video?.frames {
             if allPixels == nil {
                 allPixels = videoPixels.asType(dtype)
@@ -1000,33 +956,123 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: videoFrames)
         }
 
-        let (embeds, positionIds, ropeDeltas) = self.inputEmbeddings(
-            inputIds: input.text.tokens, pixelValues: allPixels,
-            frames: allFrames.isEmpty ? nil : allFrames)
+        return (allPixels, allFrames.isEmpty ? nil : allFrames)
+    }
 
-        // #239: Qwen25VL.swift prepare(_:cache:state:windowSize:)
-        // Seed per-call decoder state with the prefill-only MROPE positions +
-        // ropeDeltas (both nil on the no-image path). The LMOutput's `state`
-        // returned here is consumed by subsequent decode steps via
-        // `callAsFunction(_:cache:state:)`.
-        //
-        // NOTE: this intentionally does a single-shot prefill rather than the
-        // windowSize-chunked prefill added for other VLMs in #344. Mirroring
-        // Qwen25VL.swift, M-RoPE feeds `positionIds` ([3, batch, seq]) through
-        // decoder state; chunking the embeddings without slicing positionIds in
-        // lockstep would feed wrong positions to M-RoPE. Qwen25VL.swift is
-        // likewise left un-chunked for the same reason.
-        var state = LMOutput.State()
-        if let positionIds {
-            state[positionIdsKey] = positionIds
+    private func mergedVisionEmbeds(inputIds: MLXArray, pixelValues: MLXArray, frames: [THW])
+        -> MLXArray
+    {
+        let inputEmbeds = languageModel.model.embedTokens(inputIds)
+        var hiddenStates = self.visionModel(pixelValues, frames: frames)
+        if hiddenStates.ndim == 2 {
+            hiddenStates = hiddenStates[.newAxis, 0..., 0...]
         }
-        if let ropeDeltas {
+        return QwenVL.mergeInputIdsWithImageFeatures(
+            inputIds: inputIds, inputEmbeds: inputEmbeds, imageFeatures: hiddenStates,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId)
+    }
+
+    private func faCacheOffset(_ cache: [any KVCache]) -> Int {
+        cache.first?.offset ?? 0
+    }
+
+    public func prepare(
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int?
+    ) throws
+        -> PrepareResult
+    {
+        let inputIds = input.text.tokens
+
+        let window = windowSize ?? 512
+        if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
+            faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
+        {
+            return try prepareContinuation(input, cache: cache, state: state, windowSize: window)
+        }
+
+        let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
+        let (pixels, frames) = gatherVisionInputs(input)
+
+        var state = LMOutput.State()
+        var embeds: MLXArray?
+        if let pixels, let frames {
+            embeds = mergedVisionEmbeds(inputIds: inputIds2D, pixelValues: pixels, frames: frames)
+            let (positionIds, ropeDeltas) = Language.getRopeIndex(
+                inputIds: inputIds2D,
+                imageGridTHW: frames,
+                videoGridTHW: nil,
+                spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+                imageTokenId: config.baseConfiguration.imageTokenId,
+                videoTokenId: config.baseConfiguration.videoTokenId)
+            state[positionIdsKey] = positionIds
             state[ropeDeltasKey] = ropeDeltas
         }
 
-        let result = languageModel(nil, cache: cache, state: state, inputEmbedding: embeds)
+        let result = languageModel(
+            embeds == nil ? inputIds2D : nil, cache: cache, state: state, inputEmbedding: embeds)
 
         return .logits(result)
+    }
+
+    private func prepareContinuation(
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int
+    ) throws -> PrepareResult {
+        let inputIds = input.text.tokens
+        let remainderLength = inputIds.dim(-1)
+        precondition(remainderLength > 0, "prepareContinuation needs a non-empty remainder")
+
+        let cacheOffset = faCacheOffset(cache)
+        var anchorRopeDelta = 0
+        if let seeded = state?[ropeDeltasKey] {
+            anchorRopeDelta = seeded.asType(.int32).item(Int.self)
+        }
+        let positionOffset = cacheOffset + anchorRopeDelta
+
+        let (pixels, frames) = gatherVisionInputs(input)
+        var embeds: MLXArray?
+        if let pixels, let frames {
+            embeds = mergedVisionEmbeds(inputIds: inputIds, pixelValues: pixels, frames: frames)
+        }
+
+        let (positionIds, ropeDeltas) = Language.getRopeIndex(
+            inputIds: inputIds,
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            positionOffset: positionOffset)
+
+        let step = max(1, windowSize)
+        var lastLogits = MLXArray(0)
+        var start = 0
+        repeat {
+            try Task.checkCancellation()
+            let end = min(start + step, remainderLength)
+            let chunkPositions = positionIds[0..., 0..., start ..< end]
+            let output: LMOutput
+            if let embeds {
+                let chunkEmbeds = embeds[0..., start ..< end, 0...]
+                output = languageModel(
+                    nil, cache: cache, state: nil, inputEmbedding: chunkEmbeds,
+                    positionIds: chunkPositions)
+            } else {
+                let chunkInputs = inputIds[0..., start ..< end]
+                output = languageModel(
+                    chunkInputs, cache: cache, state: nil, inputEmbedding: nil,
+                    positionIds: chunkPositions)
+            }
+            lastLogits = output.logits
+            asyncEval(cache)
+            start = end
+        } while start < remainderLength
+        eval(cache)
+
+        var resumeState = LMOutput.State()
+        resumeState[ropeDeltasKey] = ropeDeltas - MLXArray(Int32(cacheOffset))
+
+        return .logits(LMOutput(logits: lastLogits, state: resumeState))
     }
 
     // #239: Qwen25VL.swift Model.callAsFunction(_:LMInput.Text,cache:,state:) (:1184)

--- a/Tests/MLXLMTests/Qwen25VLContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen25VLContinuationTests.swift
@@ -1,0 +1,355 @@
+// Copyright © 2026 Apple Inc.
+//
+// Equivalence tests for Qwen2.5-VL and Qwen2-VL windowed prefill and warm
+// (cached-prefix) continuation, on tiny random-weight models so they run in CI
+// without downloads. The invariant under test mirrors Qwen35ContinuationTests:
+// however a prompt reaches the KV cache — one shot, windowed chunks, or split
+// across a warm continuation — the next-token logits must match, because M-RoPE
+// positions must be anchored at the cache offset (plus the carried rope delta),
+// never restarted at zero.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import XCTest
+
+final class Qwen25VLContinuationTests: XCTestCase {
+
+    // MARK: - Tiny models
+
+    private func makeTinyQwen25VL() throws -> Qwen25VL {
+        let json = """
+            {
+                "model_type": "qwen2_5_vl",
+                "hidden_size": 64,
+                "num_hidden_layers": 2,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 512,
+                "max_position_embeddings": 4096,
+                "rope_theta": 1000000.0,
+                "rope_traditional": false,
+                "tie_word_embeddings": false,
+                "sliding_window": 32768,
+                "use_sliding_window": false,
+                "max_window_layers": 2,
+                "image_token_id": 500,
+                "video_token_id": 501,
+                "vision_start_token_id": 502,
+                "vision_end_token_id": 503,
+                "vision_token_id": 504,
+                "rope_scaling": {
+                    "type": "mrope",
+                    "mrope_section": [2, 3, 3]
+                },
+                "vision_config": {
+                    "depth": 2,
+                    "hidden_size": 32,
+                    "intermediate_size": 64,
+                    "out_hidden_size": 64,
+                    "num_heads": 2,
+                    "patch_size": 16,
+                    "spatial_patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2,
+                    "window_size": 64,
+                    "fullatt_block_indexes": [1],
+                    "tokens_per_second": 2,
+                    "in_chans": 3
+                }
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Qwen25VLConfiguration.self, from: Data(json.utf8))
+        return Qwen25VL(config)
+    }
+
+    private func makeTinyQwen2VL() throws -> Qwen2VL {
+        let json = """
+            {
+                "model_type": "qwen2_vl",
+                "hidden_size": 64,
+                "num_hidden_layers": 2,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 512,
+                "max_position_embeddings": 4096,
+                "rope_theta": 1000000.0,
+                "rope_traditional": false,
+                "tie_word_embeddings": false,
+                "image_token_id": 500,
+                "video_token_id": 501,
+                "rope_scaling": {
+                    "type": "mrope",
+                    "mrope_section": [2, 3, 3]
+                },
+                "vision_config": {
+                    "depth": 2,
+                    "embed_dim": 32,
+                    "hidden_size": 64,
+                    "num_heads": 2,
+                    "patch_size": 16,
+                    "mlp_ratio": 2.0,
+                    "spatial_patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 2,
+                    "in_channels": 3
+                }
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Qwen2VLConfiguration.self, from: Data(json.utf8))
+        return Qwen2VL(config)
+    }
+
+    // MARK: - Shared config constants
+
+    private let imageTokenId: Int32 = 500
+    private let visionStartTokenId: Int32 = 502
+
+    // MARK: - Helpers
+
+    /// Deterministic pseudo-random plain-text tokens, away from the special
+    /// ids (500...504).
+    private func textTokens(_ count: Int, seed: Int32 = 0) -> MLXArray {
+        var values: [Int32] = []
+        for i in 0 ..< count {
+            let value: Int = (i * 13 + 7 + Int(seed)) % 480
+            values.append(Int32(value))
+        }
+        return MLXArray(values).expandedDimensions(axis: 0)
+    }
+
+    private func lastLogits(_ result: PrepareResult) throws -> (MLXArray, LMOutput.State?) {
+        guard case .logits(let out) = result else {
+            throw XCTSkip("expected .logits from prepare")
+        }
+        return (out.logits[0..., -1, 0...], out.state)
+    }
+
+    private func maxAbsDiff(_ a: MLXArray, _ b: MLXArray) -> Float {
+        abs(a - b).max().item(Float.self)
+    }
+
+    private func imageInput() -> LMInput.ProcessedImage {
+        // One image: grid THW (1, 4, 4), merge 2 → 4 merged tokens in text.
+        let pixels = MLXRandom.normal([16, 3 * 2 * 16 * 16])
+        return LMInput.ProcessedImage(pixels: pixels, frames: [THW(1, 4, 4)])
+    }
+
+    private func imageRun() -> MLXArray {
+        MLXArray([Int32](repeating: imageTokenId, count: 4)).expandedDimensions(axis: 0)
+    }
+
+    private func visionStart() -> MLXArray {
+        MLXArray([visionStartTokenId]).expandedDimensions(axis: 0)
+    }
+
+    // MARK: - Generic assertions
+
+    /// A warm continuation (prefix in the cache, remainder prefilled on top —
+    /// the ChatSession cross-turn flow) must produce the same next-token logits
+    /// as one cold prefill of the concatenation. The decode path (token by
+    /// token, state threaded) is the offset-correct control bounding the noise.
+    private func assertWarmTextContinuation<M: LanguageModel>(_ model: M) throws {
+        MLXRandom.seed(7)
+        let t1 = textTokens(40)
+        let t2 = textTokens(8, seed: 3)
+
+        let cacheF = model.newCache(parameters: nil)
+        let (logitsF, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1))),
+                cache: cacheF, state: nil, windowSize: nil))
+
+        let cacheD = model.newCache(parameters: nil)
+        let (_, s0) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1)), cache: cacheD, state: nil, windowSize: nil))
+        var state = s0
+        var logitsD = MLXArray(0)
+        for j in 0 ..< t2.dim(1) {
+            let out = model(
+                LMInput.Text(tokens: t2[0..., j ..< (j + 1)]), cache: cacheD, state: state)
+            state = out.state
+            logitsD = out.logits[0..., -1, 0...]
+        }
+        let noiseFloor = maxAbsDiff(logitsD, logitsF)
+
+        let cacheW = model.newCache(parameters: nil)
+        _ = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+        let (logitsW, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: nil, windowSize: nil))
+
+        let drift = maxAbsDiff(logitsW, logitsF)
+        XCTAssertLessThanOrEqual(
+            drift, max(noiseFloor * 10, 1e-3),
+            "warm continuation diverged from full prefill (noise floor \(noiseFloor))")
+    }
+
+    /// With an image in turn 1, the rope delta the image accumulated must be
+    /// carried into turn 2's prefill: two-turn with threaded state ≡ one-shot
+    /// full prefill.
+    private func assertWarmImageContinuation<M: LanguageModel>(_ model: M) throws {
+        MLXRandom.seed(5)
+        let image = imageInput()
+        let t1 = concatenated(
+            [textTokens(10), visionStart(), imageRun(), textTokens(8, seed: 5)], axis: 1)
+        let t2 = textTokens(8, seed: 9)
+        let full = concatenated([t1, t2], axis: 1)
+
+        let cacheF = model.newCache(parameters: nil)
+        let (logitsF, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
+                windowSize: nil))
+
+        let cacheW = model.newCache(parameters: nil)
+        let (_, s1) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
+                windowSize: nil))
+        let (logitsW, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, windowSize: nil))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsW, logitsF), 1e-3,
+            "state-threaded warm continuation diverged from full prefill")
+    }
+
+    /// Three-turn round trip: a warm continuation whose remainder itself
+    /// contains a new image must compute that image's positions from the anchor
+    /// AND hand back a resume state that positions the following turn correctly.
+    private func assertImageMidContinuationResumeState<M: LanguageModel>(_ model: M) throws {
+        MLXRandom.seed(3)
+        let image = imageInput()
+        let t1 = textTokens(12)
+        let t2 = concatenated(
+            [textTokens(4, seed: 2), visionStart(), imageRun(), textTokens(6, seed: 4)], axis: 1)
+        let t3 = textTokens(8, seed: 6)
+        let full = concatenated([t1, t2, t3], axis: 1)
+
+        let cacheF = model.newCache(parameters: nil)
+        let (logitsF, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
+                windowSize: nil))
+
+        let cacheW = model.newCache(parameters: nil)
+        let (_, s1) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+        let (_, s2) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t2), image: image), cache: cacheW, state: s1,
+                windowSize: nil))
+        let (logitsW, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: t3)), cache: cacheW, state: s2, windowSize: nil))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsW, logitsF), 1e-3,
+            "post-image resume state positioned the following turn wrong")
+    }
+
+    /// Windowed (chunked) prefill must produce the same first-token logits as
+    /// the single-shot forward on plain text.
+    private func assertWindowedTextPrefill<M: LanguageModel>(_ model: M) throws {
+        MLXRandom.seed(11)
+        let prompt = textTokens(40)
+
+        let cacheS = model.newCache(parameters: nil)
+        let (logitsS, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt)), cache: cacheS, state: nil, windowSize: nil))
+
+        let cacheC = model.newCache(parameters: nil)
+        let (logitsC, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt)), cache: cacheC, state: nil, windowSize: 8))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsC, logitsS), 1e-3,
+            "windowed prefill diverged from single-shot")
+    }
+
+    /// Windowed prefill on an image-bearing prompt whose image straddles a
+    /// window boundary must match the single-shot forward.
+    private func assertWindowedImagePrefill<M: LanguageModel>(_ model: M) throws {
+        MLXRandom.seed(13)
+        let image = imageInput()
+        // Image tokens sit at positions 11...14 — straddling the 8-token window
+        // boundary, the hard case for chunked slicing.
+        let prompt = concatenated(
+            [textTokens(10), visionStart(), imageRun(), textTokens(12, seed: 7)], axis: 1)
+
+        let cacheS = model.newCache(parameters: nil)
+        let (logitsS, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt), image: image), cache: cacheS, state: nil,
+                windowSize: nil))
+
+        let cacheC = model.newCache(parameters: nil)
+        let (logitsC, _) = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prompt), image: image), cache: cacheC, state: nil,
+                windowSize: 8))
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsC, logitsS), 1e-3,
+            "windowed image prefill diverged from single-shot")
+    }
+
+    // MARK: - Qwen2.5-VL
+
+    func testQwen25VLWarmTextContinuationMatchesFullPrefill() throws {
+        try assertWarmTextContinuation(makeTinyQwen25VL())
+    }
+
+    func testQwen25VLWarmImageContinuationMatchesFullPrefill() throws {
+        try assertWarmImageContinuation(makeTinyQwen25VL())
+    }
+
+    func testQwen25VLImageMidContinuationResumeState() throws {
+        try assertImageMidContinuationResumeState(makeTinyQwen25VL())
+    }
+
+    func testQwen25VLWindowedPrefillMatchesSingleShot() throws {
+        try assertWindowedTextPrefill(makeTinyQwen25VL())
+    }
+
+    func testQwen25VLWindowedImagePrefillMatchesSingleShot() throws {
+        try assertWindowedImagePrefill(makeTinyQwen25VL())
+    }
+
+    // MARK: - Qwen2-VL
+
+    func testQwen2VLWarmTextContinuationMatchesFullPrefill() throws {
+        try assertWarmTextContinuation(makeTinyQwen2VL())
+    }
+
+    func testQwen2VLWarmImageContinuationMatchesFullPrefill() throws {
+        try assertWarmImageContinuation(makeTinyQwen2VL())
+    }
+
+    func testQwen2VLImageMidContinuationResumeState() throws {
+        try assertImageMidContinuationResumeState(makeTinyQwen2VL())
+    }
+
+    func testQwen2VLWindowedPrefillMatchesSingleShot() throws {
+        try assertWindowedTextPrefill(makeTinyQwen2VL())
+    }
+
+    func testQwen2VLWindowedImagePrefillMatchesSingleShot() throws {
+        try assertWindowedImagePrefill(makeTinyQwen2VL())
+    }
+}


### PR DESCRIPTION
# Qwen2.5-VL / Qwen2-VL: windowed prefill + state-threaded warm continuation (wires #420)

## Proposed changes

#399 added windowed prefill and state-threaded warm cross-turn continuation to
Qwen3.5/3.6, fixing multi-turn M-RoPE drift for that family. It also widened
`LanguageModel.prepare` to thread an optional `LMOutput.State`, but the
remaining Qwen VLMs listed in #420 were only updated to *accept and ignore* that
state (`state _:`). This PR wires the same mechanism through **Qwen2.5-VL** and
**Qwen2-VL**, so a warm KV cache is continued from its anchor instead of
recomputing M-RoPE positions from zero.

Without this, a warm continuation (multi-turn chat, tool-call restart, restored
prompt cache) silently recomputes positions from scratch: the post-image text
tail is placed at `cacheOffset + arange` instead of `cacheOffset + ropeDelta +
arange`, dropping the delta the image accumulated. On dense single-image
grounding at temperature 0 this surfaces as degenerate output.

Mirroring #399 exactly (not a bespoke path):

- **`getRopeIndex` gains an offset-aware `positionOffset`** (default `0`), applied
  to the text-only positions, the image `llmPositions`, and the returned rope
  delta — so a new image's diverging t/h/w indices are computed from the warm
  cache's anchor rather than zero. Same shape as Qwen3-VL's `getRopeIndex`.
- **`prepare` now consumes the incoming `state`** and delegates to a new
  `prepareContinuation` when the cache is already warmed (`offset > 0`) or the
  prompt is longer than `windowSize` (default `512`). The continuation runs the
  vision tower + image→token merge once over the remainder, computes the
  remainder's M-RoPE positions once from the seeded position anchor (cache offset
  plus the rope delta carried in `state`), then drives the language model forward
  in chunks of `windowSize` — bounding the full-attention scratch to
  `[heads, chunk, L]` instead of `[heads, L, L]`. The windowed loop uses
  `asyncEval` per chunk + a trailing `eval`, matching the Gemma3 chunked-prefill
  pattern.
- The returned resume state carries `getRopeIndex delta − cacheOffset`, so a
  caller threading state end-to-end continues the following turn through the
  existing decode reconstruction branch. Decode stays caller-owned.
- The single-shot `prepare` path now passes token ids (rather than a
  pre-embedded tensor) on the text-only branch, so a 2-D `[1, seq]` text
  continuation — what a warm text turn produces — is handled without the prior
  `[.newAxis, .ellipsis]` rank inflation. Image single-shot behaviour is
  unchanged.

The vision-embedding preamble is factored into small shared helpers
(`gatherVisionInputs`, `mergedVisionEmbeds`) used by both `prepare` and
`prepareContinuation`. Batched inputs keep the single-shot path.

**Qwen3-VL is intentionally left for a follow-up.** Its `prepare` threads
per-layer deepstack features and a visual mask into the language model; a
windowed continuation would have to slice those in lockstep with the embeddings
and positions, which is beyond the drop-in Qwen3.5/2.5/2 pattern. Wiring it would
be structural surgery, so it is out of scope here and its #420 box stays
unchecked.

## Tests

New `Tests/MLXLMTests/Qwen25VLContinuationTests.swift` mirrors
`Qwen35ContinuationTests`, run against tiny random-weight configs for **both**
wired models (no downloads, CI-safe). Per model:

- **Warm text continuation ≡ full prefill** — prefix in cache, remainder
  prefilled on top; bounded against a token-by-token decode noise floor.
- **Warm image continuation ≡ full prefill** — image in turn 1, rope delta
  threaded into turn 2's prefill via `state`.
- **Image-mid continuation resume state** — three turns, image in the middle
  turn; the post-image resume state must position turn 3 correctly.
- **Windowed prefill ≡ single-shot** (plain text) — `windowSize: 8` vs one shot.
- **Windowed image prefill ≡ single-shot** — image straddling the window
  boundary, the hard case for chunked slicing.

All 10 pass. The full `MLXLMTests` suite is green via
`xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -skipPackagePluginValidation`,
and `swift-format` is clean.

## #420 checklist

- [x] Qwen2.5-VL — windowed prefill + warm continuation wired
- [x] Qwen2-VL — windowed prefill + warm continuation wired
- [ ] Qwen3-VL — deferred (deepstack + visual-mask threading needs lockstep
  chunking; not a drop-in of the #399 pattern)

## Grounding validation (real weights)

Ran `mlx-community/Qwen2.5-VL-7B-Instruct-4bit` (temp 0) on 10 GUI-grounding rows
(3 canonical + 7 dense screenshots), each asked twice: COLD (fresh session, single
turn) and WARM (turn 2 of a live session whose turn 1 grounded a different image,
state threaded between turns).

| config | warm turns with a parseable box | warm empty/degenerate |
|---|---|---|
| `main` (343cae3) | 0/10 | 10/10 — empty fences, or prose describing the *cached turn-1 image* |
| this branch | **10/10** | 0/10 |

Warm coordinates track the cold single-shot within a few pixels on clean rows;
where they diverge the model is legitimately attending to turn-1 conversational
context — the controlled random-weight tests above are the positional-correctness
check (warm ≡ full prefill on logits), and this run is the end-to-end usability
check on real weights.
