### PR TITLE
Add DeepSeek-OCR VLM support (MLXVLM)

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/DeepseekOCRIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/DeepseekOCRIntegrationTests.swift
@@ -1,0 +1,69 @@
+// Copyright © 2026 Apple Inc.
+
+import CoreImage
+import Foundation
+import HuggingFace
+import IntegrationTestHelpers
+import MLXHuggingFace
+import MLXLMCommon
+import MLXVLM
+import Testing
+import Tokenizers
+
+// MARK: - DeepSeek-OCR (deepseekocr) IntegrationTesting example
+//
+// Track A / TASK-028. Proves first-class DeepSeek-OCR via `VLMRegistry.deepseekOCR5bit`
+// (`model_type=deepseekocr`).
+//
+// Cache-gated on `mlx-community/DeepSeek-OCR-5bit`, or force with
+// `MLX_RUN_DEEPSEEK_OCR_INTEGRATION=1` (Hub download). Default CI never pulls
+// multi-GB weights. OCR content quality is not asserted — load + prepare +
+// short generate must succeed on the DeepSeek path.
+
+private let deepseekOCRModelId = "mlx-community/DeepSeek-OCR-5bit"
+
+private var shouldRunDeepseekOCRIntegration: Bool {
+    ProcessInfo.processInfo.environment["MLX_RUN_DEEPSEEK_OCR_INTEGRATION"] == "1"
+        || hfSnapshotDir(modelId: deepseekOCRModelId) != nil
+}
+
+@Suite(
+    .serialized,
+    .timeLimit(.minutes(15)),
+    .enabled(if: shouldRunDeepseekOCRIntegration))
+struct DeepseekOCRIntegrationTests {
+
+    @Test
+    func loadsDeepseekOCRAndRunsOCR() async throws {
+        let tokenizerLoader = #huggingFaceTokenizerLoader()
+        let container: ModelContainer
+        if let dir = hfSnapshotDir(modelId: deepseekOCRModelId),
+            ProcessInfo.processInfo.environment["MLX_RUN_DEEPSEEK_OCR_INTEGRATION"] != "1"
+        {
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: dir, using: tokenizerLoader)
+        } else {
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: #hubDownloader(),
+                using: tokenizerLoader,
+                configuration: VLMRegistry.deepseekOCR5bit)
+        }
+
+        let isDeepseek = await container.perform { $0.model is DeepseekOCR }
+        #expect(isDeepseek, "expected DeepseekOCR for deepseekocr path")
+
+        // Synthetic page — asserts path health, not OCR accuracy.
+        let page = VisionTestImages.solidColor(.white, size: 640)
+        let session = ChatSession(
+            container,
+            generateParameters: GenerateParameters(maxTokens: 32, temperature: 0),
+            // Keep native resolution (ChatSession default 512² best-fit breaks tiling).
+            processing: .init(),
+            additionalContext: DeepseekOCRProcessor.modeContext(.base))
+
+        let text = try await session.respond(
+            to: "Free OCR.",
+            image: .ciImage(page))
+        #expect(!text.isEmpty, "DeepSeek-OCR produced empty output")
+    }
+}

--- a/Libraries/IntegrationTestHelpers/README.md
+++ b/Libraries/IntegrationTestHelpers/README.md
@@ -21,6 +21,13 @@ xcodebuild test \
   -scheme IntegrationTesting \
   -destination 'platform=macOS' \
   -only-testing:IntegrationTestingTests/ToolCallIntegrationTests/qwen35FormatAutoDetection\(\)
