### PR TITLE
Add Nanbeige4.2 (looped transformer) model support

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -45,6 +45,7 @@ public enum LLMTypeRegistry {
         "qwen3_5": create(Qwen35Configuration.self, Qwen35Model.init),
         "qwen3_5_moe": create(Qwen35Configuration.self, Qwen35MoEModel.init),
         "qwen3_5_text": create(Qwen35TextConfiguration.self, Qwen35TextModel.init),
+        "nanbeige": create(NanbeigeConfiguration.self, NanbeigeModel.init),
         "minicpm": create(MiniCPMConfiguration.self, MiniCPMModel.init),
         "starcoder2": create(Starcoder2Configuration.self, Starcoder2Model.init),
         "cohere": create(CohereConfiguration.self, CohereModel.init),

--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -1,0 +1,352 @@
+//
+//  Nanbeige.swift
+//  LLM
+//
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// Port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/nanbeige.py
+//
+// Nanbeige4.2 is a Looped Transformer: the same decoder-layer stack is applied
+// `num_loops` times per forward pass with shared weights. Each loop pass has
+// its own KV cache entries (cache count = num_loops * num_hidden_layers) and,
+// unless `skip_loop_final_norm` is set, ends with the final RMSNorm.
+
+class NanbeigeAttention: Module {
+    let args: NanbeigeConfiguration
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var wq: Linear
+    @ModuleInfo(key: "k_proj") var wk: Linear
+    @ModuleInfo(key: "v_proj") var wv: Linear
+    @ModuleInfo(key: "o_proj") var wo: Linear
+
+    let rope: RoPELayer
+
+    public init(_ args: NanbeigeConfiguration) {
+        self.args = args
+
+        let dim = args.hiddenSize
+        let heads = args.attentionHeads
+        let kvHeads = args.kvHeads
+        let headDim = args.resolvedHeadDimensions
+        self.scale = pow(Float(headDim), -0.5)
+
+        _wq.wrappedValue = Linear(dim, heads * headDim, bias: args.attentionBias)
+        _wk.wrappedValue = Linear(dim, kvHeads * headDim, bias: args.attentionBias)
+        _wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: args.attentionBias)
+        _wo.wrappedValue = Linear(heads * headDim, dim, bias: args.attentionBias)
+
+        self.rope = initializeRope(
+            dims: headDim,
+            base: args.ropeTheta,
+            traditional: false,
+            scalingConfig: args.ropeScaling,
+            maxPositionEmbeddings: args.maxPositionEmbeddings
+        )
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (B, L) = (x.dim(0), x.dim(1))
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        queries = queries.reshaped(B, L, args.attentionHeads, -1).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
+
+        let output = attentionWithCacheUpdate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            cache: cache,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return wo(output)
+    }
+}
+
+class NanbeigeMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+
+    public init(_ args: NanbeigeConfiguration) {
+        _gate.wrappedValue = Linear(args.hiddenSize, args.intermediateSize, bias: args.mlpBias)
+        _down.wrappedValue = Linear(args.intermediateSize, args.hiddenSize, bias: args.mlpBias)
+        _up.wrappedValue = Linear(args.hiddenSize, args.intermediateSize, bias: args.mlpBias)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(silu(gate(x)) * up(x))
+    }
+}
+
+class NanbeigeTransformerBlock: Module {
+    @ModuleInfo(key: "self_attn") var attention: NanbeigeAttention
+    let mlp: NanbeigeMLP
+
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    public init(_ args: NanbeigeConfiguration) {
+        _attention.wrappedValue = NanbeigeAttention(args)
+        self.mlp = NanbeigeMLP(args)
+        _inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
+        let h = x + r
+        r = mlp(postAttentionLayerNorm(h))
+        return h + r
+    }
+}
+
+public class NanbeigeModelInner: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+
+    fileprivate let layers: [NanbeigeTransformerBlock]
+    let norm: RMSNorm
+
+    let numLoops: Int
+    let skipLoopFinalNorm: Bool
+
+    /// One KV cache per (loop pass, layer) pair — the single owner of the
+    /// loops × layers layout that `callAsFunction` indexes and `newCache`
+    /// allocates.
+    var cacheSlotCount: Int { numLoops * layers.count }
+
+    public init(_ args: NanbeigeConfiguration) {
+        precondition(args.vocabularySize > 0)
+        // Mirror the Python reference's __post_init__ rejection so a direct
+        // construction cannot silently run reference-only features that have
+        // no dedicated weights. The factory path throws earlier (and
+        // recoverably) via validateModelConfiguration.
+        precondition(
+            !args.enableDoubleLoopSplit && !args.loopShareKV && !args.enableDepthAttention,
+            "enable_double_loop_split, loop_share_kv, and enable_depth_attention are not supported"
+        )
+
+        self.numLoops = args.effectiveNumLoops
+        self.skipLoopFinalNorm = args.skipLoopFinalNorm
+
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: args.vocabularySize, dimensions: args.hiddenSize)
+
+        self.layers = (0 ..< args.hiddenLayers)
+            .map { _ in
+                NanbeigeTransformerBlock(args)
+            }
+        self.norm = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+        var h = embedTokens(inputs)
+
+        let mask = createAttentionMask(h: h, cache: cache?.first)
+
+        // The layer stack is applied numLoops times with shared weights; loop
+        // pass `p` owns cache slots `p * layers.count ..< (p + 1) * layers.count`.
+        for loopIndex in 0 ..< numLoops {
+            let cacheBase = loopIndex * layers.count
+            for (i, layer) in layers.enumerated() {
+                h = layer(h, mask: mask, cache: cache?[cacheBase + i])
+            }
+            if !skipLoopFinalNorm {
+                h = norm(h)
+            }
+        }
+
+        if skipLoopFinalNorm {
+            h = norm(h)
+        }
+        return h
+    }
+}
+
+public class NanbeigeModel: Module, LLMModel {
+    public let vocabularySize: Int
+
+    public let model: NanbeigeModelInner
+    let configuration: NanbeigeConfiguration
+
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
+
+    public init(_ args: NanbeigeConfiguration) {
+        self.configuration = args
+        self.vocabularySize = args.vocabularySize
+        self.model = NanbeigeModelInner(args)
+
+        if !args.tieWordEmbeddings {
+            _lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
+        }
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var out = model(inputs, cache: cache)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        let count = model.cacheSlotCount
+        if let maxKVSize = parameters?.maxKVSize {
+            return (0 ..< count).map { _ in
+                RotatingKVCache(maxSize: maxKVSize, keep: 4)
+            }
+        } else {
+            return (0 ..< count).map { _ in KVCacheSimple() }
+        }
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var weights = weights.filter { key, _ in
+            // Remove unused precomputed rotary freqs
+            !key.contains("self_attn.rotary_emb.inv_freq")
+        }
+
+        if configuration.tieWordEmbeddings {
+            weights["lm_head.weight"] = nil
+        }
+
+        return weights
+    }
+}
+
+public struct NanbeigeConfiguration: Codable, Sendable {
+    var hiddenSize: Int
+    var hiddenLayers: Int
+    var intermediateSize: Int
+    var attentionHeads: Int
+    var rmsNormEps: Float
+    var vocabularySize: Int
+    var kvHeads: Int
+    var headDim: Int?
+    var maxPositionEmbeddings: Int?
+    var ropeTheta: Float = 10_000
+    var ropeScaling: [String: StringOrNumber]? = nil
+    var attentionBias = false
+    var mlpBias = false
+    var tieWordEmbeddings = false
+    var numLoops: Int = 1
+    var loopLossWeights: [Float]? = nil
+    var skipLoopFinalNorm = false
+    // Features of the reference implementation without dedicated weights which
+    // would otherwise load silently and produce incorrect results:
+    var enableDoubleLoopSplit = false
+    var loopShareKV = false
+    var enableDepthAttention = false
+
+    var resolvedHeadDimensions: Int {
+        headDim ?? (hiddenSize / attentionHeads)
+    }
+
+    /// Checkpoints trained with per-loop losses store one weight per extra loop.
+    var effectiveNumLoops: Int {
+        if let loopLossWeights, !loopLossWeights.isEmpty {
+            return loopLossWeights.count + 1
+        }
+        return numLoops
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case hiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case attentionHeads = "num_attention_heads"
+        case rmsNormEps = "rms_norm_eps"
+        case vocabularySize = "vocab_size"
+        case kvHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case ropeTheta = "rope_theta"
+        case ropeScaling = "rope_scaling"
+        case attentionBias = "attention_bias"
+        case mlpBias = "mlp_bias"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case numLoops = "num_loops"
+        case loopLossWeights = "loop_loss_weights"
+        case skipLoopFinalNorm = "skip_loop_final_norm"
+        case enableDoubleLoopSplit = "enable_double_loop_split"
+        case loopShareKV = "loop_share_kv"
+        case enableDepthAttention = "enable_depth_attention"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        self.hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)
+        self.intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        self.attentionHeads = try container.decode(Int.self, forKey: .attentionHeads)
+        self.rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+        self.vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
+        self.kvHeads = try container.decode(Int.self, forKey: .kvHeads)
+        self.headDim = try container.decodeIfPresent(Int.self, forKey: .headDim)
+        self.maxPositionEmbeddings = try container.decodeIfPresent(
+            Int.self, forKey: .maxPositionEmbeddings)
+        self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10_000
+        self.ropeScaling = try container.decodeIfPresent(
+            [String: StringOrNumber].self, forKey: .ropeScaling)
+        self.attentionBias =
+            try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        self.mlpBias = try container.decodeIfPresent(Bool.self, forKey: .mlpBias) ?? false
+        self.tieWordEmbeddings =
+            try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+        self.numLoops = try container.decodeIfPresent(Int.self, forKey: .numLoops) ?? 1
+        self.loopLossWeights = try container.decodeIfPresent(
+            [Float].self, forKey: .loopLossWeights)
+        self.skipLoopFinalNorm =
+            try container.decodeIfPresent(Bool.self, forKey: .skipLoopFinalNorm) ?? false
+        self.enableDoubleLoopSplit =
+            try container.decodeIfPresent(Bool.self, forKey: .enableDoubleLoopSplit) ?? false
+        self.loopShareKV = try container.decodeIfPresent(Bool.self, forKey: .loopShareKV) ?? false
+        self.enableDepthAttention =
+            try container.decodeIfPresent(Bool.self, forKey: .enableDepthAttention) ?? false
+    }
+}
+
+extension NanbeigeConfiguration: ModelConfigurationValidating {
+    public func validateModelConfiguration() throws {
+        try validateRoPEConfiguration(ropeScaling, context: "NanbeigeConfiguration.rope_scaling")
+
+        if enableDoubleLoopSplit || loopShareKV || enableDepthAttention {
+            throw ModelFactoryError.invalidConfiguration(
+                "NanbeigeConfiguration: enable_double_loop_split, loop_share_kv, and "
+                    + "enable_depth_attention are not yet supported.")
+        }
+    }
+}
+
+// MARK: - LoRA
+
+extension NanbeigeModel: LoRAModel {
+    public var loraLayers: [Module] {
+        model.layers
+    }
+}

