### PR TITLE
Add GitHub workflow for IntegrationTesting tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,12 +1,9 @@
 name: Integration Tests
 
 # Heavy integration tests (Hugging Face model downloads, Metal GPU, long-running).
-# Kept out of the PR path so they never block merges; run manually or nightly.
+# Kept out of the PR path so they never block merges
 on:
   workflow_dispatch:
-  schedule:
-    # ~02:00 US Pacific. Adjust as needed.
-    - cron: "0 9 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,52 @@
+name: Integration Tests
+
+# Heavy integration tests (Hugging Face model downloads, Metal GPU, long-running).
+# Kept out of the PR path so they never block merges; run manually or nightly.
+on:
+  workflow_dispatch:
+  schedule:
+    # ~02:00 US Pacific. Adjust as needed.
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  integration_tests:
+    if: github.repository == 'ml-explore/mlx-swift-lm'
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Verify MetalToolchain installed
+        shell: bash
+        run: xcodebuild -showComponent MetalToolchain
+
+      - name: Run IntegrationTesting tests (Xcode, macOS)
+        shell: sh
+        run: |
+          xcodebuild -version
+          swift --version
+          # Model-dependent tests must run in a single xctest worker: concurrent
+          # workers race on the shared on-disk Hugging Face cache. Disable parallel
+          # testing (see IntegrationTestingTests/.../Support/FMTestHelpers.swift).
+          xcodebuild test \
+            -project IntegrationTesting/IntegrationTesting.xcodeproj \
+            -scheme IntegrationTesting \
+            -destination 'platform=macOS' \
+            -parallel-testing-enabled NO \
+            -skipPackagePluginValidation \
+            -resultBundlePath IntegrationTesting.xcresult
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          path: |
+            IntegrationTesting.xcresult
+            ~/Library/Logs/DiagnosticReports/*
+          retention-days: 7


### PR DESCRIPTION
## Proposed changes

Runs the IntegrationTestingTests target manually (workflow_dispatch) on the self-hosted macOS runner. Kept off the PR path since the tests download HF checkpoints, require Metal, and are long-running. Uses -parallel-testing-enabled NO to avoid concurrent workers racing on the shared on-disk Hugging Face cache.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