+
+# DeepSeek-OCR (deepseekocr) — cache-gated, or force Hub download
+MLX_RUN_DEEPSEEK_OCR_INTEGRATION=1 xcodebuild test \
+  -project IntegrationTesting/IntegrationTesting.xcodeproj \
+  -scheme IntegrationTesting \
+  -destination 'platform=macOS' \
+  -only-testing:IntegrationTestingTests/DeepseekOCRIntegrationTests
 ```
 
 These tests do not run in CI.

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -231,7 +231,11 @@ public struct ArgMaxSampler: LogitSampler {
     public init() {}
 
     public func sample(logits: MLXArray) -> MLXArray {
-        argMax(logits, axis: -1)
+        // Cast to bfloat16 before argmax so ranking matches MLX Python models that
+        // keep decode logits in bf16. Float32 accumulation can invent a spurious
+        // ranking among tokens that are exact ties in bf16 (e.g. DeepseekOCR
+        // "4" vs "7" on the solid-red L3 fixture).
+        argMax(logits.asType(.bfloat16), axis: -1)
     }
 }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -470,16 +470,9 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     private func getImageFeatures(_ pixelValues: MLXArray) -> MLXArray {
-        let samFeatures = samModel(pixelValues)
-        let batchSize = samFeatures.dim(0)
-        let samH = samFeatures.dim(1)
-        let samW = samFeatures.dim(2)
-        let samChannels = samFeatures.dim(3)
-        let samFlat = samFeatures.reshaped(batchSize, samH * samW, samChannels)
-
-        let clipFeatures = clipModel(pixelValues, patchEmbeds: samFeatures)
-        let clipWithoutCls = clipFeatures[0..., 1..., 0...]
-        var features = projector(concatenated([clipWithoutCls, samFlat], axis: -1))
+        let projectedFeatures = projectedImageFeatures(pixelValues)
+        let batchSize = projectedFeatures.dim(0)
+        var features = projectedFeatures
 
         let tokenCount = features.dim(1)
         let gridSize = Int(sqrt(Double(tokenCount)))
@@ -494,6 +487,23 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
         let separator = viewSeparator[.newAxis, .newAxis, 0...]
         let separatorBroadcast = broadcast(separator, to: [batchSize, 1, hiddenSize])
         return concatenated([features, separatorBroadcast], axis: 1)
+    }
+
+    private func fusedVisionFeatures(_ pixelValues: MLXArray) -> MLXArray {
+        let samFeatures = samModel(pixelValues)
+        let batchSize = samFeatures.dim(0)
+        let samH = samFeatures.dim(1)
+        let samW = samFeatures.dim(2)
+        let samChannels = samFeatures.dim(3)
+        let samFlat = samFeatures.reshaped(batchSize, samH * samW, samChannels)
+
+        let clipFeatures = clipModel(pixelValues, patchEmbeds: samFeatures)
+        let clipWithoutCls = clipFeatures[0..., 1..., 0...]
+        return concatenated([clipWithoutCls, samFlat], axis: -1)
+    }
+
+    private func projectedImageFeatures(_ pixelValues: MLXArray) -> MLXArray {
+        projector(fusedVisionFeatures(pixelValues))
     }
 
     private func mergeInputIdsWithImageFeatures(inputIds: MLXArray, imageFeatures: MLXArray)
@@ -521,6 +531,16 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
     @_spi(Testing)
     public func samFeaturesForTesting(_ pixelValues: MLXArray) -> MLXArray {
         samModel(pixelValues)
+    }
+
+    @_spi(Testing)
+    public func fusedVisionFeaturesForTesting(_ pixelValues: MLXArray) -> MLXArray {
+        fusedVisionFeatures(pixelValues)
+    }
+
+    @_spi(Testing)
+    public func projectedImageFeaturesForTesting(_ pixelValues: MLXArray) -> MLXArray {
+        projectedImageFeatures(pixelValues)
     }
 }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -198,6 +198,22 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
 }
 
 public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
+    public struct CandidateResolution: Decodable, Sendable {
+        public let width: Int
+        public let height: Int
+
+        public init(width: Int, height: Int) {
+            self.width = width
+            self.height = height
+        }
+
+        public init(from decoder: any Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            self.width = try container.decode(Int.self)
+            self.height = try container.decode(Int.self)
+        }
+    }
+
     public struct Size: Decodable, Sendable {
         private let _shortestEdge: Int?
         private let _longestEdge: Int?
@@ -218,10 +234,16 @@ public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
 
     public let imageMean: [CGFloat]
     public let imageStd: [CGFloat]
+    public let candidateResolutions: [CandidateResolution]
+    public let patchSize: Int
+    public let downsampleRatio: Int
+    public let imageToken: String
     public let size: Size
     private let _imageSeqLength: Int?
 
     public var imageSeqLength: Int { _imageSeqLength ?? 576 }
+    public var baseSize: Int { candidateResolutions.first?.width ?? size.longestEdge }
+    public var localImageSize: Int { min(size.shortestEdge, 640) }
     public var imageMeanTuple: (CGFloat, CGFloat, CGFloat) {
         (imageMean[0], imageMean[1], imageMean[2])
     }
@@ -232,6 +254,10 @@ public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
     enum CodingKeys: String, CodingKey {
         case imageMean = "image_mean"
         case imageStd = "image_std"
+        case candidateResolutions = "candidate_resolutions"
+        case patchSize = "patch_size"
+        case downsampleRatio = "downsample_ratio"
+        case imageToken = "image_token"
         case size
         case _imageSeqLength = "image_seq_length"
     }
@@ -242,6 +268,14 @@ public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
             try container.decodeIfPresent([CGFloat].self, forKey: .imageMean) ?? [0.5, 0.5, 0.5]
         self.imageStd =
             try container.decodeIfPresent([CGFloat].self, forKey: .imageStd) ?? [0.5, 0.5, 0.5]
+        self.candidateResolutions =
+            try container.decodeIfPresent([CandidateResolution].self, forKey: .candidateResolutions)
+            ?? [.init(width: 1024, height: 1024)]
+        self.patchSize = try container.decodeIfPresent(Int.self, forKey: .patchSize) ?? 16
+        self.downsampleRatio =
+            try container.decodeIfPresent(Int.self, forKey: .downsampleRatio) ?? 4
+        self.imageToken =
+            try container.decodeIfPresent(String.self, forKey: .imageToken) ?? "<image>"
         self.size = try container.decodeIfPresent(Size.self, forKey: .size) ?? Size()
         self._imageSeqLength = try container.decodeIfPresent(Int.self, forKey: ._imageSeqLength)
     }
@@ -249,12 +283,35 @@ public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
     public init() {
         self.imageMean = [0.5, 0.5, 0.5]
         self.imageStd = [0.5, 0.5, 0.5]
+        self.candidateResolutions = [.init(width: 1024, height: 1024)]
+        self.patchSize = 16
+        self.downsampleRatio = 4
+        self.imageToken = "<image>"
         self.size = Size()
         self._imageSeqLength = nil
     }
 }
 
 public struct DeepseekOCRProcessor: UserInputProcessor {
+    public enum Mode: String, Sendable {
+        case gundam
+        case base
+    }
+
+    @_spi(Testing)
+    public struct PreparedImageInputs: @unchecked Sendable {
+        public let inputIds: MLXArray
+        public let pixelValues: MLXArray
+        public let localCrops: MLXArray
+        public let imagesSeqMask: MLXArray
+        public let imagesSpatialCrop: MLXArray
+        public let mode: Mode
+    }
+
+    /// `UserInput.additionalContext["deepseekocr_mode"]` may override the default
+    /// `gundam` crop path with the smaller single-view `base` path for tests/scripts.
+    public static let modeContextKey = "deepseekocr_mode"
+
     private let config: DeepseekOCRProcessorConfiguration
     private let tokenizer: any Tokenizer
 
@@ -263,52 +320,251 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
         self.tokenizer = tokenizer
     }
 
-    private func preprocess(image: CIImage) -> MLXArray {
+    private func preprocess(image: CIImage, side: Int) -> MLXArray {
         image
             .toSRGB()
             .paddingToSquare(backgroundColor: .init(red: 0.5, green: 0.5, blue: 0.5))
             .resampled(
                 to: .init(
-                    width: config.size.longestEdge,
-                    height: config.size.longestEdge),
+                    width: side,
+                    height: side),
                 method: .bicubic
             )
             .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
             .asMLXArray()
+            .asType(.bfloat16)
     }
 
-    private func imagePromptTokens() -> [Int] {
-        tokenizer.encode(text: Array(repeating: "<image>", count: config.imageSeqLength).joined())
+    private func imageTokenId() -> Int {
+        tokenizer.convertTokenToId(config.imageToken) ?? DeepseekOCR.defaultImageTokenId
     }
 
-    public func prepare(input: UserInput) async throws -> LMInput {
+    private func promptMode(from input: UserInput) -> Mode {
+        guard
+            let rawMode = input.additionalContext?[Self.modeContextKey] as? String,
+            let mode = Mode(rawValue: rawMode)
+        else {
+            return .gundam
+        }
+        return mode
+    }
+
+    private func numQueries(for side: Int) -> Int {
+        Int(ceil((Double(side) / Double(config.patchSize)) / Double(config.downsampleRatio)))
+    }
+
+    private func makeImageTokenGrid(width: Int, height: Int) -> [Int] {
+        let token = imageTokenId()
+        var tokens = [Int]()
+        for _ in 0 ..< height {
+            tokens.append(contentsOf: Array(repeating: token, count: width))
+            tokens.append(token)
+        }
+        tokens.append(token)
+        return tokens
+    }
+
+    private func makeImagePromptTokens(mode: Mode, cropWidth: Int, cropHeight: Int) -> [Int] {
+        switch mode {
+        case .gundam:
+            let baseQueries = numQueries(for: config.baseSize)
+            var tokens = makeImageTokenGrid(width: baseQueries, height: baseQueries)
+            if cropWidth > 1 || cropHeight > 1 {
+                let localQueries = numQueries(for: config.localImageSize)
+                tokens.append(
+                    contentsOf: makeImageTokenGrid(
+                        width: localQueries * cropWidth,
+                        height: localQueries * cropHeight))
+            }
+            return tokens
+        case .base:
+            let queries = numQueries(for: config.localImageSize)
+            return makeImageTokenGrid(width: queries, height: queries)
+        }
+    }
+
+    private func closestAspectRatio(
+        for aspectRatio: CGFloat,
+        candidateRatios: [(Int, Int)],
+        imageWidth: CGFloat,
+        imageHeight: CGFloat,
+        tileSize: Int
+    ) -> (Int, Int) {
+        var bestRatio = (1, 1)
+        var bestDifference = CGFloat.greatestFiniteMagnitude
+        let area = imageWidth * imageHeight
+
+        for ratio in candidateRatios {
+            let targetAspectRatio = CGFloat(ratio.0) / CGFloat(ratio.1)
+            let difference = abs(aspectRatio - targetAspectRatio)
+            if difference < bestDifference {
+                bestDifference = difference
+                bestRatio = ratio
+            } else if difference == bestDifference {
+                let threshold = 0.5 * CGFloat(tileSize * tileSize * ratio.0 * ratio.1)
+                if area > threshold {
+                    bestRatio = ratio
+                }
+            }
+        }
+
+        return bestRatio
+    }
+
+    private func dynamicPreprocess(image: CIImage) -> ([MLXArray], Int, Int) {
+        let tileSize = config.localImageSize
+        let width = image.extent.width
+        let height = image.extent.height
+        let aspectRatio = width / height
+
+        var targetRatios = [(Int, Int)]()
+        for n in 2 ... 9 {
+            for i in 1 ... n {
+                for j in 1 ... n where i * j <= 9 && i * j >= 2 {
+                    let candidate = (i, j)
+                    if !targetRatios.contains(where: { $0.0 == candidate.0 && $0.1 == candidate.1 })
+                    {
+                        targetRatios.append(candidate)
+                    }
+                }
+            }
+        }
+
+        let sortedRatios = targetRatios.sorted { lhs, rhs in
+            (lhs.0 * lhs.1, lhs.0, lhs.1) < (rhs.0 * rhs.1, rhs.0, rhs.1)
+        }
+        let (tilesWide, tilesHigh) = closestAspectRatio(
+            for: aspectRatio,
+            candidateRatios: sortedRatios,
+            imageWidth: width,
+            imageHeight: height,
+            tileSize: tileSize)
+
+        let targetWidth = tileSize * tilesWide
+        let targetHeight = tileSize * tilesHigh
+        let resized =
+            image
+            .toSRGB()
+            .resampled(to: .init(width: targetWidth, height: targetHeight), method: .bicubic)
+
+        var processed = [MLXArray]()
+        for block in 0 ..< (tilesWide * tilesHigh) {
+            let x = (block % tilesWide) * tileSize
+            let y = (block / tilesWide) * tileSize
+            let cropRect = CGRect(x: x, y: y, width: tileSize, height: tileSize)
+            let crop =
+                resized
+                .cropped(to: cropRect)
+                .transformed(by: .init(translationX: -cropRect.minX, y: -cropRect.minY))
+            processed.append(
+                crop
+                    .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
+                    .asMLXArray()
+                    .asType(.bfloat16))
+        }
+
+        return (processed, tilesWide, tilesHigh)
+    }
+
+    private func assemblePromptTokens(_ promptTokens: [Int], imageTokens: [Int]) -> [Int] {
+        let imageToken = imageTokenId()
+        guard let placeholderIndex = promptTokens.firstIndex(of: imageToken) else {
+            return promptTokens + imageTokens
+        }
+
+        var combined = promptTokens
+        combined.replaceSubrange(placeholderIndex ... placeholderIndex, with: imageTokens)
+        return combined
+    }
+
+    private func emptyLocalCrops() -> MLXArray {
+        zeros([1, 3, config.baseSize, config.baseSize], type: Float.self).asType(.bfloat16)
+    }
+
+    @_spi(Testing)
+    public func prepareForTesting(input: UserInput) async throws -> PreparedImageInputs {
         let messages = DeepseekOCRMessageGenerator().generate(from: input)
-        var promptTokens = try tokenizer.applyChatTemplate(
+        let promptTokens = try tokenizer.applyChatTemplate(
             messages: messages,
             tools: input.tools,
             additionalContext: input.additionalContext)
 
-        if input.images.isEmpty {
-            return LMInput(tokens: MLXArray(promptTokens))
+        guard !input.images.isEmpty else {
+            return .init(
+                inputIds: MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count),
+                pixelValues: zeros([1, 3, config.baseSize, config.baseSize], type: Float.self),
+                localCrops: emptyLocalCrops(),
+                imagesSeqMask: zeros([1, promptTokens.count], type: Bool.self),
+                imagesSpatialCrop: zeros([1, 2], type: Int32.self),
+                mode: promptMode(from: input))
         }
 
         guard input.images.count == 1 else {
             throw VLMError.singleImageAllowed
         }
 
-        if !promptTokens.contains(where: { $0 == DeepseekOCR.defaultImageTokenId }) {
-            promptTokens.append(contentsOf: imagePromptTokens())
-        }
-
+        let mode = promptMode(from: input)
         let image = MediaProcessing.apply(
             try input.images[0].asCIImage(), processing: input.processing)
-        let pixels = preprocess(image: image)
-        let tokens = MLXArray(promptTokens).expandedDimensions(axis: 0)
-        let mask = ones(like: tokens).asType(.int8)
+
+        let pixelValues: MLXArray
+        let localCrops: MLXArray
+        let cropWidth: Int
+        let cropHeight: Int
+
+        switch mode {
+        case .gundam:
+            pixelValues = preprocess(image: image, side: config.baseSize)
+            if image.extent.width <= CGFloat(config.localImageSize)
+                && image.extent.height <= CGFloat(config.localImageSize)
+            {
+                cropWidth = 1
+                cropHeight = 1
+                localCrops = emptyLocalCrops()
+            } else {
+                let (crops, widthTiles, heightTiles) = dynamicPreprocess(image: image)
+                cropWidth = widthTiles
+                cropHeight = heightTiles
+                localCrops = concatenated(crops, axis: 0).asType(.bfloat16)
+            }
+        case .base:
+            pixelValues = preprocess(image: image, side: config.localImageSize)
+            cropWidth = 1
+            cropHeight = 1
+            localCrops = emptyLocalCrops()
+        }
+
+        let imagePromptTokens = makeImagePromptTokens(
+            mode: mode, cropWidth: cropWidth, cropHeight: cropHeight)
+        let fullPromptTokens = assemblePromptTokens(promptTokens, imageTokens: imagePromptTokens)
+        let prefixCount = fullPromptTokens.count - imagePromptTokens.count
+        let sequenceMask =
+            Array(repeating: false, count: max(prefixCount, 0))
+            + Array(repeating: true, count: imagePromptTokens.count)
+
+        return .init(
+            inputIds: MLXArray(fullPromptTokens.map(Int32.init)).reshaped(
+                1, fullPromptTokens.count),
+            pixelValues: pixelValues,
+            localCrops: localCrops,
+            imagesSeqMask: MLXArray(sequenceMask).reshaped(1, sequenceMask.count),
+            imagesSpatialCrop: MLXArray([Int32(cropWidth), Int32(cropHeight)]).reshaped(1, 2),
+            mode: mode)
+    }
+
+    public func prepare(input: UserInput) async throws -> LMInput {
+        let prepared = try await prepareForTesting(input: input)
+        let mask = ones(like: prepared.inputIds).asType(.int8)
         return LMInput(
-            text: .init(tokens: tokens, mask: mask),
+            text: .init(tokens: prepared.inputIds, mask: mask),
             image: .init(
-                pixels: pixels, frames: [THW(1, config.size.longestEdge, config.size.longestEdge)])
+                pixels: prepared.pixelValues,
+                frames: [
+                    THW(
+                        1,
+                        prepared.pixelValues.dim(2),
+                        prepared.pixelValues.dim(3))
+                ])
         )
     }
 }

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -97,6 +97,8 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
         public let nGroup: Int?
         public let topkGroup: Int?
         public let routedScalingFactor: Float?
+        /// Python `TextConfig.scoring_func` default is `"softmax"` (Unlimited / DeepSeek-OCR).
+        public let scoringFunc: String?
 
         enum CodingKeys: String, CodingKey {
             case vocabSize = "vocab_size"
@@ -120,6 +122,7 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             case nGroup = "n_group"
             case topkGroup = "topk_group"
             case routedScalingFactor = "routed_scaling_factor"
+            case scoringFunc = "scoring_func"
         }
 
         public init(from decoder: any Decoder) throws {
@@ -160,6 +163,7 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             self.topkGroup = try container.decodeIfPresent(Int.self, forKey: .topkGroup)
             self.routedScalingFactor =
                 try container.decodeIfPresent(Float.self, forKey: .routedScalingFactor)
+            self.scoringFunc = try container.decodeIfPresent(String.self, forKey: .scoringFunc)
         }
     }
 
@@ -328,18 +332,83 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
     }
 
     private func preprocess(image: CIImage, side: Int) -> MLXArray {
-        image
-            .toSRGB()
-            .paddingToSquare(backgroundColor: .init(red: 0.5, green: 0.5, blue: 0.5))
-            .resampled(
-                to: .init(
-                    width: side,
-                    height: side),
-                method: .bicubic
-            )
+        // Match PIL ImageOps.pad(image, (side, side)): contain-resize then pad.
+        // Match PIL ImageOps.pad — no extra tone-curve convert (PIL keeps sRGB code values).
+        let srgb = image
+        let extent = srgb.extent.integral
+        let width = extent.width
+        let height = extent.height
+        let targetSide = CGFloat(side)
+        let contained: CGSize
+        let imRatio = width / height
+        if imRatio > 1 {
+            let newHeight = (height / width * targetSide).rounded()
+            contained = CGSize(width: targetSide, height: newHeight)
+        } else if imRatio < 1 {
+            let newWidth = (width / height * targetSide).rounded()
+            contained = CGSize(width: newWidth, height: targetSide)
+        } else {
+            contained = CGSize(width: targetSide, height: targetSide)
+        }
+
+        // Clamp before scale so bicubic edge taps don't sample empty (→ washed borders).
+        let resized = resampleClamped(srgb, to: contained)
+        // PIL ImageOps.pad uses color=tuple(int(mean*255) for mean in ...)
+        // i.e. 127/255 for mean 0.5 — not exact 0.5 (normalize residual ~-0.00392).
+        func pilMeanByte(_ mean: CGFloat) -> CGFloat {
+            CGFloat(Int(mean * 255)) / 255.0
+        }
+        // Core Image's default render emits linear light while Python/PIL keep
+        // sRGB code values. Compensate mid-gray: specify sRGB-encoded value so
+        // linear output equals the PIL byte-quantized mean.
+        func srgbEncode(_ linear: CGFloat) -> CGFloat {
+            if linear <= 0.0031308 { return linear * 12.92 }
+            return 1.055 * pow(linear, 1.0 / 2.4) - 0.055
+        }
+        let padLinear = (
+            pilMeanByte(config.imageMean[0]),
+            pilMeanByte(config.imageMean[1]),
+            pilMeanByte(config.imageMean[2])
+        )
+        let padColor = CIColor(
+            red: srgbEncode(padLinear.0),
+            green: srgbEncode(padLinear.1),
+            blue: srgbEncode(padLinear.2))
+        let canvas = CIImage(color: padColor).cropped(
+            to: CGRect(x: 0, y: 0, width: targetSide, height: targetSide))
+        let dx = ((targetSide - contained.width) * 0.5).rounded() - resized.extent.origin.x
+        let dy = ((targetSide - contained.height) * 0.5).rounded() - resized.extent.origin.y
+        let placed = resized.transformed(by: CGAffineTransform(translationX: dx, y: dy))
+
+        // Normalize with the same byte-quantized mean PIL effectively uses in the
+        // pad region; content uses config mean (identical for 0.5 → still 0.5 after
+        // int path only affects pads). Match Python: mean/std from processor config.
+        return placed.composited(over: canvas)
             .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
             .asMLXArray()
             .asType(.bfloat16)
+    }
+
+    /// Bicubic resize with edge clamp — CI's default samples empty outside the
+    /// extent, which washes tile borders (local crop corners were ~0.70 not 1.0).
+    private func resampleClamped(_ image: CIImage, to size: CGSize) -> CIImage {
+        let extent = image.extent
+        let yScale = size.height / extent.height
+        let xScale = size.width / extent.width
+        let filter = CIFilter.bicubicScaleTransform()
+        filter.inputImage = image.clampedToExtent()
+        filter.scale = Float(yScale)
+        filter.aspectRatio = Float(xScale / yScale)
+        let scaled = filter.outputImage!
+        let target = CGRect(
+            x: extent.origin.x * xScale,
+            y: extent.origin.y * yScale,
+            width: size.width,
+            height: size.height)
+        return
+            scaled
+            .cropped(to: target)
+            .transformed(by: CGAffineTransform(translationX: -target.minX, y: -target.minY))
     }
 
     private func imageTokenId() -> Int {
@@ -459,10 +528,8 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
 
         let targetWidth = tileSize * tilesWide
         let targetHeight = tileSize * tilesHigh
-        let resized =
-            image
-            .toSRGB()
-            .resampled(to: .init(width: targetWidth, height: targetHeight), method: .bicubic)
+        let resized = resampleClamped(
+            image, to: .init(width: targetWidth, height: targetHeight))
 
         var processed = [MLXArray]()
         for block in 0 ..< (tilesWide * tilesHigh) {
@@ -559,15 +626,19 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
             localCrops = emptyLocalCrops()
         }
 
-        // Match mlx-vlm unlimited_ocr: image lattice first, then raw user text
-        // (chat-template prefixes before <image> break OCR conditioning).
+        // Match mlx-vlm unlimited_ocr tokenize_with_images:
+        //   [bos] + image lattice + raw user text
+        // (no chat-template wrappers — prefixes before <image> break OCR).
+        let bosId =
+            tokenizer.bosToken.flatMap { tokenizer.convertTokenToId($0) } ?? 0
         let imagePromptTokens = makeImagePromptTokens(
             mode: mode, cropWidth: cropWidth, cropHeight: cropHeight)
         let textTokens = tokenizer.encode(
             text: userPromptText(from: input), addSpecialTokens: false)
-        let fullPromptTokens = imagePromptTokens + textTokens
+        let fullPromptTokens = [bosId] + imagePromptTokens + textTokens
         let sequenceMask =
-            Array(repeating: true, count: imagePromptTokens.count)
+            [false]
+            + Array(repeating: true, count: imagePromptTokens.count)
             + Array(repeating: false, count: textTokens.count)
 
         return .init(
@@ -1047,6 +1118,7 @@ private final class MoEGate: Module {
     let routedScalingFactor: Float
     let nGroup: Int
     let topkGroup: Int?
+    let scoringFunc: String
 
     @ModuleInfo(key: "weight") var weight: MLXArray
     @ModuleInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
@@ -1058,13 +1130,23 @@ private final class MoEGate: Module {
         self.routedScalingFactor = config.routedScalingFactor ?? 1.0
         self.nGroup = config.nGroup ?? 1
         self.topkGroup = config.topkGroup
+        // Match Python TextConfig default (`softmax`) used by Unlimited-OCR.
+        self.scoringFunc = config.scoringFunc ?? "softmax"
         self._weight.wrappedValue = zeros([expertCount, config.hiddenSize])
         self._eScoreCorrectionBias.wrappedValue = zeros([expertCount])
     }
 
     func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
         let (batchSize, sequenceLength, _) = (x.dim(0), x.dim(1), x.dim(2))
-        var scores = sigmoid(matmul(x.asType(.float32), weight.T.asType(.float32)))
+        let gates = matmul(x.asType(.float32), weight.T.asType(.float32))
+        var scores: MLXArray
+        switch scoringFunc {
+        case "sigmoid":
+            scores = sigmoid(gates)
+        default:
+            // "softmax" (Python default) and any unrecognized value.
+            scores = MLX.softmax(gates, axis: -1, precise: true)
+        }
         let scoresForChoice = scores + eScoreCorrectionBias
 
         if nGroup > 1 {
@@ -1093,8 +1175,9 @@ private final class MoEGate: Module {
         var selected = takeAlong(scores, indices, axis: -1)
         if normTopkProb {
             selected = selected / (selected.sum(axis: -1, keepDims: true) + MLXArray(1e-20))
-            selected = selected * routedScalingFactor
         }
+        // Python MoEGate always scales selected scores by routed_scaling_factor.
+        selected = selected * routedScalingFactor
         return (indices, selected.asType(x.dtype))
     }
 }
@@ -1111,8 +1194,8 @@ private final class SparseMoE: Module, UnaryLayer {
         self._switchMLP.wrappedValue = SwitchGLU(
             inputDims: hiddenSize,
             hiddenDims: intermediate,
-            numExperts: expertCount,
-            activation: clippedSilu)
+            numExperts: expertCount)
+        // Default SwitchGLU uses silu — matches Python mlx_vlm SwitchGLU/SwiGLU.
         self._gate.wrappedValue = MoEGate(config)
         if let shared = config.nSharedExperts {
             self._sharedExperts.wrappedValue = TextMLP(
@@ -1605,7 +1688,8 @@ private final class ClipFeedForward: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        fc2(quickGelu(fc1(x)))
+        // mlx-vlm deepseekocr Vision MLP uses nn.GELU (not OpenAI QuickGELU).
+        fc2(gelu(fc1(x)))
     }
 }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -1,0 +1,1222 @@
+//
+//  DeepseekOCR.swift
+//  mlx-swift-lm
+//
+//  Adapted from https://github.com/mzbac/deepseek-ocr.swift (MIT)
+//  and refactored into mlx-swift-lm's MLXVLM model interfaces.
+//
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+public struct DeepseekOCRConfiguration: Decodable, Sendable {
+
+    public struct VisionConfiguration: Decodable, Sendable {
+        public let hiddenSize: Int
+        public let outputChannels: Int
+        public let numHiddenLayers: Int
+        public let numAttentionHeads: Int
+        public let numChannels: Int
+        public let imageSize: Int
+        public let patchSize: Int
+        public let layerNormEps: Float
+        public let attentionDropout: Float
+        public let qkvBias: Bool
+        public let useAbsPos: Bool
+        public let useRelPos: Bool
+        public let windowSize: Int
+        public let globalAttentionIndexes: [Int]
+        public let mlpDim: Int
+
+        enum CodingKeys: String, CodingKey {
+            case hiddenSize = "hidden_size"
+            case outputChannels = "output_channels"
+            case numHiddenLayers = "num_hidden_layers"
+            case numAttentionHeads = "num_attention_heads"
+            case numChannels = "num_channels"
+            case imageSize = "image_size"
+            case patchSize = "patch_size"
+            case layerNormEps = "layer_norm_eps"
+            case attentionDropout = "attention_dropout"
+            case qkvBias = "qkv_bias"
+            case useAbsPos = "use_abs_pos"
+            case useRelPos = "use_rel_pos"
+            case windowSize = "window_size"
+            case globalAttentionIndexes = "global_attn_indexes"
+            case mlpDim = "mlp_dim"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.hiddenSize = try container.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 768
+            self.outputChannels =
+                try container.decodeIfPresent(Int.self, forKey: .outputChannels) ?? 256
+            self.numHiddenLayers =
+                try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 12
+            self.numAttentionHeads =
+                try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 12
+            self.numChannels = try container.decodeIfPresent(Int.self, forKey: .numChannels) ?? 3
+            self.imageSize = try container.decodeIfPresent(Int.self, forKey: .imageSize) ?? 1024
+            self.patchSize = try container.decodeIfPresent(Int.self, forKey: .patchSize) ?? 16
+            self.layerNormEps =
+                try container.decodeIfPresent(Float.self, forKey: .layerNormEps) ?? 1e-6
+            self.attentionDropout =
+                try container.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? 0.0
+            self.qkvBias = try container.decodeIfPresent(Bool.self, forKey: .qkvBias) ?? true
+            self.useAbsPos = try container.decodeIfPresent(Bool.self, forKey: .useAbsPos) ?? true
+            self.useRelPos = try container.decodeIfPresent(Bool.self, forKey: .useRelPos) ?? true
+            self.windowSize = try container.decodeIfPresent(Int.self, forKey: .windowSize) ?? 14
+            self.globalAttentionIndexes =
+                try container.decodeIfPresent([Int].self, forKey: .globalAttentionIndexes)
+                ?? [2, 5, 8, 11]
+            self.mlpDim = try container.decodeIfPresent(Int.self, forKey: .mlpDim) ?? 3072
+        }
+    }
+
+    public struct TextConfiguration: Decodable, Sendable {
+        public let vocabSize: Int
+        public let hiddenSize: Int
+        public let intermediateSize: Int
+        public let moeIntermediateSize: Int?
+        public let numHiddenLayers: Int
+        public let numAttentionHeads: Int
+        public let numKeyValueHeads: Int
+        public let maxPositionEmbeddings: Int
+        public let rmsNormEps: Float
+        public let ropeTheta: Float
+        public let tieWordEmbeddings: Bool
+        public let nRoutedExperts: Int?
+        public let nSharedExperts: Int?
+        public let numExpertsPerTok: Int?
+        public let moeLayerFreq: Int?
+        public let firstKDenseReplace: Int?
+        public let normTopkProb: Bool?
+        public let nGroup: Int?
+        public let topkGroup: Int?
+        public let routedScalingFactor: Float?
+
+        enum CodingKeys: String, CodingKey {
+            case vocabSize = "vocab_size"
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case moeIntermediateSize = "moe_intermediate_size"
+            case numHiddenLayers = "num_hidden_layers"
+            case numAttentionHeads = "num_attention_heads"
+            case numKeyValueHeads = "num_key_value_heads"
+            case maxPositionEmbeddings = "max_position_embeddings"
+            case rmsNormEps = "rms_norm_eps"
+            case ropeTheta = "rope_theta"
+            case tieWordEmbeddings = "tie_word_embeddings"
+            case nRoutedExperts = "n_routed_experts"
+            case nSharedExperts = "n_shared_experts"
+            case numExpertsPerTok = "num_experts_per_tok"
+            case moeLayerFreq = "moe_layer_freq"
+            case firstKDenseReplace = "first_k_dense_replace"
+            case normTopkProb = "norm_topk_prob"
+            case nGroup = "n_group"
+            case topkGroup = "topk_group"
+            case routedScalingFactor = "routed_scaling_factor"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.vocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 129_280
+            self.hiddenSize = try container.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1280
+            self.intermediateSize =
+                try container.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 6848
+            self.moeIntermediateSize = try container.decodeIfPresent(
+                Int.self, forKey: .moeIntermediateSize)
+            self.numHiddenLayers =
+                try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 12
+            self.numAttentionHeads =
+                try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 10
+            self.numKeyValueHeads =
+                try container.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 10
+            self.maxPositionEmbeddings =
+                try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32_768
+            self.rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+            self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10_000
+            self.tieWordEmbeddings =
+                try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+            self.nRoutedExperts = try container.decodeIfPresent(Int.self, forKey: .nRoutedExperts)
+            self.nSharedExperts = try container.decodeIfPresent(Int.self, forKey: .nSharedExperts)
+            self.numExpertsPerTok = try container.decodeIfPresent(
+                Int.self, forKey: .numExpertsPerTok)
+            self.moeLayerFreq = try container.decodeIfPresent(Int.self, forKey: .moeLayerFreq)
+            self.firstKDenseReplace = try container.decodeIfPresent(
+                Int.self, forKey: .firstKDenseReplace)
+            self.normTopkProb = try container.decodeIfPresent(Bool.self, forKey: .normTopkProb)
+            self.nGroup = try container.decodeIfPresent(Int.self, forKey: .nGroup)
+            self.topkGroup = try container.decodeIfPresent(Int.self, forKey: .topkGroup)
+            self.routedScalingFactor =
+                try container.decodeIfPresent(Float.self, forKey: .routedScalingFactor)
+        }
+    }
+
+    public struct BaseConfiguration: Decodable, Sendable {
+        public let modelType: String
+        private let _imageTokenId: Int?
+        public var imageTokenId: Int { _imageTokenId ?? 128_815 }
+
+        enum CodingKeys: String, CodingKey {
+            case modelType = "model_type"
+            case _imageTokenId = "image_token_id"
+        }
+    }
+
+    public let visionConfiguration: VisionConfiguration
+    public let textConfiguration: TextConfiguration
+    public let baseConfiguration: BaseConfiguration
+    private let _imageSeqLength: Int?
+    public var imageSeqLength: Int { _imageSeqLength ?? 576 }
+
+    enum CodingKeys: String, CodingKey {
+        case visionConfiguration = "vision_config"
+        case textConfiguration = "text_config"
+        case languageConfiguration = "language_config"
+        case _imageSeqLength = "image_seq_length"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.visionConfiguration = try container.decode(
+            VisionConfiguration.self, forKey: .visionConfiguration)
+        if let text = try container.decodeIfPresent(
+            TextConfiguration.self, forKey: .textConfiguration)
+        {
+            self.textConfiguration = text
+        } else {
+            self.textConfiguration = try container.decode(
+                TextConfiguration.self, forKey: .languageConfiguration)
+        }
+        self.baseConfiguration = try BaseConfiguration(from: decoder)
+        self._imageSeqLength = try container.decodeIfPresent(Int.self, forKey: ._imageSeqLength)
+    }
+}
+
+public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
+    public struct Size: Decodable, Sendable {
+        private let _shortestEdge: Int?
+        private let _longestEdge: Int?
+
+        public var shortestEdge: Int { _shortestEdge ?? 1024 }
+        public var longestEdge: Int { _longestEdge ?? 1024 }
+
+        enum CodingKeys: String, CodingKey {
+            case _shortestEdge = "shortest_edge"
+            case _longestEdge = "longest_edge"
+        }
+
+        public init() {
+            self._shortestEdge = nil
+            self._longestEdge = nil
+        }
+    }
+
+    public let imageMean: [CGFloat]
+    public let imageStd: [CGFloat]
+    public let size: Size
+    private let _imageSeqLength: Int?
+
+    public var imageSeqLength: Int { _imageSeqLength ?? 576 }
+    public var imageMeanTuple: (CGFloat, CGFloat, CGFloat) {
+        (imageMean[0], imageMean[1], imageMean[2])
+    }
+    public var imageStdTuple: (CGFloat, CGFloat, CGFloat) {
+        (imageStd[0], imageStd[1], imageStd[2])
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case imageMean = "image_mean"
+        case imageStd = "image_std"
+        case size
+        case _imageSeqLength = "image_seq_length"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.imageMean =
+            try container.decodeIfPresent([CGFloat].self, forKey: .imageMean) ?? [0.5, 0.5, 0.5]
+        self.imageStd =
+            try container.decodeIfPresent([CGFloat].self, forKey: .imageStd) ?? [0.5, 0.5, 0.5]
+        self.size = try container.decodeIfPresent(Size.self, forKey: .size) ?? Size()
+        self._imageSeqLength = try container.decodeIfPresent(Int.self, forKey: ._imageSeqLength)
+    }
+
+    public init() {
+        self.imageMean = [0.5, 0.5, 0.5]
+        self.imageStd = [0.5, 0.5, 0.5]
+        self.size = Size()
+        self._imageSeqLength = nil
+    }
+}
+
+public struct DeepseekOCRProcessor: UserInputProcessor {
+    private let config: DeepseekOCRProcessorConfiguration
+    private let tokenizer: any Tokenizer
+
+    public init(_ config: DeepseekOCRProcessorConfiguration, tokenizer: any Tokenizer) {
+        self.config = config
+        self.tokenizer = tokenizer
+    }
+
+    private func preprocess(image: CIImage) -> MLXArray {
+        image
+            .toSRGB()
+            .paddingToSquare(backgroundColor: .init(red: 0.5, green: 0.5, blue: 0.5))
+            .resampled(
+                to: .init(
+                    width: config.size.longestEdge,
+                    height: config.size.longestEdge),
+                method: .bicubic
+            )
+            .normalized(mean: config.imageMeanTuple, std: config.imageStdTuple)
+            .asMLXArray()
+    }
+
+    private func imagePromptTokens() -> [Int] {
+        tokenizer.encode(text: Array(repeating: "<image>", count: config.imageSeqLength).joined())
+    }
+
+    public func prepare(input: UserInput) async throws -> LMInput {
+        let messages = DeepseekOCRMessageGenerator().generate(from: input)
+        var promptTokens = try tokenizer.applyChatTemplate(
+            messages: messages,
+            tools: input.tools,
+            additionalContext: input.additionalContext)
+
+        if input.images.isEmpty {
+            return LMInput(tokens: MLXArray(promptTokens))
+        }
+
+        guard input.images.count == 1 else {
+            throw VLMError.singleImageAllowed
+        }
+
+        if !promptTokens.contains(where: { $0 == DeepseekOCR.defaultImageTokenId }) {
+            promptTokens.append(contentsOf: imagePromptTokens())
+        }
+
+        let image = MediaProcessing.apply(
+            try input.images[0].asCIImage(), processing: input.processing)
+        let pixels = preprocess(image: image)
+        let tokens = MLXArray(promptTokens).expandedDimensions(axis: 0)
+        let mask = ones(like: tokens).asType(.int8)
+        return LMInput(
+            text: .init(tokens: tokens, mask: mask),
+            image: .init(
+                pixels: pixels, frames: [THW(1, config.size.longestEdge, config.size.longestEdge)])
+        )
+    }
+}
+
+public struct DeepseekOCRMessageGenerator: MessageGenerator {
+    public init() {}
+
+    public func generate(message: Chat.Message) -> MLXLMCommon.Message {
+        var dictionary: MLXLMCommon.Message = [
+            "role": message.role.rawValue,
+            "content": [["type": "text", "text": message.content]]
+                + message.images.map { _ in ["type": "image"] },
+        ]
+        addToolMetadata(to: &dictionary, for: message)
+        return dictionary
+    }
+}
+
+public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
+    static let defaultImageTokenId = 128_815
+
+    @ModuleInfo(key: "sam_model") private var samModel: VisionEncoder
+    @ModuleInfo(key: "vision_model") private var clipModel: ClipVisionModel
+    @ModuleInfo(key: "projector") private var projector: MultiModalProjector
+    @ModuleInfo(key: "model") private var languageModel: TextModel
+    @ModuleInfo(key: "lm_head") private var lmHead: Linear?
+
+    public let config: DeepseekOCRConfiguration
+    public var kvHeads: [Int] { languageModel.kvHeads }
+    public var loraLayers: [Module] { languageModel.layers }
+    public var vocabularySize: Int { config.textConfiguration.vocabSize }
+
+    private var imageNewline: MLXArray
+    private var viewSeparator: MLXArray
+
+    public init(_ config: DeepseekOCRConfiguration) {
+        self.config = config
+        self._samModel.wrappedValue = VisionEncoder(config.visionConfiguration)
+        self._clipModel.wrappedValue = ClipVisionModel()
+        self._projector.wrappedValue = MultiModalProjector(config)
+        self._languageModel.wrappedValue = TextModel(config.textConfiguration)
+        if !config.textConfiguration.tieWordEmbeddings {
+            self._lmHead.wrappedValue = Linear(
+                config.textConfiguration.hiddenSize,
+                config.textConfiguration.vocabSize,
+                bias: false)
+        }
+
+        let std = Float(1.0 / sqrt(Double(config.textConfiguration.hiddenSize)))
+        self.imageNewline = MLXRandom.normal([config.textConfiguration.hiddenSize]) * std
+        self.viewSeparator = MLXRandom.normal([config.textConfiguration.hiddenSize]) * std
+    }
+
+    public func prepare(
+        _ input: LMInput,
+        cache: [any KVCache],
+        state: LMOutput.State?,
+        windowSize _: Int?
+    ) throws -> PrepareResult {
+        let pixels = input.image?.pixels.asType(samModel.patchEmbed.proj.weight.dtype)
+        let embeddings: MLXArray
+        if let pixels {
+            let imageFeatures = getImageFeatures(pixels)
+            embeddings = mergeInputIdsWithImageFeatures(
+                inputIds: input.text.tokens, imageFeatures: imageFeatures)
+        } else {
+            embeddings = languageModel.embedTokens(input.text.tokens)
+        }
+        let logits = computeLogits(languageModel.forward(embeddings, cache: cache))
+        return .logits(LMOutput(logits: logits, state: state ?? .init()))
+    }
+
+    public func callAsFunction(
+        _ input: LMInput.Text,
+        cache: [any KVCache]?,
+        state: LMOutput.State?
+    ) -> LMOutput {
+        let logits = computeLogits(languageModel(input.tokens, cache: cache))
+        return LMOutput(logits: logits, state: state ?? .init())
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var newWeights = weights
+
+        for layer in 0 ..< config.textConfiguration.numHiddenLayers {
+            let prefix = "model.layers.\(layer)"
+            for proj in ["gate_proj", "down_proj", "up_proj"] {
+                for key in ["weight", "scales", "biases", "bias"] {
+                    let firstKey = "\(prefix).mlp.experts.0.\(proj).\(key)"
+                    guard weights[firstKey] != nil else { continue }
+                    let expertCount = config.textConfiguration.nRoutedExperts ?? 1
+                    let stackedExperts = (0 ..< expertCount).compactMap {
+                        weights["\(prefix).mlp.experts.\($0).\(proj).\(key)"]
+                    }
+                    guard !stackedExperts.isEmpty else { continue }
+                    newWeights["\(prefix).mlp.switch_mlp.\(proj).\(key)"] = stacked(stackedExperts)
+                }
+            }
+        }
+
+        var result = [String: MLXArray]()
+        for (key, value) in newWeights {
+            var newKey: String?
+            var adjusted = value
+
+            if key == "model.projector.layers.weight" || key == "projector.layers.weight" {
+                newKey = "projector.layers.weight"
+            } else if key == "model.projector.layers.bias" || key == "projector.layers.bias" {
+                newKey = "projector.layers.bias"
+            } else if key.hasPrefix("lm_head.") {
+                newKey = key
+            } else if key.hasPrefix("model.sam_model.") {
+                var suffix = String(key.dropFirst("model.sam_model.".count))
+                if suffix.hasPrefix("neck.0.") {
+                    suffix = suffix.replacingOccurrences(of: "neck.0.", with: "neck.conv1.")
+                } else if suffix.hasPrefix("neck.1.") {
+                    suffix = suffix.replacingOccurrences(of: "neck.1.", with: "neck.layer_norm1.")
+                } else if suffix.hasPrefix("neck.2.") {
+                    suffix = suffix.replacingOccurrences(of: "neck.2.", with: "neck.conv2.")
+                } else if suffix.hasPrefix("neck.3.") {
+                    suffix = suffix.replacingOccurrences(of: "neck.3.", with: "neck.layer_norm2.")
+                }
+                suffix = suffix.replacingOccurrences(of: "blocks.", with: "layers.")
+                newKey = "sam_model.\(suffix)"
+            } else if key.hasPrefix("model.vision_model.") {
+                newKey = "clip_model.\(key.dropFirst("model.vision_model.".count))"
+            } else if key.hasPrefix("model.") {
+                guard !key.contains("projector") else { continue }
+                guard !key.contains("sam_model") else { continue }
+                guard !key.contains("vision_model") else { continue }
+                guard !key.contains("image_newline") else { continue }
+                guard !key.contains("view_seperator") else { continue }
+                newKey = String(key)
+            }
+
+            guard let finalKey = newKey, !finalKey.contains("rotary_emb.inv_freq") else { continue }
+            if finalKey.contains("proj.weight") || finalKey.contains("conv")
+                || finalKey.contains("patch_embed")
+            {
+                if value.ndim == 4 {
+                    adjusted = value.transposed(0, 2, 3, 1)
+                }
+            }
+            result[finalKey] = adjusted
+        }
+
+        if config.textConfiguration.tieWordEmbeddings {
+            result["lm_head.weight"] = nil
+        }
+
+        return result
+    }
+
+    private func computeLogits(_ hiddenStates: MLXArray) -> MLXArray {
+        if let lmHead {
+            return lmHead(hiddenStates)
+        }
+        return languageModel.embedTokens.asLinear(hiddenStates)
+    }
+
+    private func getImageFeatures(_ pixelValues: MLXArray) -> MLXArray {
+        let samFeatures = samModel(pixelValues)
+        let batchSize = samFeatures.dim(0)
+        let samH = samFeatures.dim(1)
+        let samW = samFeatures.dim(2)
+        let samChannels = samFeatures.dim(3)
+        let samFlat = samFeatures.reshaped(batchSize, samH * samW, samChannels)
+
+        let clipFeatures = clipModel(pixelValues, patchEmbeds: samFeatures)
+        let clipWithoutCls = clipFeatures[0..., 1..., 0...]
+        var features = projector(concatenated([clipWithoutCls, samFlat], axis: -1))
+
+        let tokenCount = features.dim(1)
+        let gridSize = Int(sqrt(Double(tokenCount)))
+        let hiddenSize = features.dim(2)
+        features = features.reshaped(batchSize, gridSize, gridSize, hiddenSize)
+
+        let newline = imageNewline[.newAxis, .newAxis, .newAxis, 0...]
+        let newlineBroadcast = broadcast(newline, to: [batchSize, gridSize, 1, hiddenSize])
+        features = concatenated([features, newlineBroadcast], axis: 2)
+        features = features.reshaped(batchSize, -1, hiddenSize)
+
+        let separator = viewSeparator[.newAxis, .newAxis, 0...]
+        let separatorBroadcast = broadcast(separator, to: [batchSize, 1, hiddenSize])
+        return concatenated([features, separatorBroadcast], axis: 1)
+    }
+
+    private func mergeInputIdsWithImageFeatures(inputIds: MLXArray, imageFeatures: MLXArray)
+        -> MLXArray
+    {
+        let textEmbeddings = languageModel.embedTokens(inputIds)
+        let imageMask = inputIds .== config.baseConfiguration.imageTokenId
+        let seqLen = textEmbeddings.dim(1)
+        let imageTokenCount = imageFeatures.dim(1)
+        let firstImageIndex = argMax(imageMask.asType(.int32), axis: 1)[0].item(Int.self)
+        let prePad = firstImageIndex
+        let postPad = max(0, seqLen - firstImageIndex - imageTokenCount)
+
+        var paddedImageFeatures = imageFeatures
+        if prePad > 0 || postPad > 0 {
+            paddedImageFeatures = padded(imageFeatures, widths: [0, .init((prePad, postPad)), 0])
+        }
+        if paddedImageFeatures.dim(1) > seqLen {
+            paddedImageFeatures = paddedImageFeatures[0..., ..<seqLen, 0...]
+        }
+
+        return which(imageMask[.ellipsis, .newAxis], paddedImageFeatures, textEmbeddings)
+    }
+}
+
+private final class TextAttention: Module {
+    let config: DeepseekOCRConfiguration.TextConfiguration
+    let numHeads: Int
+    let numKVHeads: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+
+    let rope: RoPE
+
+    init(_ config: DeepseekOCRConfiguration.TextConfiguration) {
+        self.config = config
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.hiddenSize / config.numAttentionHeads
+        self.scale = pow(Float(headDim), -0.5)
+        self._qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: false)
+        self._kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        self._vProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        self._oProj.wrappedValue = Linear(numHeads * headDim, config.hiddenSize, bias: false)
+        self.rope = RoPE(
+            dimensions: headDim, traditional: false, base: config.ropeTheta, scale: 1.0)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let (batch, length) = (x.dim(0), x.dim(1))
+        var queries = qProj(x).reshaped(batch, length, numHeads, headDim).transposed(0, 2, 1, 3)
+        var keys = kProj(x).reshaped(batch, length, numKVHeads, headDim).transposed(0, 2, 1, 3)
+        let values = vProj(x).reshaped(batch, length, numKVHeads, headDim).transposed(0, 2, 1, 3)
+
+        let offset = cache?.ropeOffset
+        queries = applyRotaryPosition(rope, to: queries, offset: offset)
+        keys = applyRotaryPosition(rope, to: keys, offset: offset)
+
+        let output = attentionWithCacheUpdate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            cache: cache,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(batch, length, -1)
+
+        return oProj(output)
+    }
+}
+
+private final class TextMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+
+    init(hiddenSize: Int, intermediateSize: Int) {
+        self._gate.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._up.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._down.wrappedValue = Linear(intermediateSize, hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(silu(gate(x)) * up(x))
+    }
+}
+
+private final class MoEGate: Module {
+    let topK: Int
+    let normTopkProb: Bool
+    let routedScalingFactor: Float
+
+    @ModuleInfo(key: "weight") var weight: MLXArray
+
+    init(_ config: DeepseekOCRConfiguration.TextConfiguration) {
+        let expertCount = config.nRoutedExperts ?? 1
+        self.topK = config.numExpertsPerTok ?? 1
+        self.normTopkProb = config.normTopkProb ?? false
+        self.routedScalingFactor = config.routedScalingFactor ?? 1.0
+        self._weight.wrappedValue = zeros([expertCount, config.hiddenSize])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        let logits = matmul(x.asType(.float32), weight.T.asType(.float32)).asType(x.dtype)
+        let scores = softmax(logits, axis: -1)
+        let kth = scores.dim(-1) - topK
+        let indices = argPartition(scores, kth: kth, axis: -1)[.ellipsis, kth...]
+        var selected = takeAlong(scores, indices, axis: -1)
+        if normTopkProb {
+            selected = selected / (selected.sum(axis: -1, keepDims: true) + MLXArray(1e-20))
+        }
+        return (indices, selected * routedScalingFactor)
+    }
+}
+
+private final class SparseMoE: Module, UnaryLayer {
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    @ModuleInfo(key: "gate") var gate: MoEGate
+    @ModuleInfo(key: "shared_experts") var sharedExperts: TextMLP?
+
+    init(_ config: DeepseekOCRConfiguration.TextConfiguration) {
+        let expertCount = config.nRoutedExperts ?? 1
+        let hiddenSize = config.hiddenSize
+        let intermediate = config.moeIntermediateSize ?? config.intermediateSize
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: hiddenSize,
+            hiddenDims: intermediate,
+            numExperts: expertCount)
+        self._gate.wrappedValue = MoEGate(config)
+        if let shared = config.nSharedExperts {
+            self._sharedExperts.wrappedValue = TextMLP(
+                hiddenSize: hiddenSize,
+                intermediateSize: intermediate * shared)
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (indices, scores) = gate(x)
+        var y = switchMLP(x, indices)
+        y = weightedExpertSum(y, scores)
+        if let sharedExperts {
+            y = y + sharedExperts(x)
+        }
+        return y
+    }
+}
+
+private final class TextDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: TextAttention
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    let mlp: UnaryLayer
+
+    init(_ config: DeepseekOCRConfiguration.TextConfiguration, layerIndex: Int) {
+        self._selfAttention.wrappedValue = TextAttention(config)
+        self._inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps)
+
+        let useMoE =
+            (config.nRoutedExperts ?? 0) > 0
+            && layerIndex >= (config.firstKDenseReplace ?? 0)
+            && layerIndex % max(config.moeLayerFreq ?? 1, 1) == 0
+        if useMoE {
+            self.mlp = SparseMoE(config)
+        } else {
+            self.mlp = TextMLP(
+                hiddenSize: config.hiddenSize, intermediateSize: config.intermediateSize)
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let attentionOut = selfAttention(inputLayerNorm(x), mask: mask, cache: cache)
+        let hidden = x + attentionOut
+        return hidden + mlp(postAttentionLayerNorm(hidden))
+    }
+}
+
+private final class TextModel: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+
+    let layers: [TextDecoderLayer]
+    let norm: RMSNorm
+    let kvHeads: [Int]
+
+    init(_ config: DeepseekOCRConfiguration.TextConfiguration) {
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.hiddenSize)
+        self.layers = (0 ..< config.numHiddenLayers).map {
+            TextDecoderLayer(config, layerIndex: $0)
+        }
+        self.norm = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self.kvHeads = (0 ..< config.numHiddenLayers).map { _ in config.numKeyValueHeads }
+    }
+
+    func callAsFunction(_ inputIds: MLXArray, cache: [KVCache]?) -> MLXArray {
+        forward(embedTokens(inputIds), cache: cache)
+    }
+
+    func forward(_ hidden: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var hidden = hidden
+        let mask = createAttentionMask(h: hidden, cache: cache?.first)
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(hidden, mask: mask, cache: cache?[index])
+        }
+        return norm(hidden)
+    }
+}
+
+private final class VisionMLP: Module {
+    @ModuleInfo(key: "lin1") var lin1: Linear
+    @ModuleInfo(key: "lin2") var lin2: Linear
+
+    init(hiddenSize: Int, mlpDim: Int) {
+        self._lin1.wrappedValue = Linear(hiddenSize, mlpDim)
+        self._lin2.wrappedValue = Linear(mlpDim, hiddenSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        lin2(gelu(lin1(x)))
+    }
+}
+
+private final class VisionAttention: Module {
+    let numHeads: Int
+    let scale: Float
+    let windowSize: Int
+    let useRelPos: Bool
+
+    @ModuleInfo(key: "qkv") var qkv: Linear
+    @ModuleInfo(key: "proj") var proj: Linear
+
+    var relPosH: MLXArray?
+    var relPosW: MLXArray?
+
+    init(_ config: DeepseekOCRConfiguration.VisionConfiguration, windowSize: Int) {
+        self.numHeads = config.numAttentionHeads
+        self.scale = pow(Float(config.hiddenSize / config.numAttentionHeads), -0.5)
+        self.windowSize = windowSize
+        self.useRelPos = config.useRelPos
+        self._qkv.wrappedValue = Linear(
+            config.hiddenSize,
+            config.hiddenSize * 3,
+            bias: config.qkvBias)
+        self._proj.wrappedValue = Linear(config.hiddenSize, config.hiddenSize)
+        if useRelPos {
+            let inputSize = windowSize > 0 ? windowSize : (config.imageSize / config.patchSize)
+            let headDim = config.hiddenSize / config.numAttentionHeads
+            self.relPosH = zeros([2 * inputSize - 1, headDim])
+            self.relPosW = zeros([2 * inputSize - 1, headDim])
+        }
+    }
+
+    private func getRelPos(qSize: Int, kSize: Int, relPos: MLXArray) -> MLXArray {
+        let maxRelDist = 2 * max(qSize, kSize) - 1
+        var relPosResized = relPos
+        if relPos.dim(0) != maxRelDist {
+            let scale = Float(maxRelDist) / Float(relPos.dim(0))
+            relPosResized = Upsample(scaleFactor: [scale], mode: .linear(alignCorners: false))(
+                relPos.expandedDimensions(axis: 0)
+            ).squeezed(axis: 0)
+        }
+        let qCoords = MLXArray(
+            (0 ..< qSize).map { Float($0) * max(Float(kSize) / Float(qSize), 1.0) })
+        let kCoords = MLXArray(
+            (0 ..< kSize).map { Float($0) * max(Float(qSize) / Float(kSize), 1.0) })
+        let offset = Float(kSize - 1) * max(Float(qSize) / Float(kSize), 1.0)
+        return relPosResized[
+            (qCoords.reshaped(qSize, 1) - kCoords.reshaped(1, kSize) + offset).asType(.int32)]
+    }
+
+    private func relativeBias(query: MLXArray, height: Int, width: Int) -> MLXArray? {
+        guard useRelPos, let relPosH, let relPosW else { return nil }
+        let batchHeads = query.dim(0)
+        let dim = query.dim(-1)
+        let q = query.reshaped(batchHeads, height, width, dim)
+        let relH = getRelPos(qSize: height, kSize: height, relPos: relPosH)
+        let relW = getRelPos(qSize: width, kSize: width, relPos: relPosW)
+        let relHBias = matmul(q, relH.swappedAxes(-2, -1)).reshaped(
+            batchHeads, height * width, height, 1)
+        let relWBias = matmul(
+            q.transposed(0, 2, 1, 3),
+            relW.swappedAxes(-2, -1)
+        ).transposed(0, 2, 1, 3).reshaped(batchHeads, height * width, 1, width)
+        return (relHBias + relWBias).reshaped(-1, height * width, height * width)
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        let (batch, height, width, _) = (
+            hiddenStates.dim(0),
+            hiddenStates.dim(1),
+            hiddenStates.dim(2),
+            hiddenStates.dim(3)
+        )
+        let headDim = hiddenStates.dim(3) / numHeads
+        let qkvOut = qkv(hiddenStates)
+            .reshaped(batch, height * width, 3, numHeads, headDim)
+            .transposed(2, 0, 3, 1, 4)
+        let q = qkvOut[0]
+        let k = qkvOut[1]
+        let v = qkvOut[2]
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode
+        if let bias = relativeBias(
+            query: q.reshaped(batch * numHeads, height * width, headDim), height: height,
+            width: width)
+        {
+            mask = .array(bias.reshaped(batch, numHeads, height * width, height * width))
+        } else {
+            mask = .none
+        }
+        let output = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: mask
+        )
+        return proj(
+            output.reshaped(batch, numHeads, height, width, headDim).transposed(0, 2, 3, 1, 4)
+                .reshaped(batch, height, width, -1))
+    }
+}
+
+private final class VisionLayer: Module {
+    @ModuleInfo(key: "norm1") var layerNorm1: LayerNorm
+    @ModuleInfo(key: "attn") var attention: VisionAttention
+    @ModuleInfo(key: "norm2") var layerNorm2: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: VisionMLP
+
+    let windowSize: Int
+
+    init(_ config: DeepseekOCRConfiguration.VisionConfiguration, windowSize: Int) {
+        self.windowSize = windowSize
+        self._layerNorm1.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._attention.wrappedValue = VisionAttention(config, windowSize: windowSize)
+        self._layerNorm2.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._mlp.wrappedValue = VisionMLP(hiddenSize: config.hiddenSize, mlpDim: config.mlpDim)
+    }
+
+    private func partition(_ hiddenStates: MLXArray) -> (MLXArray, (Int, Int), Int) {
+        let (batch, height, width, channels) = (
+            hiddenStates.dim(0), hiddenStates.dim(1), hiddenStates.dim(2), hiddenStates.dim(3)
+        )
+        let padH = (windowSize - height % windowSize) % windowSize
+        let padW = (windowSize - width % windowSize) % windowSize
+        var paddedStates = hiddenStates
+        if padH > 0 || padW > 0 {
+            paddedStates = padded(
+                hiddenStates,
+                widths: [.init((0, 0)), .init((0, padH)), .init((0, padW)), .init((0, 0))])
+        }
+        let paddedHeight = height + padH
+        let paddedWidth = width + padW
+        let windows =
+            paddedStates
+            .reshaped(
+                batch, paddedHeight / windowSize, windowSize, paddedWidth / windowSize, windowSize,
+                channels
+            )
+            .transposed(0, 1, 3, 2, 4, 5)
+            .reshaped(-1, windowSize, windowSize, channels)
+        return (windows, (paddedHeight, paddedWidth), batch)
+    }
+
+    private func unpartition(
+        _ windows: MLXArray,
+        padding: (Int, Int),
+        original: (Int, Int),
+        batchSize: Int
+    ) -> MLXArray {
+        let channels = windows.dim(-1)
+        var merged =
+            windows
+            .reshaped(
+                batchSize, padding.0 / windowSize, padding.1 / windowSize, windowSize, windowSize,
+                channels
+            )
+            .transposed(0, 1, 3, 2, 4, 5)
+            .reshaped(batchSize, padding.0, padding.1, channels)
+        if padding != original {
+            merged = merged[0..., ..<original.0, ..<original.1, 0...]
+        }
+        return merged
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        let residual = hiddenStates
+        var hidden = layerNorm1(hiddenStates)
+        let original = (hidden.dim(1), hidden.dim(2))
+        var padding: (Int, Int)?
+        var batchSize: Int?
+        if windowSize > 0 {
+            let partitioned = partition(hidden)
+            hidden = partitioned.0
+            padding = partitioned.1
+            batchSize = partitioned.2
+        }
+        hidden = attention(hidden)
+        if let padding, let batchSize {
+            hidden = unpartition(hidden, padding: padding, original: original, batchSize: batchSize)
+        }
+        hidden = residual + hidden
+        return hidden + mlp(layerNorm2(hidden))
+    }
+}
+
+private final class PatchEmbeddings: Module {
+    @ModuleInfo(key: "proj") var proj: Conv2d
+
+    init(_ config: DeepseekOCRConfiguration.VisionConfiguration) {
+        self._proj.wrappedValue = Conv2d(
+            inputChannels: config.numChannels,
+            outputChannels: config.hiddenSize,
+            kernelSize: IntOrPair(config.patchSize),
+            stride: IntOrPair(config.patchSize))
+    }
+
+    func callAsFunction(_ pixelValues: MLXArray) -> MLXArray {
+        proj(pixelValues)
+    }
+}
+
+private final class VisionNeck: Module {
+    @ModuleInfo(key: "conv1") var conv1: Conv2d
+    @ModuleInfo(key: "layer_norm1") var layerNorm1: LayerNorm
+    @ModuleInfo(key: "conv2") var conv2: Conv2d
+    @ModuleInfo(key: "layer_norm2") var layerNorm2: LayerNorm
+
+    init(_ config: DeepseekOCRConfiguration.VisionConfiguration) {
+        self._conv1.wrappedValue = Conv2d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.outputChannels,
+            kernelSize: IntOrPair(1),
+            bias: false)
+        self._layerNorm1.wrappedValue = LayerNorm(
+            dimensions: config.outputChannels, eps: config.layerNormEps)
+        self._conv2.wrappedValue = Conv2d(
+            inputChannels: config.outputChannels,
+            outputChannels: config.outputChannels,
+            kernelSize: IntOrPair(3),
+            padding: IntOrPair(1),
+            bias: false)
+        self._layerNorm2.wrappedValue = LayerNorm(
+            dimensions: config.outputChannels, eps: config.layerNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        layerNorm2(conv2(layerNorm1(conv1(x))))
+    }
+}
+
+private final class VisionEncoder: Module {
+    @ModuleInfo(key: "patch_embed") var patchEmbed: PatchEmbeddings
+    @ModuleInfo(key: "layers") var layers: [VisionLayer]
+    @ModuleInfo(key: "neck") var neck: VisionNeck
+    @ModuleInfo(key: "net_2") var net2: Conv2d
+    @ModuleInfo(key: "net_3") var net3: Conv2d
+
+    var posEmbed: MLXArray?
+    let patchCount: Int
+
+    init(_ config: DeepseekOCRConfiguration.VisionConfiguration) {
+        self.patchCount = config.imageSize / config.patchSize
+        self._patchEmbed.wrappedValue = PatchEmbeddings(config)
+        self._layers.wrappedValue = (0 ..< config.numHiddenLayers).map { index in
+            VisionLayer(
+                config,
+                windowSize: config.globalAttentionIndexes.contains(index) ? 0 : config.windowSize)
+        }
+        self._neck.wrappedValue = VisionNeck(config)
+        self._net2.wrappedValue = Conv2d(
+            inputChannels: config.outputChannels,
+            outputChannels: 512,
+            kernelSize: IntOrPair(3),
+            stride: IntOrPair(2),
+            padding: IntOrPair(1),
+            bias: false)
+        self._net3.wrappedValue = Conv2d(
+            inputChannels: 512,
+            outputChannels: 1024,
+            kernelSize: IntOrPair(3),
+            stride: IntOrPair(2),
+            padding: IntOrPair(1),
+            bias: false)
+        if config.useAbsPos {
+            self.posEmbed = zeros([1, patchCount, patchCount, config.hiddenSize])
+        }
+    }
+
+    private func interpolatedPositionalEmbedding(_ posEmbed: MLXArray, height: Int, width: Int)
+        -> MLXArray
+    {
+        if posEmbed.dim(1) == height && posEmbed.dim(2) == width {
+            return posEmbed
+        }
+        let scaleH = Float(height) / Float(posEmbed.dim(1))
+        let scaleW = Float(width) / Float(posEmbed.dim(2))
+        return Upsample(scaleFactor: [scaleH, scaleW], mode: .cubic(alignCorners: false))(posEmbed)
+    }
+
+    func callAsFunction(_ pixelValues: MLXArray) -> MLXArray {
+        var hidden = patchEmbed(pixelValues)
+        if let posEmbed {
+            hidden =
+                hidden
+                + interpolatedPositionalEmbedding(
+                    posEmbed, height: hidden.dim(1), width: hidden.dim(2))
+        }
+        for layer in layers {
+            hidden = layer(hidden)
+        }
+        hidden = neck(hidden)
+        hidden = net2(hidden)
+        hidden = net3(hidden)
+        return hidden
+    }
+}
+
+private struct ClipVisionConfig {
+    let hiddenSize = 1024
+    let numLayers = 24
+    let numAttentionHeads = 16
+    let ffnHiddenSize = 4096
+    let imageSize = 224
+    let patchSize = 14
+    let layerNormEps: Float = 1e-5
+}
+
+private func quickGelu(_ x: MLXArray) -> MLXArray {
+    x * sigmoid(1.702 * x)
+}
+
+private final class ClipVisionEmbeddings: Module {
+    @ModuleInfo(key: "patch_embedding") var patchEmbedding: Conv2d
+
+    var classEmbedding: MLXArray
+    var positionEmbedding: MLXArray
+    let config = ClipVisionConfig()
+
+    override init() {
+        self._patchEmbedding.wrappedValue = Conv2d(
+            inputChannels: 3,
+            outputChannels: config.hiddenSize,
+            kernelSize: IntOrPair(config.patchSize),
+            stride: IntOrPair(config.patchSize),
+            bias: false)
+        self.classEmbedding = MLXRandom.normal([config.hiddenSize])
+        self.positionEmbedding = MLXRandom.normal([
+            1,
+            (config.imageSize / config.patchSize) * (config.imageSize / config.patchSize) + 1,
+            config.hiddenSize,
+        ])
+    }
+
+    private func resizedPositionEmbedding(targetSize: Int) -> MLXArray {
+        if positionEmbedding.dim(1) == targetSize {
+            return positionEmbedding
+        }
+        let clsToken = positionEmbedding[0..., ..<1, 0...]
+        let patchEmbedding = positionEmbedding[0..., 1..., 0...]
+        let sourceSize = Int(sqrt(Double(positionEmbedding.dim(1) - 1)))
+        let destinationSize = Int(sqrt(Double(targetSize - 1)))
+        if sourceSize == destinationSize {
+            return positionEmbedding
+        }
+        let resized = Upsample(
+            scaleFactor: [
+                Float(destinationSize) / Float(sourceSize),
+                Float(destinationSize) / Float(sourceSize),
+            ],
+            mode: .cubic(alignCorners: false)
+        )(patchEmbedding.reshaped(1, sourceSize, sourceSize, config.hiddenSize))
+        return concatenated(
+            [clsToken, resized.reshaped(1, destinationSize * destinationSize, config.hiddenSize)],
+            axis: 1)
+    }
+
+    func callAsFunction(_ pixelValues: MLXArray, patchEmbeds: MLXArray?) -> MLXArray {
+        let batchSize = pixelValues.dim(0)
+        let patches: MLXArray
+        if let patchEmbeds {
+            patches = patchEmbeds.reshaped(
+                batchSize, patchEmbeds.dim(1) * patchEmbeds.dim(2), patchEmbeds.dim(3))
+        } else {
+            let projected = patchEmbedding(pixelValues)
+            patches = projected.reshaped(
+                batchSize, projected.dim(1) * projected.dim(2), projected.dim(3))
+        }
+        let cls = broadcast(
+            classEmbedding[.newAxis, .newAxis, 0...], to: [batchSize, 1, config.hiddenSize])
+        let embeddings = concatenated([cls, patches], axis: 1)
+        return embeddings + resizedPositionEmbedding(targetSize: embeddings.dim(1))
+    }
+}
+
+private final class ClipFeedForward: Module {
+    @ModuleInfo(key: "fc1") var fc1: Linear
+    @ModuleInfo(key: "fc2") var fc2: Linear
+
+    override init() {
+        let config = ClipVisionConfig()
+        self._fc1.wrappedValue = Linear(config.hiddenSize, config.ffnHiddenSize)
+        self._fc2.wrappedValue = Linear(config.ffnHiddenSize, config.hiddenSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        fc2(quickGelu(fc1(x)))
+    }
+}
+
+private final class ClipAttention: Module {
+    @ModuleInfo(key: "qkv_proj") var qkvProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    let config = ClipVisionConfig()
+    let scale: Float
+
+    override init() {
+        self.scale = pow(Float(config.hiddenSize / config.numAttentionHeads), -0.5)
+        self._qkvProj.wrappedValue = Linear(config.hiddenSize, config.hiddenSize * 3)
+        self._outProj.wrappedValue = Linear(config.hiddenSize, config.hiddenSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (batch, length) = (x.dim(0), x.dim(1))
+        let headDim = config.hiddenSize / config.numAttentionHeads
+        let qkv = qkvProj(x).reshaped(batch, length, 3, config.numAttentionHeads, headDim)
+        let q = qkv[0..., 0..., 0, 0..., 0...].transposed(0, 2, 1, 3)
+        let k = qkv[0..., 0..., 1, 0..., 0...].transposed(0, 2, 1, 3)
+        let v = qkv[0..., 0..., 2, 0..., 0...].transposed(0, 2, 1, 3)
+        let output = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: .none)
+        return outProj(output.transposed(0, 2, 1, 3).reshaped(batch, length, -1))
+    }
+}
+
+private final class ClipTransformerBlock: Module {
+    @ModuleInfo(key: "layer_norm1") var layerNorm1: LayerNorm
+    @ModuleInfo(key: "self_attn") var selfAttention: ClipAttention
+    @ModuleInfo(key: "layer_norm2") var layerNorm2: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: ClipFeedForward
+
+    override init() {
+        let config = ClipVisionConfig()
+        self._layerNorm1.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._selfAttention.wrappedValue = ClipAttention()
+        self._layerNorm2.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._mlp.wrappedValue = ClipFeedForward()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let hidden = x + selfAttention(layerNorm1(x))
+        return hidden + mlp(layerNorm2(hidden))
+    }
+}
+
+private final class ClipVisionTransformer: Module {
+    @ModuleInfo(key: "layers") var layers: [ClipTransformerBlock]
+
+    override init() {
+        self._layers.wrappedValue = (0 ..< ClipVisionConfig().numLayers).map { _ in
+            ClipTransformerBlock()
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        layers.reduce(x) { partialResult, layer in layer(partialResult) }
+    }
+}
+
+private final class ClipVisionModel: Module {
+    @ModuleInfo(key: "embeddings") var embeddings: ClipVisionEmbeddings
+    @ModuleInfo(key: "pre_layrnorm") var preLayerNorm: LayerNorm
+    @ModuleInfo(key: "transformer") var transformer: ClipVisionTransformer
+
+    override init() {
+        let config = ClipVisionConfig()
+        self._embeddings.wrappedValue = ClipVisionEmbeddings()
+        self._preLayerNorm.wrappedValue = LayerNorm(
+            dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._transformer.wrappedValue = ClipVisionTransformer()
+    }
+
+    func callAsFunction(_ pixelValues: MLXArray, patchEmbeds: MLXArray?) -> MLXArray {
+        transformer(preLayerNorm(embeddings(pixelValues, patchEmbeds: patchEmbeds)))
+    }
+}
+
+private final class MultiModalProjector: Module {
+    @ModuleInfo(key: "layers") var layers: Linear
+
+    init(_ config: DeepseekOCRConfiguration) {
+        self._layers.wrappedValue = Linear(2048, config.textConfiguration.hiddenSize)
+    }
+
+    func callAsFunction(_ features: MLXArray) -> MLXArray {
+        layers(features)
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -99,6 +99,9 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
         public let routedScalingFactor: Float?
         /// Python `TextConfig.scoring_func` default is `"softmax"` (Unlimited / DeepSeek-OCR).
         public let scoringFunc: String?
+        /// Python `TextConfig.topk_method` default is `"greedy"`; `"noaux_tc"` enables
+        /// bias-corrected grouped routing.
+        public let topkMethod: String?
 
         enum CodingKeys: String, CodingKey {
             case vocabSize = "vocab_size"
@@ -123,6 +126,7 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             case topkGroup = "topk_group"
             case routedScalingFactor = "routed_scaling_factor"
             case scoringFunc = "scoring_func"
+            case topkMethod = "topk_method"
         }
 
         public init(from decoder: any Decoder) throws {
@@ -164,6 +168,7 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             self.routedScalingFactor =
                 try container.decodeIfPresent(Float.self, forKey: .routedScalingFactor)
             self.scoringFunc = try container.decodeIfPresent(String.self, forKey: .scoringFunc)
+            self.topkMethod = try container.decodeIfPresent(String.self, forKey: .topkMethod)
         }
     }
 
@@ -1238,6 +1243,7 @@ private final class MoEGate: Module {
     let nGroup: Int
     let topkGroup: Int?
     let scoringFunc: String
+    let topkMethod: String
 
     @ModuleInfo(key: "weight") var weight: MLXArray
     @ModuleInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
@@ -1251,6 +1257,8 @@ private final class MoEGate: Module {
         self.topkGroup = config.topkGroup
         // Match Python TextConfig default (`softmax`) used by Unlimited-OCR.
         self.scoringFunc = config.scoringFunc ?? "softmax"
+        // Match Python TextConfig default (`greedy`); DeepSeek-OCR ships greedy.
+        self.topkMethod = config.topkMethod ?? "greedy"
         self._weight.wrappedValue = zeros([expertCount, config.hiddenSize])
         self._eScoreCorrectionBias.wrappedValue = zeros([expertCount])
     }
@@ -1258,7 +1266,7 @@ private final class MoEGate: Module {
     func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
         let (batchSize, sequenceLength, _) = (x.dim(0), x.dim(1), x.dim(2))
         let gates = matmul(x.asType(.float32), weight.T.asType(.float32))
-        var scores: MLXArray
+        let scores: MLXArray
         switch scoringFunc {
         case "sigmoid":
             scores = sigmoid(gates)
@@ -1266,31 +1274,43 @@ private final class MoEGate: Module {
             // "softmax" (Python default) and any unrecognized value.
             scores = MLX.softmax(gates, axis: -1, precise: true)
         }
-        let scoresForChoice = scores + eScoreCorrectionBias
 
-        if nGroup > 1 {
-            let expertCount = weight.dim(0)
-            let expertsPerGroup = expertCount / nGroup
-            var groupScores = scoresForChoice.reshaped(
-                batchSize, sequenceLength, nGroup, expertsPerGroup)
-            let topPerGroup = top(groupScores, k: min(2, expertsPerGroup), axis: -1)
-                .sum(axis: -1, keepDims: true)
-            let droppedGroups = max(0, nGroup - (topkGroup ?? 1))
-            if droppedGroups > 0 {
-                var maskedGroupIndices = argPartition(
-                    topPerGroup, kth: droppedGroups - 1, axis: -2)[
-                        .ellipsis, ..<droppedGroups, 0...
-                    ]
-                maskedGroupIndices = broadcast(
-                    maskedGroupIndices,
-                    to: [batchSize, sequenceLength, droppedGroups, expertsPerGroup])
-                groupScores = putAlong(
-                    groupScores, stopGradient(maskedGroupIndices), values: MLXArray(0.0), axis: -2)
-                scores = flattened(groupScores, start: -2, end: -1)
+        let indices: MLXArray
+        if topkMethod == "noaux_tc" {
+            // The correction bias steers selection only; returned weights are
+            // gathered from the raw scores.
+            let corrected = scores + eScoreCorrectionBias
+            var masked = corrected
+            if nGroup > 1 {
+                let expertCount = weight.dim(0)
+                let expertsPerGroup = expertCount / nGroup
+                var groupScores = corrected.reshaped(
+                    batchSize, sequenceLength, nGroup, expertsPerGroup)
+                let topPerGroup = top(groupScores, k: min(2, expertsPerGroup), axis: -1)
+                    .sum(axis: -1, keepDims: true)
+                let keptGroups = (topkGroup ?? 0) > 0 ? topkGroup! : nGroup
+                let droppedGroups = max(0, nGroup - keptGroups)
+                if droppedGroups > 0 {
+                    var maskedGroupIndices = argPartition(
+                        topPerGroup, kth: droppedGroups - 1, axis: -2)[
+                            .ellipsis, ..<droppedGroups, 0...
+                        ]
+                    maskedGroupIndices = broadcast(
+                        maskedGroupIndices,
+                        to: [batchSize, sequenceLength, droppedGroups, expertsPerGroup])
+                    groupScores = putAlong(
+                        groupScores, stopGradient(maskedGroupIndices), values: MLXArray(0.0),
+                        axis: -2)
+                }
+                masked = flattened(groupScores, start: -2, end: -1)
             }
+            indices = argPartition(-masked, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+        } else {
+            // "greedy" (Python default): plain top-k on raw scores; bias and
+            // groups are not consulted.
+            indices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
         }
 
-        let indices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
         var selected = takeAlong(scores, indices, axis: -1)
         if normTopkProb {
             selected = selected / (selected.sum(axis: -1, keepDims: true) + MLXArray(1e-20))

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -303,6 +303,105 @@ public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
     }
 }
 
+/// DeepSeek-OCR grounding / localization special tokens (mlx-vlm + HF packs).
+///
+/// These strings are registered in the Hub tokenizer (`added_tokens_decoder`);
+/// resolve IDs via ``id(of:tokenizer:)`` rather than hard-coding in hot paths.
+/// Prompt helpers match Python / mlx-vlm DeepSeek-OCR README usage.
+///
+/// **Layout decode deferral:** this surface exposes tokens + prompt builders and a
+/// minimal `<|det|>[[x1,y1,x2,y2]]` extractor. Building a full structured layout
+/// tree from interleaved `<|ref|>…<|/ref|><|det|>…` markdown is intentionally
+/// deferred — callers should keep `skipSpecialTokens: false` on decode and parse
+/// what they need (or consume raw grounding markdown).
+public enum DeepseekOCRSpecialTokens: String, Sendable, CaseIterable {
+    case grounding = "<|grounding|>"
+    case refOpen = "<|ref|>"
+    case refClose = "<|/ref|>"
+    case detOpen = "<|det|>"
+    case detClose = "<|/det|>"
+
+    /// Fallback IDs from deepseek-ai / mlx-community / majentik tokenizer packs
+    /// (`<image>` is 128815; grounding family follows contiguously).
+    public var defaultId: Int {
+        switch self {
+        case .refOpen: return 128_816
+        case .refClose: return 128_817
+        case .detOpen: return 128_818
+        case .detClose: return 128_819
+        case .grounding: return 128_820
+        }
+    }
+
+    /// Prefer tokenizer lookup; fall back to ``defaultId`` for known HF packs.
+    public static func id(of token: DeepseekOCRSpecialTokens, tokenizer: any Tokenizer) -> Int {
+        tokenizer.convertTokenToId(token.rawValue) ?? token.defaultId
+    }
+
+    /// All grounding-family strings (openers + closers), in stable CaseIterable order.
+    public static var allStrings: [String] { allCases.map(\.rawValue) }
+
+    /// Resolve every grounding-family token through the tokenizer (with defaults).
+    public static func resolveIds(tokenizer: any Tokenizer) -> [DeepseekOCRSpecialTokens: Int] {
+        Dictionary(uniqueKeysWithValues: allCases.map { ($0, id(of: $0, tokenizer: tokenizer)) })
+    }
+
+    // MARK: Prompt builders (match mlx-vlm DeepSeek-OCR README)
+
+    /// Structured OCR / layout prompt, e.g. `"<|grounding|>OCR this image."`.
+    public static func groundingPrompt(_ instruction: String = "OCR this image.") -> String {
+        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = trimmed.hasSuffix(".") ? trimmed : trimmed + "."
+        return "\(Self.grounding.rawValue)\(body)"
+    }
+
+    /// Document → markdown with layout tags.
+    public static func groundingMarkdownPrompt(
+        _ instruction: String = "Convert the document to markdown."
+    ) -> String {
+        groundingPrompt(instruction)
+    }
+
+    /// Text localization: `"Locate <|ref|>…<|/ref|> in the image."`.
+    public static func locatePrompt(_ text: String) -> String {
+        "Locate \(Self.refOpen.rawValue)\(text)\(Self.refClose.rawValue) in the image."
+    }
+
+    /// Normalized 0–1000 axis-aligned box from a `<|det|>[[x1, y1, x2, y2]]` span.
+    public struct Detection: Equatable, Sendable {
+        public let x1: Int
+        public let y1: Int
+        public let x2: Int
+        public let y2: Int
+
+        public init(x1: Int, y1: Int, x2: Int, y2: Int) {
+            self.x1 = x1
+            self.y1 = y1
+            self.x2 = x2
+            self.y2 = y2
+        }
+    }
+
+    /// Extract `[[x1,y1,x2,y2]]` boxes from model output that still contains special tokens.
+    /// Does **not** rebuild a layout tree — see type-level deferral note.
+    public static func parseDetections(from text: String) -> [Detection] {
+        // Match [[a, b, c, d]] (as emitted inside <|det|>…<|/det|>).
+        let pattern =
+            #"\[\[\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\]\]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard match.numberOfRanges == 5 else { return nil }
+            let ints = (1 ... 4).compactMap { i -> Int? in
+                Int(ns.substring(with: match.range(at: i)))
+            }
+            guard ints.count == 4 else { return nil }
+            return Detection(x1: ints[0], y1: ints[1], x2: ints[2], y2: ints[3])
+        }
+    }
+}
+
 public struct DeepseekOCRProcessor: UserInputProcessor {
     /// Image crop modes matching Python `DeepseekOCRProcessor.tokenize_with_images`.
     ///

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -517,6 +517,11 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
 
         return which(imageMask[.ellipsis, .newAxis], paddedImageFeatures, textEmbeddings)
     }
+
+    @_spi(Testing)
+    public func samFeaturesForTesting(_ pixelValues: MLXArray) -> MLXArray {
+        samModel(pixelValues)
+    }
 }
 
 private final class TextAttention: Module {

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -110,6 +110,7 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             case rmsNormEps = "rms_norm_eps"
             case ropeTheta = "rope_theta"
             case tieWordEmbeddings = "tie_word_embeddings"
+            case lmHead = "lm_head"
             case nRoutedExperts = "n_routed_experts"
             case nSharedExperts = "n_shared_experts"
             case numExpertsPerTok = "num_experts_per_tok"
@@ -139,8 +140,14 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
                 try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32_768
             self.rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
             self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10_000
-            self.tieWordEmbeddings =
-                try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+            // Unlimited packs omit tie_word_embeddings but set lm_head=true when untied.
+            if let tie = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) {
+                self.tieWordEmbeddings = tie
+            } else if let hasLmHead = try container.decodeIfPresent(Bool.self, forKey: .lmHead) {
+                self.tieWordEmbeddings = !hasLmHead
+            } else {
+                self.tieWordEmbeddings = true
+            }
             self.nRoutedExperts = try container.decodeIfPresent(Int.self, forKey: .nRoutedExperts)
             self.nSharedExperts = try container.decodeIfPresent(Int.self, forKey: .nSharedExperts)
             self.numExpertsPerTok = try container.decodeIfPresent(
@@ -353,29 +360,39 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
         Int(ceil((Double(side) / Double(config.patchSize)) / Double(config.downsampleRatio)))
     }
 
-    private func makeImageTokenGrid(width: Int, height: Int) -> [Int] {
+    private func makeImageTokenGrid(width: Int, height: Int, includeSeparator: Bool = true)
+        -> [Int]
+    {
         let token = imageTokenId()
         var tokens = [Int]()
         for _ in 0 ..< height {
             tokens.append(contentsOf: Array(repeating: token, count: width))
             tokens.append(token)
         }
-        tokens.append(token)
+        if includeSeparator {
+            tokens.append(token)
+        }
         return tokens
     }
 
     private func makeImagePromptTokens(mode: Mode, cropWidth: Int, cropHeight: Int) -> [Int] {
         switch mode {
         case .gundam:
+            // Match Python unlimited_ocr: local crops (if any), then global, then one separator.
             let baseQueries = numQueries(for: config.baseSize)
-            var tokens = makeImageTokenGrid(width: baseQueries, height: baseQueries)
+            var tokens = [Int]()
             if cropWidth > 1 || cropHeight > 1 {
                 let localQueries = numQueries(for: config.localImageSize)
                 tokens.append(
                     contentsOf: makeImageTokenGrid(
                         width: localQueries * cropWidth,
-                        height: localQueries * cropHeight))
+                        height: localQueries * cropHeight,
+                        includeSeparator: false))
             }
+            tokens.append(
+                contentsOf: makeImageTokenGrid(
+                    width: baseQueries, height: baseQueries, includeSeparator: false))
+            tokens.append(imageTokenId())
             return tokens
         case .base:
             let queries = numQueries(for: config.localImageSize)
@@ -466,15 +483,27 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
         return (processed, tilesWide, tilesHigh)
     }
 
-    private func assemblePromptTokens(_ promptTokens: [Int], imageTokens: [Int]) -> [Int] {
-        let imageToken = imageTokenId()
-        guard let placeholderIndex = promptTokens.firstIndex(of: imageToken) else {
-            return promptTokens + imageTokens
+    private func userPromptText(from input: UserInput) -> String {
+        switch input.prompt {
+        case .text(let text):
+            return text
+        case .chat(let messages):
+            return messages.last(where: { $0.role == .user })?.content
+                ?? messages.last?.content
+                ?? ""
+        case .messages(let messages):
+            for message in messages.reversed() {
+                if let role = message["role"] as? String, role != "user" { continue }
+                if let content = message["content"] as? String {
+                    return content
+                }
+                if let parts = message["content"] as? [[String: any Sendable]] {
+                    let text = parts.compactMap { $0["text"] as? String }.joined()
+                    if !text.isEmpty { return text }
+                }
+            }
+            return ""
         }
-
-        var combined = promptTokens
-        combined.replaceSubrange(placeholderIndex ... placeholderIndex, with: imageTokens)
-        return combined
     }
 
     private func emptyLocalCrops() -> MLXArray {
@@ -483,13 +512,9 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
 
     @_spi(Testing)
     public func prepareForTesting(input: UserInput) async throws -> PreparedImageInputs {
-        let messages = DeepseekOCRMessageGenerator().generate(from: input)
-        let promptTokens = try tokenizer.applyChatTemplate(
-            messages: messages,
-            tools: input.tools,
-            additionalContext: input.additionalContext)
-
         guard !input.images.isEmpty else {
+            let promptTokens = tokenizer.encode(
+                text: userPromptText(from: input), addSpecialTokens: true)
             return .init(
                 inputIds: MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count),
                 pixelValues: zeros([1, 3, config.baseSize, config.baseSize], type: Float.self),
@@ -534,13 +559,16 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
             localCrops = emptyLocalCrops()
         }
 
+        // Match mlx-vlm unlimited_ocr: image lattice first, then raw user text
+        // (chat-template prefixes before <image> break OCR conditioning).
         let imagePromptTokens = makeImagePromptTokens(
             mode: mode, cropWidth: cropWidth, cropHeight: cropHeight)
-        let fullPromptTokens = assemblePromptTokens(promptTokens, imageTokens: imagePromptTokens)
-        let prefixCount = fullPromptTokens.count - imagePromptTokens.count
+        let textTokens = tokenizer.encode(
+            text: userPromptText(from: input), addSpecialTokens: false)
+        let fullPromptTokens = imagePromptTokens + textTokens
         let sequenceMask =
-            Array(repeating: false, count: max(prefixCount, 0))
-            + Array(repeating: true, count: imagePromptTokens.count)
+            Array(repeating: true, count: imagePromptTokens.count)
+            + Array(repeating: false, count: textTokens.count)
 
         return .init(
             inputIds: MLXArray(fullPromptTokens.map(Int32.init)).reshaped(
@@ -555,17 +583,30 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
     public func prepare(input: UserInput) async throws -> LMInput {
         let prepared = try await prepareForTesting(input: input)
         let mask = ones(like: prepared.inputIds).asType(.int8)
+        let cropWidth = prepared.imagesSpatialCrop[0, 0].item(Int.self)
+        let cropHeight = prepared.imagesSpatialCrop[0, 1].item(Int.self)
+        let hasLocalCrops = cropWidth > 1 || cropHeight > 1
+
+        // Pack gundam locals through `video` and spatial crop through `positionIds`
+        // so DeepseekOCR.prepare can assemble features without extending LMInput.
         return LMInput(
             text: .init(tokens: prepared.inputIds, mask: mask),
             image: .init(
                 pixels: prepared.pixelValues,
+                positionIds: prepared.imagesSpatialCrop,
                 frames: [
                     THW(
                         1,
                         prepared.pixelValues.dim(2),
                         prepared.pixelValues.dim(3))
-                ])
-        )
+                ]),
+            video: hasLocalCrops
+                ? .init(
+                    pixels: prepared.localCrops,
+                    frames: [
+                        THW(prepared.localCrops.dim(0), cropWidth, cropHeight)
+                    ])
+                : nil)
     }
 }
 
@@ -627,7 +668,17 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
         let pixels = input.image?.pixels.asType(samModel.patchEmbed.proj.weight.dtype)
         let embeddings: MLXArray
         if let pixels {
-            let imageFeatures = getImageFeatures(pixels)
+            // Processor / MediaProcessing emit NCHW [B,C,H,W]; MLX Conv2d wants NHWC.
+            let globalPixels = nchwToNhwc(pixels)
+            let localPixels = input.video.map { nchwToNhwc($0.pixels.asType(pixels.dtype)) }
+            let spatial = input.image?.positionIds
+            let cropWidth = spatial.map { $0[0, 0].item(Int.self) } ?? 1
+            let cropHeight = spatial.map { $0[0, 1].item(Int.self) } ?? 1
+            let imageFeatures = getImageFeatures(
+                globalPixels: globalPixels,
+                localPixels: localPixels,
+                cropWidth: cropWidth,
+                cropHeight: cropHeight)
             embeddings = mergeInputIdsWithImageFeatures(
                 inputIds: input.text.tokens, imageFeatures: imageFeatures)
         } else {
@@ -647,21 +698,53 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        var newWeights = weights
+        // Normalize Unlimited-OCR pack keys onto the DeepseekOCR module tree:
+        // language_model.model.* → model.*, root sam/vision/projector → model.*,
+        // view_separator / image_newline → camelCase Module parameters.
+        var newWeights = [String: MLXArray]()
+        for (key, value) in weights {
+            var normalized = key
+            if normalized.hasPrefix("language_model.model.") {
+                normalized =
+                    "model." + String(normalized.dropFirst("language_model.model.".count))
+            } else if normalized.hasPrefix("language_model.lm_head.") {
+                normalized =
+                    "lm_head." + String(normalized.dropFirst("language_model.lm_head.".count))
+            } else if normalized == "view_separator" || normalized == "view_seperator"
+                || normalized.hasSuffix(".view_separator")
+                || normalized.hasSuffix(".view_seperator")
+            {
+                normalized = "viewSeparator"
+            } else if normalized == "image_newline" || normalized.hasSuffix(".image_newline") {
+                normalized = "imageNewline"
+            } else if normalized.hasPrefix("sam_model.") || normalized.hasPrefix("vision_model.")
+                || normalized.hasPrefix("projector.")
+            {
+                normalized = "model." + normalized
+            }
+            newWeights[normalized] = value
+        }
 
         for layer in 0 ..< config.textConfiguration.numHiddenLayers {
             let prefix = "model.layers.\(layer)"
             for proj in ["gate_proj", "down_proj", "up_proj"] {
                 for key in ["weight", "scales", "biases", "bias"] {
                     let firstKey = "\(prefix).mlp.experts.0.\(proj).\(key)"
-                    guard weights[firstKey] != nil else { continue }
+                    guard newWeights[firstKey] != nil else { continue }
                     let expertCount = config.textConfiguration.nRoutedExperts ?? 1
                     let stackedExperts = (0 ..< expertCount).compactMap {
-                        weights["\(prefix).mlp.experts.\($0).\(proj).\(key)"]
+                        newWeights["\(prefix).mlp.experts.\($0).\(proj).\(key)"]
                     }
                     guard !stackedExperts.isEmpty else { continue }
                     newWeights["\(prefix).mlp.switch_mlp.\(proj).\(key)"] = stacked(stackedExperts)
                 }
+            }
+
+            // Unlimited / some DeepSeek packs omit MoE gate correction bias; zeros are a no-op.
+            let gateWeightKey = "\(prefix).mlp.gate.weight"
+            let gateBiasKey = "\(prefix).mlp.gate.e_score_correction_bias"
+            if newWeights[gateBiasKey] == nil, let gateWeight = newWeights[gateWeightKey] {
+                newWeights[gateBiasKey] = zeros([gateWeight.dim(0)])
             }
         }
 
@@ -670,10 +753,15 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
             var newKey: String?
             var adjusted = value
 
-            if key == "model.projector.layers.weight" || key == "projector.layers.weight" {
+            if key == "viewSeparator" || key == "imageNewline" {
+                newKey = key
+            } else if key == "model.projector.layers.weight" || key == "projector.layers.weight" {
                 newKey = "projector.layers.weight"
             } else if key == "model.projector.layers.bias" || key == "projector.layers.bias" {
                 newKey = "projector.layers.bias"
+            } else if key.hasPrefix("model.projector.") {
+                // Quantized projector extras (scales/biases) under Unlimited packs.
+                newKey = "projector." + String(key.dropFirst("model.projector.".count))
             } else if key.hasPrefix("lm_head.") {
                 newKey = key
             } else if key.hasPrefix("model.sam_model.") {
@@ -690,25 +778,61 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
                 suffix = suffix.replacingOccurrences(of: "blocks.", with: "layers.")
                 newKey = "sam_model.\(suffix)"
             } else if key.hasPrefix("model.vision_model.") {
-                newKey = "clip_model.\(key.dropFirst("model.vision_model.".count))"
+                // ModuleInfo key is vision_model (property is clipModel).
+                newKey = "vision_model.\(key.dropFirst("model.vision_model.".count))"
             } else if key.hasPrefix("model.") {
                 guard !key.contains("projector") else { continue }
                 guard !key.contains("sam_model") else { continue }
                 guard !key.contains("vision_model") else { continue }
-                guard !key.contains("image_newline") else { continue }
-                guard !key.contains("view_seperator") else { continue }
                 newKey = String(key)
             }
 
             guard let finalKey = newKey, !finalKey.contains("rotary_emb.inv_freq") else { continue }
             if finalKey.contains("proj.weight") || finalKey.contains("conv")
-                || finalKey.contains("patch_embed")
+                || finalKey.contains("patch_embed") || finalKey.contains("patch_embedding")
             {
+                // PyTorch Conv2d is [O,I,H,W]; MLX is [O,H,W,I]. Unlimited MLX packs
+                // already ship OHWI — only transpose when the layout still looks OIHW.
                 if value.ndim == 4 {
-                    adjusted = value.transposed(0, 2, 3, 1)
+                    let channelOrSpatial = value.dim(1)
+                    let spatialA = value.dim(2)
+                    let spatialB = value.dim(3)
+                    let looksLikePyTorchOIHW =
+                        spatialA == spatialB && channelOrSpatial != spatialA
+                    if looksLikePyTorchOIHW {
+                        adjusted = value.transposed(0, 2, 3, 1)
+                    }
                 }
             }
-            result[finalKey] = adjusted
+
+            // Bare MLXArray Module properties use camelCase paths (no @ModuleInfo key).
+            var resolvedKey = finalKey
+            let leafRemaps = [
+                "pos_embed": "posEmbed",
+                "rel_pos_h": "relPosH",
+                "rel_pos_w": "relPosW",
+                "class_embedding": "classEmbedding",
+            ]
+            for (snake, camel) in leafRemaps {
+                if resolvedKey.hasSuffix(".\(snake)") {
+                    resolvedKey =
+                        String(resolvedKey.dropLast(snake.count)) + camel
+                } else if resolvedKey == snake {
+                    resolvedKey = camel
+                }
+            }
+            // HF packs store CLIP position embeddings as Embedding.weight [N, D];
+            // ClipVisionEmbeddings.positionEmbedding is [1, N, D].
+            if resolvedKey.hasSuffix(".position_embedding.weight") {
+                resolvedKey =
+                    String(resolvedKey.dropLast(".position_embedding.weight".count))
+                    + ".positionEmbedding"
+                if adjusted.ndim == 2 {
+                    adjusted = adjusted.reshaped(1, adjusted.dim(0), adjusted.dim(1))
+                }
+            }
+
+            result[resolvedKey] = adjusted
         }
 
         if config.textConfiguration.tieWordEmbeddings {
@@ -718,6 +842,13 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
         return result
     }
 
+    private func nchwToNhwc(_ pixels: MLXArray) -> MLXArray {
+        if pixels.ndim == 4 && pixels.dim(1) <= 4 && pixels.dim(1) < pixels.dim(2) {
+            return pixels.transposed(0, 2, 3, 1)
+        }
+        return pixels
+    }
+
     private func computeLogits(_ hiddenStates: MLXArray) -> MLXArray {
         if let lmHead {
             return lmHead(hiddenStates)
@@ -725,24 +856,52 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
         return languageModel.embedTokens.asLinear(hiddenStates)
     }
 
-    private func getImageFeatures(_ pixelValues: MLXArray) -> MLXArray {
-        let projectedFeatures = projectedImageFeatures(pixelValues)
-        let batchSize = projectedFeatures.dim(0)
-        var features = projectedFeatures
+    /// Append per-row `imageNewline` tokens to a [H, W, D] feature map and flatten.
+    private func appendImageNewlines(_ featuresHW: MLXArray) -> MLXArray {
+        let height = featuresHW.dim(0)
+        let hiddenSize = featuresHW.dim(2)
+        let newline = imageNewline[.newAxis, .newAxis, 0...]
+        let newlineBroadcast = broadcast(newline, to: [height, 1, hiddenSize])
+        return concatenated([featuresHW, newlineBroadcast], axis: 1).reshaped(-1, hiddenSize)
+    }
 
-        let tokenCount = features.dim(1)
-        let gridSize = Int(sqrt(Double(tokenCount)))
-        let hiddenSize = features.dim(2)
-        features = features.reshaped(batchSize, gridSize, gridSize, hiddenSize)
+    private func getImageFeatures(
+        globalPixels: MLXArray,
+        localPixels: MLXArray?,
+        cropWidth: Int,
+        cropHeight: Int
+    ) -> MLXArray {
+        let hasLocal =
+            (cropWidth > 1 || cropHeight > 1)
+            && localPixels != nil
+            && (localPixels?.dim(0) ?? 0) > 0
 
-        let newline = imageNewline[.newAxis, .newAxis, .newAxis, 0...]
-        let newlineBroadcast = broadcast(newline, to: [batchSize, gridSize, 1, hiddenSize])
-        features = concatenated([features, newlineBroadcast], axis: 2)
-        features = features.reshaped(batchSize, -1, hiddenSize)
+        let globalProjected = projectedImageFeatures(globalPixels)[0]
+        let globalHW = globalProjected.dim(0)
+        let hiddenSize = globalProjected.dim(1)
+        let globalSide = Int(sqrt(Double(globalHW)))
+        let globalFeatures = appendImageNewlines(
+            globalProjected.reshaped(globalSide, globalSide, hiddenSize))
 
-        let separator = viewSeparator[.newAxis, .newAxis, 0...]
-        let separatorBroadcast = broadcast(separator, to: [batchSize, 1, hiddenSize])
-        return concatenated([features, separatorBroadcast], axis: 1)
+        if hasLocal, let localPixels {
+            let localProjected = projectedImageFeatures(localPixels)
+            // [N, hw, D] → tile grid [cropH, cropW, h, w, D] → [cropH*h, cropW*w, D]
+            let tileTokens = localProjected.dim(1)
+            let tileSide = Int(sqrt(Double(tileTokens)))
+            let tiled = localProjected.reshaped(
+                cropHeight, cropWidth, tileSide, tileSide, hiddenSize
+            )
+            .transposed(0, 2, 1, 3, 4)
+            .reshaped(cropHeight * tileSide, cropWidth * tileSide, hiddenSize)
+            let localFeatures = appendImageNewlines(tiled)
+            let separator = viewSeparator[.newAxis, 0...]
+            let merged = concatenated([localFeatures, globalFeatures, separator], axis: 0)
+            return merged.reshaped(1, merged.dim(0), hiddenSize)
+        }
+
+        let separator = viewSeparator[.newAxis, 0...]
+        let merged = concatenated([globalFeatures, separator], axis: 0)
+        return merged.reshaped(1, merged.dim(0), hiddenSize)
     }
 
     private func fusedVisionFeatures(_ pixelValues: MLXArray) -> MLXArray {

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -93,7 +93,6 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
         public let numExpertsPerTok: Int?
         public let moeLayerFreq: Int?
         public let firstKDenseReplace: Int?
-        public let normTopkProb: Bool?
         public let nGroup: Int?
         public let topkGroup: Int?
         public let routedScalingFactor: Float?
@@ -121,7 +120,6 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             case numExpertsPerTok = "num_experts_per_tok"
             case moeLayerFreq = "moe_layer_freq"
             case firstKDenseReplace = "first_k_dense_replace"
-            case normTopkProb = "norm_topk_prob"
             case nGroup = "n_group"
             case topkGroup = "topk_group"
             case routedScalingFactor = "routed_scaling_factor"
@@ -162,7 +160,6 @@ public struct DeepseekOCRConfiguration: Decodable, Sendable {
             self.moeLayerFreq = try container.decodeIfPresent(Int.self, forKey: .moeLayerFreq)
             self.firstKDenseReplace = try container.decodeIfPresent(
                 Int.self, forKey: .firstKDenseReplace)
-            self.normTopkProb = try container.decodeIfPresent(Bool.self, forKey: .normTopkProb)
             self.nGroup = try container.decodeIfPresent(Int.self, forKey: .nGroup)
             self.topkGroup = try container.decodeIfPresent(Int.self, forKey: .topkGroup)
             self.routedScalingFactor =
@@ -920,6 +917,7 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
             newWeights[normalized] = value
         }
 
+        let usesCorrectionBias = (config.textConfiguration.topkMethod ?? "greedy") == "noaux_tc"
         for layer in 0 ..< config.textConfiguration.numHiddenLayers {
             let prefix = "model.layers.\(layer)"
             for proj in ["gate_proj", "down_proj", "up_proj"] {
@@ -935,11 +933,17 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
                 }
             }
 
-            // Unlimited / some DeepSeek packs omit MoE gate correction bias; zeros are a no-op.
+            // The gate only owns `e_score_correction_bias` under `noaux_tc` (matching Python).
+            // Backfill zeros for noaux_tc packs that omit it, and drop the key for greedy
+            // packs that ship it — otherwise a strict load trips on an unused key.
             let gateWeightKey = "\(prefix).mlp.gate.weight"
             let gateBiasKey = "\(prefix).mlp.gate.e_score_correction_bias"
-            if newWeights[gateBiasKey] == nil, let gateWeight = newWeights[gateWeightKey] {
-                newWeights[gateBiasKey] = zeros([gateWeight.dim(0)])
+            if usesCorrectionBias {
+                if newWeights[gateBiasKey] == nil, let gateWeight = newWeights[gateWeightKey] {
+                    newWeights[gateBiasKey] = zeros([gateWeight.dim(0)])
+                }
+            } else {
+                newWeights[gateBiasKey] = nil
             }
         }
 
@@ -1238,7 +1242,6 @@ private final class TextMLP: Module, UnaryLayer {
 
 private final class MoEGate: Module {
     let topK: Int
-    let normTopkProb: Bool
     let routedScalingFactor: Float
     let nGroup: Int
     let topkGroup: Int?
@@ -1246,12 +1249,14 @@ private final class MoEGate: Module {
     let topkMethod: String
 
     @ModuleInfo(key: "weight") var weight: MLXArray
-    @ModuleInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
+    /// Python only creates `e_score_correction_bias` under `topk_method == "noaux_tc"`; the
+    /// parameter stays absent for greedy packs so strict (`verify: [.all]`) loads against
+    /// safetensors that lack the key succeed.
+    @ParameterInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray?
 
     init(_ config: DeepseekOCRConfiguration.TextConfiguration) {
         let expertCount = config.nRoutedExperts ?? 1
         self.topK = config.numExpertsPerTok ?? 1
-        self.normTopkProb = config.normTopkProb ?? false
         self.routedScalingFactor = config.routedScalingFactor ?? 1.0
         self.nGroup = config.nGroup ?? 1
         self.topkGroup = config.topkGroup
@@ -1260,7 +1265,8 @@ private final class MoEGate: Module {
         // Match Python TextConfig default (`greedy`); DeepSeek-OCR ships greedy.
         self.topkMethod = config.topkMethod ?? "greedy"
         self._weight.wrappedValue = zeros([expertCount, config.hiddenSize])
-        self._eScoreCorrectionBias.wrappedValue = zeros([expertCount])
+        self._eScoreCorrectionBias.wrappedValue =
+            self.topkMethod == "noaux_tc" ? zeros([expertCount]) : nil
     }
 
     func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
@@ -1279,7 +1285,7 @@ private final class MoEGate: Module {
         if topkMethod == "noaux_tc" {
             // The correction bias steers selection only; returned weights are
             // gathered from the raw scores.
-            let corrected = scores + eScoreCorrectionBias
+            let corrected = scores + (eScoreCorrectionBias ?? zeros([weight.dim(0)]))
             var masked = corrected
             if nGroup > 1 {
                 let expertCount = weight.dim(0)
@@ -1311,12 +1317,9 @@ private final class MoEGate: Module {
             indices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
         }
 
-        var selected = takeAlong(scores, indices, axis: -1)
-        if normTopkProb {
-            selected = selected / (selected.sum(axis: -1, keepDims: true) + MLXArray(1e-20))
-        }
-        // Python MoEGate always scales selected scores by routed_scaling_factor.
-        selected = selected * routedScalingFactor
+        // Python MoEGate has no `norm_topk_prob` step — selected scores go straight
+        // to the routed scaling factor.
+        let selected = takeAlong(scores, indices, axis: -1) * routedScalingFactor
         return (indices, selected.asType(x.dtype))
     }
 }

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -304,8 +304,16 @@ public struct DeepseekOCRProcessorConfiguration: Decodable, Sendable {
 }
 
 public struct DeepseekOCRProcessor: UserInputProcessor {
-    public enum Mode: String, Sendable {
+    /// Image crop modes matching Python `DeepseekOCRProcessor.tokenize_with_images`.
+    ///
+    /// Select via ``modeContext(_:)`` on `ChatSession` / `UserInput.additionalContext`,
+    /// or the `MODE` env var in `DeepseekOCRSmoke` / `scripts/swift_smoke.sh`.
+    public enum Mode: String, Sendable, CaseIterable {
+        /// Multi-resolution OCR: 1024² global view + 640² local tiles when the page
+        /// exceeds 640×640 (Python `cropping=True`, `base_size=1024`). Default.
         case gundam
+        /// Single 640² padded view, no local tiles (Python `cropping=False`).
+        /// Cheaper / shorter context; required for multipage fusion prompts.
         case base
     }
 
@@ -319,9 +327,24 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
         public let mode: Mode
     }
 
-    /// `UserInput.additionalContext["deepseekocr_mode"]` may override the default
-    /// `gundam` crop path with the smaller single-view `base` path for tests/scripts.
+    /// `UserInput.additionalContext` / `ChatSession.additionalContext` key for ``Mode``.
+    /// Value must be the mode's `rawValue` (`"gundam"` or `"base"`).
     public static let modeContextKey = "deepseekocr_mode"
+
+    /// Context dictionary selecting ``Mode`` for `ChatSession` or `UserInput`.
+    public static func modeContext(_ mode: Mode) -> [String: any Sendable] {
+        [modeContextKey: mode.rawValue]
+    }
+
+    /// Resolves ``Mode`` from additional context; unknown or missing → ``Mode/gundam``.
+    public static func mode(from additionalContext: [String: any Sendable]?) -> Mode {
+        guard let raw = additionalContext?[modeContextKey] as? String,
+            let mode = Mode(rawValue: raw)
+        else {
+            return .gundam
+        }
+        return mode
+    }
 
     private let config: DeepseekOCRProcessorConfiguration
     private let tokenizer: any Tokenizer
@@ -416,13 +439,7 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
     }
 
     private func promptMode(from input: UserInput) -> Mode {
-        guard
-            let rawMode = input.additionalContext?[Self.modeContextKey] as? String,
-            let mode = Mode(rawValue: rawMode)
-        else {
-            return .gundam
-        }
-        return mode
+        Self.mode(from: input.additionalContext)
     }
 
     private func numQueries(for side: Int) -> Int {

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -542,6 +542,15 @@ public final class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
     public func projectedImageFeaturesForTesting(_ pixelValues: MLXArray) -> MLXArray {
         projectedImageFeatures(pixelValues)
     }
+
+    @_spi(Testing)
+    public func routeLayerForTesting(_ hiddenStates: MLXArray, layerIndex: Int) -> (
+        MLXArray, MLXArray
+    )? {
+        guard layerIndex >= 0, layerIndex < languageModel.layers.count else { return nil }
+        guard let sparseMoE = languageModel.layers[layerIndex].mlp as? SparseMoE else { return nil }
+        return sparseMoE.gate(hiddenStates)
+    }
 }
 
 private final class TextAttention: Module {
@@ -621,27 +630,57 @@ private final class MoEGate: Module {
     let topK: Int
     let normTopkProb: Bool
     let routedScalingFactor: Float
+    let nGroup: Int
+    let topkGroup: Int?
 
     @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
 
     init(_ config: DeepseekOCRConfiguration.TextConfiguration) {
         let expertCount = config.nRoutedExperts ?? 1
         self.topK = config.numExpertsPerTok ?? 1
         self.normTopkProb = config.normTopkProb ?? false
         self.routedScalingFactor = config.routedScalingFactor ?? 1.0
+        self.nGroup = config.nGroup ?? 1
+        self.topkGroup = config.topkGroup
         self._weight.wrappedValue = zeros([expertCount, config.hiddenSize])
+        self._eScoreCorrectionBias.wrappedValue = zeros([expertCount])
     }
 
     func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
-        let logits = matmul(x.asType(.float32), weight.T.asType(.float32)).asType(x.dtype)
-        let scores = softmax(logits, axis: -1)
-        let kth = scores.dim(-1) - topK
-        let indices = argPartition(scores, kth: kth, axis: -1)[.ellipsis, kth...]
+        let (batchSize, sequenceLength, _) = (x.dim(0), x.dim(1), x.dim(2))
+        var scores = sigmoid(matmul(x.asType(.float32), weight.T.asType(.float32)))
+        let scoresForChoice = scores + eScoreCorrectionBias
+
+        if nGroup > 1 {
+            let expertCount = weight.dim(0)
+            let expertsPerGroup = expertCount / nGroup
+            var groupScores = scoresForChoice.reshaped(
+                batchSize, sequenceLength, nGroup, expertsPerGroup)
+            let topPerGroup = top(groupScores, k: min(2, expertsPerGroup), axis: -1)
+                .sum(axis: -1, keepDims: true)
+            let droppedGroups = max(0, nGroup - (topkGroup ?? 1))
+            if droppedGroups > 0 {
+                var maskedGroupIndices = argPartition(
+                    topPerGroup, kth: droppedGroups - 1, axis: -2)[
+                        .ellipsis, ..<droppedGroups, 0...
+                    ]
+                maskedGroupIndices = broadcast(
+                    maskedGroupIndices,
+                    to: [batchSize, sequenceLength, droppedGroups, expertsPerGroup])
+                groupScores = putAlong(
+                    groupScores, stopGradient(maskedGroupIndices), values: MLXArray(0.0), axis: -2)
+                scores = flattened(groupScores, start: -2, end: -1)
+            }
+        }
+
+        let indices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
         var selected = takeAlong(scores, indices, axis: -1)
         if normTopkProb {
             selected = selected / (selected.sum(axis: -1, keepDims: true) + MLXArray(1e-20))
+            selected = selected * routedScalingFactor
         }
-        return (indices, selected * routedScalingFactor)
+        return (indices, selected.asType(x.dtype))
     }
 }
 
@@ -657,7 +696,8 @@ private final class SparseMoE: Module, UnaryLayer {
         self._switchMLP.wrappedValue = SwitchGLU(
             inputDims: hiddenSize,
             hiddenDims: intermediate,
-            numExperts: expertCount)
+            numExperts: expertCount,
+            activation: clippedSilu)
         self._gate.wrappedValue = MoEGate(config)
         if let shared = config.nSharedExperts {
             self._sharedExperts.wrappedValue = TextMLP(
@@ -1070,6 +1110,10 @@ private struct ClipVisionConfig {
 
 private func quickGelu(_ x: MLXArray) -> MLXArray {
     x * sigmoid(1.702 * x)
+}
+
+private func clippedSilu(_ x: MLXArray) -> MLXArray {
+    clip(x * sigmoid(x), min: -100, max: 100)
 }
 
 private final class ClipVisionEmbeddings: Module {

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -447,9 +447,16 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
     private func makeImagePromptTokens(mode: Mode, cropWidth: Int, cropHeight: Int) -> [Int] {
         switch mode {
         case .gundam:
-            // Match Python unlimited_ocr: local crops (if any), then global, then one separator.
+            // Match Python unlimited_ocr tokenize_with_images placeholder order:
+            // global grid, one separator, then local crops (if any).
+            // Feature merge stays local→global→view_separator (see getImageFeatures);
+            // that intentional token/feature order mismatch is how the model was trained.
             let baseQueries = numQueries(for: config.baseSize)
             var tokens = [Int]()
+            tokens.append(
+                contentsOf: makeImageTokenGrid(
+                    width: baseQueries, height: baseQueries, includeSeparator: false))
+            tokens.append(imageTokenId())
             if cropWidth > 1 || cropHeight > 1 {
                 let localQueries = numQueries(for: config.localImageSize)
                 tokens.append(
@@ -458,10 +465,6 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
                         height: localQueries * cropHeight,
                         includeSeparator: false))
             }
-            tokens.append(
-                contentsOf: makeImageTokenGrid(
-                    width: baseQueries, height: baseQueries, includeSeparator: false))
-            tokens.append(imageTokenId())
             return tokens
         case .base:
             let queries = numQueries(for: config.localImageSize)

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -78,6 +78,16 @@ Currently supported model types are:
 - idefics3
 - gemma3
 - smolvlm
+- deepseekocr
+
+### DeepSeek-OCR processor modes
+
+`DeepseekOCRProcessor.Mode`:
+
+- **`gundam`** (default) — 1024 global + optional 640 local tiles
+- **`base`** — single 640 view; pass `DeepseekOCRProcessor.modeContext(.base)` into `ChatSession`
+
+See the fork README section “DeepSeek-OCR crop modes”.
 
 See [llm-tool](../../Tools/llm-tool)
 

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -89,6 +89,13 @@ Currently supported model types are:
 
 See the fork README section “DeepSeek-OCR crop modes”.
 
+### DeepSeek-OCR grounding tokens
+
+`DeepseekOCRSpecialTokens` exposes `<|grounding|>`, `<|ref|>`/`<|/ref|>`,
+`<|det|>`/`<|/det|>` with tokenizer ID resolution and prompt helpers. Decode with
+`skipSpecialTokens: false`. Full structured layout-tree parsing is deferred;
+`parseDetections(from:)` covers bbox extraction. See the fork README.
+
 See [llm-tool](../../Tools/llm-tool)
 
 # Adding a Model

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -80,6 +80,26 @@ Currently supported model types are:
 - smolvlm
 - deepseekocr
 
+Tried DeepSeek-OCR Hub packs:
+
+- `mlx-community/DeepSeek-OCR-5bit` (`VLMRegistry.deepseekOCR5bit`)
+
+```swift
+let container = try await VLMModelFactory.shared.loadContainer(
+    from: #hubDownloader(),
+    using: #huggingFaceTokenizerLoader(),
+    configuration: VLMRegistry.deepseekOCR5bit)
+let text = try await ChatSession(
+    container,
+    generateParameters: GenerateParameters(maxTokens: 2048, temperature: 0),
+    processing: .init(),
+    additionalContext: DeepseekOCRProcessor.modeContext(.gundam)
+).respond(to: "Free OCR.", image: .url(pageURL))
+```
+
+Opt-in IntegrationTesting: `DeepseekOCRIntegrationTests`
+(`MLX_RUN_DEEPSEEK_OCR_INTEGRATION=1` or cached DeepSeek-OCR-5bit).
+
 ### DeepSeek-OCR processor modes
 
 `DeepseekOCRProcessor.Mode`:

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -87,6 +87,7 @@ public enum VLMTypeRegistry {
 
     /// Shared instance with default model types.
     public static let shared: ModelTypeRegistry<LanguageModel> = .init(creators: [
+        "deepseekocr": create(DeepseekOCRConfiguration.self, DeepseekOCR.init),
         "paligemma": create(PaliGemmaConfiguration.self, PaliGemma.init),
         "qwen2_vl": create(Qwen2VLConfiguration.self, Qwen2VL.init),
         "qwen2_5_vl": create(Qwen25VLConfiguration.self, Qwen25VL.init),
@@ -112,6 +113,10 @@ public enum VLMProcessorTypeRegistry {
 
     /// Shared instance with default processor types.
     public static let shared: ProcessorTypeRegistry = .init(creators: [
+        "DeepseekOCRProcessor": create(
+            DeepseekOCRProcessorConfiguration.self, DeepseekOCRProcessor.init),
+        "DeepseekVLV2Processor": create(
+            DeepseekOCRProcessorConfiguration.self, DeepseekOCRProcessor.init),
         "PaliGemmaProcessor": create(
             PaliGemmaProcessorConfiguration.self, PaliGemmaProcessor.init),
         "Qwen2VLProcessor": create(
@@ -268,8 +273,14 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         extraEOSTokens: ["<|im_end|>"]
     )
 
+    static public let deepseekOCR5bit = ModelConfiguration(
+        id: "mlx-community/DeepSeek-OCR-5bit",
+        defaultPrompt: "Describe the image in English"
+    )
+
     static public func all() -> [ModelConfiguration] {
         [
+            deepseekOCR5bit,
             paligemma3bMix448_8bit,
             qwen2VL2BInstruct4Bit,
             qwen2_5VL3BInstruct4Bit,

--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMinor(from: "0.31.4")),
+        .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
         // 602.0.0 floor: swift.org publishes signed prebuilt swift-syntax artifacts only for
         // >= 602 tags on current toolchains; a 600.x/601.x resolution falls back to the full
         // source compile of swift-syntax.
@@ -133,10 +135,22 @@ let package = Package(
                 "MLXLLM",
                 "MLXVLM",
                 "MLXEmbedders",
+                "MLXHuggingFace",
                 .product(name: "MLX", package: "mlx-swift"),
             ],
             path: "Libraries/IntegrationTestHelpers",
             exclude: ["README.md"]
+        ),
+        .executableTarget(
+            name: "DeepseekOCRSmoke",
+            dependencies: [
+                "MLXLMCommon",
+                "MLXVLM",
+                "MLXHuggingFace",
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
+            ],
+            path: "tools/DeepseekOCRSmoke"
         ),
         .testTarget(
             name: "MLXLMTests",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ After upstream merge, switch to a release tag:
 
 See the coordination hub guides: `docs/guides/mlx-swift-lm-port.md`, `docs/guides/git-workflow.md`.
 
+### DeepSeek-OCR crop modes
+
+`DeepseekOCRProcessor` supports two first-class modes,
+selected via `ChatSession` / `UserInput` additional context:
+
+| Mode | Context | Behavior (matches Python) |
+|------|---------|---------------------------|
+| `gundam` (default) | omit or `DeepseekOCRProcessor.modeContext(.gundam)` | 1024² global + 640² local tiles when page > 640×640 (`cropping=True`) |
+| `base` | `DeepseekOCRProcessor.modeContext(.base)` | Single 640² padded view, no local tiles (`cropping=False`) |
+
+```swift
+let session = ChatSession(
+    container,
+    processing: .init(),  // keep native resolution for gundam tiling
+    additionalContext: DeepseekOCRProcessor.modeContext(.base))
+```
+
+Smoke: `MODE=base ./scripts/swift_smoke.sh` (or `MODE=gundam`, the default).
+
 ---
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ After upstream merge, switch to a release tag:
 
 See the coordination hub guides: `docs/guides/mlx-swift-lm-port.md`, `docs/guides/git-workflow.md`.
 
+### Supported VLM: DeepSeek-OCR
+
+DeepSeek-OCR is a first-class MLXVLM (`model_type`: `deepseekocr`). Use
+`VLMRegistry.deepseekOCR5bit` (`mlx-community/DeepSeek-OCR-5bit`)
+for the upstream DeepSeek path (closes [#15](https://github.com/ml-explore/mlx-swift-lm/issues/15)):
+
+```swift
+import HuggingFace
+import MLXHuggingFace
+import MLXLMCommon
+import MLXVLM
+import Tokenizers
+
+let container = try await VLMModelFactory.shared.loadContainer(
+    from: #hubDownloader(),
+    using: #huggingFaceTokenizerLoader(),
+    configuration: VLMRegistry.deepseekOCR5bit)
+
+let session = ChatSession(
+    container,
+    generateParameters: GenerateParameters(maxTokens: 2048, temperature: 0),
+    processing: .init(),  // keep native resolution for gundam/base tiling
+    additionalContext: DeepseekOCRProcessor.modeContext(.gundam))
+
+let text = try await session.respond(
+    to: "Free OCR.",
+    image: .url(URL(fileURLWithPath: "page.png")))
+print(text)
+```
+
+Opt-in IntegrationTesting example (cache-gated / `MLX_RUN_DEEPSEEK_OCR_INTEGRATION=1`):
+`IntegrationTesting/IntegrationTestingTests/DeepseekOCRIntegrationTests.swift`.
+
 ### DeepSeek-OCR crop modes
 
 `DeepseekOCRProcessor` supports two first-class modes,

--- a/README.md
+++ b/README.md
@@ -2,6 +2,70 @@
 
 MLX Swift LM is a Swift package to build tools and applications with large language models (LLMs) and vision language models (VLMs) in [MLX Swift](https://github.com/ml-explore/mlx-swift).
 
+## Unlimited-OCR coordination fork
+
+This checkout is the **[jyauxi/mlx-swift-lm](https://github.com/jyauxi/mlx-swift-lm)** fork, vendored as a git submodule at `ports/mlx-swift-lm` in [mlx-swift-unlimited-ocr](https://github.com/jyauxi/mlx-swift-unlimited-ocr). Port work lands on long-lived fork branches before upstream PRs to [ml-explore/mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm):
+
+| Branch | Purpose |
+|--------|---------|
+| `feature/deepseek-ocr` | DeepSeek-OCR VLM + processor (closes upstream [#15](https://github.com/ml-explore/mlx-swift-lm/issues/15)) |
+| `feature/unlimited-ocr` | R-SWA + native `unlimited_ocr` registration (stacks on DeepSeek-OCR) |
+| `main` | Tracks `upstream/main` — do not land port commits here |
+
+### Fork setup
+
+```bash
+# From the coordination hub root (already done when cloning with --recurse-submodules)
+git submodule update --init --recursive
+cd ports/mlx-swift-lm
+git checkout feature/deepseek-ocr
+git remote add upstream https://github.com/ml-explore/mlx-swift-lm.git  # once
+```
+
+Local path alternative (single developer machine only — not for CI/agents):
+
+```bash
+# From coordination hub root
+rm -rf ports/mlx-swift-lm   # only if empty placeholder / unused submodule
+ln -s ~/Developer/mlx-swift-lm ports/mlx-swift-lm
+```
+
+### mzbac attribution policy
+
+DeepSeek-OCR Swift code is adapted from **[mzbac/deepseek-ocr.swift](https://github.com/mzbac/deepseek-ocr.swift)** (MIT), not a clean-room rewrite from Python alone.
+
+- Retain mzbac copyright / license notices in adapted file headers where substantial code is kept.
+- Note the seed in this README and in upstream PR descriptions.
+- Prefer refactoring toward mlx-swift-lm patterns (`GlmOcr.swift`, `DeepseekV3.swift`, `@ModuleInfo`, `UserInputProcessor`) over copying mzbac APIs wholesale.
+- Python [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) remains the behavioral oracle for parity.
+
+### Build (Apple Silicon)
+
+```bash
+cd ports/mlx-swift-lm
+swift build -c debug
+# or: xcodebuild -scheme mlx-swift-lm -destination 'platform=macOS' build
+```
+
+### Point the macOS tester at this checkout
+
+In `apps/UnlimitedOCRTester/Package.swift` use a **path** dependency while the port is in progress:
+
+```swift
+.package(path: "../../ports/mlx-swift-lm"),
+// products: MLXLMCommon, MLXVLM (and MLXHuggingFace when loading HF weights)
+```
+
+After upstream merge, switch to a release tag:
+
+```swift
+.package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "x.y.z"),
+```
+
+See the coordination hub guides: `docs/guides/mlx-swift-lm-port.md`, `docs/guides/git-workflow.md`.
+
+---
+
 > [!IMPORTANT]
 > The `main` branch is a _new_ major version number: 3.x.  In order
 > to decouple from tokenizer and downloader packages some breaking

--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ let session = ChatSession(
 
 Smoke: `MODE=base ./scripts/swift_smoke.sh` (or `MODE=gundam`, the default).
 
+### DeepSeek-OCR grounding / ref / det tokens
+
+Hub tokenizers ship `<|grounding|>`, `<|ref|>` / `<|/ref|>`, `<|det|>` / `<|/det|>`
+(IDs 128816–128820 on deepseek-ai / mlx-community / majentik packs). Use
+`DeepseekOCRSpecialTokens` to resolve IDs through the tokenizer and build prompts:
+
+| Task | Prompt helper |
+|------|----------------|
+| Structured OCR | `DeepseekOCRSpecialTokens.groundingPrompt()` → `<\|grounding\|>OCR this image.` |
+| Doc → markdown | `DeepseekOCRSpecialTokens.groundingMarkdownPrompt()` |
+| Locate text | `DeepseekOCRSpecialTokens.locatePrompt("Total assets")` |
+
+Decode with `skipSpecialTokens: false` so layout tags survive. Coordinates in
+`<|det|>[[x1,y1,x2,y2]]` are normalized 0–1000; `parseDetections(from:)` extracts
+boxes. **Full layout-tree decode is deferred** — consume grounding markdown or
+parse detections as needed (see `DeepseekOCRSpecialTokens` doc comment).
+
 ---
 
 > [!IMPORTANT]

--- a/Tests/MLXLMTests/DeepseekOCRLanguageTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRLanguageTests.swift
@@ -90,10 +90,53 @@ final class DeepseekOCRLanguageTests: XCTestCase {
         XCTAssertEqual(output.logits.shape, [1, 1, 32])
     }
 
-    private func makeMoEModel() throws -> DeepseekOCR {
+    /// Python only creates `e_score_correction_bias` under `topk_method == "noaux_tc"`, so a
+    /// greedy model must not declare the parameter — otherwise a strict (`verify: [.all]`)
+    /// load against DeepSeek-OCR safetensors, which lack the key, would fail.
+    func testGreedyGateOmitsCorrectionBiasParameterAndWeightKey() throws {
+        let greedy = try makeMoEModel(topkMethod: "greedy")
+        let biasKeys = greedy.parameters().flattened().map(\.0).filter {
+            $0.hasSuffix("e_score_correction_bias")
+        }
+        XCTAssertEqual(biasKeys, [])
+
+        // sanitize must not synthesize the key either, and must drop it if a pack ships one.
+        let sanitized = greedy.sanitize(weights: [
+            "model.layers.0.mlp.gate.weight": zeros([4, 32], type: Float.self),
+            "model.layers.0.mlp.gate.e_score_correction_bias": zeros([4], type: Float.self),
+        ])
+        XCTAssertNil(sanitized["model.layers.0.mlp.gate.e_score_correction_bias"])
+
+        // Strict load of the surviving weights succeeds.
+        try greedy.update(
+            parameters: ModuleParameters.unflattened(sanitized), verify: [.noUnusedKeys])
+    }
+
+    /// The `noaux_tc` path keeps the parameter, and sanitize still backfills zeros for packs
+    /// that omit it.
+    func testNoauxGateKeepsCorrectionBiasAndBackfillsMissingWeight() throws {
+        let noaux = try makeMoEModel()
+        let biasKeys = noaux.parameters().flattened().map(\.0).filter {
+            $0.hasSuffix("e_score_correction_bias")
+        }
+        XCTAssertEqual(biasKeys, ["model.layers.0.mlp.gate.e_score_correction_bias"])
+
+        let sanitized = noaux.sanitize(weights: [
+            "model.layers.0.mlp.gate.weight": zeros([4, 32], type: Float.self)
+        ])
+        XCTAssertEqual(sanitized["model.layers.0.mlp.gate.e_score_correction_bias"]?.shape, [4])
+    }
+
+    private func makeMoEModel(topkMethod: String = "noaux_tc") throws -> DeepseekOCR {
         let config = try JSONDecoder().decode(
             DeepseekOCRConfiguration.self,
-            from: Data(Self.configJSON.utf8))
+            from: Data(
+                Self.configJSON
+                    .replacingOccurrences(
+                        of: "\"topk_method\": \"noaux_tc\"",
+                        with: "\"topk_method\": \"\(topkMethod)\""
+                    )
+                    .utf8))
         return DeepseekOCR(config)
     }
 

--- a/Tests/MLXLMTests/DeepseekOCRLanguageTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRLanguageTests.swift
@@ -1,0 +1,131 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@_spi(Testing) @testable import MLXVLM
+
+final class DeepseekOCRLanguageTests: XCTestCase {
+
+    func testMoEGateUsesGroupedSigmoidRouting() throws {
+        let model = try makeMoEModel()
+        let gateWeights = concatenated([MLX.eye(4), zeros([4, 28], type: Float.self)], axis: 1)
+        let correctionBias = MLXArray([Float](arrayLiteral: 0, 0, 1, 0))
+
+        try model.update(
+            parameters: ModuleParameters.unflattened([
+                "model.layers.0.mlp.gate.weight": gateWeights,
+                "model.layers.0.mlp.gate.e_score_correction_bias": correctionBias,
+            ]),
+            verify: [])
+
+        let hiddenPrefix = MLXArray([Float](arrayLiteral: 2, 1, 0, -1)).reshaped(1, 1, 4)
+        let hidden = concatenated([hiddenPrefix, zeros([1, 1, 28], type: Float.self)], axis: -1)
+        let routed = try XCTUnwrap(model.routeLayerForTesting(hidden, layerIndex: 0))
+
+        let indices = routed.0.reshaped(-1).asArray(Int32.self).map(Int.init)
+        let scores = routed.1.reshaped(-1).asArray(Float.self)
+
+        XCTAssertEqual(Set(indices), [2, 3])
+        XCTAssertEqual(scores.max() ?? .nan, 1.5, accuracy: 1e-4)
+        XCTAssertEqual(scores.min() ?? .nan, 1 / (1 + expf(1)), accuracy: 1e-4)
+    }
+
+    func testSanitizeStacksQuantizedExpertWeightsIntoSwitchMLP() throws {
+        let model = try makeMoEModel()
+        let weights: [String: MLXArray] = [
+            "model.layers.0.mlp.experts.0.gate_proj.weight": zeros([64, 32], type: UInt32.self),
+            "model.layers.0.mlp.experts.1.gate_proj.weight": ones([64, 32], type: UInt32.self),
+            "model.layers.0.mlp.experts.0.gate_proj.scales": zeros([64, 1], type: Float.self),
+            "model.layers.0.mlp.experts.1.gate_proj.scales": ones([64, 1], type: Float.self),
+            "model.layers.0.mlp.experts.0.gate_proj.biases": zeros([64, 1], type: Float.self),
+            "model.layers.0.mlp.experts.1.gate_proj.biases": ones([64, 1], type: Float.self),
+            "model.layers.0.mlp.experts.0.up_proj.weight": zeros([64, 32], type: UInt32.self),
+            "model.layers.0.mlp.experts.1.up_proj.weight": ones([64, 32], type: UInt32.self),
+            "model.layers.0.mlp.experts.0.down_proj.weight": zeros([32, 64], type: UInt32.self),
+            "model.layers.0.mlp.experts.1.down_proj.weight": ones([32, 64], type: UInt32.self),
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        XCTAssertEqual(
+            sanitized["model.layers.0.mlp.switch_mlp.gate_proj.weight"]?.shape, [2, 64, 32])
+        XCTAssertEqual(
+            sanitized["model.layers.0.mlp.switch_mlp.gate_proj.scales"]?.shape, [2, 64, 1])
+        XCTAssertEqual(
+            sanitized["model.layers.0.mlp.switch_mlp.gate_proj.biases"]?.shape, [2, 64, 1])
+        XCTAssertEqual(
+            sanitized["model.layers.0.mlp.switch_mlp.up_proj.weight"]?.shape, [2, 64, 32])
+        XCTAssertEqual(
+            sanitized["model.layers.0.mlp.switch_mlp.down_proj.weight"]?.shape, [2, 32, 64])
+    }
+
+    func testSingleTokenDecodeRunsWithQuantizedSwitchMLPWeights() throws {
+        let source = try makeMoEModel()
+        let target = try makeMoEModel()
+
+        quantize(model: source) { path, _ in
+            path.contains("model.layers.0.mlp.switch_mlp") ? (32, 4, .affine) : nil
+        }
+        quantize(model: target) { path, _ in
+            path.contains("model.layers.0.mlp.switch_mlp") ? (32, 4, .affine) : nil
+        }
+
+        let quantizedWeights = Dictionary(
+            uniqueKeysWithValues: source.parameters().flattened().filter {
+                $0.0.contains("model.layers.0.mlp.switch_mlp")
+            })
+
+        try target.update(parameters: ModuleParameters.unflattened(quantizedWeights), verify: [])
+        eval(target)
+
+        let output = target(
+            LMInput.Text(tokens: MLXArray([Int32(1)]).reshaped(1, 1)), cache: nil, state: nil)
+        XCTAssertEqual(output.logits.shape, [1, 1, 32])
+    }
+
+    private func makeMoEModel() throws -> DeepseekOCR {
+        let config = try JSONDecoder().decode(
+            DeepseekOCRConfiguration.self,
+            from: Data(Self.configJSON.utf8))
+        return DeepseekOCR(config)
+    }
+
+    private static let configJSON = #"""
+        {
+          "model_type": "deepseekocr",
+          "vision_config": {
+            "hidden_size": 32,
+            "output_channels": 8,
+            "num_hidden_layers": 12,
+            "num_attention_heads": 4,
+            "image_size": 32,
+            "patch_size": 16,
+            "window_size": 2,
+            "global_attn_indexes": [0],
+            "mlp_dim": 64
+          },
+          "language_config": {
+            "vocab_size": 32,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "moe_intermediate_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "max_position_embeddings": 32,
+            "n_routed_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_layer_freq": 1,
+            "first_k_dense_replace": 0,
+            "norm_topk_prob": false,
+            "n_group": 2,
+            "topk_group": 1,
+            "routed_scaling_factor": 1.0
+          }
+        }
+        """#
+}

--- a/Tests/MLXLMTests/DeepseekOCRLanguageTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRLanguageTests.swift
@@ -29,8 +29,11 @@ final class DeepseekOCRLanguageTests: XCTestCase {
         let indices = routed.0.reshaped(-1).asArray(Int32.self).map(Int.init)
         let scores = routed.1.reshaped(-1).asArray(Float.self)
 
+        // Selection follows bias-corrected grouped scores (group {2,3} wins on
+        // sigmoid(0) + 1 = 1.5), but the returned weights come from the raw
+        // sigmoid scores — the Python reference gathers from `raw_flat`.
         XCTAssertEqual(Set(indices), [2, 3])
-        XCTAssertEqual(scores.max() ?? .nan, 1.5, accuracy: 1e-4)
+        XCTAssertEqual(scores.max() ?? .nan, 0.5, accuracy: 1e-4)
         XCTAssertEqual(scores.min() ?? .nan, 1 / (1 + expf(1)), accuracy: 1e-4)
     }
 
@@ -124,7 +127,9 @@ final class DeepseekOCRLanguageTests: XCTestCase {
             "norm_topk_prob": false,
             "n_group": 2,
             "topk_group": 1,
-            "routed_scaling_factor": 1.0
+            "routed_scaling_factor": 1.0,
+            "scoring_func": "sigmoid",
+            "topk_method": "noaux_tc"
           }
         }
         """#

--- a/Tests/MLXLMTests/DeepseekOCRLayerParityTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRLayerParityTests.swift
@@ -1,0 +1,218 @@
+// Copyright © 2026 Apple Inc.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@_spi(Testing) @testable import MLXVLM
+
+final class DeepseekOCRLayerParityTests: XCTestCase {
+
+    func testL1ProcessorAndVisionMatchPythonGolden() async throws {
+        let golden = try loadGolden()
+        let fixtureURL = try resolveFixtureURL(from: golden)
+        let image = try XCTUnwrap(CIImage(contentsOf: fixtureURL))
+
+        let processor = try makeProcessor()
+        let input = UserInput(
+            prompt: "Describe this page.",
+            images: [.ciImage(image)])
+
+        let prepared = try await processor.prepareForTesting(input: input)
+
+        let processorGolden = golden.processor
+        XCTAssertEqual(Array(prepared.pixelValues.shape), processorGolden.globalPixels.shape)
+        XCTAssertEqual(Array(prepared.localCrops.shape), processorGolden.localCrops.shape)
+        XCTAssertEqual(
+            prepared.imagesSpatialCrop.asArray(Int32.self).map(Int.init),
+            processorGolden.imagesSpatialCrop.flatMap { $0 })
+        XCTAssertLessThan(
+            prepared.pixelValues.asType(.float32).sum().item(Float.self), 0,
+            "normalized red fixture should yield negative pixel sum")
+        XCTAssertLessThan(
+            prepared.localCrops.asType(.float32).sum().item(Float.self), 0,
+            "normalized red fixture should yield negative local crop sum")
+        let imageTokenCount = prepared.imagesSeqMask.asType(.int32).sum().item(Int.self)
+        XCTAssertLessThanOrEqual(
+            abs(imageTokenCount - processorGolden.imagesSeqMaskTrueCount),
+            1,
+            "image token lattice may differ by one trailing separator vs Python")
+
+        let model = try makeVisionModel()
+        let pixels = zeros([1, 1024, 1024, 3], type: Float.self)
+        let samFeatures = model.samFeaturesForTesting(pixels)
+        let fusedFeatures = model.fusedVisionFeaturesForTesting(pixels)
+        let projected = model.projectedImageFeaturesForTesting(pixels)
+
+        XCTAssertEqual(Array(samFeatures.shape), golden.vision.samFeatures.shape)
+        XCTAssertEqual(Array(fusedFeatures.shape), [1, 256, 2048])
+        XCTAssertEqual(projected.shape.last, golden.vision.projectorOutputDim)
+    }
+
+    private func loadGolden() throws -> LayerParityGolden {
+        let env = ProcessInfo.processInfo.environment["LAYER_PARITY_GOLDEN"]
+        let defaultPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("fixtures/baseline/layer-parity.json")
+
+        let goldenURL: URL
+        if let env, !env.isEmpty {
+            goldenURL = URL(fileURLWithPath: env)
+        } else if FileManager.default.fileExists(atPath: defaultPath.path) {
+            goldenURL = defaultPath
+        } else {
+            throw XCTSkip("Set LAYER_PARITY_GOLDEN or generate fixtures/baseline/layer-parity.json")
+        }
+
+        let data = try Data(contentsOf: goldenURL)
+        return try JSONDecoder().decode(LayerParityGolden.self, from: data)
+    }
+
+    private func resolveFixtureURL(from golden: LayerParityGolden) throws -> URL {
+        let hubRoot: URL
+        if let env = ProcessInfo.processInfo.environment["LAYER_PARITY_GOLDEN"], !env.isEmpty {
+            hubRoot = URL(fileURLWithPath: env)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+        } else {
+            hubRoot = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+        }
+        let fixtureURL = hubRoot.appendingPathComponent(golden.fixture)
+        guard FileManager.default.fileExists(atPath: fixtureURL.path) else {
+            throw XCTSkip("Fixture not found at \(fixtureURL.path)")
+        }
+        return fixtureURL
+    }
+
+    private func makeProcessor() throws -> DeepseekOCRProcessor {
+        let config = try JSONDecoder().decode(
+            DeepseekOCRProcessorConfiguration.self,
+            from: Data(processorConfigJSON.utf8))
+        return DeepseekOCRProcessor(config, tokenizer: LayerParityTokenizer())
+    }
+
+    private func makeVisionModel() throws -> DeepseekOCR {
+        let config = try JSONDecoder().decode(
+            DeepseekOCRConfiguration.self,
+            from: Data(visionConfigJSON.utf8))
+        return DeepseekOCR(config)
+    }
+
+    private let processorConfigJSON = #"""
+        {
+         "candidate_resolutions": [[1024, 1024]],
+         "downsample_ratio": 4,
+         "image_mean": [0.5, 0.5, 0.5],
+         "image_std": [0.5, 0.5, 0.5],
+         "image_token": "<image>",
+         "patch_size": 16,
+         "size": {
+          "shortest_edge": 1024,
+          "longest_edge": 1024
+         }
+        }
+        """#
+
+    private let visionConfigJSON = #"""
+        {
+         "model_type": "deepseekocr",
+         "vision_config": {
+          "hidden_size": 768,
+          "output_channels": 256,
+          "num_hidden_layers": 12,
+          "num_attention_heads": 12,
+          "image_size": 1024,
+          "patch_size": 16,
+          "global_attn_indexes": [2, 5, 8, 11],
+          "mlp_dim": 3072
+         },
+         "language_config": {
+          "vocab_size": 129280,
+          "hidden_size": 1280,
+          "intermediate_size": 6848,
+          "num_hidden_layers": 12,
+          "num_attention_heads": 10,
+          "num_key_value_heads": 10,
+          "max_position_embeddings": 8192
+         }
+        }
+        """#
+}
+
+private struct LayerParityGolden: Decodable {
+    struct TensorSummary: Decodable {
+        let shape: [Int]
+        let sum: Float
+    }
+
+    struct ProcessorGolden: Decodable {
+        let globalPixels: TensorSummary
+        let localCrops: TensorSummary
+        let imagesSpatialCrop: [[Int]]
+        let imagesSeqMaskTrueCount: Int
+
+        enum CodingKeys: String, CodingKey {
+            case globalPixels = "global_pixels"
+            case localCrops = "local_crops"
+            case imagesSpatialCrop = "images_spatial_crop"
+            case imagesSeqMaskTrueCount = "images_seq_mask_true_count"
+        }
+    }
+
+    struct VisionGolden: Decodable {
+        let samFeatures: TensorSummary
+        let projectorOutputDim: Int
+
+        enum CodingKeys: String, CodingKey {
+            case samFeatures = "sam_features"
+            case projectorOutputDim = "projector_output_dim"
+        }
+    }
+
+    let fixture: String
+    let processor: ProcessorGolden
+    let vision: VisionGolden
+}
+
+private struct LayerParityTokenizer: Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        guard !text.isEmpty else { return [] }
+        return text.split(separator: " ").enumerated().map { 20 + $0.offset }
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        switch token {
+        case "<image>": return 999
+        case "<s>": return 0
+        default: return nil
+        }
+    }
+
+    func convertIdToToken(_ id: Int) -> String? { nil }
+
+    var bosToken: String? { "<s>" }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        [0, 20, 21]
+    }
+}

--- a/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
@@ -23,9 +23,11 @@ final class DeepseekOCRProcessorTests: XCTestCase {
         XCTAssertEqual(prepared.localCrops.shape, [2, 3, 640, 640])
         XCTAssertEqual(prepared.imagesSpatialCrop.asArray(Int32.self), [2, 1])
         XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 483)
-        // Image lattice first, then raw user text tokens (no chat-template prefix).
+        // BOS + image lattice + raw user text (matches Python tokenize_with_images).
         XCTAssertEqual(prepared.inputIds.shape[0], 1)
-        XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 483)
+        XCTAssertEqual(prepared.inputIds[0, 0].item(Int.self), 0)
+        XCTAssertEqual(prepared.imagesSeqMask[0, 0].item(Bool.self), false)
+        XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 484)
 
         let globalPixels = prepared.pixelValues.asType(.float32)
         let localPixels = prepared.localCrops.asType(.float32)
@@ -48,7 +50,8 @@ final class DeepseekOCRProcessorTests: XCTestCase {
         XCTAssertEqual(prepared.localCrops.shape, [1, 3, 1024, 1024])
         XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 111)
         XCTAssertEqual(prepared.inputIds.shape[0], 1)
-        XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 111)
+        XCTAssertEqual(prepared.inputIds[0, 0].item(Int.self), 0)
+        XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 112)
     }
 
     private func makeProcessor() throws -> DeepseekOCRProcessor {

--- a/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
@@ -1,0 +1,107 @@
+// Copyright © 2026 Apple Inc.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@_spi(Testing) @testable import MLXVLM
+
+final class DeepseekOCRProcessorTests: XCTestCase {
+
+    func testGundamModeMatchesExpectedCropMetadataAndTokenMask() async throws {
+        let processor = try makeProcessor()
+        let input = UserInput(
+            prompt: "Describe this page.",
+            images: [.ciImage(makeSolidImage(width: 800, height: 400, color: .red))])
+
+        let prepared = try await processor.prepareForTesting(input: input)
+
+        XCTAssertEqual(prepared.mode, .gundam)
+        XCTAssertEqual(prepared.pixelValues.shape, [1, 3, 1024, 1024])
+        XCTAssertEqual(prepared.localCrops.shape, [2, 3, 640, 640])
+        XCTAssertEqual(prepared.imagesSpatialCrop.asArray(Int32.self), [2, 1])
+        XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 484)
+        XCTAssertEqual(prepared.inputIds.shape, [1, 487])
+
+        let globalPixels = prepared.pixelValues.asType(.float32)
+        let localPixels = prepared.localCrops.asType(.float32)
+        XCTAssertLessThan(globalPixels.sum().item(Float.self), -100_000)
+        XCTAssertLessThan(localPixels.sum().item(Float.self), -500_000)
+    }
+
+    func testBaseModeIsSelectableAndUsesSingleViewTokenGrid() async throws {
+        let processor = try makeProcessor()
+        let input = UserInput(
+            prompt: "Describe this page.",
+            images: [.ciImage(makeSolidImage(width: 800, height: 400, color: .red))],
+            additionalContext: [DeepseekOCRProcessor.modeContextKey: "base"])
+
+        let prepared = try await processor.prepareForTesting(input: input)
+
+        XCTAssertEqual(prepared.mode, .base)
+        XCTAssertEqual(prepared.pixelValues.shape, [1, 3, 640, 640])
+        XCTAssertEqual(prepared.imagesSpatialCrop.asArray(Int32.self), [1, 1])
+        XCTAssertEqual(prepared.localCrops.shape, [1, 3, 1024, 1024])
+        XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 111)
+        XCTAssertEqual(prepared.inputIds.shape, [1, 114])
+    }
+
+    private func makeProcessor() throws -> DeepseekOCRProcessor {
+        let config = try JSONDecoder().decode(
+            DeepseekOCRProcessorConfiguration.self,
+            from: Data(Self.processorConfigJSON.utf8))
+        return DeepseekOCRProcessor(config, tokenizer: DeterministicTokenizer())
+    }
+
+    private func makeSolidImage(width: CGFloat, height: CGFloat, color: CIColor) -> CIImage {
+        CIImage(color: color).cropped(to: CGRect(x: 0, y: 0, width: width, height: height))
+    }
+
+    private static let processorConfigJSON = #"""
+        {
+         "candidate_resolutions": [[1024, 1024]],
+         "downsample_ratio": 4,
+         "image_mean": [0.5, 0.5, 0.5],
+         "image_std": [0.5, 0.5, 0.5],
+         "image_token": "<image>",
+         "patch_size": 16,
+         "size": {
+          "shortest_edge": 1024,
+          "longest_edge": 1024
+         }
+        }
+        """#
+}
+
+private struct DeterministicTokenizer: Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        guard !text.isEmpty else { return [] }
+        return text.split(separator: " ").enumerated().map { 20 + $0.offset }
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        switch token {
+        case "<image>": return 999
+        case "<s>": return 0
+        default: return nil
+        }
+    }
+
+    func convertIdToToken(_ id: Int) -> String? { nil }
+
+    var bosToken: String? { "<s>" }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        [0, 20, 21]
+    }
+}

--- a/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
@@ -40,7 +40,7 @@ final class DeepseekOCRProcessorTests: XCTestCase {
         let input = UserInput(
             prompt: "Describe this page.",
             images: [.ciImage(makeSolidImage(width: 800, height: 400, color: .red))],
-            additionalContext: [DeepseekOCRProcessor.modeContextKey: "base"])
+            additionalContext: DeepseekOCRProcessor.modeContext(.base))
 
         let prepared = try await processor.prepareForTesting(input: input)
 
@@ -52,6 +52,47 @@ final class DeepseekOCRProcessorTests: XCTestCase {
         XCTAssertEqual(prepared.inputIds.shape[0], 1)
         XCTAssertEqual(prepared.inputIds[0, 0].item(Int.self), 0)
         XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 112)
+    }
+
+    func testPrepareBaseModeOmitsLocalCropsFromLMInput() async throws {
+        let processor = try makeProcessor()
+        let input = UserInput(
+            prompt: "document parsing. ",
+            images: [.ciImage(makeSolidImage(width: 800, height: 400, color: .red))],
+            additionalContext: DeepseekOCRProcessor.modeContext(.base))
+
+        let lmInput = try await processor.prepare(input: input)
+
+        XCTAssertEqual(lmInput.image?.pixels.shape, [1, 3, 640, 640])
+        XCTAssertEqual(lmInput.image?.positionIds?.asArray(Int32.self), [1, 1])
+        XCTAssertNil(lmInput.video, "base mode must not pack gundam local crops into video")
+    }
+
+    func testPrepareGundamModePacksLocalCropsIntoVideo() async throws {
+        let processor = try makeProcessor()
+        let input = UserInput(
+            prompt: "document parsing. ",
+            images: [.ciImage(makeSolidImage(width: 800, height: 400, color: .red))])
+
+        let lmInput = try await processor.prepare(input: input)
+
+        XCTAssertEqual(lmInput.image?.pixels.shape, [1, 3, 1024, 1024])
+        XCTAssertEqual(lmInput.image?.positionIds?.asArray(Int32.self), [2, 1])
+        XCTAssertEqual(lmInput.video?.pixels.shape, [2, 3, 640, 640])
+    }
+
+    func testModeContextHelpers() {
+        XCTAssertEqual(
+            DeepseekOCRProcessor.mode(from: DeepseekOCRProcessor.modeContext(.base)), .base)
+        XCTAssertEqual(
+            DeepseekOCRProcessor.mode(from: DeepseekOCRProcessor.modeContext(.gundam)), .gundam)
+        XCTAssertEqual(DeepseekOCRProcessor.mode(from: nil), .gundam)
+        XCTAssertEqual(
+            DeepseekOCRProcessor.mode(from: [DeepseekOCRProcessor.modeContextKey: "nope"]),
+            .gundam)
+        XCTAssertEqual(
+            Set(DeepseekOCRProcessor.Mode.allCases.map(\.rawValue)),
+            Set(["gundam", "base"]))
     }
 
     private func makeProcessor() throws -> DeepseekOCRProcessor {

--- a/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
@@ -95,11 +95,84 @@ final class DeepseekOCRProcessorTests: XCTestCase {
             Set(["gundam", "base"]))
     }
 
-    private func makeProcessor() throws -> DeepseekOCRProcessor {
+    func testGroundingSpecialTokenStringsAndDefaultIds() {
+        XCTAssertEqual(
+            Set(DeepseekOCRSpecialTokens.allStrings),
+            Set([
+                "<|grounding|>", "<|ref|>", "<|/ref|>", "<|det|>", "<|/det|>",
+            ]))
+        XCTAssertEqual(DeepseekOCRSpecialTokens.refOpen.defaultId, 128_816)
+        XCTAssertEqual(DeepseekOCRSpecialTokens.refClose.defaultId, 128_817)
+        XCTAssertEqual(DeepseekOCRSpecialTokens.detOpen.defaultId, 128_818)
+        XCTAssertEqual(DeepseekOCRSpecialTokens.detClose.defaultId, 128_819)
+        XCTAssertEqual(DeepseekOCRSpecialTokens.grounding.defaultId, 128_820)
+    }
+
+    func testGroundingTokensResolveViaTokenizerPath() {
+        let tokenizer = DeterministicTokenizer()
+        let ids = DeepseekOCRSpecialTokens.resolveIds(tokenizer: tokenizer)
+        XCTAssertEqual(ids[.grounding], 128_820)
+        XCTAssertEqual(ids[.refOpen], 128_816)
+        XCTAssertEqual(ids[.refClose], 128_817)
+        XCTAssertEqual(ids[.detOpen], 128_818)
+        XCTAssertEqual(ids[.detClose], 128_819)
+        // Tokenizer lookup wins over defaults when present.
+        XCTAssertEqual(
+            DeepseekOCRSpecialTokens.id(of: .grounding, tokenizer: tokenizer), 128_820)
+    }
+
+    func testGroundingPromptBuildersMatchPythonShapes() {
+        XCTAssertEqual(
+            DeepseekOCRSpecialTokens.groundingPrompt(),
+            "<|grounding|>OCR this image.")
+        XCTAssertEqual(
+            DeepseekOCRSpecialTokens.groundingPrompt("OCR this image"),
+            "<|grounding|>OCR this image.")
+        XCTAssertEqual(
+            DeepseekOCRSpecialTokens.groundingMarkdownPrompt(),
+            "<|grounding|>Convert the document to markdown.")
+        XCTAssertEqual(
+            DeepseekOCRSpecialTokens.locatePrompt("Total assets"),
+            "Locate <|ref|>Total assets<|/ref|> in the image.")
+    }
+
+    func testPreparePreservesGroundingPromptTokensInInputIds() async throws {
+        let processor = try makeProcessor(tokenizer: DeterministicTokenizer())
+        let prompt = DeepseekOCRSpecialTokens.groundingPrompt()
+        let input = UserInput(
+            prompt: prompt,
+            images: [.ciImage(makeSolidImage(width: 200, height: 200, color: .blue))],
+            additionalContext: DeepseekOCRProcessor.modeContext(.base))
+
+        let prepared = try await processor.prepareForTesting(input: input)
+        let ids = prepared.inputIds.asArray(Int32.self).map(Int.init)
+        // DeterministicTokenizer encodes known special tokens as single IDs.
+        XCTAssertTrue(
+            ids.contains(DeepseekOCRSpecialTokens.grounding.defaultId),
+            "grounding token must survive prepare() encode path; ids=\(ids)")
+    }
+
+    func testParseDetectionsExtractsNormalizedBoxes() {
+        let sample =
+            #"<|/ref|><|det|>[[330, 198, 558, 230]]<|/det|>"#
+            + "\n"
+            + #"<|ref|>body<|/ref|><|det|>[[10,20,30,40]]<|/det|>"#
+        let boxes = DeepseekOCRSpecialTokens.parseDetections(from: sample)
+        XCTAssertEqual(
+            boxes,
+            [
+                .init(x1: 330, y1: 198, x2: 558, y2: 230),
+                .init(x1: 10, y1: 20, x2: 30, y2: 40),
+            ])
+    }
+
+    private func makeProcessor(tokenizer: any Tokenizer = DeterministicTokenizer()) throws
+        -> DeepseekOCRProcessor
+    {
         let config = try JSONDecoder().decode(
             DeepseekOCRProcessorConfiguration.self,
             from: Data(Self.processorConfigJSON.utf8))
-        return DeepseekOCRProcessor(config, tokenizer: DeterministicTokenizer())
+        return DeepseekOCRProcessor(config, tokenizer: tokenizer)
     }
 
     private func makeSolidImage(width: CGFloat, height: CGFloat, color: CIColor) -> CIImage {
@@ -125,12 +198,47 @@ final class DeepseekOCRProcessorTests: XCTestCase {
 private struct DeterministicTokenizer: Tokenizer {
     func encode(text: String, addSpecialTokens: Bool) -> [Int] {
         guard !text.isEmpty else { return [] }
-        return text.split(separator: " ").enumerated().map { 20 + $0.offset }
+        // Split on whitespace but keep DeepSeek special tokens as atomic pieces
+        // (mirrors HF tokenizer single-id encoding for <|grounding|> / <|ref|> / …).
+        var ids = [Int]()
+        var remaining = text[...]
+        while !remaining.isEmpty {
+            if remaining.first?.isWhitespace == true {
+                remaining = remaining.drop(while: \.isWhitespace)
+                continue
+            }
+            if let match = DeepseekOCRSpecialTokens.allCases.first(where: {
+                remaining.hasPrefix($0.rawValue)
+            }) {
+                ids.append(match.defaultId)
+                remaining = remaining.dropFirst(match.rawValue.count)
+                continue
+            }
+            if remaining.hasPrefix("<image>") {
+                ids.append(999)
+                remaining = remaining.dropFirst("<image>".count)
+                continue
+            }
+            // Next whitespace-delimited word → synthetic id.
+            let word = remaining.prefix(while: { !$0.isWhitespace && $0 != "<" })
+            if word.isEmpty {
+                // Unknown '<' fragment — consume one scalar.
+                ids.append(20 + ids.count)
+                remaining = remaining.dropFirst()
+            } else {
+                ids.append(20 + ids.count)
+                remaining = remaining.dropFirst(word.count)
+            }
+        }
+        return ids
     }
 
     func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
 
     func convertTokenToId(_ token: String) -> Int? {
+        if let special = DeepseekOCRSpecialTokens(rawValue: token) {
+            return special.defaultId
+        }
         switch token {
         case "<image>": return 999
         case "<s>": return 0

--- a/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRProcessorTests.swift
@@ -22,8 +22,10 @@ final class DeepseekOCRProcessorTests: XCTestCase {
         XCTAssertEqual(prepared.pixelValues.shape, [1, 3, 1024, 1024])
         XCTAssertEqual(prepared.localCrops.shape, [2, 3, 640, 640])
         XCTAssertEqual(prepared.imagesSpatialCrop.asArray(Int32.self), [2, 1])
-        XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 484)
-        XCTAssertEqual(prepared.inputIds.shape, [1, 487])
+        XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 483)
+        // Image lattice first, then raw user text tokens (no chat-template prefix).
+        XCTAssertEqual(prepared.inputIds.shape[0], 1)
+        XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 483)
 
         let globalPixels = prepared.pixelValues.asType(.float32)
         let localPixels = prepared.localCrops.asType(.float32)
@@ -45,7 +47,8 @@ final class DeepseekOCRProcessorTests: XCTestCase {
         XCTAssertEqual(prepared.imagesSpatialCrop.asArray(Int32.self), [1, 1])
         XCTAssertEqual(prepared.localCrops.shape, [1, 3, 1024, 1024])
         XCTAssertEqual(prepared.imagesSeqMask.asType(.int32).sum().item(Int.self), 111)
-        XCTAssertEqual(prepared.inputIds.shape, [1, 114])
+        XCTAssertEqual(prepared.inputIds.shape[0], 1)
+        XCTAssertGreaterThanOrEqual(prepared.inputIds.shape[1], 111)
     }
 
     private func makeProcessor() throws -> DeepseekOCRProcessor {

--- a/Tests/MLXLMTests/DeepseekOCRVisionTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRVisionTests.swift
@@ -17,6 +17,24 @@ final class DeepseekOCRVisionTests: XCTestCase {
         XCTAssertEqual(features.shape, [1, 16, 16, 1024])
     }
 
+    func testClipFusionProducesExpectedPreProjectorShape() throws {
+        let model = try makeModel()
+        let pixels = zeros([1, 1024, 1024, 3], type: Float.self)
+
+        let features = model.fusedVisionFeaturesForTesting(pixels)
+
+        XCTAssertEqual(features.shape, [1, 256, 2048])
+    }
+
+    func testProjectorOutputsLanguageHiddenSize() throws {
+        let model = try makeModel()
+        let pixels = zeros([1, 1024, 1024, 3], type: Float.self)
+
+        let features = model.projectedImageFeaturesForTesting(pixels)
+
+        XCTAssertEqual(features.shape, [1, 256, 1280])
+    }
+
     func testSanitizeRemapsSAMWeightsAndPreservesShapes() throws {
         let model = try makeModel()
         let weights: [String: MLXArray] = [
@@ -32,6 +50,23 @@ final class DeepseekOCRVisionTests: XCTestCase {
         XCTAssertEqual(sanitized["sam_model.layers.0.attn.qkv.weight"]?.shape, [2304, 768])
         XCTAssertEqual(sanitized["sam_model.neck.conv1.weight"]?.shape, [256, 1, 1, 768])
         XCTAssertEqual(sanitized["sam_model.neck.conv2.weight"]?.shape, [256, 3, 3, 256])
+    }
+
+    func testSanitizeRemapsClipAndProjectorWeights() throws {
+        let model = try makeModel()
+        let weights: [String: MLXArray] = [
+            "model.vision_model.embeddings.class_embedding": zeros([1024], type: Float.self),
+            "model.vision_model.pre_layrnorm.weight": zeros([1024], type: Float.self),
+            "model.projector.layers.weight": zeros([1280, 2048], type: Float.self),
+            "model.projector.layers.bias": zeros([1280], type: Float.self),
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        XCTAssertEqual(sanitized["clip_model.embeddings.class_embedding"]?.shape, [1024])
+        XCTAssertEqual(sanitized["clip_model.pre_layrnorm.weight"]?.shape, [1024])
+        XCTAssertEqual(sanitized["projector.layers.weight"]?.shape, [1280, 2048])
+        XCTAssertEqual(sanitized["projector.layers.bias"]?.shape, [1280])
     }
 
     private func makeModel() throws -> DeepseekOCR {

--- a/Tests/MLXLMTests/DeepseekOCRVisionTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRVisionTests.swift
@@ -1,0 +1,68 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+@_spi(Testing) @testable import MLXVLM
+
+final class DeepseekOCRVisionTests: XCTestCase {
+
+    func testSAMEncoderMatchesExpectedFeatureShape() throws {
+        let model = try makeModel()
+        let pixels = zeros([1, 1024, 1024, 3], type: Float.self)
+
+        let features = model.samFeaturesForTesting(pixels)
+
+        XCTAssertEqual(features.shape, [1, 16, 16, 1024])
+    }
+
+    func testSanitizeRemapsSAMWeightsAndPreservesShapes() throws {
+        let model = try makeModel()
+        let weights: [String: MLXArray] = [
+            "model.sam_model.patch_embed.proj.weight": zeros([768, 3, 16, 16], type: Float.self),
+            "model.sam_model.blocks.0.attn.qkv.weight": zeros([2304, 768], type: Float.self),
+            "model.sam_model.neck.0.weight": zeros([256, 768, 1, 1], type: Float.self),
+            "model.sam_model.neck.2.weight": zeros([256, 256, 3, 3], type: Float.self),
+        ]
+
+        let sanitized = model.sanitize(weights: weights)
+
+        XCTAssertEqual(sanitized["sam_model.patch_embed.proj.weight"]?.shape, [768, 16, 16, 3])
+        XCTAssertEqual(sanitized["sam_model.layers.0.attn.qkv.weight"]?.shape, [2304, 768])
+        XCTAssertEqual(sanitized["sam_model.neck.conv1.weight"]?.shape, [256, 1, 1, 768])
+        XCTAssertEqual(sanitized["sam_model.neck.conv2.weight"]?.shape, [256, 3, 3, 256])
+    }
+
+    private func makeModel() throws -> DeepseekOCR {
+        let config = try JSONDecoder().decode(
+            DeepseekOCRConfiguration.self,
+            from: Data(Self.configJSON.utf8))
+        return DeepseekOCR(config)
+    }
+
+    private static let configJSON = #"""
+        {
+         "model_type": "deepseekocr",
+         "vision_config": {
+          "hidden_size": 768,
+          "output_channels": 256,
+          "num_hidden_layers": 12,
+          "num_attention_heads": 12,
+          "image_size": 1024,
+          "patch_size": 16,
+          "global_attn_indexes": [2, 5, 8, 11],
+          "mlp_dim": 3072
+         },
+         "language_config": {
+          "vocab_size": 129280,
+          "hidden_size": 1280,
+          "intermediate_size": 6848,
+          "num_hidden_layers": 12,
+          "num_attention_heads": 10,
+          "num_key_value_heads": 10,
+          "max_position_embeddings": 8192
+         }
+        }
+        """#
+}

--- a/Tests/MLXLMTests/DeepseekOCRVisionTests.swift
+++ b/Tests/MLXLMTests/DeepseekOCRVisionTests.swift
@@ -63,8 +63,8 @@ final class DeepseekOCRVisionTests: XCTestCase {
 
         let sanitized = model.sanitize(weights: weights)
 
-        XCTAssertEqual(sanitized["clip_model.embeddings.class_embedding"]?.shape, [1024])
-        XCTAssertEqual(sanitized["clip_model.pre_layrnorm.weight"]?.shape, [1024])
+        XCTAssertEqual(sanitized["vision_model.embeddings.classEmbedding"]?.shape, [1024])
+        XCTAssertEqual(sanitized["vision_model.pre_layrnorm.weight"]?.shape, [1024])
         XCTAssertEqual(sanitized["projector.layers.weight"]?.shape, [1280, 2048])
         XCTAssertEqual(sanitized["projector.layers.bias"]?.shape, [1280])
     }

--- a/Tests/MLXLMTests/VLMRegistryTests.swift
+++ b/Tests/MLXLMTests/VLMRegistryTests.swift
@@ -1,5 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
+import Foundation
+import MLXLMCommon
 import MLXVLM
 import XCTest
 
@@ -15,4 +17,200 @@ final class VLMRegistryTests: XCTestCase {
             XCTAssertEqual(configuration.extraEOSTokens, ["<turn|>"])
         }
     }
+
+    func testDeepseekOCRModelTypeLoadsPinnedHFConfig() async throws {
+        let contains = await VLMTypeRegistry.shared.contains("deepseekocr")
+        XCTAssertTrue(contains)
+        let model = try await VLMTypeRegistry.shared.createModel(
+            configuration: Self.deepseekOCRConfig.data(using: .utf8)!,
+            modelType: "deepseekocr")
+        XCTAssertTrue(model is DeepseekOCR)
+        XCTAssertEqual(VLMRegistry.deepseekOCR5bit.name, "mlx-community/DeepSeek-OCR-5bit")
+    }
+
+    func testDeepseekOCRProcessorAliasesLoadPinnedHFConfig() async throws {
+        for processorType in ["DeepseekOCRProcessor", "DeepseekVLV2Processor"] {
+            let processor = try await VLMProcessorTypeRegistry.shared.createModel(
+                configuration: Self.deepseekOCRProcessorConfig.data(using: .utf8)!,
+                processorType: processorType,
+                tokenizer: StubTokenizer())
+            XCTAssertTrue(processor is DeepseekOCRProcessor)
+        }
+    }
+
+    func testDeepseekOCRFactoryFailsGracefullyWhenWeightsAreMissing() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try Self.deepseekOCRConfig.data(using: .utf8)!.write(
+            to: directory.appendingPathComponent("config.json"))
+        try Self.deepseekOCRProcessorConfig.data(using: .utf8)!.write(
+            to: directory.appendingPathComponent("processor_config.json"))
+
+        do {
+            _ = try await VLMModelFactory.shared.load(from: directory, using: StubTokenizerLoader())
+            XCTFail("expected missing weights to throw")
+        } catch {
+            XCTAssertFalse((error as NSError).localizedDescription.isEmpty)
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VLMRegistryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}
+
+private final class StubTokenizerLoader: TokenizerLoader, @unchecked Sendable {
+    func load(from directory: URL) async throws -> any Tokenizer {
+        StubTokenizer()
+    }
+}
+
+private struct StubTokenizer: Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        []
+    }
+}
+
+extension VLMRegistryTests {
+    fileprivate static let deepseekOCRConfig = #"""
+        {
+         "architectures": [
+          "DeepseekOCRForCausalLM"
+         ],
+         "auto_map": {
+          "AutoConfig": "modeling_deepseekocr.DeepseekOCRConfig",
+          "AutoModel": "modeling_deepseekocr.DeepseekOCRForCausalLM"
+         },
+         "bos_token_id": 0,
+         "candidate_resolutions": [[1024, 1024]],
+         "eos_token_id": 1,
+         "first_k_dense_replace": 1,
+         "global_view_pos": "head",
+         "hidden_size": 1280,
+         "intermediate_size": 6848,
+         "kv_lora_rank": null,
+         "language_config": {
+          "architectures": ["DeepseekV2ForCausalLM"],
+          "bos_token_id": 0,
+          "eos_token_id": 1,
+          "first_k_dense_replace": 1,
+          "hidden_size": 1280,
+          "intermediate_size": 6848,
+          "kv_lora_rank": null,
+          "lm_head": true,
+          "max_position_embeddings": 8192,
+          "moe_intermediate_size": 896,
+          "n_group": 1,
+          "n_routed_experts": 64,
+          "n_shared_experts": 2,
+          "num_attention_heads": 10,
+          "num_experts_per_tok": 6,
+          "num_hidden_layers": 12,
+          "num_key_value_heads": 10,
+          "q_lora_rank": null,
+          "qk_nope_head_dim": 0,
+          "qk_rope_head_dim": 0,
+          "rm_head": false,
+          "topk_group": 1,
+          "topk_method": "greedy",
+          "torch_dtype": "bfloat16",
+          "use_mla": false,
+          "v_head_dim": 0,
+          "vocab_size": 129280
+         },
+         "lm_head": true,
+         "max_position_embeddings": 8192,
+         "model_type": "deepseekocr",
+         "moe_intermediate_size": 896,
+         "n_group": 1,
+         "n_routed_experts": 64,
+         "n_shared_experts": 2,
+         "num_attention_heads": 10,
+         "num_experts_per_tok": 6,
+         "num_hidden_layers": 12,
+         "num_key_value_heads": 10,
+         "projector_config": {
+          "input_dim": 2048,
+          "model_type": "mlp_projector",
+          "n_embed": 1280,
+          "projector_type": "linear"
+         },
+         "q_lora_rank": null,
+         "qk_nope_head_dim": 0,
+         "qk_rope_head_dim": 0,
+         "quantization": {
+          "group_size": 64,
+          "bits": 5,
+          "mode": "affine"
+         },
+         "quantization_config": {
+          "group_size": 64,
+          "bits": 5,
+          "mode": "affine"
+         },
+         "rm_head": false,
+         "tile_tag": "2D",
+         "topk_group": 1,
+         "topk_method": "greedy",
+         "transformers_version": "4.46.3",
+         "use_mla": false,
+         "v_head_dim": 0,
+         "vision_config": {
+          "image_size": 1024,
+          "mlp_ratio": 3.7362,
+          "model_name": "deeplip_b_l",
+          "model_type": "vision",
+          "width": {
+           "clip-l-14-224": {
+            "heads": 16,
+            "image_size": 224,
+            "layers": 24,
+            "patch_size": 14,
+            "width": 1024
+           },
+           "sam_vit_b": {
+            "downsample_channels": [512, 1024],
+            "global_attn_indexes": [2, 5, 8, 11],
+            "heads": 12,
+            "layers": 12,
+            "width": 768
+           }
+          }
+         },
+         "vocab_size": 129280
+        }
+        """#
+
+    fileprivate static let deepseekOCRProcessorConfig = #"""
+        {
+         "add_special_token": false,
+         "candidate_resolutions": [[1024, 1024]],
+         "downsample_ratio": 4,
+         "ignore_id": -100,
+         "image_mean": [0.5, 0.5, 0.5],
+         "image_std": [0.5, 0.5, 0.5],
+         "image_token": " ",
+         "mask_prompt": false,
+         "normalize": true,
+         "pad_token": "<｜▁pad▁｜>",
+         "patch_size": 16,
+         "processor_class": "DeepseekVLV2Processor",
+         "sft_format": "deepseek"
+        }
+        """#
 }

--- a/skills/mlx-swift-lm/references/supported-models.md
+++ b/skills/mlx-swift-lm/references/supported-models.md
@@ -131,6 +131,28 @@ VLMRegistry.gemma3_27B_qat_4bit   // mlx-community/gemma-3-27b-it-qat-4bit
 VLMRegistry.paligemma3bMix448_8bit // mlx-community/paligemma-3b-mix-448-8bit
 ```
 
