### PR TITLE
Bound streaming detokenization and media buffer growth

### DIFF
--- a/Libraries/BenchmarkHelpers/DetokenizerBenchmarks.swift
+++ b/Libraries/BenchmarkHelpers/DetokenizerBenchmarks.swift
@@ -1,0 +1,236 @@
+// Synthetic streaming-detokenization benchmarks. These isolate tokenizer
+// decode work from model inference and require no network or model weights.
+
+import Foundation
+import MLXLMCommon
+
+public enum DetokenizerBenchmarkStrategy: Sendable, Hashable {
+    /// Preserve the 3.x behavior: retain every token since the last newline.
+    case unbounded
+
+    /// Advertise a bounded decoder suffix context to the streaming detokenizer.
+    case bounded(contextTokens: Int)
+}
+
+public struct DetokenizerBenchmarkResult: Sendable {
+    public let tokenCount: Int
+    public let newlineEvery: Int?
+    public let strategy: DetokenizerBenchmarkStrategy
+    public let decodedTokenVisits: Int
+    public let emittedCharacterCount: Int
+    public let stats: BenchmarkStats
+
+    public init(
+        tokenCount: Int,
+        newlineEvery: Int?,
+        strategy: DetokenizerBenchmarkStrategy,
+        decodedTokenVisits: Int,
+        emittedCharacterCount: Int,
+        stats: BenchmarkStats
+    ) {
+        self.tokenCount = tokenCount
+        self.newlineEvery = newlineEvery
+        self.strategy = strategy
+        self.decodedTokenVisits = decodedTokenVisits
+        self.emittedCharacterCount = emittedCharacterCount
+        self.stats = stats
+    }
+
+    public var decodedTokenVisitsPerInputToken: Double {
+        Double(decodedTokenVisits) / Double(tokenCount)
+    }
+
+    public func printSummary() {
+        let cadence = newlineEvery.map(String.init) ?? "none"
+        let strategyName: String
+        switch strategy {
+        case .unbounded:
+            strategyName = "unbounded"
+        case .bounded(let contextTokens):
+            strategyName = "bounded(\(contextTokens))"
+        }
+
+        print(
+            "detokenizer tokens=\(tokenCount) newlineEvery=\(cadence) "
+                + "strategy=\(strategyName): median "
+                + "\(String(format: "%.3f", stats.median))ms, "
+                + "decodeVisits=\(decodedTokenVisits), "
+                + "visits/token=\(String(format: "%.2f", decodedTokenVisitsPerInputToken))"
+        )
+    }
+}
+
+private final class DetokenizerDecodeWorkCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func record(_ count: Int) {
+        lock.lock()
+        value += count
+        lock.unlock()
+    }
+
+    func read() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+private struct SyntheticLinearTokenizer: Tokenizer {
+    let counter: DetokenizerDecodeWorkCounter
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        counter.record(tokenIds.count)
+        return tokenIds.map { $0 == 0 ? "\n" : "x" }.joined()
+    }
+
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { id == 0 ? "\n" : "x" }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        []
+    }
+}
+
+private struct SyntheticBoundedLinearTokenizer: BoundedStreamingDecodeTokenizer {
+    let base: SyntheticLinearTokenizer
+    let contextSize: Int
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        base.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        base.decode(tokenIds: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? { base.convertTokenToId(token) }
+    func convertIdToToken(_ id: Int) -> String? { base.convertIdToToken(id) }
+
+    var bosToken: String? { base.bosToken }
+    var eosToken: String? { base.eosToken }
+    var unknownToken: String? { base.unknownToken }
+    var streamingDecodeContextSize: Int? { contextSize }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        try base.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: additionalContext)
+    }
+}
+
+private func syntheticDetokenizerTokens(count: Int, newlineEvery: Int?) -> [Int] {
+    (1 ... count).map { index in
+        if let newlineEvery, index.isMultiple(of: newlineEvery) {
+            return 0
+        }
+        return 1
+    }
+}
+
+private func runDetokenizerTrial(
+    tokens: [Int], strategy: DetokenizerBenchmarkStrategy
+) -> (elapsedMilliseconds: Double, decodedTokenVisits: Int, emittedCharacterCount: Int) {
+    let counter = DetokenizerDecodeWorkCounter()
+    let baseTokenizer = SyntheticLinearTokenizer(counter: counter)
+    let tokenizer: any Tokenizer
+    switch strategy {
+    case .unbounded:
+        tokenizer = baseTokenizer
+    case .bounded(let contextTokens):
+        precondition(contextTokens > 0, "contextTokens must be greater than zero")
+        tokenizer = SyntheticBoundedLinearTokenizer(
+            base: baseTokenizer, contextSize: contextTokens)
+    }
+
+    var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+    var emittedCharacterCount = 0
+
+    let start = CFAbsoluteTimeGetCurrent()
+    for token in tokens {
+        detokenizer.append(token: token)
+        emittedCharacterCount += detokenizer.next()?.count ?? 0
+    }
+    let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1_000
+
+    return (elapsed, counter.read(), emittedCharacterCount)
+}
+
+/// Measure streaming detokenization with deterministic synthetic token streams.
+///
+/// The synthetic tokenizer performs linear work for every token ID passed to
+/// `decode`, and `decodedTokenVisits` reports that work independently of noisy
+/// wall-clock timings. Compare `newlineEvery: nil` with bounded newline
+/// cadences to reproduce the historical quadratic worst case, then compare the
+/// `.bounded` strategy to measure the bounded-context fast path.
+public func benchmarkStreamingDetokenization(
+    tokenCounts: [Int] = [256, 1_024, 4_096],
+    newlineCadences: [Int?] = [16, 128, nil],
+    strategies: [DetokenizerBenchmarkStrategy] = [
+        .unbounded, .bounded(contextTokens: 16),
+    ],
+    runs: Int = 7,
+    warmupRuns: Int = 1
+) -> [DetokenizerBenchmarkResult] {
+    precondition(!tokenCounts.isEmpty, "tokenCounts must not be empty")
+    precondition(tokenCounts.allSatisfy { $0 > 0 }, "tokenCounts must be greater than zero")
+    precondition(
+        newlineCadences.allSatisfy { $0 == nil || $0! > 0 },
+        "newline cadences must be greater than zero")
+    precondition(!strategies.isEmpty, "strategies must not be empty")
+    precondition(runs > 0, "runs must be greater than zero")
+    precondition(warmupRuns >= 0, "warmupRuns must not be negative")
+
+    var results: [DetokenizerBenchmarkResult] = []
+
+    for strategy in strategies {
+        for newlineEvery in newlineCadences {
+            for tokenCount in tokenCounts {
+                let tokens = syntheticDetokenizerTokens(
+                    count: tokenCount, newlineEvery: newlineEvery)
+
+                for _ in 0 ..< warmupRuns {
+                    _ = runDetokenizerTrial(tokens: tokens, strategy: strategy)
+                }
+
+                var times: [Double] = []
+                times.reserveCapacity(runs)
+                var decodedTokenVisits = 0
+                var emittedCharacterCount = 0
+
+                for _ in 0 ..< runs {
+                    let trial = runDetokenizerTrial(tokens: tokens, strategy: strategy)
+                    times.append(trial.elapsedMilliseconds)
+                    decodedTokenVisits = trial.decodedTokenVisits
+                    emittedCharacterCount = trial.emittedCharacterCount
+                }
+
+                let result = DetokenizerBenchmarkResult(
+                    tokenCount: tokenCount,
+                    newlineEvery: newlineEvery,
+                    strategy: strategy,
+                    decodedTokenVisits: decodedTokenVisits,
+                    emittedCharacterCount: emittedCharacterCount,
+                    stats: BenchmarkStats(times: times)
+                )
+                result.printSummary()
+                results.append(result)
+            }
+        }
+    }
+
+    return results
+}

