### PR TITLE
Qwen3.5/3.6: fold the GDN decode conv into the compiled step

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -372,10 +372,15 @@ final class Qwen35GatedDeltaNet: Module {
             qkv = MLX.where(mask[.ellipsis, .newAxis], qkv, 0)
         }
 
-        let convInput = concatenated([convState, qkv], axis: 1)
-        let newConvState = contiguous(convInput[0..., (-(convKernelSize - 1))..., 0...])
-
-        let convOut = silu(conv1d(convInput))
+        let convOut: MLXArray
+        let newConvState: MLXArray
+        if S == 1 {
+            (convOut, newConvState) = decodeConv(convState: convState, qkv: qkv)
+        } else {
+            let convInput = concatenated([convState, qkv], axis: 1)
+            newConvState = contiguous(convInput[0..., (-(convKernelSize - 1))..., 0...])
+            convOut = silu(conv1d(convInput))
+        }
 
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
         let q = convSplit[0].reshaped(B, S, numKHeads, headKDim)
@@ -405,6 +410,28 @@ final class Qwen35GatedDeltaNet: Module {
 
         let gated = norm(out, gate: z)
         return (outProj(gated.reshaped(B, S, -1)), newConvState, newRecState)
+    }
+
+    /// The S == 1 depthwise conv as `convKernelSize` fused multiply-adds —
+    /// elementwise ops `compile` folds into the surrounding segment, deleting
+    /// a dispatch and a hazard barrier per GDN layer. f32 accumulation with a
+    /// single final round reproduces MLX's `Convolution` kernel bit-for-bit
+    /// (native-dtype accumulation differs in ~47% of channels);
+    /// `Qwen35GDNDecodeBitwiseTests` pins the contract.
+    func decodeConv(
+        convState: MLXArray, qkv: MLXArray
+    ) -> (convOut: MLXArray, newConvState: MLXArray) {
+        var acc =
+            convState[0..., 0, 0...].asType(.float32)
+            * conv1d.weight[0..., 0, 0].asType(.float32)
+        for tap in 1 ..< convKernelSize {
+            let row =
+                tap < convKernelSize - 1
+                ? convState[0..., tap, 0...] : qkv[0..., 0, 0...]
+            acc = acc + row.asType(.float32) * conv1d.weight[0..., tap, 0].asType(.float32)
+        }
+        let convOut = silu(acc.asType(qkv.dtype).reshaped(convState.dim(0), 1, convDim))
+        return (convOut, concatenated([convState[0..., 1..., 0...], qkv], axis: 1))
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -372,15 +372,13 @@ final class Qwen35GatedDeltaNet: Module {
             qkv = MLX.where(mask[.ellipsis, .newAxis], qkv, 0)
         }
 
-        let convOut: MLXArray
-        let newConvState: MLXArray
-        if S == 1 {
-            (convOut, newConvState) = decodeConv(convState: convState, qkv: qkv)
-        } else {
-            let convInput = concatenated([convState, qkv], axis: 1)
-            newConvState = contiguous(convInput[0..., (-(convKernelSize - 1))..., 0...])
-            convOut = silu(conv1d(convInput))
-        }
+        let fusedDecode =
+            S == 1 && mask == nil && (qkv.dtype == .float16 || qkv.dtype == .bfloat16)
+        let (convPre, newConvState) =
+            fusedDecode
+            ? decodeConv(convState: convState, qkv: qkv)
+            : generalConv(convState: convState, qkv: qkv)
+        let convOut = silu(convPre)
 
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
         let q = convSplit[0].reshaped(B, S, numKHeads, headKDim)
@@ -412,15 +410,15 @@ final class Qwen35GatedDeltaNet: Module {
         return (outProj(gated.reshaped(B, S, -1)), newConvState, newRecState)
     }
 
-    /// The S == 1 depthwise conv as `convKernelSize` fused multiply-adds —
-    /// elementwise ops `compile` folds into the surrounding segment, deleting
-    /// a dispatch and a hazard barrier per GDN layer. f32 accumulation with a
-    /// single final round reproduces MLX's `Convolution` kernel bit-for-bit
-    /// (native-dtype accumulation differs in ~47% of channels);
-    /// `Qwen35GDNDecodeBitwiseTests` pins the contract.
+    /// The S == 1 depthwise conv as elementwise multiply-adds, so `compile`
+    /// folds it into the surrounding segment. f32 accumulation with a single
+    /// final round matches `generalConv`'s `Convolution` kernel bit-for-bit
+    /// for f16/bf16 (pinned by `Qwen35GDNDecodeBitwiseTests`); the kernel's
+    /// own f32 accumulation orders differently, so f32 input stays on
+    /// `generalConv`.
     func decodeConv(
         convState: MLXArray, qkv: MLXArray
-    ) -> (convOut: MLXArray, newConvState: MLXArray) {
+    ) -> (conv: MLXArray, state: MLXArray) {
         var acc =
             convState[0..., 0, 0...].asType(.float32)
             * conv1d.weight[0..., 0, 0].asType(.float32)
@@ -430,8 +428,22 @@ final class Qwen35GatedDeltaNet: Module {
                 ? convState[0..., tap, 0...] : qkv[0..., 0, 0...]
             acc = acc + row.asType(.float32) * conv1d.weight[0..., tap, 0].asType(.float32)
         }
-        let convOut = silu(acc.asType(qkv.dtype).reshaped(convState.dim(0), 1, convDim))
-        return (convOut, concatenated([convState[0..., 1..., 0...], qkv], axis: 1))
+        return (
+            acc.asType(qkv.dtype).reshaped(convState.dim(0), 1, convDim),
+            concatenated([convState[0..., 1..., 0...], qkv], axis: 1)
+        )
+    }
+
+    /// The sliding-window conv via MLX's `Convolution` kernel — the reference
+    /// `decodeConv` is pinned against.
+    func generalConv(
+        convState: MLXArray, qkv: MLXArray
+    ) -> (conv: MLXArray, state: MLXArray) {
+        let convInput = concatenated([convState, qkv], axis: 1)
+        return (
+            conv1d(convInput),
+            contiguous(convInput[0..., (-(convKernelSize - 1))..., 0...])
+        )
     }
 }
 