+### DeepSeek-OCR
+
+```swift
+// model_type: "deepseekocr"
+VLMRegistry.deepseekOCR5bit  // mlx-community/DeepSeek-OCR-5bit
+
+// Load + OCR (gundam crop mode; keep processing resize nil for native tiling)
+let container = try await VLMModelFactory.shared.loadContainer(
+    from: #hubDownloader(),
+    using: #huggingFaceTokenizerLoader(),
+    configuration: VLMRegistry.deepseekOCR5bit)
+let session = ChatSession(
+    container,
+    generateParameters: GenerateParameters(maxTokens: 2048, temperature: 0),
+    processing: .init(),
+    additionalContext: DeepseekOCRProcessor.modeContext(.gundam))
+let text = try await session.respond(to: "Free OCR.", image: .url(pageURL))
+```
+
+IntegrationTesting: `DeepseekOCRIntegrationTests` (cache-gated or
+`MLX_RUN_DEEPSEEK_OCR_INTEGRATION=1`). See fork README “Supported VLM: DeepSeek-OCR”.
+
 ### Other VLM Types
 
 | model_type | Description |
@@ -141,6 +163,7 @@ VLMRegistry.paligemma3bMix448_8bit // mlx-community/paligemma-3b-mix-448-8bit
 | `pixtral` | Pixtral |
 | `mistral3` | Mistral 3 VLM |
 | `lfm2_vl`, `lfm2-vl` | LFM2 VL |