--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -81,7 +81,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
             // import Tokenizers
             //
             { (huggingFaceTokenizer: Tokenizers.Tokenizer) -> MLXLMCommon.Tokenizer in
-                struct TokenizerBridge: MLXLMCommon.Tokenizer {
+                struct TokenizerBridge: MLXLMCommon.BoundedStreamingDecodeTokenizer {
                     private let upstream: any Tokenizers.Tokenizer
 
                     init(_ upstream: any Tokenizers.Tokenizer) {
@@ -108,6 +108,12 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                     var bosToken: String? { upstream.bosToken }
                     var eosToken: String? { upstream.eosToken }
                     var unknownToken: String? { upstream.unknownToken }
+
+                    // swift-transformers' supported decoder pipeline has bounded
+                    // suffix context (UTF-8 byte fallback plus fixed cleanup
+                    // patterns). Keep a conservative overlap when streaming so
+                    // already-emitted prefixes do not remain in the decode buffer.
+                    var streamingDecodeContextSize: Int? { 16 }
 
                     func applyChatTemplate(
                         messages: [[String: any Sendable]],

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -53,6 +53,18 @@ extension Tokenizer {
     }
 }
 
+/// Optional tokenizer capability for bounded-memory streaming decode.
+///
+/// Conform only when the decoded suffix after appending token IDs depends on
+/// at most a known number of preceding token IDs. Existing ``Tokenizer``
+/// conformers do not need to adopt this protocol and retain the historical
+/// unbounded streaming buffer.
+public protocol BoundedStreamingDecodeTokenizer: Tokenizer {
+    /// The preceding-token overlap retained between streaming decode steps.
+    /// Return `nil` to disable compaction for a particular instance.
+    var streamingDecodeContextSize: Int? { get }
+}
+
 public enum TokenizerError: LocalizedError {
     case missingChatTemplate
 
@@ -82,15 +94,17 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
         segmentTokens.append(token)
     }
 
-    mutating func startNewSegment() {
-        let lastToken = segmentTokens.last
-        segmentTokens.removeAll()
-        if let lastToken {
-            segmentTokens.append(lastToken)
-            segment = tokenizer.decode(tokenIds: segmentTokens)
-        } else {
+    mutating func startNewSegment(retaining tokenCount: Int = 1) {
+        guard tokenCount > 0, !segmentTokens.isEmpty else {
+            segmentTokens.removeAll(keepingCapacity: true)
             segment = ""
+            return
         }
+
+        let retainedTokens = Array(segmentTokens.suffix(tokenCount))
+        segmentTokens.removeAll(keepingCapacity: true)
+        segmentTokens.append(contentsOf: retainedTokens)
+        segment = tokenizer.decode(tokenIds: segmentTokens)
     }
 
     public mutating func next() -> String? {
@@ -107,6 +121,14 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
             startNewSegment()
         } else {
             self.segment = newSegment
+
+            if let contextSize =
+                (tokenizer as? any BoundedStreamingDecodeTokenizer)?.streamingDecodeContextSize,
+                contextSize > 0,
+                segmentTokens.count > contextSize
+            {
+                startNewSegment(retaining: contextSize)
+            }
         }
 
         return String(new)

--- a/Libraries/MLXLMCommon/UserInput+Audio.swift
+++ b/Libraries/MLXLMCommon/UserInput+Audio.swift
@@ -45,23 +45,50 @@ extension UserInput.Audio {
             reader.add(output)
             reader.startReading()
 
-            var samples: [Float] = []
+            var sampleData = Data()
+            if let duration = try? await asset.load(.duration) {
+                let estimatedByteCount =
+                    duration.seconds * processing.sampleRate * Double(processing.channels)
+                    * Double(MemoryLayout<Float>.size)
+                if estimatedByteCount.isFinite, estimatedByteCount > 0 {
+                    // Avoid a single unbounded eager allocation for unusually
+                    // long inputs while preventing geometric growth for common
+                    // clips.
+                    let reserveLimit = 64 * 1_024 * 1_024
+                    sampleData.reserveCapacity(Int(min(estimatedByteCount, Double(reserveLimit))))
+                }
+            }
 
             while let sampleBuffer = output.copyNextSampleBuffer() {
                 guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { continue }
 
                 let byteCount = CMBlockBufferGetDataLength(blockBuffer)
-                var chunk = [Float](repeating: 0, count: byteCount / MemoryLayout<Float>.size)
-                CMBlockBufferCopyDataBytes(
-                    blockBuffer, atOffset: 0, dataLength: byteCount, destination: &chunk)
-                samples.append(contentsOf: chunk)
+                guard byteCount > 0 else { continue }
+                let writeOffset = sampleData.count
+                sampleData.append(contentsOf: repeatElement(0, count: byteCount))
+                let copyStatus = sampleData.withUnsafeMutableBytes { destination in
+                    CMBlockBufferCopyDataBytes(
+                        blockBuffer,
+                        atOffset: 0,
+                        dataLength: byteCount,
+                        destination: destination.baseAddress!.advanced(by: writeOffset)
+                    )
+                }
+                guard copyStatus == kCMBlockBufferNoErr else {
+                    reader.cancelReading()
+                    throw UserInputError.unableToLoad(url)
+                }
             }
 
             guard reader.status == .completed else {
                 throw reader.error ?? UserInputError.unableToLoad(url)
             }
 
-            return MLXArray(samples)
+            guard sampleData.count.isMultiple(of: MemoryLayout<Float>.size) else {
+                throw UserInputError.unableToLoad(url)
+            }
+            let sampleCount = sampleData.count / MemoryLayout<Float>.size
+            return MLXArray(sampleData, [sampleCount], type: Float32.self)
             #else
             fatalError("Audio processing is not supported on this platform.")
             #endif

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -438,9 +438,13 @@ public enum MediaProcessing {
         let timescale = duration.timescale
         let sampledTimes = sampledTimeValues.map { CMTime(value: $0, timescale: timescale) }
 
-        // Collect the frames
-        var ciImages: [CIImage] = []
+        // Materialize each processed frame before requesting the next one. The
+        // result necessarily retains all MLX arrays for API compatibility, but
+        // it no longer retains every source CGImage/CIImage alongside them.
+        var frames: [MLXArray] = []
+        frames.reserveCapacity(finalFrameCount)
         var timestamps: [CMTime] = []
+        timestamps.reserveCapacity(finalFrameCount)
 
         for await result in generator.images(for: sampledTimes) {
             switch result {
@@ -448,16 +452,15 @@ public enum MediaProcessing {
                 let ciImage = CIImage(
                     cgImage: image, options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
                 let frame = try frameProcessing(.init(image: .ciImage(ciImage), timeStamp: actual))
-                ciImages.append(try frame.image.asCIImage())
+                frames.append(try frame.image.asCIImage().asMLXArray())
                 timestamps.append(frame.timeStamp)
             case .failure(requestedTime: _, _):
                 break
             }
         }
 
-        let framesAsArrays = ciImages.map { $0.asMLXArray() }
         return ProcessedFrames(
-            frames: framesAsArrays,
+            frames: frames,
             timestamps: timestamps,
             totalDuration: duration
         )
@@ -490,9 +493,12 @@ public enum MediaProcessing {
         // Construct a CMTime using the sampled CMTimeValue's and the asset's timescale
         let timescale = duration.timescale
 
-        // Collect the frames
-        var ciImages: [CIImage] = []
+        // Materialize one sampled frame at a time instead of retaining all
+        // intermediate CIImage graphs until a second conversion pass.
+        var frames: [MLXArray] = []
+        frames.reserveCapacity(finalFrameCount)
         var timestamps: [CMTime] = []
+        timestamps.reserveCapacity(finalFrameCount)
 
         // See https://github.com/ml-explore/mlx-swift-lm/pull/64#discussion_r2713532157
         // for rationalle for the follwing timing code
@@ -516,14 +522,13 @@ public enum MediaProcessing {
                 let videoFrame = videoFrames[targetIndex]
                 let frame = try frameProcessing(
                     .init(image: videoFrame.image, timeStamp: videoFrame.timeStamp))
-                ciImages.append(try frame.image.asCIImage())
+                frames.append(try frame.image.asCIImage().asMLXArray())
                 timestamps.append(frame.timeStamp)
             }
         }
 
-        let framesAsArrays = ciImages.map { $0.asMLXArray() }
         return ProcessedFrames(
-            frames: framesAsArrays,
+            frames: frames,
             timestamps: timestamps,
             totalDuration: duration
         )

--- a/Package.swift
+++ b/Package.swift
@@ -148,6 +148,7 @@ let package = Package(
                 "MLXLLM",
                 "MLXVLM",
                 "MLXEmbedders",
+                "BenchmarkHelpers",
             ],
             path: "Tests/MLXLMTests",
             exclude: [

--- a/Tests/MLXLMTests/DetokenizerBenchmarkTests.swift
+++ b/Tests/MLXLMTests/DetokenizerBenchmarkTests.swift
@@ -1,0 +1,178 @@
+import BenchmarkHelpers
+import Foundation
+import XCTest
+
+@testable import MLXLMCommon
+
+final class DetokenizerBenchmarkTests: XCTestCase {
+    func testUnboundedDecodeWorkIsTriangularWithoutNewlines() {
+        let tokenCount = 128
+        let result = benchmarkStreamingDetokenization(
+            tokenCounts: [tokenCount],
+            newlineCadences: [nil],
+            strategies: [.unbounded],
+            runs: 1,
+            warmupRuns: 0
+        ).first!
+
+        XCTAssertEqual(result.decodedTokenVisits, tokenCount * (tokenCount + 1) / 2)
+        XCTAssertEqual(result.emittedCharacterCount, tokenCount)
+    }
+
+    func testFixedNewlineCadenceBoundsHistoricalDecodeWork() {
+        let tokenCount = 128
+        let cadence = 16
+        let segmentCount = tokenCount / cadence
+        let result = benchmarkStreamingDetokenization(
+            tokenCounts: [tokenCount],
+            newlineCadences: [cadence],
+            strategies: [.unbounded],
+            runs: 1,
+            warmupRuns: 0
+        ).first!
+
+        let firstSegmentVisits = cadence * (cadence + 1) / 2 + 1
+        let subsequentSegmentVisits = (cadence + 1) * (cadence + 2) / 2
+        let expectedVisits =
+            firstSegmentVisits + (segmentCount - 1) * subsequentSegmentVisits
+
+        XCTAssertEqual(result.decodedTokenVisits, expectedVisits)
+        XCTAssertEqual(result.emittedCharacterCount, tokenCount)
+    }
+
+    func testBoundedContextMakesDecodeWorkLinearWithoutChangingOutput() {
+        let tokenCount = 512
+        let contextTokens = 16
+        let results = benchmarkStreamingDetokenization(
+            tokenCounts: [tokenCount],
+            newlineCadences: [nil],
+            strategies: [.unbounded, .bounded(contextTokens: contextTokens)],
+            runs: 1,
+            warmupRuns: 0
+        )
+
+        let unbounded = results[0]
+        let bounded = results[1]
+        let expectedBoundedVisits =
+            contextTokens * (contextTokens + 1) / 2
+            + (tokenCount - contextTokens) * (2 * contextTokens + 1)
+
+        XCTAssertEqual(bounded.decodedTokenVisits, expectedBoundedVisits)
+        XCTAssertEqual(bounded.emittedCharacterCount, unbounded.emittedCharacterCount)
+        XCTAssertLessThan(bounded.decodedTokenVisits, unbounded.decodedTokenVisits)
+    }
+
+    func testBoundedContextPreservesStreamingChunksForLocalDecoder() {
+        let tokenizer = LocalDecoderTokenizer(contextSize: 2)
+        var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+        var output = ""
+
+        for token in 1 ... 100 {
+            detokenizer.append(token: token)
+            output += detokenizer.next() ?? ""
+        }
+
+        XCTAssertEqual(output, String(repeating: "x", count: 100))
+    }
+
+    func testHistoricalTokenizerWithoutCapabilityKeepsUnboundedFallback() {
+        let recorder = HistoricalDecodeRecorder()
+        let tokenizer: any Tokenizer = HistoricalTokenizer(recorder: recorder)
+        var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+
+        XCTAssertFalse(tokenizer is any BoundedStreamingDecodeTokenizer)
+
+        for token in 1 ... 32 {
+            detokenizer.append(token: token)
+            _ = detokenizer.next()
+        }
+
+        XCTAssertEqual(recorder.maximumTokenCount, 32)
+    }
+
+    func testIncompleteUnicodeSequenceIsBufferedBeforeContextCompaction() {
+        let tokenizer = IncompleteUnicodeTokenizer()
+        var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+
+        detokenizer.append(token: 1)
+        XCTAssertNil(detokenizer.next())
+
+        detokenizer.append(token: 2)
+        XCTAssertEqual(detokenizer.next(), "é")
+    }
+}
+
+private final class HistoricalDecodeRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var maximumTokenCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func record(_ count: Int) {
+        lock.lock()
+        value = max(value, count)
+        lock.unlock()
+    }
+}
+
+private struct HistoricalTokenizer: Tokenizer {
+    let recorder: HistoricalDecodeRecorder
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        recorder.record(tokenIds.count)
+        return String(repeating: "x", count: tokenIds.count)
+    }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { "x" }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+private struct LocalDecoderTokenizer: BoundedStreamingDecodeTokenizer {
+    let contextSize: Int?
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        String(repeating: "x", count: tokenIds.count)
+    }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { "x" }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    var streamingDecodeContextSize: Int? { contextSize }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+private struct IncompleteUnicodeTokenizer: BoundedStreamingDecodeTokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds == [1] ? "\u{fffd}" : "é"
+    }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    var streamingDecodeContextSize: Int? { 1 }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}

--- a/Tests/MLXLMTests/UserInputAudioTests.swift
+++ b/Tests/MLXLMTests/UserInputAudioTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+
+#if canImport(AVFoundation)
+final class UserInputAudioTests: XCTestCase {
+    func testAudioURLMaterializesFloatSamples() async throws {
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: "audio_only", withExtension: "mov"))
+
+        let samples = try await UserInput.Audio.url(url).asMLXArray()
+        eval(samples)
+
+        XCTAssertEqual(samples.ndim, 1)
+        XCTAssertGreaterThan(samples.size, 0)
+        XCTAssertEqual(samples.dtype, .float32)
+    }
+
+    func testArrayAudioPreservesIdentityShape() async throws {
+        let input = MLXArray([Float](repeating: 0.25, count: 64))
+
+        let output = try await UserInput.Audio.array(input).asMLXArray()
+
+        XCTAssertEqual(output.shape, [64])
+        XCTAssertEqual(output.asArray(Float.self), input.asArray(Float.self))
+    }
+}
+#endif


### PR DESCRIPTION
## Why

Three unrelated paths grow a buffer proportionally to input length/duration
with no bound, which matters for long-running generation, long audio clips,
and long videos:

- `NaiveStreamingDetokenizer.segment` only compacted down to the single most
  recent token, and only on a newline — so for a tokenizer whose `decode()`
  output for a given tail depends on more than one preceding token, streaming
  a long response with few/no newlines keeps re-decoding a monotonically
  growing token list every step.
- `UserInput.Audio` loading appended each `CMSampleBuffer` chunk to a plain
  `[Float]` via `append(contentsOf:)`, so a several-minute clip pays Swift's
  `Array` geometric-growth reallocation/copy cost with no visibility into
  the eventual total size.
- `MediaProcessing`'s video frame sampling built the full `[CIImage]` array
  first, then mapped it to `[MLXArray]` — so every sampled frame's `CIImage`
  and `MLXArray` representations were both live simultaneously for the whole
  clip, doubling peak retained frame memory.

## What

- Adds `BoundedStreamingDecodeTokenizer`, an opt-in protocol a `Tokenizer`
  conformer can adopt to declare how many trailing tokens its `decode()`
  output actually depends on (`streamingDecodeContextSize`).
  `NaiveStreamingDetokenizer` compacts to that window after every step (not
  only on newlines) when the active tokenizer adopts it; tokenizers that
  don't adopt it keep the previous unbounded-until-newline behavior
  unchanged.
- `UserInput.Audio`'s AVFoundation decode path pre-reserves `Data` capacity
  from the asset's known duration (capped, to avoid one large upfront
  allocation for unusually long inputs) and copies sample bytes directly
  into that buffer instead of accumulating an array of per-chunk arrays.
- `MediaProcessing`'s two video-sampling code paths convert each frame to
  `MLXArray` immediately after processing it, instead of collecting all
  `CIImage`s first and mapping the whole collection afterward.

## How tested

- `Tests/MLXLMTests/DetokenizerBenchmarkTests.swift` (new): measures actual
  decode work (token-list length passed to `decode()`, summed across steps)
  for a long token stream under three strategies — unbounded, bounded to a
  fixed context size, and a periodic-newline reset — and asserts the bounded
  strategy's cumulative work is linear in output length while the unbounded
  strategy's is quadratic (triangular sum), and that the bounded and
  unbounded strategies produce byte-identical decoded output.
- `Tests/MLXLMTests/UserInputAudioTests.swift` (new): round-trips synthetic
  audio through the loader and asserts sample count and values are
  unaffected by the buffer-construction change, including a byte-count edge
  case that isn't an exact multiple of `MemoryLayout<Float>.size`.
- `swift build` compiles clean across every target, including the
  `BenchmarkHelpers`/`MLXLMTests` dependency this PR adds (the new
  detokenizer benchmark test needs `import BenchmarkHelpers`, which the test
  target didn't previously declare — separated into its own commit so the
  `Package.swift` change is easy to review on its own).
