### PR TITLE
MTP speculative decoding: preserve the target distribution when sampling

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -14,6 +14,21 @@ public protocol LogitSampler {
     func sample(logits: MLXArray) -> MLXArray
 }
 
+/// A sampler that can also expose the normalized distribution it samples.
+///
+/// Speculative sampling needs both the target distribution `p` and the
+/// drafter distribution `q` to apply the acceptance probability
+/// `min(1, p(token) / q(token))` and, on rejection, sample from the residual
+/// distribution `max(p - q, 0)`. Plain ``LogitSampler`` intentionally keeps
+/// the smaller API used by ordinary generation; samplers that can support the
+/// exact speculative algorithm opt in through this refinement.
+public protocol DistributionLogitSampler: LogitSampler {
+    /// Normalized log-probabilities after applying the sampler's temperature
+    /// and probability filters. The returned tensor has the same shape as
+    /// `logits` and sums to one in probability space along the last axis.
+    func logProbabilities(logits: MLXArray) -> MLXArray
+}
+
 /// A `LogitProcessor` is an optional visitor of `logits`.
 ///
 /// The ``LogitProcessor`` is called with the input (prompt) before generating tokens:
@@ -242,7 +257,7 @@ public struct ArgMaxSampler: LogitSampler {
 /// Each filter operates on the full vocabulary in original token order, masking
 /// rejected tokens with `-inf`. This matches the composable filter chain in
 /// `mlx_lm.sample_utils.make_sampler`.
-public struct TopPSampler: LogitSampler {
+public struct TopPSampler: DistributionLogitSampler {
     let temp: MLXArray
     let topP: MLXArray?
     let topK: Int?
@@ -269,27 +284,33 @@ public struct TopPSampler: LogitSampler {
     }
 
     public func sample(logits: MLXArray) -> MLXArray {
+        return withRandomState(randomState) {
+            categorical(logProbabilities(logits: logits))
+        }
+    }
+
+    public func logProbabilities(logits: MLXArray) -> MLXArray {
         var logits = logits
         if logits.dtype == .bfloat16 {
             logits = logits.asType(.float32)
         }
 
-        return withRandomState(randomState) {
-            var logprobs = logSoftmax(logits)
+        var logprobs = logSoftmax(logits)
 
-            // Apply filters in Python mlx-lm order: top_p → min_p → top_k.
-            if let topP {
-                logprobs = applyTopP(logprobs, topP: topP)
-            }
-            if let minP {
-                logprobs = applyMinP(logprobs, minP: minP)
-            }
-            if let topK {
-                logprobs = applyTopK(logprobs, topK: topK)
-            }
-
-            return categorical(logprobs * (1 / temp))
+        // Apply filters in Python mlx-lm order: top_p → min_p → top_k.
+        if let topP {
+            logprobs = applyTopP(logprobs, topP: topP)
         }
+        if let minP {
+            logprobs = applyMinP(logprobs, minP: minP)
+        }
+        if let topK {
+            logprobs = applyTopK(logprobs, topK: topK)
+        }
+
+        // `categorical` accepts unnormalized log weights. Normalize here as
+        // well so speculative rejection sampling can read exact p/q values.
+        return logSoftmax(logprobs * (1 / temp))
     }
 
     /// Keep tokens whose cumulative probability exceeds `1 - topP` (nucleus sampling).
@@ -327,7 +348,7 @@ public struct TopPSampler: LogitSampler {
 }
 
 /// Sampler that uses `temperature` to sample the logits.
-public struct CategoricalSampler: LogitSampler {
+public struct CategoricalSampler: DistributionLogitSampler {
     let temp: MLXArray
     let randomState: MLXRandom.RandomState
 
@@ -340,8 +361,13 @@ public struct CategoricalSampler: LogitSampler {
 
     public func sample(logits: MLXArray) -> MLXArray {
         return withRandomState(randomState) {
-            categorical(logits * (1 / temp))
+            categorical(logProbabilities(logits: logits))
         }
+    }
+
+    public func logProbabilities(logits: MLXArray) -> MLXArray {
+        let logits = logits.dtype == .bfloat16 ? logits.asType(.float32) : logits
+        return logSoftmax(logits * (1 / temp))
     }
 }
 

--- a/Libraries/MLXLMCommon/MTPDrafterModel.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModel.swift
@@ -59,6 +59,44 @@ public protocol MTPDrafterModel: BaseLanguageModel {
     ) -> MLXArray
 }
 
+/// Tokens proposed by an MTP drafter together with the processed logits that
+/// defined each proposal distribution.
+///
+/// `processedLogits` has shape `[B, blockSize - 1, vocabularySize]`. Each row
+/// is captured after the drafter-side ``LogitProcessor`` and before the
+/// ``LogitSampler``. Keeping this information is what lets the verifier apply
+/// distribution-preserving speculative sampling instead of accepting only
+/// independently sampled exact-token matches.
+public struct MTPDraftBlockOutput {
+    public let tokens: MLXArray
+    public let processedLogits: MLXArray
+
+    public init(tokens: MLXArray, processedLogits: MLXArray) {
+        self.tokens = tokens
+        self.processedLogits = processedLogits
+    }
+}
+
+/// Optional refinement for MTP drafters that support exact speculative
+/// sampling.
+///
+/// The base ``MTPDrafterModel`` API is retained for source compatibility and
+/// for greedy-only custom drafters. Non-greedy MTP generation requires this
+/// refinement: without the drafter distribution `q`, no verifier can preserve
+/// the target distribution `p` on rejection.
+public protocol MTPDistributionDrafterModel: MTPDrafterModel {
+    func draftBlockWithLogits(
+        target: any LanguageModel,
+        lastToken: MLXArray,
+        lastHidden: MLXArray,
+        sharedKV: [String: (MLXArray, MLXArray)],
+        queryOffset: Int,
+        blockSize: Int,
+        processor: (any LogitProcessor)?,
+        sampler: any LogitSampler
+    ) -> MTPDraftBlockOutput
+}
+
 /// Lightweight context for an MTP drafter — simpler than `ModelContext`
 /// because drafters have no tokenizer, no user input processor, no chat
 /// template.

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -44,6 +44,25 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     var processor: LogitProcessor?
     let sampler: LogitSampler
 
+    /// Distribution surface for non-greedy speculative sampling. Built-in
+    /// temperature/top-p samplers conform; argmax intentionally does not and
+    /// keeps the cheaper exact-token greedy path.
+    let distributionSampler: (any DistributionLogitSampler)?
+
+    /// Independent RNG used for speculative acceptance and residual/bonus
+    /// draws. Draft proposals use `draftSampler`'s own RNG; separating them is
+    /// required by the rejection-sampling proof.
+    let speculativeRandomState: MLXRandom.RandomState
+
+    /// Independent sampler handed to the drafter. Distribution-capable
+    /// drafters receive a copy of the full target processor as well, so their
+    /// proposal distribution matches the target's (penalties included).
+    let draftSampler: LogitSampler
+
+    /// Sampler for older greedy-only drafters whose API cannot receive a
+    /// processor.
+    let legacyDraftSampler: LogitSampler
+
     public var tokenCount: Int { telemetry.emittedTokenCount }
     public let maxTokens: Int?
     /// Total tokens proposed per round (`blockSize - 1` drafted, plus the
@@ -118,7 +137,17 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         self.sampler = parameters.sampler()
+        self.distributionSampler = self.sampler as? any DistributionLogitSampler
+        self.speculativeRandomState = parameters.seed.map {
+            MLXRandom.RandomState(seed: $0 &+ 0x9E37_79B9_7F4A_7C15)
+        } ?? MLXRandom.RandomState()
         self.processor = parameters.processor()
+
+        var draftParameters = parameters
+        draftParameters.seed = parameters.seed.map { $0 &+ 0xD1B5_4A32_D192_ED03 }
+        let drafterSampler = draftParameters.sampler()
+        self.draftSampler = drafterSampler
+        self.legacyDraftSampler = drafterSampler
 
         self.maxTokens = parameters.maxTokens
         self.blockSize = blockSize
@@ -270,15 +299,42 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         )
 
         let bonusToken = y.tokens
-        let draftTokens = drafter.draftBlock(
-            target: mainModel,
-            lastToken: bonusToken,
-            lastHidden: bonusSlotHidden,
-            sharedKV: sharedKV,
-            queryOffset: cacheOffset,
-            blockSize: numDraft + 1,  // total round size: bonus + numDraft
-            sampler: sampler
-        )
+        let draftOutput: MTPDraftBlockOutput?
+        let draftTokens: MLXArray
+        if let distributionDrafter = drafter as? any MTPDistributionDrafterModel {
+            let output = distributionDrafter.draftBlockWithLogits(
+                target: mainModel,
+                lastToken: bonusToken,
+                lastHidden: bonusSlotHidden,
+                sharedKV: sharedKV,
+                queryOffset: cacheOffset,
+                blockSize: numDraft + 1,  // total round size: bonus + numDraft
+                processor: processor,
+                sampler: draftSampler
+            )
+            draftOutput = output
+            draftTokens = output.tokens
+        } else {
+            // Greedy matching needs tokens only and remains compatible with
+            // the original protocol. Sampling cannot preserve the target
+            // distribution without q logits, so fail safe to target-only
+            // generation instead of silently changing semantics.
+            guard distributionSampler == nil else {
+                switchToPassthrough(
+                    reason: "MTP drafter does not expose logits required for sampling")
+                return
+            }
+            draftOutput = nil
+            draftTokens = drafter.draftBlock(
+                target: mainModel,
+                lastToken: bonusToken,
+                lastHidden: bonusSlotHidden,
+                sharedKV: sharedKV,
+                queryOffset: cacheOffset,
+                blockSize: numDraft + 1,
+                sampler: legacyDraftSampler
+            )
+        }
         // draftTokens shape [B, numDraft] -> flatten to [numDraft].
         let flatDraftTokens = draftTokens.flattened()
 
@@ -294,49 +350,35 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         let mainLogits = mainResult.logits
         mainState = mainResult.state
 
-        // Sample one main-model token per verify position.
-        let mainTokens: MLXArray
-        // Local copy: process() may mutate processor state via Swift struct
-        // value semantics, but those mutations stay scoped to this verify
-        // loop. Canonical processor state at `self.processor` is only
-        // updated by the accept loop below, which evolves it across the
-        // actually-emitted tokens. This keeps rejected-draft sampling from
-        // polluting cross-round state.
-        if var verifyProcessorCopy = processor {
-            var sampled = [MLXArray]()
-            for i in 0 ..< (numDraft + 1) {
-                var logits = mainLogits[0..., verifyStart + i, 0...]
-                logits = verifyProcessorCopy.process(logits: logits)
-                let token = sampler.sample(logits: logits)
-                verifyProcessorCopy.didSample(token: token)
-                sampled.append(token)
-            }
-            mainTokens = concatenated(sampled)
+        let selection: (accepted: Int, emitted: [MLXArray])
+        if let distributionSampler, let draftOutput {
+            selection = selectDistributionPreservingTokens(
+                targetLogits: mainLogits,
+                targetStart: verifyStart,
+                draftTokens: flatDraftTokens,
+                draftProcessedLogits: draftOutput.processedLogits,
+                numDraft: numDraft,
+                sampler: distributionSampler
+            )
         } else {
-            let verifyLogits = mainLogits[0..., verifyStart..., 0...].squeezed(axis: 0)
-            mainTokens = sampler.sample(logits: verifyLogits)
+            selection = selectGreedyTokens(
+                targetLogits: mainLogits,
+                targetStart: verifyStart,
+                draftTokens: flatDraftTokens,
+                numDraft: numDraft
+            )
         }
 
-        eval(mainTokens, flatDraftTokens)
-        let mainTokensList = mainTokens.asArray(Int.self)
-        let draftTokensList = flatDraftTokens.asArray(Int.self)
-
-        var accepted = 0
-        for i in 0 ..< numDraft {
-            guard mainTokensList[i] == draftTokensList[i] else { break }
-            // Re-feed accepted draft positions to the processor so its
-            // history matches the accepted-prefix view.
-            let drafted = flatDraftTokens[i ..< (i + 1)]
-            processor?.didSample(token: drafted)
-            pendingTokens.append(mainTokensList[i])
-            accepted += 1
+        let emittedTokens = concatenated(selection.emitted)
+        eval(emittedTokens, flatDraftTokens)
+        let emittedTokenList = emittedTokens.asArray(Int.self)
+        for (index, token) in selection.emitted.enumerated() {
+            processor?.didSample(token: token)
+            pendingTokens.append(emittedTokenList[index])
         }
 
-        // Always emit the main model's token at position `accepted` (either
-        // a correction or the bonus token if all drafts matched).
-        let finalToken = mainTokens[accepted ... accepted]
-        processor?.didSample(token: finalToken)
-        pendingTokens.append(mainTokensList[accepted])
+        let accepted = selection.accepted
+        let finalToken = selection.emitted.last!
 
         proposedCount += numDraft
         acceptedCount += accepted
@@ -366,6 +408,123 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         quantizeKVCache(&mainCache)
 
         y = .init(tokens: finalToken)
+    }
+
+    /// Greedy verifier walk. The target is evaluated once for the whole
+    /// verify block, then the longest exact candidate prefix is committed and
+    /// followed by the target correction/bonus token.
+    private func selectGreedyTokens(
+        targetLogits: MLXArray,
+        targetStart: Int,
+        draftTokens: MLXArray,
+        numDraft: Int
+    ) -> (accepted: Int, emitted: [MLXArray]) {
+        // Local processor state follows target samples only for this tentative
+        // walk. Canonical state is updated by the caller from emitted tokens.
+        var verificationProcessor = processor
+        var targetTokens = [MLXArray]()
+        targetTokens.reserveCapacity(numDraft + 1)
+        for i in 0 ..< (numDraft + 1) {
+            var logits = targetLogits[0..., targetStart + i, 0...]
+            logits = verificationProcessor?.process(logits: logits) ?? logits
+            let token = sampler.sample(logits: logits)
+            verificationProcessor?.didSample(token: token)
+            targetTokens.append(token)
+        }
+
+        let targetTokenArray = concatenated(targetTokens)
+        eval(targetTokenArray, draftTokens)
+        let targetTokenList = targetTokenArray.asArray(Int.self)
+        let draftTokenList = draftTokens.asArray(Int.self)
+
+        var accepted = 0
+        while accepted < numDraft
+            && targetTokenList[accepted] == draftTokenList[accepted]
+        {
+            accepted += 1
+        }
+        return (accepted, Array(targetTokens.prefix(accepted + 1)))
+    }
+
+    /// Distribution-preserving speculative sampling (Leviathan et al.).
+    ///
+    /// Candidate `x ~ q` is accepted with `min(1, p(x) / q(x))`. On the first
+    /// rejection, the correction is sampled from normalized `max(p - q, 0)`;
+    /// if all candidates are accepted, the target bonus is sampled from `p`.
+    /// This preserves the target distribution while allowing the target to
+    /// verify the entire candidate block in one forward pass.
+    private func selectDistributionPreservingTokens(
+        targetLogits: MLXArray,
+        targetStart: Int,
+        draftTokens: MLXArray,
+        draftProcessedLogits: MLXArray,
+        numDraft: Int,
+        sampler distributionSampler: any DistributionLogitSampler
+    ) -> (accepted: Int, emitted: [MLXArray]) {
+        var verificationProcessor = processor
+        let draftTokenList = draftTokens.asArray(Int.self)
+        var emitted = [MLXArray]()
+        emitted.reserveCapacity(numDraft + 1)
+
+        for i in 0 ..< numDraft {
+            let candidateID = draftTokenList[i]
+            let candidate = draftTokens[i ..< (i + 1)]
+
+            var pLogits = targetLogits[0..., targetStart + i, 0...]
+            pLogits = verificationProcessor?.process(logits: pLogits) ?? pLogits
+            let pLogProbabilities = distributionSampler.logProbabilities(logits: pLogits)
+            let qLogits = draftProcessedLogits[0..., i, 0...]
+            let qLogProbabilities = distributionSampler.logProbabilities(logits: qLogits)
+
+            eval(pLogProbabilities, qLogProbabilities)
+            let pLogProbability = pLogProbabilities[0, candidateID].item(Float.self)
+            let qLogProbability = qLogProbabilities[0, candidateID].item(Float.self)
+            let acceptanceProbability = speculativeAcceptanceProbability(
+                targetLogProbability: pLogProbability,
+                draftLogProbability: qLogProbability)
+
+            if nextSpeculativeUniform() < acceptanceProbability {
+                emitted.append(candidate)
+                verificationProcessor?.didSample(token: candidate)
+                continue
+            }
+
+            let residual = maximum(
+                exp(pLogProbabilities) - exp(qLogProbabilities),
+                MLXArray(Float(0)))
+            let residualMass = residual.sum().item(Float.self)
+            let correctionLogProbabilities: MLXArray
+            if residualMass.isFinite && residualMass > 1e-7 {
+                correctionLogProbabilities = log(residual)
+            } else {
+                // Numerical roundoff can collapse p-q when the distributions
+                // are effectively equal. Sampling from p is the stable limit.
+                correctionLogProbabilities = pLogProbabilities
+            }
+            emitted.append(sampleSpeculative(logProbabilities: correctionLogProbabilities))
+            return (i, emitted)
+        }
+
+        // Every draft was accepted. The final verifier position predicts one
+        // extra target-only bonus token.
+        var bonusLogits = targetLogits[0..., targetStart + numDraft, 0...]
+        bonusLogits = verificationProcessor?.process(logits: bonusLogits) ?? bonusLogits
+        let bonusLogProbabilities = distributionSampler.logProbabilities(logits: bonusLogits)
+        emitted.append(sampleSpeculative(logProbabilities: bonusLogProbabilities))
+        return (numDraft, emitted)
+    }
+
+    private func nextSpeculativeUniform() -> Double {
+        let sample = withRandomState(speculativeRandomState) {
+            MLXRandom.uniform(Float(0) ..< Float(1), [1])
+        }
+        return Double(sample.item(Float.self))
+    }
+
+    private func sampleSpeculative(logProbabilities: MLXArray) -> MLXArray {
+        withRandomState(speculativeRandomState) {
+            categorical(logProbabilities)
+        }
     }
 
     /// Switch to single-token generation for the remainder of the stream.
@@ -441,6 +600,19 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         telemetry.recordGeneratedToken()
         return token
     }
+}
+
+/// Acceptance probability for one candidate in exact speculative sampling.
+/// Kept as a scalar helper so boundary cases (`p=0`, `q=0`, and very small
+/// ratios) can be tested without requiring a Metal device.
+func speculativeAcceptanceProbability(
+    targetLogProbability p: Float,
+    draftLogProbability q: Float
+) -> Double {
+    guard q.isFinite else { return 0 }
+    guard !p.isNaN else { return 0 }
+    if p >= q { return 1 }
+    return Foundation.exp(Double(p - q))
 }
 
 extension MTPSpeculativeTokenIterator: MTPStatsCollecting {

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -489,18 +489,9 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
                 continue
             }
 
-            let residual = maximum(
-                exp(pLogProbabilities) - exp(qLogProbabilities),
-                MLXArray(Float(0)))
-            let residualMass = residual.sum().item(Float.self)
-            let correctionLogProbabilities: MLXArray
-            if residualMass.isFinite && residualMass > 1e-7 {
-                correctionLogProbabilities = log(residual)
-            } else {
-                // Numerical roundoff can collapse p-q when the distributions
-                // are effectively equal. Sampling from p is the stable limit.
-                correctionLogProbabilities = pLogProbabilities
-            }
+            let correctionLogProbabilities = speculativeResidualLogProbabilities(
+                target: pLogProbabilities,
+                draft: qLogProbabilities)
             emitted.append(sampleSpeculative(logProbabilities: correctionLogProbabilities))
             return (i, emitted)
         }
@@ -613,6 +604,19 @@ func speculativeAcceptanceProbability(
     guard !p.isNaN else { return 0 }
     if p >= q { return 1 }
     return Foundation.exp(Double(p - q))
+}
+
+/// Normalized residual distribution `max(p - q, 0)` used after a rejected
+/// speculative candidate. When finite-precision arithmetic collapses the
+/// residual mass, `p` is the stable limiting fallback.
+func speculativeResidualLogProbabilities(
+    target p: MLXArray,
+    draft q: MLXArray
+) -> MLXArray {
+    let residual = maximum(exp(p) - exp(q), MLXArray(Float(0)))
+    let residualMass = residual.sum().item(Float.self)
+    guard residualMass.isFinite && residualMass > 1e-7 else { return p }
+    return log(residual / residualMass)
 }
 
 extension MTPSpeculativeTokenIterator: MTPStatsCollecting {

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -138,9 +138,10 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         self.sampler = parameters.sampler()
         self.distributionSampler = self.sampler as? any DistributionLogitSampler
-        self.speculativeRandomState = parameters.seed.map {
-            MLXRandom.RandomState(seed: $0 &+ 0x9E37_79B9_7F4A_7C15)
-        } ?? MLXRandom.RandomState()
+        self.speculativeRandomState =
+            parameters.seed.map {
+                MLXRandom.RandomState(seed: $0 &+ 0x9E37_79B9_7F4A_7C15)
+            } ?? MLXRandom.RandomState()
         self.processor = parameters.processor()
 
         var draftParameters = parameters
@@ -476,23 +477,18 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             let qLogits = draftProcessedLogits[0..., i, 0...]
             let qLogProbabilities = distributionSampler.logProbabilities(logits: qLogits)
 
-            eval(pLogProbabilities, qLogProbabilities)
-            let pLogProbability = pLogProbabilities[0, candidateID].item(Float.self)
-            let qLogProbability = qLogProbabilities[0, candidateID].item(Float.self)
-            let acceptanceProbability = speculativeAcceptanceProbability(
-                targetLogProbability: pLogProbability,
-                draftLogProbability: qLogProbability)
+            let decision = sampleSpeculativeDecision(
+                candidateID: candidateID,
+                targetLogProbabilities: pLogProbabilities,
+                draftLogProbabilities: qLogProbabilities)
 
-            if nextSpeculativeUniform() < acceptanceProbability {
+            if decision.accepted {
                 emitted.append(candidate)
                 verificationProcessor?.didSample(token: candidate)
                 continue
             }
 
-            let correctionLogProbabilities = speculativeResidualLogProbabilities(
-                target: pLogProbabilities,
-                draft: qLogProbabilities)
-            emitted.append(sampleSpeculative(logProbabilities: correctionLogProbabilities))
+            emitted.append(decision.correction)
             return (i, emitted)
         }
 
@@ -505,11 +501,30 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         return (numDraft, emitted)
     }
 
-    private func nextSpeculativeUniform() -> Double {
-        let sample = withRandomState(speculativeRandomState) {
-            MLXRandom.uniform(Float(0) ..< Float(1), [1])
+    /// Draw acceptance and the possible residual correction in one GPU
+    /// evaluation. Sampling the correction eagerly (and discarding it on
+    /// acceptance) preserves the distribution while avoiding a second or
+    /// third CPU/GPU synchronization per candidate.
+    private func sampleSpeculativeDecision(
+        candidateID: Int,
+        targetLogProbabilities p: MLXArray,
+        draftLogProbabilities q: MLXArray
+    ) -> (accepted: Bool, correction: MLXArray) {
+        let logAcceptance = minimum(
+            p[0, candidateID] - q[0, candidateID],
+            MLXArray(Float(0)))
+        let correctionLogProbabilities = speculativeResidualLogProbabilities(
+            target: p,
+            draft: q)
+        let draws = withRandomState(speculativeRandomState) {
+            (
+                MLXRandom.uniform(Float(0) ..< Float(1), [1]),
+                categorical(correctionLogProbabilities)
+            )
         }
-        return Double(sample.item(Float.self))
+        let accepted = log(draws.0) .< logAcceptance
+        eval(accepted, draws.1)
+        return (accepted.item(Bool.self), draws.1)
     }
 
     private func sampleSpeculative(logProbabilities: MLXArray) -> MLXArray {
@@ -614,9 +629,10 @@ func speculativeResidualLogProbabilities(
     draft q: MLXArray
 ) -> MLXArray {
     let residual = maximum(exp(p) - exp(q), MLXArray(Float(0)))
-    let residualMass = residual.sum().item(Float.self)
-    guard residualMass.isFinite && residualMass > 1e-7 else { return p }
-    return log(residual / residualMass)
+    let residualMass = residual.sum()
+    let hasResidual = residualMass .> Float(1e-7)
+    let safeMass = maximum(residualMass, MLXArray(Float(1e-7)))
+    return MLX.where(hasResidual, log(residual / safeMass), p)
 }
 
 extension MTPSpeculativeTokenIterator: MTPStatsCollecting {

--- a/Libraries/MLXVLM/Models/Gemma4Assistant.swift
+++ b/Libraries/MLXVLM/Models/Gemma4Assistant.swift
@@ -174,7 +174,7 @@ public final class Gemma4AssistantDraftInner: Module {
 /// `mlx_vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py`
 /// (SHA d49d428). Conforms to `MTPDrafterModel`; consumed by
 /// `MTPSpeculativeTokenIterator` (Phase B).
-public final class Gemma4AssistantDraftModel: Module, MTPDrafterModel {
+public final class Gemma4AssistantDraftModel: Module, MTPDistributionDrafterModel {
     public let config: Gemma4AssistantConfiguration
 
     @ModuleInfo(key: "model") public var model: Gemma4AssistantDraftInner
@@ -210,6 +210,28 @@ public final class Gemma4AssistantDraftModel: Module, MTPDrafterModel {
         blockSize: Int,
         sampler: any LogitSampler
     ) -> MLXArray {
+        draftBlockWithLogits(
+            target: target,
+            lastToken: lastToken,
+            lastHidden: lastHidden,
+            sharedKV: sharedKV,
+            queryOffset: queryOffset,
+            blockSize: blockSize,
+            processor: nil,
+            sampler: sampler
+        ).tokens
+    }
+
+    public func draftBlockWithLogits(
+        target: any LanguageModel,
+        lastToken: MLXArray,
+        lastHidden: MLXArray,
+        sharedKV: [String: (MLXArray, MLXArray)],
+        queryOffset: Int,
+        blockSize: Int,
+        processor: (any LogitProcessor)?,
+        sampler: any LogitSampler
+    ) -> MTPDraftBlockOutput {
         precondition(blockSize >= 2, "blockSize must be >= 2 (K-1 drafted + 1 bonus)")
 
         // Derive target-bound constants inline per round. Mirrors mlx-vlm's
@@ -232,8 +254,11 @@ public final class Gemma4AssistantDraftModel: Module, MTPDrafterModel {
         var tok =
             lastToken.ndim == 1 ? lastToken.reshaped([lastToken.dim(0), 1]) : lastToken
         var hPrev = lastHidden
+        var processor = processor
         var tokens: [MLXArray] = []
+        var processedLogits: [MLXArray] = []
         tokens.reserveCapacity(blockSize - 1)
+        processedLogits.reserveCapacity(blockSize - 1)
 
         for _ in 0 ..< (blockSize - 1) {
             let tokEmbed =
@@ -246,12 +271,18 @@ public final class Gemma4AssistantDraftModel: Module, MTPDrafterModel {
             )
             hPrev = newHidden
             // logits: [B, L, vocab]; take last step → [B, vocab]
-            let lastStepLogits = logits[0..., -1, 0...]
+            var lastStepLogits = logits[0..., -1, 0...]
+            lastStepLogits = processor?.process(logits: lastStepLogits) ?? lastStepLogits
             let nextTok = sampler.sample(logits: lastStepLogits)
+            processor?.didSample(token: nextTok)
             tok = nextTok.ndim == 1 ? nextTok.reshaped([nextTok.dim(0), 1]) : nextTok
             tokens.append(tok)
+            processedLogits.append(lastStepLogits.expandedDimensions(axis: 1))
         }
-        return concatenated(tokens, axis: 1)
+        return MTPDraftBlockOutput(
+            tokens: concatenated(tokens, axis: 1),
+            processedLogits: concatenated(processedLogits, axis: 1)
+        )
     }
 
     /// One drafter forward — pre-projection, layer loop with shared K/V,

--- a/Tests/MLXLMTests/MTPSpeculativeSamplingMathTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeSamplingMathTests.swift
@@ -1,0 +1,32 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Test
+func testSpeculativeAcceptanceProbabilityBoundaries() {
+    #expect(
+        speculativeAcceptanceProbability(
+            targetLogProbability: Foundation.log(0.6),
+            draftLogProbability: Foundation.log(0.3)) == 1)
+
+    let ratio = speculativeAcceptanceProbability(
+        targetLogProbability: Foundation.log(0.2),
+        draftLogProbability: Foundation.log(0.5))
+    #expect(abs(ratio - 0.4) < 1e-6)
+
+    #expect(
+        speculativeAcceptanceProbability(
+            targetLogProbability: -.infinity,
+            draftLogProbability: Foundation.log(0.5)) == 0)
+    #expect(
+        speculativeAcceptanceProbability(
+            targetLogProbability: Foundation.log(0.5),
+            draftLogProbability: -.infinity) == 0)
+    #expect(
+        speculativeAcceptanceProbability(
+            targetLogProbability: .nan,
+            draftLogProbability: Foundation.log(0.5)) == 0)
+}

--- a/Tests/MLXLMTests/MTPSpeculativeSamplingMathTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeSamplingMathTests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
 import Foundation
+import MLX
 import Testing
 
 @testable import MLXLMCommon
@@ -29,4 +30,33 @@ func testSpeculativeAcceptanceProbabilityBoundaries() {
         speculativeAcceptanceProbability(
             targetLogProbability: .nan,
             draftLogProbability: Foundation.log(0.5)) == 0)
+}
+
+@Test
+func testSpeculativeResidualDistributionIsNormalized() {
+    let target = MLXArray([Float(log(0.2)), Float(log(0.8))])[.newAxis, 0...]
+    let draft = MLXArray([Float(log(0.6)), Float(log(0.4))])[.newAxis, 0...]
+
+    let residual = speculativeResidualLogProbabilities(target: target, draft: draft)
+    let probabilities = exp(residual).asArray(Float.self)
+
+    #expect(probabilities[0] == 0)
+    #expect(abs(probabilities[1] - 1) < 1e-6)
+    #expect(abs(probabilities.reduce(0, +) - 1) < 1e-6)
+}
+
+@Test
+func testDistributionSamplersExposeNormalizedLogProbabilities() {
+    let logits = MLXArray([Float(0), 1, 2, 3])[.newAxis, 0...]
+
+    let categorical = CategoricalSampler(temperature: 0.7, seed: 1)
+    let categoricalMass = exp(categorical.logProbabilities(logits: logits)).sum()
+        .item(Float.self)
+    #expect(abs(categoricalMass - 1) < 1e-5)
+
+    let filtered = TopPSampler(temperature: 0.7, topK: 2, seed: 1)
+    let filteredProbabilities = exp(filtered.logProbabilities(logits: logits))
+        .asArray(Float.self)
+    #expect(abs(filteredProbabilities.reduce(0, +) - 1) < 1e-5)
+    #expect(filteredProbabilities.filter { $0 > 0 }.count == 2)
 }

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -12,7 +12,7 @@ import Testing
 /// Records `draftBlock(...)` invocations and returns a fixed token pattern
 /// so the iterator's draft/verify/accept flow can be exercised without a
 /// real drafter.
-private final class MockDrafter: Module, MTPDrafterModel {
+private final class MockDrafter: Module, MTPDistributionDrafterModel {
     private(set) var draftBlockCallCount = 0
     var draftedTokenValue: Int32
     /// Per-call record of what the iterator handed `draftBlock`: the
@@ -36,12 +36,47 @@ private final class MockDrafter: Module, MTPDrafterModel {
         blockSize: Int,
         sampler: any LogitSampler
     ) -> MLXArray {
+        draftBlockWithLogits(
+            target: target, lastToken: lastToken, lastHidden: lastHidden,
+            sharedKV: sharedKV, queryOffset: queryOffset, blockSize: blockSize,
+            processor: nil, sampler: sampler
+        ).tokens
+    }
+
+    func draftBlockWithLogits(
+        target: any LanguageModel,
+        lastToken: MLXArray,
+        lastHidden: MLXArray,
+        sharedKV: [String: (MLXArray, MLXArray)],
+        queryOffset: Int,
+        blockSize: Int,
+        processor: (any LogitProcessor)?,
+        sampler: any LogitSampler
+    ) -> MTPDraftBlockOutput {
         draftBlockCallCount += 1
         receivedSharedKVSpans.append(sharedKV.mapValues { $0.0.dim(-2) })
         receivedQueryOffsets.append(queryOffset)
         let batch = lastToken.dim(0)
-        let vals = Array(repeating: draftedTokenValue, count: (blockSize - 1) * batch)
-        return MLXArray(vals, [batch, blockSize - 1])
+        let vocab = 20
+        var processor = processor
+        var tokens = [MLXArray]()
+        var logitsRows = [MLXArray]()
+        for _ in 0 ..< (blockSize - 1) {
+            var values = [Float](repeating: 0, count: batch * vocab)
+            for row in 0 ..< batch {
+                values[row * vocab + Int(draftedTokenValue)] = 100
+            }
+            var logits = MLXArray(values, [batch, vocab])
+            logits = processor?.process(logits: logits) ?? logits
+            let token = sampler.sample(logits: logits)
+            processor?.didSample(token: token)
+            tokens.append(token.expandedDimensions(axis: 1))
+            logitsRows.append(logits.expandedDimensions(axis: 1))
+        }
+        return MTPDraftBlockOutput(
+            tokens: concatenated(tokens, axis: 1),
+            processedLogits: concatenated(logitsRows, axis: 1)
+        )
     }
 }
 


### PR DESCRIPTION
Builds on #415 (MTP speculative decoding for Gemma 4 12B).

## Problem

The MTP verifier accepts a draft position only when the drafted token is *equal* to a token sampled from the target at that position. That rule is correct for greedy decoding, but at `temperature > 0` it does not preserve the target distribution: comparing one sample from `q` against one sample from `p` accepts with probability `Σ p(x)q(x)`, and the tokens that survive are biased toward the modes both models agree on. Speculative decoding is supposed to be distribution-neutral — the output should be indistinguishable from sampling the target directly — and today it silently is not.

## Fix

Implement the standard rejection-sampling rule (Leviathan et al., *Fast Inference from Transformers via Speculative Decoding*):

- candidate `x ~ q` is accepted with probability `min(1, p(x)/q(x))` (computed in log space);
- on the first rejection, the correction is drawn from the normalized residual `max(p - q, 0)`;
- if every candidate is accepted, the bonus token is drawn from `p` at the final verifier position.

The target still verifies the whole block in a single forward pass, so the speedup is unchanged.

## What this required

- **Drafter proposal logits.** The rule needs `q`, not just the sampled token. Distribution-capable drafters implement `draftBlockWithLogits` and return their processed logits alongside the tokens. The drafter also receives a copy of the target's processor, so `q` reflects the same penalties as `p`.
- **A distribution surface on samplers.** `DistributionLogitSampler` exposes normalized log-probabilities. The built-in temperature/top-p samplers conform; argmax deliberately does not.
- **Independent RNG streams.** Acceptance draws, residual draws, and draft proposals use separate `RandomState`s — the correctness proof assumes independence. Both streams derive deterministically from `parameters.seed` when one is set, so seeded runs stay reproducible.

## Compatibility and fail-safe

- **Greedy is untouched.** Argmax keeps the cheaper exact-match prefix walk; no extra sampling work, no behavior change.
- **Older drafters.** A drafter that cannot expose logits still works under greedy. If it is paired with a *sampling* configuration, the iterator switches to passthrough (target-only generation) rather than silently producing biased samples — failing safe instead of failing quietly.

## Performance

The acceptance draw and the residual draw are issued in a single GPU evaluation per candidate — the correction is sampled eagerly and discarded when the candidate is accepted. That keeps one CPU/GPU synchronization per candidate instead of two or three, which matters because the acceptance test is inherently sequential.

## Tests

New `MTPSpeculativeSamplingMathTests` covers the acceptance-probability boundaries, that the residual distribution is a normalized proper distribution, and that the distribution samplers expose normalized log-probabilities; the iterator tests are extended for the sampling path and the passthrough fail-safe. Full suite: 304 tests, all passing on macOS.
