### PR TITLE
Fix guided generation dropping required properties (streaming detokenizer)

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/RequiredPropertyStressTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/RequiredPropertyStressTests.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 Apple Inc.
+
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
+
+import Foundation
+import Testing
+import FoundationModels
+
+@testable import MLXFoundationModels
+
+// Types from the bug report: a top-level object with three required
+// properties, one of which is a nested object.
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@Generable
+private struct NPC: Equatable {
+    let name: String
+    let coffeeOrder: String
+    let picture: Picture
+}
+
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+@Generable
+private struct Picture: Equatable {
+    @Guide(description: "Avoid human-like descriptions. Stick to animals, plants, or objects.")
+    let imageDescription: String
+}
+
+/// End-to-end regression for the bug where guided generation dropped a required
+/// object property. A Gemma-4 (SentencePiece) checkpoint could emit a token
+/// whose decode was not append-only (a space collapsing before a comma), and
+/// the streaming detokenizer's character-count diff silently dropped the comma,
+/// producing invalid JSON that failed `Generable` decoding. See the fix in
+/// `NaiveStreamingDetokenizer.next()` and the model-free regression in
+/// `StreamingDetokenizerTests`.
+///
+/// Heavyweight (downloads a Gemma-4 checkpoint and runs many generations), so
+/// gated behind `MLX_RUN_REQUIRED_PROPERTY_STRESS=1` — it must not run on every
+/// integration pass. Mirrors the `MLX_RUN_VLM_INTEGRATION` / `MLX_RUN_COLD_FETCH`
+/// gates elsewhere in this target.
+@Suite(
+    .serialized,
+    .timeLimit(.minutes(30)),
+    .enabled(if: ProcessInfo.processInfo.environment["MLX_RUN_REQUIRED_PROPERTY_STRESS"] == "1")
+)
+struct RequiredPropertyStressTests {
+
+    private static let instructions = """
+        A conversation between a user and a helpful assistant. This is a fantasy RPG game that \
+        takes place at Dream Coffee, the beloved coffee shop of the dream realm. Your role is to \
+        use your imagination to generate fun game characters.
+        """
+
+    private static let prompt = """
+        Create an NPC customer with a fun personality suitable for the dream realm. Have the \
+        customer order coffee. Here are some examples to inspire you:
+        {name: "Thimblefoot", imageDescription: "A horse with a rainbow mane", coffeeOrder: "I \
+        would like a coffee that's refreshing and sweet like grass of a summer meadow"}
+        {name: "Spiderkid", imageDescription: "A furry spider with a cool baseball cap", \
+        coffeeOrder: "An iced coffee please, that's as spooky as me!"}
+        """
+
+    @Test
+    func gemma4DoesNotDropRequiredProperties() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+        let model = makeTestModel(TestFixtures.gemma4ModelID, capabilities: [.guidedGeneration])
+
+        let iterations = 25
+        var failures = 0
+
+        for i in 1 ... iterations {
+            let session = LanguageModelSession(model: model) { Self.instructions }
+            do {
+                let npc = try await session.respond(to: Self.prompt, generating: NPC.self).content
+                print("[\(i)] OK: \(npc.name)")
+            } catch {
+                failures += 1
+                print("[\(i)] FAIL: \(error)")
+            }
+        }
+
+        print("Failures: \(failures)/\(iterations)")
+        await releaseAllGPUMemory()
+        #expect(failures == 0, "\(failures)/\(iterations) generations dropped a required property")
+    }
+}
+
+#endif  // FoundationModelsIntegration && canImport(FoundationModels, _version: 2)

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -95,7 +95,26 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
 
     public mutating func next() -> String? {
         let newSegment = tokenizer.decode(tokenIds: segmentTokens)
-        let new = newSegment.suffix(newSegment.count - segment.count)
+
+        // Emit the part of `newSegment` beyond its common prefix with the text
+        // already emitted for this segment. A character-count suffix
+        // (`newSegment.suffix(newSegment.count - segment.count)`) assumes
+        // `decode` is append-only, but SentencePiece decoding is not: appending
+        // a token can rewrite earlier whitespace. For example, with Gemma's
+        // tokenizer `decode([\n, "  "]) == "\n  "` while
+        // `decode([\n, "  ", ","]) == "\n ,"` — a space collapses. The
+        // count-based suffix then computes `suffix(0)` and silently drops the
+        // newly decoded character, including structural JSON commas, which
+        // corrupts guided-generation output into unparseable JSON.
+        //
+        // This recovers correctly as long as the already-emitted prefix is
+        // stable — i.e. the rewrite happens at or after the divergence point.
+        // Real SentencePiece decoding only collapses whitespace at the append
+        // boundary, so that holds; a decode that rewrote an already-emitted
+        // interior character would re-emit the tail (no worse than the old
+        // behavior, and not observed in practice).
+        let common = newSegment.commonPrefix(with: segment)
+        let new = newSegment.dropFirst(common.count)
 
         // if the new segment ends with REPLACEMENT CHARACTER this means
         // that the token didn't produce a complete unicode character

--- a/Tests/MLXLMTests/StreamingDetokenizerTests.swift
+++ b/Tests/MLXLMTests/StreamingDetokenizerTests.swift
@@ -1,0 +1,169 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLXLMCommon
+
+/// A tokenizer whose `decode` is deliberately NOT append-only: a two-space
+/// token followed by a comma decodes to `" ,"` (one space), mirroring the
+/// SentencePiece whitespace normalization that Gemma's real tokenizer performs
+/// (`decode([\n,"  "]) == "\n  "` but `decode([\n,"  ",","]) == "\n ,"`).
+private struct WhitespaceCollapsingTokenizer: MLXLMCommon.Tokenizer {
+    static let pieces: [Int: String] = [10: "\n", 20: "  ", 30: ",", 40: "\""]
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        let joined = tokenIds.map { Self.pieces[$0] ?? "" }.joined()
+        // SentencePiece-style: collapse the run of spaces before a comma.
+        return joined.replacingOccurrences(of: "  ,", with: " ,")
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        Self.pieces.first { $0.value == token }?.key
+    }
+    func convertIdToToken(_ id: Int) -> String? { Self.pieces[id] }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+/// A normal append-only tokenizer: `decode` is exactly the concatenation of
+/// per-token pieces. Guards against the fix changing well-behaved tokenizers.
+private struct AppendOnlyTokenizer: MLXLMCommon.Tokenizer {
+    let pieces: [Int: String]
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.map { pieces[$0] ?? "" }.joined()
+    }
+    func convertTokenToId(_ token: String) -> Int? { pieces.first { $0.value == token }?.key }
+    func convertIdToToken(_ id: Int) -> String? { pieces[id] }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+/// Models a multi-byte character split across two byte-fallback tokens: token
+/// 50 alone decodes to the Unicode REPLACEMENT CHARACTER (incomplete), and the
+/// pair [50, 51] decodes to the completed character. Mirrors how a SentencePiece
+/// byte-fallback tokenizer emits a partial UTF-8 sequence mid-generation.
+private struct SplitMultibyteTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        var out = ""
+        var i = 0
+        while i < tokenIds.count {
+            switch tokenIds[i] {
+            case 50:
+                if i + 1 < tokenIds.count, tokenIds[i + 1] == 51 {
+                    out += "\u{4E2D}"  // 中 — completed once the second half arrives
+                    i += 2
+                    continue
+                }
+                out += "\u{fffd}"  // incomplete: only the first half so far
+            case 51:
+                out += "\u{fffd}"  // second half without its first half
+            case 65: out += "a"
+            case 66: out += "b"
+            default: break
+            }
+            i += 1
+        }
+        return out
+    }
+
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+final class StreamingDetokenizerTests: XCTestCase {
+
+    private func stream(_ tokens: [Int], _ tokenizer: any Tokenizer) -> String {
+        var det = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+        var out = ""
+        for id in tokens {
+            det.append(token: id)
+            if let text = det.next() { out += text }
+        }
+        return out
+    }
+
+    /// Regression for the guided-generation "dropped required property" bug:
+    /// a structural comma committed to the grammar must not vanish from the
+    /// emitted text just because the tokenizer's decode is not append-only.
+    func testDoesNotDropCommaWhenDecodeIsNotAppendOnly() {
+        let tokenizer = WhitespaceCollapsingTokenizer()
+        let tokens = [10, 20, 30, 40]  // \n  "  "  ,  "
+
+        let full = tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false)
+        XCTAssertTrue(full.contains(","), "sanity: full decode should contain the comma")
+
+        let streamed = stream(tokens, tokenizer)
+        XCTAssertTrue(
+            streamed.contains(","),
+            "streaming detokenizer dropped the comma: \(streamed.debugDescription)")
+    }
+
+    /// The fix must not change behavior for a normal append-only tokenizer.
+    func testAppendOnlyStreamMatchesFullDecode() {
+        let tokenizer = AppendOnlyTokenizer(pieces: [1: "Hel", 2: "lo", 3: ", ", 4: "world"])
+        let tokens = [1, 2, 3, 4]
+        XCTAssertEqual(
+            stream(tokens, tokenizer),
+            tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false))
+    }
+
+    /// A multi-byte character split across tokens must be emitted exactly once,
+    /// after its final byte arrives — not dropped, not duplicated, and the
+    /// intermediate REPLACEMENT CHARACTER must be suppressed. Exercises the
+    /// `new.last == "\u{fffd}"` early-return branch in `next()`.
+    func testSplitMultibyteUnicodeEmitsCompletedCharacterOnce() {
+        let tokenizer = SplitMultibyteTokenizer()
+        let tokens = [65, 50, 51, 66]  // "a", 中(first half), 中(second half), "b"
+
+        let streamed = stream(tokens, tokenizer)
+        XCTAssertEqual(
+            streamed, "a\u{4E2D}b",
+            "expected 'a中b', got \(streamed.debugDescription)")
+        XCTAssertFalse(
+            streamed.contains("\u{fffd}"),
+            "replacement character leaked into output: \(streamed.debugDescription)")
+        XCTAssertEqual(
+            streamed, tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false))
+    }
+
+    /// The newline-triggered `startNewSegment()` reset must still preserve a
+    /// structural character when the post-reset decode is non-append-only.
+    func testNewlineResetPreservesCommaWithNonAppendOnlyDecode() {
+        let tokenizer = WhitespaceCollapsingTokenizer()
+        let tokens = [10, 20, 30]  // "\n" (resets segment), "  ", "," (collapses "  ," -> " ,")
+
+        let streamed = stream(tokens, tokenizer)
+        XCTAssertTrue(
+            streamed.contains(","),
+            "comma dropped across a newline segment reset: \(streamed.debugDescription)")
+    }
+}


