### PR TITLE
Load EOS token IDs from nested text configs

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -573,7 +573,7 @@ public final class LLMModelFactory: GenericModelFactory {
         }
 
         // Load EOS token IDs from config.json, with optional override from generation_config.json
-        var eosTokenIds = Set(baseConfig.eosTokenIds?.values ?? [])
+        var eosTokenIds = baseConfig.effectiveEOSTokenIds
         let generationConfigURL = modelDirectory.appending(component: "generation_config.json")
         let generationConfig: GenerationConfigFile? =
             if let generationData = try? Data(contentsOf: generationConfigURL) {

--- a/Libraries/MLXLMCommon/BaseConfiguration.swift
+++ b/Libraries/MLXLMCommon/BaseConfiguration.swift
@@ -185,11 +185,27 @@ public struct BaseConfiguration: Codable, Sendable {
         }
     }
 
+    private struct TextConfiguration: Codable, Sendable {
+        var eosTokenIds: IntOrIntArray?
+
+        enum CodingKeys: String, CodingKey {
+            case eosTokenIds = "eos_token_id"
+        }
+    }
+
     /// Internal storage for quantization details extracted from `config.json`.
     var quantizationContainer: QuantizationContainer?
 
+    /// Text-model metadata nested by composite model configurations.
+    private var textConfiguration: TextConfiguration?
+
     /// EOS token IDs from config.json. Can be a single Int or an array of Ints.
     public var eosTokenIds: IntOrIntArray?
+
+    /// EOS token IDs declared at either the model root or in `text_config`.
+    public var effectiveEOSTokenIds: Set<Int> {
+        Set(eosTokenIds?.values ?? textConfiguration?.eosTokenIds?.values ?? [])
+    }
 
     /// The default quantization settings.
     @available(*, deprecated, message: "Please use perLayerQuantization instead")
@@ -205,6 +221,7 @@ public struct BaseConfiguration: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
         case quantizationContainer = "quantization"
+        case textConfiguration = "text_config"
         case eosTokenIds = "eos_token_id"
     }
 }

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -365,7 +365,7 @@ public final class VLMModelFactory: GenericModelFactory {
         }
 
         // Load EOS token IDs from config.json, with optional override from generation_config.json
-        var eosTokenIds = Set(baseConfig.eosTokenIds?.values ?? [])
+        var eosTokenIds = baseConfig.effectiveEOSTokenIds
         let generationConfigURL = modelDirectory.appending(component: "generation_config.json")
         let generationConfig: GenerationConfigFile? =
             if let generationData = try? Data(contentsOf: generationConfigURL) {

--- a/Tests/MLXLMTests/BaseConfigurationTests.swift
+++ b/Tests/MLXLMTests/BaseConfigurationTests.swift
@@ -67,4 +67,41 @@ public class BaseConfigurationTests: XCTestCase {
             .init(groupSize: 64, bits: 4))
     }
 
+    func testNestedTextConfigurationEOSTokenIds() throws {
+        let json =
+            """
+            {
+                "model_type": "qwen3_5",
+                "text_config": {
+                    "eos_token_id": 248044
+                }
+            }
+            """
+
+        let config = try JSONDecoder().decode(
+            BaseConfiguration.self, from: json.data(using: .utf8)!)
+
+        XCTAssertNil(config.eosTokenIds)
+        XCTAssertEqual(config.effectiveEOSTokenIds, [248044])
+    }
+
+    func testRootEOSTokenIdsTakePrecedenceOverNestedValues() throws {
+        let json =
+            """
+            {
+                "model_type": "qwen3_5",
+                "eos_token_id": 248046,
+                "text_config": {
+                    "eos_token_id": [248044, 248046]
+                }
+            }
+            """
+
+        let config = try JSONDecoder().decode(
+            BaseConfiguration.self, from: json.data(using: .utf8)!)
+
+        XCTAssertEqual(config.eosTokenIds?.values, [248046])
+        XCTAssertEqual(config.effectiveEOSTokenIds, [248046])
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Composite model configurations such as Qwen3.5 store `eos_token_id` under `text_config`. `mlx-swift-lm` only read the root-level value, so `<|endoftext|>` (`248044`) was not included in the stop-token set. When the model emitted it, generation continued into subsequent chat-template content, producing output such as `<|endoftext|><|im_start|>user`.

This change:

- Reads `eos_token_id` from `text_config` when it is absent at the model root.
- Preserves root-level and `generation_config.json` precedence.
- Uses the resolved IDs for both LLM and VLM loading.
- Adds focused tests for nested EOS decoding and root-level precedence.

This follows the same configuration precedence used by Hugging Face Transformers and mlx-vlm: generation attributes fall back to the nested text configuration when they are absent at the model root.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)