### PR TITLE
fix(GlmOcr): carry M-RoPE delta into generation (repetition loop on large images)

### DIFF
--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -275,6 +275,17 @@ private enum Language {
         fileprivate let norm: RMSNorm
         let rotaryEmb: GlmOcrRotaryEmbedding
 
+        // M-RoPE delta carried from prefill into every autoregressive step. GLM-OCR's image tokens
+        // pack many patches onto few M-RoPE positions, so the LM's *last* position after prefill is
+        // far below the token count (delta = maxPosition + 1 - tokenCount, a large NEGATIVE number
+        // for a full page). Generated tokens must continue from that last position — NOT from the
+        // raw KV-cache offset. mlx-vlm stores this on the model instance (`self._rope_deltas`); the
+        // Swift port only put it on the transient LMOutput.State, which the generate loop does not
+        // carry — so generation fell back to sequential cache-offset positions (0,1,2… → 4830,4831…
+        // for a large image), a catastrophic M-RoPE mismatch that degenerates into a repetition
+        // loop. Persisting it here restores parity with mlx-vlm. Set in `prepare(_:cache:windowSize:)`.
+        fileprivate var glmRopeDelta: Int32 = 0
+
         public init(_ args: GlmOcrConfiguration.TextConfiguration) {
             precondition(args.vocabularySize > 0)
 
@@ -307,7 +318,7 @@ private enum Language {
             } else {
                 let offset = cache?.first?.offset ?? 0
                 let seqLen = h.dim(h.ndim - 2)
-                let positions = MLXArray(Int32(offset) ..< Int32(offset + seqLen))
+                let positions = MLXArray((Int32(offset) + glmRopeDelta) ..< (Int32(offset + seqLen) + glmRopeDelta))
                     .expandedDimensions(axis: 0)
                 posIds = tiled(positions, repetitions: [3, 1, 1])
             }
@@ -320,7 +331,6 @@ private enum Language {
                     h, mask: mask, cache: cache?[i],
                     positionEmbeddings: positionEmbeddings)
             }
-
             return norm(h)
         }
     }
@@ -1036,6 +1046,9 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
         var state = LMOutput.State()
         state[precomputedPositionIdsKey] = positionIds
         state[ropeDeltasKey] = ropeDeltas
+        if let ropeDeltas {
+            languageModel.model.glmRopeDelta = ropeDeltas.asType(.int32).item(Int32.self)
+        }
 
         let result = languageModel(
             nil, cache: cache, state: state, inputEmbedding: inputEmbeddings)


### PR DESCRIPTION
# fix(GlmOcr): carry M-RoPE delta into generation (repetition loop on large images)

## Problem

`GLM-OCR` (e.g. `mlx-community/GLM-OCR-4bit`) degenerates into an `AgAgAg…`
repetition loop when transcribing **large** document images, while
transcribing **small** images correctly with the same model, prompt and
`temperature = 0`. The Python reference (`mlx-vlm`) handles the same full-res
images fine, so this is a Swift-port bug, not a model/quantization issue.

## Root cause

GLM-OCR uses M-RoPE (3D positions). Its image tokens pack many patches onto a
small span of M-RoPE positions, so after prefill the language model's *last*
position is far below the token count. `get_rope_index` computes a
`rope_delta = maxPosition + 1 - tokenCount` — a large **negative** number for a
full page — that generated tokens must use to continue from the last real
position rather than from the raw KV-cache offset.

In the Swift port, that delta is stored only on the transient `LMOutput.State`
created in `prepare(_:cache:windowSize:)`. The generation loop does **not**
carry that state into subsequent autoregressive steps, so
`LanguageModel.callAsFunction` finds no stored positions and
`GlmOcrTextModel` falls back to **sequential KV-cache-offset positions**
(e.g. 4830, 4831, 4832 …) instead of continuing from ~90. Because the delta is
tiny for small images and huge for large ones, the mismatch is tolerable for
small images and catastrophic for large ones — exactly the observed size
threshold.

`mlx-vlm` avoids this by persisting the delta on the model instance
(`self._rope_deltas`); the Swift port only put it on the per-call state.

## Fix

Persist the M-RoPE delta on the `GlmOcrTextModel` instance and apply it to the
autoregressive position computation. One file, `Libraries/MLXVLM/Models/GlmOcr.swift`.

## Verification

Reproduced with a minimal Swift harness that mirrors the exact
`VLMModelFactory` load + `UserInput(images:)` path. On a full 1700×2200 page:

- **before:** `AgAgAgAg…` (repetition loop)
- **after:** faithful transcription, byte-for-byte plausible against `mlx-vlm`
  on the same image.

Layer-by-layer tensor-stat comparison against `mlx-vlm` confirmed the vision
encoder, prefill hidden states, position ids and rope_delta all matched; the
only divergence was the generation-phase positions, which this patch corrects.