### PR DESCRIPTION
## Summary

Guided generation (`LanguageModelSession(model:).respond(to:generating:)`) intermittently returned an object missing a **required** property, throwing `GeneratedContent does not contain a property '<name>'`. Reproduced reliably with Gemma-4; Qwen never hit it.

The root cause is **not** in the schema or the grammar — both were verified correct. It is in `NaiveStreamingDetokenizer.next()`, which dropped a token's text when the tokenizer's `decode()` is not append-only.

## Root cause

`next()` computed each incremental delta as a **character-count diff**:

```swift
let new = newSegment.suffix(newSegment.count - segment.count)
```

This assumes `decode(tokens)` grows append-only. SentencePiece decoding does not: appending a token can rewrite earlier whitespace. With Gemma's tokenizer:

- `decode([\n, "  "]) == "\n  "` (length 3)
- `decode([\n, "  ", ","]) == "\n ,"` (length 3 — a space collapses)

So `newSegment.count - segment.count == 0`, `suffix(0) == ""`, and the newly decoded character — here a **structural JSON comma** — is silently dropped. The grammar had committed the comma and stayed valid (`grammarTerminated == true`), but the *text streamed to FoundationModels* was invalid JSON, so parsing failed on a required property. Qwen uses byte-level BPE (append-only), so it never triggered the bug.