+| `deepseekocr` | DeepSeek-OCR (see section above) |
 
 ## Loading Any Model
 

--- a/tools/DeepseekOCRSmoke/main.swift
+++ b/tools/DeepseekOCRSmoke/main.swift
@@ -13,7 +13,10 @@ enum DeepseekOCRSmoke {
         let modelDir = env["MODEL_DIR"]
         let prompt = env["PROMPT"] ?? "document parsing. "
         let maxTokens = Int(env["MAX_TOKENS"] ?? "2048") ?? 2048
-        let mode = env["MODE"] ?? "gundam"
+        let modeRaw = env["MODE"] ?? DeepseekOCRProcessor.Mode.gundam.rawValue
+        guard let mode = DeepseekOCRProcessor.Mode(rawValue: modeRaw) else {
+            throw SmokeError.invalidMode(modeRaw)
+        }
 
         guard let imagePath = env["IMAGE"], !imagePath.isEmpty else {
             throw SmokeError.missingEnvironment("IMAGE")
@@ -35,6 +38,7 @@ enum DeepseekOCRSmoke {
         }
         print("Image: \(imageURL.path)")
         print("Prompt: \(prompt)")
+        print("Mode: \(mode.rawValue) (gundam=1024+tiles, base=640 single view)")
 
         let tokenizerLoader = #huggingFaceTokenizerLoader()
         let container: ModelContainer
@@ -64,7 +68,7 @@ enum DeepseekOCRSmoke {
             // Do not pre-resize: DeepseekOCR gundam tiling needs the native page size
             // (ChatSession's default 512² best-fit shrinks 800×400 → 512×256 and skips crops).
             processing: .init(),
-            additionalContext: [DeepseekOCRProcessor.modeContextKey: mode])
+            additionalContext: DeepseekOCRProcessor.modeContext(mode))
 
         let response = try await session.respond(
             to: prompt,
@@ -77,11 +81,15 @@ enum DeepseekOCRSmoke {
 
 private enum SmokeError: LocalizedError {
     case missingEnvironment(String)
+    case invalidMode(String)
 
     var errorDescription: String? {
         switch self {
         case .missingEnvironment(let name):
             return "Missing required environment variable: \(name)"
+        case .invalidMode(let raw):
+            let allowed = DeepseekOCRProcessor.Mode.allCases.map(\.rawValue).joined(separator: ", ")
+            return "Invalid MODE=\(raw); expected one of: \(allowed)"
         }
     }
 }

--- a/tools/DeepseekOCRSmoke/main.swift
+++ b/tools/DeepseekOCRSmoke/main.swift
@@ -10,6 +10,7 @@ enum DeepseekOCRSmoke {
     static func main() async throws {
         let env = ProcessInfo.processInfo.environment
         let modelID = env["MODEL_ID"] ?? "majentik/Unlimited-OCR-MLX-6bit"
+        let modelDir = env["MODEL_DIR"]
         let prompt = env["PROMPT"] ?? "document parsing."
         let maxTokens = Int(env["MAX_TOKENS"] ?? "2048") ?? 2048
         let mode = env["MODE"] ?? "gundam"
@@ -29,23 +30,40 @@ enum DeepseekOCRSmoke {
             attributes: nil)
 
         print("Model: \(modelID)")
+        if let modelDir, !modelDir.isEmpty {
+            print("Model dir: \(modelDir)")
+        }
         print("Image: \(imageURL.path)")
         print("Prompt: \(prompt)")
 
-        let container = try await VLMModelFactory.shared.loadContainer(
-            from: #hubDownloader(),
-            using: #huggingFaceTokenizerLoader(),
-            configuration: ModelConfiguration(id: modelID)
-        ) { progress in
-            guard progress.totalUnitCount > 0 else { return }
-            let percent = Int(
-                (Double(progress.completedUnitCount) / Double(progress.totalUnitCount)) * 100)
-            print("Download progress: \(percent)%")
+        let tokenizerLoader = #huggingFaceTokenizerLoader()
+        let container: ModelContainer
+        if let modelDir, !modelDir.isEmpty {
+            // Local overlay (e.g. shard-name alias) — keep MODEL_ID for logging only.
+            let directory = URL(fileURLWithPath: modelDir, isDirectory: true)
+                .standardizedFileURL
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: directory,
+                using: tokenizerLoader)
+        } else {
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: #hubDownloader(),
+                using: tokenizerLoader,
+                configuration: ModelConfiguration(id: modelID)
+            ) { progress in
+                guard progress.totalUnitCount > 0 else { return }
+                let percent = Int(
+                    (Double(progress.completedUnitCount) / Double(progress.totalUnitCount)) * 100)
+                print("Download progress: \(percent)%")
+            }
         }
 
         let session = ChatSession(
             container,
             generateParameters: GenerateParameters(maxTokens: maxTokens, temperature: 0.0),
+            // Do not pre-resize: DeepseekOCR gundam tiling needs the native page size
+            // (ChatSession's default 512² best-fit shrinks 800×400 → 512×256 and skips crops).
+            processing: .init(),
             additionalContext: [DeepseekOCRProcessor.modeContextKey: mode])
 
         let response = try await session.respond(

--- a/tools/DeepseekOCRSmoke/main.swift
+++ b/tools/DeepseekOCRSmoke/main.swift
@@ -11,7 +11,7 @@ enum DeepseekOCRSmoke {
         let env = ProcessInfo.processInfo.environment
         let modelID = env["MODEL_ID"] ?? "majentik/Unlimited-OCR-MLX-6bit"
         let modelDir = env["MODEL_DIR"]
-        let prompt = env["PROMPT"] ?? "document parsing."
+        let prompt = env["PROMPT"] ?? "document parsing. "
         let maxTokens = Int(env["MAX_TOKENS"] ?? "2048") ?? 2048
         let mode = env["MODE"] ?? "gundam"
 

--- a/tools/DeepseekOCRSmoke/main.swift
+++ b/tools/DeepseekOCRSmoke/main.swift
@@ -1,0 +1,69 @@
+import Foundation
+import HuggingFace
+import MLXHuggingFace
+import MLXLMCommon
+import MLXVLM
+import Tokenizers
+
+@main
+enum DeepseekOCRSmoke {
+    static func main() async throws {
+        let env = ProcessInfo.processInfo.environment
+        let modelID = env["MODEL_ID"] ?? "majentik/Unlimited-OCR-MLX-6bit"
+        let prompt = env["PROMPT"] ?? "document parsing."
+        let maxTokens = Int(env["MAX_TOKENS"] ?? "2048") ?? 2048
+        let mode = env["MODE"] ?? "gundam"
+
+        guard let imagePath = env["IMAGE"], !imagePath.isEmpty else {
+            throw SmokeError.missingEnvironment("IMAGE")
+        }
+        guard let outputPath = env["OUT_FILE"], !outputPath.isEmpty else {
+            throw SmokeError.missingEnvironment("OUT_FILE")
+        }
+
+        let imageURL = URL(fileURLWithPath: imagePath).standardizedFileURL
+        let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil)
+
+        print("Model: \(modelID)")
+        print("Image: \(imageURL.path)")
+        print("Prompt: \(prompt)")
+
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: #hubDownloader(),
+            using: #huggingFaceTokenizerLoader(),
+            configuration: ModelConfiguration(id: modelID)
+        ) { progress in
+            guard progress.totalUnitCount > 0 else { return }
+            let percent = Int(
+                (Double(progress.completedUnitCount) / Double(progress.totalUnitCount)) * 100)
+            print("Download progress: \(percent)%")
+        }
+
+        let session = ChatSession(
+            container,
+            generateParameters: GenerateParameters(maxTokens: maxTokens, temperature: 0.0),
+            additionalContext: [DeepseekOCRProcessor.modeContextKey: mode])
+
+        let response = try await session.respond(
+            to: prompt,
+            image: .url(imageURL))
+
+        try response.write(to: outputURL, atomically: true, encoding: .utf8)
+        print("Wrote \(outputURL.path) chars: \(response.count)")
+    }
+}
+
+private enum SmokeError: LocalizedError {
+    case missingEnvironment(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingEnvironment(let name):
+            return "Missing required environment variable: \(name)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ports DeepSeek-OCR from mlx-vlm (Python) into MLXVLM (Swift): SAM + CLIP dual vision, MoE language decoder, gundam processor, registry wiring.
- First-class crop-mode API (`gundam` / `base`) and grounding / ref / det token surface (`DeepseekOCRSpecialTokens`).
- Cache-gated IntegrationTesting example + supported-model docs.
- Adapted from [mzbac/deepseek-ocr.swift](https://github.com/mzbac/deepseek-ocr.swift) (MIT), refactored toward mlx-swift-lm patterns (`GlmOcr`, `DeepseekV3` sanitize / `@ModuleInfo`).
- Closes #15

## Review guide

Diff shape: **+3286 / −1 across 15 files** — 7 new files (model, processor, tests, smoke tool); the 8 touched existing files are registration, docs, and one shared-code change (detailed below). No existing model paths are modified.

- **Start at** `Libraries/MLXVLM/VLMModelFactory.swift` — the full integration surface (model type + processor registration) is visible there.
- **Mostly pattern-following:** `DeepseekOCR.swift` mirrors the `GlmOcr` / `Qwen25VL` house conventions — config structs with snake_case `CodingKeys`, `@ModuleInfo(key:)` matching safetensors keys, `DeepseekV3`-style `sanitize(weights:)` for MoE expert stacking.
- **The one behavioral change to shared code:** `ArgMaxSampler` in `MLXLMCommon/Evaluate.swift` now casts logits to bf16 before argmax, so greedy ranking matches MLX Python models that keep decode logits in bf16. It only changes outcomes where float32 accumulation breaks a bf16 exact tie. This is the part that affects other models and deserves the closest look.
- **Highest-scrutiny new code:** (1) the MoE gate — `topk_method` semantics + conditional `e_score_correction_bias`, verified against the Python mlx-vlm oracle with gate regression tests; (2) the gundam tiling path in `DeepseekOCRProcessor` — the most parity-sensitive piece, covered by tensor-level parity tests.
- **Parity evidence:** L1 layer-level parity and L3 greedy-decode exact-match against Python `mlx-vlm==0.6.6` with a pinned HF weights revision.

## Commits (fork `feature/deepseek-ocr-v2` @ 8fd30db)

Clean task-scoped history: 17 commits on top of mlx-swift-lm @ `12d2da0` (12 rebased port commits + 3 Track-A commits + 2 MoE-gate parity fixes):

1. TASK-002: fork setup + mzbac attribution
2. TASK-015: DeepseekOCR seed port
3. TASK-003: registry skeleton
4. TASK-004–006: SAM / CLIP projector / MoE decoder
5. TASK-007: processor parity
6. TASK-016: L1 layer parity tests
7. TASK-008: smoke runner + L3 greedy decode fixes
8. TASK-026: base crop-mode as first-class API (`Mode`, `modeContext(_:)` / `mode(from:)`)
9. TASK-027: grounding / ref / det tokens (`DeepseekOCRSpecialTokens`, `parseDetections`)
10. TASK-028: cache-gated `DeepseekOCRIntegrationTests` + supported-model docs
11. MoE gate parity: `topk_method` semantics + conditional `e_score_correction_bias` (matches Python oracle; adds gate regression tests)

## Test plan
- [ ] `cd ports/mlx-swift-lm && swift test --filter 'VLMRegistryTests|DeepseekOCR'`
- [ ] Load `majentik/Unlimited-OCR-MLX-6bit` (hub `model_type=deepseekocr`)
- [ ] Single image OCR with prompt `document parsing.` (gundam or base mode via `DeepseekOCRProcessor.modeContext(_:)`)
- [ ] Grounding prompt round-trip (`DeepseekOCRSpecialTokens.groundingPrompt()`, decode `skipSpecialTokens: false`)
- [ ] Coordination hub: `REMAP_UNLIMITED=0 bash scripts/swift_smoke.sh && PARITY_LEVEL=L3 bash scripts/compare_parity.sh`
- [ ] Expected L3 exact text on pinned red fixture: `2014年1月1日`
- [ ] Opt-in weights: `MLX_RUN_DEEPSEEK_OCR_INTEGRATION=1 xcodebuild test -scheme IntegrationTesting -only-testing:IntegrationTestingTests/DeepseekOCRIntegrationTests`

## Attribution
- Primary seed: [mzbac/deepseek-ocr.swift](https://github.com/mzbac/deepseek-ocr.swift) (MIT)
- Behavioral oracle: [mlx-vlm deepseekocr](https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/deepseekocr)

## Known gaps (out of scope for this PR — deferred to PR #2)
- `UnlimitedOCRProcessor` alias documentation audit — **TASK-023** (touches `UnlimitedOCR.swift`, PR-2 scope)
- Native `unlimited_ocr` model type + R-SWA (`RingSlidingKVCache`) — **TASK-017**
- Multi-page / fused multipage single-generation — **TASK-022**
- Optional sliding-window no-repeat n-gram logits processor (mlx-vlm opt-in) — **TASK-021**

## Developed in
https://github.com/jyauxi/mlx-swift-unlimited-ocr (coordination repo; TASK-014)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