--- a/Libraries/MLXLMCommon/ReasoningConfig.swift
+++ b/Libraries/MLXLMCommon/ReasoningConfig.swift
@@ -147,6 +147,15 @@ public struct ReasoningConfig: Sendable, Equatable {
                 isSpecialToken: true)
         }
 
+        // Nanbeige4.2+: <think>/</think>, thinking toggled via `enable_thinking`
+        // (template default true), same contract as the Qwen3 family.
+        if type.hasPrefix("nanbeige") {
+            return ReasoningConfig(
+                startDelimiter: "<think>", endDelimiter: "</think>",
+                promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
+                isSpecialToken: true)
+        }
+
         // DeepSeek-R1 (and R1-Distill): always-on <think>/</think>.
         //
         // R1-Distill reports its *base* model_type ("qwen2"/"llama"), so it must

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -216,6 +216,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .xmlFunction
         }
 
+        // Nanbeige4.2+ — chat template supports XML and JSON; XML is the trained
+        // default and the model card's recommendation for agentic use
+        if type.hasPrefix("nanbeige") {
+            return .xmlFunction
+        }
+
         // Mistral3 family (mistral3, mistral3_text, etc.)
         if type.hasPrefix("mistral3") {
             return .mistral

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -1,0 +1,184 @@
+// Copyright © 2026 Apple Inc.
+//
+// Nanbeige (Looped Transformer) tests: the layer stack runs
+// `effective_num_loops` times with shared weights, and each loop pass owns
+// its own slice of the KV cache array. On a tiny random-weight model so they
+// run in CI without downloads.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MLXLLM
+
+final class NanbeigeTests: XCTestCase {
+
+    // MARK: - Tiny model
+
+    private func makeConfig(
+        loopLossWeights: String = "[]", extra: String = ""
+    ) throws -> NanbeigeConfiguration {
+        let json = """
+            {
+                "model_type": "nanbeige",
+                "hidden_size": 64,
+                "num_hidden_layers": 3,
+                "intermediate_size": 128,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 16,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 512,
+                "rope_theta": 70000000.0,
+                "max_position_embeddings": 4096,
+                "num_loops": 2,
+                "loop_loss_weights": \(loopLossWeights),
+                "skip_loop_final_norm": false\(extra)
+            }
+            """
+        return try JSONDecoder().decode(NanbeigeConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Deterministic pseudo-random tokens, 1-D — the shape the default
+    /// `LLMModel.prepare` chunked-prefill path expects.
+    private func textTokens(_ count: Int, seed: Int = 0) -> MLXArray {
+        var values: [Int32] = []
+        for i in 0 ..< count {
+            values.append(Int32((i * 13 + 7 + seed) % 512))
+        }
+        return MLXArray(values)
+    }
+
+    /// Prefill `tokens` into `cache` via `prepare` (the TokenIterator flow)
+    /// and return the next-token logits from evaluating the remainder.
+    private func prefillLogits(
+        _ model: NanbeigeModel, _ tokens: MLXArray, cache: [KVCache]
+    ) throws -> MLXArray {
+        let result = try model.prepare(
+            LMInput(text: .init(tokens: tokens)), cache: cache, state: nil, windowSize: 16)
+        switch result {
+        case .tokens(let remainder):
+            let out = model(remainder.tokens[.newAxis], cache: cache)
+            return out[0..., -1, 0...]
+        case .logits(let out):
+            return out.logits[0..., -1, 0...]
+        }
+    }
+
+    private func maxAbsDiff(_ a: MLXArray, _ b: MLXArray) -> Float {
+        abs(a - b).max().item(Float.self)
+    }
+
+    // MARK: - Configuration
+
+    func testConfigDecodeAndEffectiveLoops() throws {
+        let config = try makeConfig()
+        XCTAssertEqual(config.hiddenLayers, 3)
+        XCTAssertEqual(config.numLoops, 2)
+        // Empty loop_loss_weights (the released Nanbeige4.2-3B config) must
+        // fall through to num_loops, matching the Python truthiness check.
+        XCTAssertEqual(config.effectiveNumLoops, 2)
+    }
+
+    func testEffectiveLoopsDerivedFromLossWeights() throws {
+        let config = try makeConfig(loopLossWeights: "[0.5, 0.5]")
+        // One weight per extra loop: 2 weights -> 3 loops, overriding num_loops.
+        XCTAssertEqual(config.effectiveNumLoops, 3)
+    }
+
+    func testUnsupportedReferenceFeaturesThrow() throws {
+        let config = try makeConfig(extra: ",\n\"enable_depth_attention\": true")
+        XCTAssertThrowsError(try config.validateModelConfiguration())
+    }
+
+    func testSupportedConfigValidates() throws {
+        XCTAssertNoThrow(try makeConfig().validateModelConfiguration())
+    }
+
+    // MARK: - Cache layout
+
+    func testNewCacheAllocatesOneCachePerLoopLayerPair() throws {
+        let model = NanbeigeModel(try makeConfig())
+        XCTAssertEqual(model.newCache(parameters: nil).count, 6)
+    }
+
+    /// The released Nanbeige4.2-3B shape: 22 hidden layers, 2 loops → 44
+    /// caches (tiny dims so module init stays cheap).
+    func testReleasedCheckpointShapeAllocates44Caches() throws {
+        let json = """
+            {
+                "model_type": "nanbeige",
+                "hidden_size": 16,
+                "num_hidden_layers": 22,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 64,
+                "num_loops": 2,
+                "loop_loss_weights": [],
+                "skip_loop_final_norm": false
+            }
+            """
+        let config = try JSONDecoder().decode(NanbeigeConfiguration.self, from: Data(json.utf8))
+        XCTAssertEqual(NanbeigeModel(config).newCache(parameters: nil).count, 44)
+    }
+
+    // MARK: - Sanitize
+
+    func testSanitizeDropsRotaryFreqsAndTiedHead() throws {
+        let tied = try makeConfig(extra: ",\n\"tie_word_embeddings\": true")
+        let model = NanbeigeModel(tied)
+        let sanitized = model.sanitize(weights: [
+            "model.layers.0.self_attn.rotary_emb.inv_freq": MLXArray([Float(1)]),
+            "model.layers.0.self_attn.q_proj.weight": MLXArray([Float(1)]),
+            "lm_head.weight": MLXArray([Float(1)]),
+        ])
+        XCTAssertEqual(
+            Set(sanitized.keys), ["model.layers.0.self_attn.q_proj.weight"])
+    }
+
+    // MARK: - Looped forward
+
+    /// The loop must change the computation: a 2-loop forward differs from a
+    /// 1-loop forward of the same weights (guards against a port that ignores
+    /// `num_loops` and silently degenerates to a single pass).
+    func testSecondLoopChangesLogits() throws {
+        MLXRandom.seed(11)
+        let looped = NanbeigeModel(try makeConfig())
+        MLXRandom.seed(11)
+        var singleConfig = try makeConfig()
+        singleConfig.numLoops = 1
+        let single = NanbeigeModel(singleConfig)
+
+        let tokens = textTokens(9)[.newAxis]
+        let loopedOut = looped(tokens, cache: nil)[0..., -1, 0...]
+        let singleOut = single(tokens, cache: nil)[0..., -1, 0...]
+        XCTAssertGreaterThan(maxAbsDiff(loopedOut, singleOut), 1e-4)
+    }
+
+    /// Warm continuation (prefix in cache, remainder prefilled on top) must
+    /// match one cold prefill of the concatenation. This is the invariant
+    /// that breaks if the per-loop cache slices are mis-indexed — loop 2
+    /// reading loop 1's keys shows up here immediately.
+    func testWarmContinuationMatchesFullPrefill() throws {
+        MLXRandom.seed(7)
+        let model = NanbeigeModel(try makeConfig())
+        let t1 = textTokens(40)
+        let t2 = textTokens(8, seed: 3)
+        let full = concatenated([t1, t2], axis: 0)
+
+        let cacheF = model.newCache(parameters: nil)
+        let logitsF = try prefillLogits(model, full, cache: cacheF)
+
+        let cacheW = model.newCache(parameters: nil)
+        _ = try prefillLogits(model, t1, cache: cacheW)
+        let logitsW = try prefillLogits(model, t2, cache: cacheW)
+
+        XCTAssertLessThanOrEqual(
+            maxAbsDiff(logitsW, logitsF), 1e-3,
+            "warm continuation diverged from cold full prefill")
+    }
+}

--- a/Tests/MLXLMTests/ReasoningConfigTests.swift
+++ b/Tests/MLXLMTests/ReasoningConfigTests.swift
@@ -17,6 +17,14 @@ struct ReasoningConfigTests {
         #expect(config?.promptStrategy == .templateFlag(key: "enable_thinking", defaultOn: true))
     }
 
+    @Test func inferNanbeige() {
+        let config = ReasoningConfig.infer(
+            from: "nanbeige", modelId: "Nanbeige/Nanbeige4.2-3B")
+        #expect(config?.startDelimiter == "<think>")
+        #expect(config?.endDelimiter == "</think>")
+        #expect(config?.promptStrategy == .templateFlag(key: "enable_thinking", defaultOn: true))
+    }
+
     @Test func inferDeepSeekV3IsAlwaysOn() {
         let config = ReasoningConfig.infer(
             from: "deepseek_v3", modelId: "mlx-community/DeepSeek-R1-4bit")

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -1030,6 +1030,10 @@ struct ToolTests {
         #expect(ToolCallFormat.infer(from: "qwen3_next_moe") == .xmlFunction)
         #expect(ToolCallFormat.infer(from: "QWEN3_NEXT") == .xmlFunction)
 
+        // Nanbeige models (prefix matching)
+        #expect(ToolCallFormat.infer(from: "nanbeige") == .xmlFunction)
+        #expect(ToolCallFormat.infer(from: "NANBEIGE") == .xmlFunction)
+
         // Mistral3 models (prefix matching)
         #expect(ToolCallFormat.infer(from: "mistral3") == .mistral)
         #expect(ToolCallFormat.infer(from: "Mistral3") == .mistral)


### PR DESCRIPTION
Adds support for Nanbeige's Nanbeige4.2 models (`model_type: "nanbeige"`), e.g. [Nanbeige4.2-3B](https://huggingface.co/Nanbeige/Nanbeige4.2-3B).

The architecture is a looped transformer: the decoder stack of `num_hidden_layers` shared-weight layers runs `num_loops` times per forward. Each loop pass owns its own slice of the KV cache array, so `newCache` returns `num_loops * num_hidden_layers` caches and the forward indexes `cache[loopIndex * layers.count + i]`. The final RMSNorm is re-applied after each loop unless `skip_loop_final_norm` is set. Everything else is a standard Llama-style dense decoder (SwiGLU MLP, RoPE with the checkpoint's theta, no QK-norm).

This is a port of the Python mlx-lm implementation (MercuriusDream/mlx-lm `add-nanbeige-model`, not yet merged there either), checked against the official `modeling_nanbeige.py` on the HF repo. Config features the released checkpoints don't enable and that would need dedicated weights (`enable_double_loop_split`, `loop_share_kv`, `enable_depth_attention`, hyper-connections) are rejected at config validation rather than silently mis-running.

Also registers the model's chat conventions: XML function tool calls (the template's trained default) and Qwen3-style `<think>` reasoning with the `enable_thinking` template flag.

Verification:
- Greedy continuations match the Python implementation token-for-token on the same 8-bit weights ([MercuriusDream/Nanbeige4.2-3B-mlx-8bit](https://huggingface.co/MercuriusDream/Nanbeige4.2-3B-mlx-8bit)), long shared prefixes with single-token divergence/re-convergence at quantization noise level.
- 9 unit tests (no weights needed): config parsing/validation, cache slot layout, loop norm placement, warm continuation vs full prefill on a tiny random-weight model.
- `swift-format` clean, full package builds on current `main`.