## Fix

Diff by **common prefix** instead of character count:

```swift
let common = newSegment.commonPrefix(with: segment)
let new = newSegment.dropFirst(common.count)
```

- Identical to the previous behavior for append-only tokenizers.
- For non-append-only decodes it never drops characters.
- Bonus: removes a latent scalar-vs-grapheme hazard, since `commonPrefix`/`count`/`dropFirst` all operate on grapheme clusters. A comment documents that correctness relies on the already-emitted prefix being stable (true for SentencePiece, which only collapses whitespace at the append boundary).

One file of production code changed: `Libraries/MLXLMCommon/Tokenizer.swift`.

## Testing

All runs on Apple silicon, macOS 27 SDK, Xcode 27. **No failure is attributable to this change.** The three pre-existing failures below fail identically on the baseline (fix stashed) and are unrelated; they're documented as follow-ups.

### New tests added
| Test | Kind | Result |
|---|---|---|
| `StreamingDetokenizerTests` — comma-drop regression, append-only guard, split-multibyte `\u{fffd}` path, newline-reset + non-append-only | model-free unit (`Tests/MLXLMTests`) | 4/4 pass (comma-drop test fails on old code, passes on new) |
| `RequiredPropertyStressTests` — 25× guided NPC generation on Gemma-4, env-gated `MLX_RUN_REQUIRED_PROPERTY_STRESS` | integration | **0/25 failures with the fix (was 3/15 before)** |