--- a/Tests/MLXLMTests/Qwen35GDNDecodeBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35GDNDecodeBitwiseTests.swift
@@ -1,0 +1,89 @@
+// Copyright © 2026 Apple Inc.
+//
+// CI pin for the bitwise contract GDN decode rests on: `decodeConv`
+// (elementwise multiply-adds, f32 accumulation) must reproduce MLX's
+// `Convolution` kernel bit-for-bit, or compiled decode silently diverges
+// from prefill after an MLX bump.
+
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+final class Qwen35GDNDecodeBitwiseTests: XCTestCase {
+
+    /// Bitwise equality, dtype and shape included. The f32 upcast is
+    /// injective for f16/bf16/f32 finite values, so bit-comparing the upcast
+    /// compares the originals.
+    private func assertBitIdentical(
+        _ got: MLXArray, _ want: MLXArray, _ label: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(got.dtype, want.dtype, "\(label): dtype", file: file, line: line)
+        XCTAssertEqual(got.shape, want.shape, "\(label): shape", file: file, line: line)
+        let a = got.asType(.float32).asArray(Float.self)
+        let b = want.asType(.float32).asArray(Float.self)
+        let mismatches = zip(a, b).filter { $0.bitPattern != $1.bitPattern }.count
+        XCTAssertEqual(
+            mismatches, 0, "\(label): \(mismatches)/\(a.count) elements differ bitwise",
+            file: file, line: line)
+    }
+
+    /// 256 conv channels — wide enough that an accumulation-order change in
+    /// MLX's Convolution kernel cannot pass by coincidence (native-dtype
+    /// accumulation diverges in ~47% of channels).
+    private func tinyGDNConfiguration() throws -> Qwen35TextConfiguration {
+        let json = """
+            {
+                "model_type": "qwen3_5_moe",
+                "hidden_size": 64,
+                "num_hidden_layers": 2,
+                "intermediate_size": 64,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 32,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 32,
+                "linear_conv_kernel_dim": 4,
+                "vocab_size": 32,
+                "full_attention_interval": 2,
+                "num_experts": 16,
+                "num_experts_per_tok": 4,
+                "moe_intermediate_size": 32,
+                "shared_expert_intermediate_size": 32
+            }
+            """
+        return try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Data(json.utf8))
+    }
+
+    func testDecodeConvMatchesConvolutionKernelBitwise() throws {
+        let config = try tinyGDNConfiguration()
+        for dtype in [DType.float16, DType.bfloat16] {
+            MLXRandom.seed(11)
+            let gdn = Qwen35GatedDeltaNet(config)
+            gdn.update(parameters: gdn.parameters().mapValues { $0.asType(dtype) })
+
+            let qkv = MLXRandom.normal([1, 1, gdn.convDim]).asType(dtype)
+            let convState = MLXRandom.normal(
+                [1, gdn.convKernelSize - 1, gdn.convDim]
+            ).asType(dtype)
+            eval(qkv, convState)
+
+            let (convOut, newConvState) = gdn.decodeConv(convState: convState, qkv: qkv)
+
+            let convInput = concatenated([convState, qkv], axis: 1)
+            let refOut = silu(gdn.conv1d(convInput))
+            let refState = contiguous(convInput[0..., (-(gdn.convKernelSize - 1))..., 0...])
+            eval(convOut, newConvState, refOut, refState)
+
+            assertBitIdentical(convOut, refOut, "conv output (\(dtype))")
+            assertBitIdentical(newConvState, refState, "conv state (\(dtype))")
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen35GDNDecodeBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35GDNDecodeBitwiseTests.swift
@@ -1,9 +1,7 @@
 // Copyright © 2026 Apple Inc.
 //
-// CI pin for the bitwise contract GDN decode rests on: `decodeConv`
-// (elementwise multiply-adds, f32 accumulation) must reproduce MLX's
-// `Convolution` kernel bit-for-bit, or compiled decode silently diverges
-// from prefill after an MLX bump.
+// Pins `decodeConv` bit-for-bit against `generalConv` (MLX's `Convolution`
+// kernel); a mismatch means compiled decode silently diverges from prefill.
 
 import Foundation
 import MLX
@@ -11,13 +9,11 @@ import MLXNN
 import XCTest
 
 @testable import MLXLLM
-@testable import MLXLMCommon
 
 final class Qwen35GDNDecodeBitwiseTests: XCTestCase {
 
-    /// Bitwise equality, dtype and shape included. The f32 upcast is
-    /// injective for f16/bf16/f32 finite values, so bit-comparing the upcast
-    /// compares the originals.
+    /// The f32 upcast is injective on finite f16/bf16/f32 values, so
+    /// bit-comparing the upcast compares the originals.
     private func assertBitIdentical(
         _ got: MLXArray, _ want: MLXArray, _ label: String,
         file: StaticString = #filePath, line: UInt = #line
@@ -26,7 +22,7 @@ final class Qwen35GDNDecodeBitwiseTests: XCTestCase {
         XCTAssertEqual(got.shape, want.shape, "\(label): shape", file: file, line: line)
         let a = got.asType(.float32).asArray(Float.self)
         let b = want.asType(.float32).asArray(Float.self)
-        let mismatches = zip(a, b).filter { $0.bitPattern != $1.bitPattern }.count
+        let mismatches = zip(a, b).lazy.filter { $0.bitPattern != $1.bitPattern }.count
         XCTAssertEqual(
             mismatches, 0, "\(label): \(mismatches)/\(a.count) elements differ bitwise",
             file: file, line: line)
@@ -67,7 +63,8 @@ final class Qwen35GDNDecodeBitwiseTests: XCTestCase {
         for dtype in [DType.float16, DType.bfloat16] {
             MLXRandom.seed(11)
             let gdn = Qwen35GatedDeltaNet(config)
-            gdn.update(parameters: gdn.parameters().mapValues { $0.asType(dtype) })
+            gdn.conv1d.update(
+                parameters: gdn.conv1d.parameters().mapValues { $0.asType(dtype) })
 
             let qkv = MLXRandom.normal([1, 1, gdn.convDim]).asType(dtype)
             let convState = MLXRandom.normal(
@@ -75,15 +72,12 @@ final class Qwen35GDNDecodeBitwiseTests: XCTestCase {
             ).asType(dtype)
             eval(qkv, convState)
 
-            let (convOut, newConvState) = gdn.decodeConv(convState: convState, qkv: qkv)
+            let (conv, state) = gdn.decodeConv(convState: convState, qkv: qkv)
+            let (refConv, refState) = gdn.generalConv(convState: convState, qkv: qkv)
+            eval(conv, state, refConv, refState)
 
-            let convInput = concatenated([convState, qkv], axis: 1)
-            let refOut = silu(gdn.conv1d(convInput))
-            let refState = contiguous(convInput[0..., (-(gdn.convKernelSize - 1))..., 0...])
-            eval(convOut, newConvState, refOut, refState)
-
-            assertBitIdentical(convOut, refOut, "conv output (\(dtype))")
-            assertBitIdentical(newConvState, refState, "conv state (\(dtype))")
+            assertBitIdentical(conv, refConv, "conv output (\(dtype))")
+            assertBitIdentical(state, refState, "conv state (\(dtype))")
         }
     }
 }


### PR DESCRIPTION
At S == 1 the GDN depthwise conv is a fixed 4-term dot per channel. Written as elementwise multiply-adds it folds into the compiled decode segment from #467, which deletes one dispatch and one hazard barrier per GDN layer per token. Prefill and any S > 1 call keep the conv kernel.

**Why it is bitwise, not approximately equal**

- The multiply-adds accumulate in f32 and round once at the end, which is exactly what MLX's Convolution kernel does for f16/bf16 input. Probed over 8192 channels: every channel matches bit for bit, while native-dtype accumulation differs in ~47% of them.
- f32 input is the exception: the kernel's own f32 path accumulates in a different order (102 of 256 channels differ), so f32 stays on the kernel.

**Tests**

The fused and general conv are two named bodies, `decodeConv` and `generalConv`, and the new test pins one against the other bit for bit in CI. If an MLX bump changes conv accumulation, a unit test fails instead of decode silently diverging from prefill.

**Decode throughput (M3 Max)**

- MoE 35B-A3B (4-bit): +1.77% median at 8K context, +0.60% at 128
- Dense flat; prefill and peak memory unchanged; parity gate 32/32 pairs token-identical

Part of the perf batch in #466.