### Regression suites run to validate
| Suite / group | Tests | Result |
|---|---|---|
| `MLXLMTests` (model-free unit) | 238 | 0 failures |
| `MLXGuidedGenerationTests` (model-free unit) | 69 | 0 failures |
| `MLXFoundationModelsTests` (model-free unit) | 138 | 1 pre-existing failure (`grammarBuilderHoistsNestedDefsInBothArms`), unrelated |
| Guided-generation integration group (12 suites: StreamingDelta, GenerableRoundTrip, PlainChatGeneration, MultiModelGuidedGeneration, GuidedGenerationIntegration, GuidedGeneration, MaxTokenTruncation, StopTokenRegression, XGrammarBridge, LoopInvariantsOnXGrammar, FastForwardTokenizationDisagreement, GoldenReplay) | 60 | 3 pre-existing failures on the tiny `gemma-3-270m` model (truncated JSON / runaway integer overflow), unrelated |
| Tool-calling integration group (5 suites: StructuredToolOutputSession, ToolCallRoundTrip, FoundationModelsToolCalling, MultiTurnToolCalling, ToolCallGrammarCharacterization) | 20 | 0 failures |
| End-to-end stress loop (`RequiredPropertyStressTests`) | 25 generations | 0 failures |

**Total: ~525 individual tests across ~44 suites, plus the 25-generation stress loop.** Both Gemma (SentencePiece) and Qwen (byte-level BPE) paths, guided generation, free-form generation, tool calling, and grammar handling are all covered. The most sensitive check — `StreamingDeltaTests`, which asserts exact streaming deltas — passes.

### Pre-existing failures (not caused by this PR; each confirmed identical on the baseline with the fix stashed)
1. `ToolCallingSchemaTests.grammarBuilderHoistsNestedDefsInBothArms` — tool-calling schema-shape assertion mismatch.
2. `GuidedGenerationTests` "Single Activity schema…" — `gemma-3-270m` emits truncated JSON.
3. `MultiModelGuidedGenerationTests.intRoundTrip[gemma-3-270m]` — `gemma-3-270m` emits a runaway integer that overflows Swift's `Int`.