### PR TITLE
Qwen3.5/3.6 MoE: fused router top-k kernel for decode (bit-identical, CI-pinned)

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -9,7 +9,6 @@
 
 import Foundation
 import MLX
-import MLXFast
 import MLXLMCommon
 import MLXNN
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -14,37 +14,19 @@ import MLXNN
 
 // MARK: - Fused router top-k
 
-/// One-kernel replacement for the decode router tail:
+/// One-kernel replacement for the decode router tail: `chainRouterTopK`
+/// fully sorts all `E` experts (`ArgPartition::eval_gpu` delegates to
+/// `gpu_merge_sort`) just to name `K` — three serial dispatches, three
+/// encoder-wide barriers, where barrier-bound decode needs one.
 ///
-/// ```
-/// inds   = argPartition(gates, kth: E-K)[..., (E-K)...]
-/// scores = takeAlong(gates, inds, axis: -1)
-/// scores = scores / scores.sum(axis: -1, keepDims: true)
-/// ```
-///
-/// `ArgPartition::eval_gpu` delegates to `gpu_merge_sort`, so the path above
-/// fully sorts all `E` experts just to name `K` of them — three serial
-/// dispatches, and three encoder-wide hazard barriers, for a 256→8 selection.
-/// Decode is barrier-bound (MLX's dispatch schedule already sits at the
-/// dispatch graph's critical-path depth, so the only way to drop a barrier is
-/// to drop a serial link), which makes collapsing these three into one worth
-/// far more than the arithmetic they do.
-///
-/// Bit-identical to the chain it replaces, by construction:
-///
-/// - **order** — `sort.h`'s `LessThan` compares values only, `ThreadSort` swaps
-///   on strict less-than and `merge_step` takes from A on ties, so the sort is
-///   *stable*: element `i` lands at ascending position
-///   `#{j: v_j < v_i} + #{j: v_j == v_i, j < i}`. Counting the elements that
-///   rank *above* `i` instead gives the same slot as `K-1-count`, and packing
-///   the index into the low bits of a monotone bit key folds the tie-break into
-///   that one comparison. NaN maps above `+inf` (all NaNs tie, as in
-///   `LessThan`) and the sign of zero is normalised, since `-0.0` and `+0.0`
-///   compare equal there but not as bit patterns.
-/// - **sum** — `reduce.metal` instantiates float16 with `U = float16_t`, and a
-///   row of 8 takes `thread_reduce`: sequential accumulation in the output
-///   dtype, from zero, in slot order.
-/// - **divide** — elementwise, same dtype.
+/// Bit-identical to the chain by construction: the sort is stable
+/// (`sort.h`'s `LessThan` compares values only, ties keep input order), so
+/// counting the elements ranked strictly above `i` — with the index packed
+/// into the low bits of a monotone bit key as the tie-break — reproduces
+/// each winner's slot. `±0.0` normalises to one bit pattern (they compare
+/// equal but differ bitwise), NaN maps above `+inf` (all NaNs tie), and the
+/// sum accumulates sequentially in the output dtype from zero, in slot
+/// order, matching `reduce.metal`'s `thread_reduce`.
 private let routerTopKSource = """
     uint row = threadgroup_position_in_grid.y;
     uint t = thread_position_in_threadgroup.x;
@@ -95,23 +77,15 @@ private final class RouterTopKKernel: Sendable {
     }
 }
 
-/// Metal's threads-per-threadgroup ceiling: the fused kernel launches one
-/// thread per expert, so past this the dispatch is invalid — a correctness
-/// bound, not a tuning knob.
+/// Metal's threads-per-threadgroup ceiling; one thread per expert, so past
+/// this the dispatch is invalid, not just slow.
 private let maxFusedRouterExperts = 1024
 
-/// Top-`k` selection + optional normalisation over the last axis, in one
-/// dispatch. Returns `(indices, scores)` shaped `[..., k]`, matching the
-/// argPartition/takeAlong/normalise chain bit for bit — including the
-/// `uint32` index dtype `argPartition` produces.
-///
-/// One threadgroup per row and an `O(E²)` rank count, which is only the right
-/// shape when there are very few rows — at prefill the block sort's
-/// `O(E log² E)` wins and there is no barrier to save, so callers gate this on
-/// the single-row decode case.
-///
-/// Internal (not private) so `Qwen35RouterTopKBitwiseTests` can hold the fused
-/// form against the chain it replaces.
+/// Top-`k` + optional normalisation over the last axis in one dispatch:
+/// `(indices, scores)` shaped `[..., k]`, bit-identical to
+/// `chainRouterTopK`, `uint32` indices included. One threadgroup per row
+/// with an `O(E²)` rank count — callers gate this on the single-row decode
+/// case. Internal so the bitwise test can reach it.
 func fusedRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
     let e = gates.dim(-1)
     let rows = gates.size / e
@@ -129,10 +103,8 @@ func fusedRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, M
     return (out[0], out[1])
 }
 
-/// The exact three-dispatch chain the fused kernel replaces — the prefill
-/// path. Internal (not private) so `Qwen35RouterTopKBitwiseTests` holds the
-/// fused kernel against the chain production actually falls back to, not a
-/// copy of it.
+/// The three-dispatch router tail the fused kernel replaces — the prefill
+/// path, and the bitwise test's reference.
 func chainRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
     let kth = gates.dim(-1) - k
     let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
@@ -557,13 +529,9 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         return combined + sharedY
     }
 
-    /// Pick the top-`k` experts and normalise their scores.
-    ///
-    /// At decode there is exactly one row, and `chainRouterTopK` is three
-    /// encoder-wide barriers spent on a 256→8 selection; the fused kernel
-    /// does it in one and is bit-identical (see `fusedRouterTopK`). Prefill
-    /// keeps the chain: many rows make the fused kernel's `O(E²)` rank count
-    /// the wrong shape, and a GEMM-bound pass has no barrier to save.
+    /// Decode (one row): the fused kernel, one dispatch instead of three
+    /// barriers, bit-identical. Prefill: the chain — many rows make the
+    /// `O(E²)` rank count the wrong shape, and there is no barrier to save.
     private func routerTopK(_ gates: MLXArray, k: Int) -> (MLXArray, MLXArray) {
         let e = gates.dim(-1)
         if gates.size == e, e <= maxFusedRouterExperts {

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -51,7 +51,6 @@ private let routerTopKSource = """
 
     threadgroup ulong sk[E_];
     threadgroup float top_v[K_];
-    threadgroup uint  top_i[K_];
 
     float v = static_cast<float>(gates[row * E_ + t]);
     uint b = (v == 0.0f) ? 0u : as_type<uint>(v);
@@ -66,7 +65,7 @@ private let routerTopKSource = """
     }
     if (above < K_) {
         top_v[K_ - 1 - above] = v;
-        top_i[K_ - 1 - above] = t;
+        inds[row * K_ + (K_ - 1 - above)] = t;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -79,9 +78,6 @@ private let routerTopKSource = """
             T s = static_cast<T>(top_v[q]);
             scores[row * K_ + q] = NORM_ ? (s / acc) : s;
         }
-    }
-    if (t < K_) {
-        inds[row * K_ + t] = top_i[t];
     }
     """
 
@@ -99,6 +95,11 @@ private final class RouterTopKKernel: Sendable {
     }
 }
 
+/// Metal's threads-per-threadgroup ceiling: the fused kernel launches one
+/// thread per expert, so past this the dispatch is invalid — a correctness
+/// bound, not a tuning knob.
+private let maxFusedRouterExperts = 1024
+
 /// Top-`k` selection + optional normalisation over the last axis, in one
 /// dispatch. Returns `(indices, scores)` shaped `[..., k]`, matching the
 /// argPartition/takeAlong/normalise chain bit for bit — including the
@@ -114,6 +115,7 @@ private final class RouterTopKKernel: Sendable {
 func fusedRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
     let e = gates.dim(-1)
     let rows = gates.size / e
+    let shape = Array(gates.shape.dropLast()) + [k]
     let out = RouterTopKKernel.shared.kernel(
         [gates],
         template: [
@@ -121,10 +123,24 @@ func fusedRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, M
         ],
         grid: (e, rows, 1),
         threadGroup: (e, 1, 1),
-        outputShapes: [[rows, k], [rows, k]],
+        outputShapes: [shape, shape],
         outputDTypes: [.uint32, gates.dtype]
     )
     return (out[0], out[1])
+}
+
+/// The exact three-dispatch chain the fused kernel replaces — the prefill
+/// path. Internal (not private) so `Qwen35RouterTopKBitwiseTests` holds the
+/// fused kernel against the chain production actually falls back to, not a
+/// copy of it.
+func chainRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
+    let kth = gates.dim(-1) - k
+    let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
+    var scores = MLX.takeAlong(gates, inds, axis: -1)
+    if normalize {
+        scores = scores / scores.sum(axis: -1, keepDims: true)
+    }
+    return (inds, scores)
 }
 
 // MARK: - Configuration
@@ -530,8 +546,7 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         var gates = gate(x)
         gates = MLX.softmax(gates, axis: -1, precise: true)
 
-        let k = topK
-        let (inds, scores) = routerTopK(gates, k: k)
+        let (inds, scores) = routerTopK(gates, k: topK)
 
         let y = switchMLP(x, inds)
         let combined = weightedExpertSum(y, scores)
@@ -544,27 +559,17 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
 
     /// Pick the top-`k` experts and normalise their scores.
     ///
-    /// At decode there is exactly one row, and the three-dispatch chain below
-    /// is three encoder-wide barriers spent on a 256→8 selection; the fused
-    /// kernel does it in one and is bit-identical (see `fusedRouterTopK`).
-    /// Prefill keeps the chain: many rows make the fused kernel's `O(E²)` rank
-    /// count the wrong shape, and a GEMM-bound pass has no barrier to save.
+    /// At decode there is exactly one row, and `chainRouterTopK` is three
+    /// encoder-wide barriers spent on a 256→8 selection; the fused kernel
+    /// does it in one and is bit-identical (see `fusedRouterTopK`). Prefill
+    /// keeps the chain: many rows make the fused kernel's `O(E²)` rank count
+    /// the wrong shape, and a GEMM-bound pass has no barrier to save.
     private func routerTopK(_ gates: MLXArray, k: Int) -> (MLXArray, MLXArray) {
         let e = gates.dim(-1)
-        if gates.size == e, e <= 1024 {
-            let (inds, scores) = fusedRouterTopK(gates, k: k, normalize: normTopkProb)
-            var shape = gates.shape
-            shape[shape.count - 1] = k
-            return (inds.reshaped(shape), scores.reshaped(shape))
+        if gates.size == e, e <= maxFusedRouterExperts {
+            return fusedRouterTopK(gates, k: k, normalize: normTopkProb)
         }
-
-        let kth = e - k
-        let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
-        var scores = MLX.takeAlong(gates, inds, axis: -1)
-        if normTopkProb {
-            scores = scores / scores.sum(axis: -1, keepDims: true)
-        }
-        return (inds, scores)
+        return chainRouterTopK(gates, k: k, normalize: normTopkProb)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -9,8 +9,124 @@
 
 import Foundation
 import MLX
+import MLXFast
 import MLXLMCommon
 import MLXNN
+
+// MARK: - Fused router top-k
+
+/// One-kernel replacement for the decode router tail:
+///
+/// ```
+/// inds   = argPartition(gates, kth: E-K)[..., (E-K)...]
+/// scores = takeAlong(gates, inds, axis: -1)
+/// scores = scores / scores.sum(axis: -1, keepDims: true)
+/// ```
+///
+/// `ArgPartition::eval_gpu` delegates to `gpu_merge_sort`, so the path above
+/// fully sorts all `E` experts just to name `K` of them — three serial
+/// dispatches, and three encoder-wide hazard barriers, for a 256→8 selection.
+/// Decode is barrier-bound (MLX's dispatch schedule already sits at the
+/// dispatch graph's critical-path depth, so the only way to drop a barrier is
+/// to drop a serial link), which makes collapsing these three into one worth
+/// far more than the arithmetic they do.
+///
+/// Bit-identical to the chain it replaces, by construction:
+///
+/// - **order** — `sort.h`'s `LessThan` compares values only, `ThreadSort` swaps
+///   on strict less-than and `merge_step` takes from A on ties, so the sort is
+///   *stable*: element `i` lands at ascending position
+///   `#{j: v_j < v_i} + #{j: v_j == v_i, j < i}`. Counting the elements that
+///   rank *above* `i` instead gives the same slot as `K-1-count`, and packing
+///   the index into the low bits of a monotone bit key folds the tie-break into
+///   that one comparison. NaN maps above `+inf` (all NaNs tie, as in
+///   `LessThan`) and the sign of zero is normalised, since `-0.0` and `+0.0`
+///   compare equal there but not as bit patterns.
+/// - **sum** — `reduce.metal` instantiates float16 with `U = float16_t`, and a
+///   row of 8 takes `thread_reduce`: sequential accumulation in the output
+///   dtype, from zero, in slot order.
+/// - **divide** — elementwise, same dtype.
+private let routerTopKSource = """
+    uint row = threadgroup_position_in_grid.y;
+    uint t = thread_position_in_threadgroup.x;
+
+    threadgroup ulong sk[E_];
+    threadgroup float top_v[K_];
+    threadgroup uint  top_i[K_];
+
+    float v = static_cast<float>(gates[row * E_ + t]);
+    uint b = (v == 0.0f) ? 0u : as_type<uint>(v);
+    uint mono = isnan(v) ? 0xFFFFFFFFu : (b ^ ((uint)(((int)b) >> 31) | 0x80000000u));
+    ulong key = (((ulong)mono) << 32) | (ulong)t;
+    sk[t] = key;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    int above = 0;
+    for (uint j = 0; j < E_; ++j) {
+        above += (sk[j] > key) ? 1 : 0;
+    }
+    if (above < K_) {
+        top_v[K_ - 1 - above] = v;
+        top_i[K_ - 1 - above] = t;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (t == 0) {
+        T acc = static_cast<T>(0);
+        for (int q = 0; q < K_; ++q) {
+            acc = static_cast<T>(top_v[q]) + acc;
+        }
+        for (int q = 0; q < K_; ++q) {
+            T s = static_cast<T>(top_v[q]);
+            scores[row * K_ + q] = NORM_ ? (s / acc) : s;
+        }
+    }
+    if (t < K_) {
+        inds[row * K_ + t] = top_i[t];
+    }
+    """
+
+private final class RouterTopKKernel: Sendable {
+    static let shared = RouterTopKKernel()
+    let kernel: MLXFast.MLXFastKernel
+
+    private init() {
+        kernel = MLXFast.metalKernel(
+            name: "router_topk_norm",
+            inputNames: ["gates"],
+            outputNames: ["inds", "scores"],
+            source: routerTopKSource
+        )
+    }
+}
+
+/// Top-`k` selection + optional normalisation over the last axis, in one
+/// dispatch. Returns `(indices, scores)` shaped `[..., k]`, matching the
+/// argPartition/takeAlong/normalise chain bit for bit — including the
+/// `uint32` index dtype `argPartition` produces.
+///
+/// One threadgroup per row and an `O(E²)` rank count, which is only the right
+/// shape when there are very few rows — at prefill the block sort's
+/// `O(E log² E)` wins and there is no barrier to save, so callers gate this on
+/// the single-row decode case.
+///
+/// Internal (not private) so `Qwen35RouterTopKBitwiseTests` can hold the fused
+/// form against the chain it replaces.
+func fusedRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
+    let e = gates.dim(-1)
+    let rows = gates.size / e
+    let out = RouterTopKKernel.shared.kernel(
+        [gates],
+        template: [
+            ("T", gates.dtype), ("E_", e), ("K_", k), ("NORM_", normalize ? 1 : 0),
+        ],
+        grid: (e, rows, 1),
+        threadGroup: (e, 1, 1),
+        outputShapes: [[rows, k], [rows, k]],
+        outputDTypes: [.uint32, gates.dtype]
+    )
+    return (out[0], out[1])
+}
 
 // MARK: - Configuration
 
@@ -416,12 +532,7 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         gates = MLX.softmax(gates, axis: -1, precise: true)
 
         let k = topK
-        let kth = gates.dim(-1) - k
-        let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
-        var scores = MLX.takeAlong(gates, inds, axis: -1)
-        if normTopkProb {
-            scores = scores / scores.sum(axis: -1, keepDims: true)
-        }
+        let (inds, scores) = routerTopK(gates, k: k)
 
         let y = switchMLP(x, inds)
         let combined = weightedExpertSum(y, scores)
@@ -430,6 +541,31 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         sharedY = sigmoid(sharedExpertGate(x)) * sharedY
 
         return combined + sharedY
+    }
+
+    /// Pick the top-`k` experts and normalise their scores.
+    ///
+    /// At decode there is exactly one row, and the three-dispatch chain below
+    /// is three encoder-wide barriers spent on a 256→8 selection; the fused
+    /// kernel does it in one and is bit-identical (see `fusedRouterTopK`).
+    /// Prefill keeps the chain: many rows make the fused kernel's `O(E²)` rank
+    /// count the wrong shape, and a GEMM-bound pass has no barrier to save.
+    private func routerTopK(_ gates: MLXArray, k: Int) -> (MLXArray, MLXArray) {
+        let e = gates.dim(-1)
+        if gates.size == e, e <= 1024 {
+            let (inds, scores) = fusedRouterTopK(gates, k: k, normalize: normTopkProb)
+            var shape = gates.shape
+            shape[shape.count - 1] = k
+            return (inds.reshaped(shape), scores.reshaped(shape))
+        }
+
+        let kth = e - k
+        let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
+        var scores = MLX.takeAlong(gates, inds, axis: -1)
+        if normTopkProb {
+            scores = scores / scores.sum(axis: -1, keepDims: true)
+        }
+        return (inds, scores)
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,6 @@ let package = Package(
             dependencies: [
                 "MLXLMCommon",
                 .product(name: "MLX", package: "mlx-swift"),
-                .product(name: "MLXFast", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,7 @@ let package = Package(
             dependencies: [
                 "MLXLMCommon",
                 .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXOptimizers", package: "mlx-swift"),
             ],

--- a/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
@@ -9,13 +9,10 @@
 // this fails a unit test instead of silently splitting decode (fused
 // kernel) from prefill (chain).
 
-import Foundation
 import MLX
-import MLXNN
 import XCTest
 
 @testable import MLXLLM
-@testable import MLXLMCommon
 
 final class Qwen35RouterTopKBitwiseTests: XCTestCase {
 
@@ -34,19 +31,6 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
         XCTAssertEqual(
             mismatches, 0, "\(label): \(mismatches)/\(a.count) elements differ bitwise",
             file: file, line: line)
-    }
-
-    /// The exact chain `routerTopK` falls back to at prefill.
-    private func chainRouterTopK(
-        _ gates: MLXArray, k: Int, normalize: Bool
-    ) -> (MLXArray, MLXArray) {
-        let kth = gates.dim(-1) - k
-        let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
-        var scores = MLX.takeAlong(gates, inds, axis: -1)
-        if normalize {
-            scores = scores / scores.sum(axis: -1, keepDims: true)
-        }
-        return (inds, scores)
     }
 
     private func assertRouterMatchesChain(

--- a/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
@@ -1,0 +1,124 @@
+// Copyright © 2026 Apple Inc.
+//
+// CI pin for the bitwise contract behind the fused router top-k kernel:
+// it replaces the argPartition/takeAlong/normalise chain and must
+// reproduce the stable sort's selection order (ties, signed zeros,
+// NaN-above-everything) and the K-wide sequential in-dtype sum, bit for
+// bit, including the `uint32` index dtype argPartition produces. If an
+// MLX bump changes the sort's tie-breaking or the reduce's accumulation,
+// this fails a unit test instead of silently splitting decode (fused
+// kernel) from prefill (chain).
+
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+final class Qwen35RouterTopKBitwiseTests: XCTestCase {
+
+    /// Bitwise equality, dtype and shape included. The f32 upcast is exact
+    /// and injective for f16/bf16/f32 finite values, so bit-comparing the
+    /// upcast compares the originals.
+    private func assertBitIdentical(
+        _ got: MLXArray, _ want: MLXArray, _ label: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(got.dtype, want.dtype, "\(label): dtype", file: file, line: line)
+        XCTAssertEqual(got.shape, want.shape, "\(label): shape", file: file, line: line)
+        let a = got.asType(.float32).asArray(Float.self)
+        let b = want.asType(.float32).asArray(Float.self)
+        let mismatches = zip(a, b).filter { $0.bitPattern != $1.bitPattern }.count
+        XCTAssertEqual(
+            mismatches, 0, "\(label): \(mismatches)/\(a.count) elements differ bitwise",
+            file: file, line: line)
+    }
+
+    /// The exact chain `routerTopK` falls back to at prefill.
+    private func chainRouterTopK(
+        _ gates: MLXArray, k: Int, normalize: Bool
+    ) -> (MLXArray, MLXArray) {
+        let kth = gates.dim(-1) - k
+        let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
+        var scores = MLX.takeAlong(gates, inds, axis: -1)
+        if normalize {
+            scores = scores / scores.sum(axis: -1, keepDims: true)
+        }
+        return (inds, scores)
+    }
+
+    private func assertRouterMatchesChain(
+        _ gates: MLXArray, k: Int, normalize: Bool, _ label: String,
+        indicesOnly: Bool = false,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        let (chainInds, chainScores) = chainRouterTopK(gates, k: k, normalize: normalize)
+        let (fusedInds, fusedScores) = fusedRouterTopK(gates, k: k, normalize: normalize)
+        eval(chainInds, chainScores, fusedInds, fusedScores)
+
+        XCTAssertEqual(
+            fusedInds.dtype, chainInds.dtype,
+            "\(label): index dtype must match argPartition's", file: file, line: line)
+        let a = chainInds.reshaped(-1).asArray(UInt32.self)
+        let b = fusedInds.reshaped(-1).asArray(UInt32.self)
+        XCTAssertEqual(a, b, "\(label): expert selection order", file: file, line: line)
+
+        // NaN score payloads are propagation-order-dependent and not part of
+        // the contract (production gates are softmax outputs, NaN-free); the
+        // NaN cases pin the *ordering* only.
+        if !indicesOnly {
+            assertBitIdentical(
+                fusedScores.reshaped(-1, k), chainScores.reshaped(-1, k),
+                "\(label): scores", file: file, line: line)
+        }
+    }
+
+    func testFusedRouterTopKMatchesChain() {
+        let rows = 64
+        for (e, k) in [(256, 8), (128, 8)] {
+            for dtype in [DType.float16, DType.bfloat16, DType.float32] {
+                for normalize in [true, false] {
+                    MLXRandom.seed(UInt64(e + k + (normalize ? 1 : 0)))
+                    let tag = "E=\(e) K=\(k) \(dtype) norm=\(normalize)"
+
+                    // The production distribution: softmax outputs.
+                    let soft = MLX.softmax(
+                        MLXRandom.normal([rows, e]), axis: -1, precise: true
+                    ).asType(dtype)
+                    assertRouterMatchesChain(soft, k: k, normalize: normalize, "softmax \(tag)")
+
+                    // Heavy ties — the stable tie-break is the hard part.
+                    let ties = (MLX.round(MLXRandom.normal([rows, e]) * 2) / 2).asType(dtype)
+                    assertRouterMatchesChain(ties, k: k, normalize: normalize, "ties \(tag)")
+
+                    // All-equal rows: pure index-order selection.
+                    let equal = MLX.full([rows, e], values: MLXArray(Float(0.25))).asType(dtype)
+                    assertRouterMatchesChain(equal, k: k, normalize: normalize, "all-equal \(tag)")
+
+                    // Signed zeros compare equal but differ bitwise; the tie
+                    // class must merge and the surviving values keep their sign.
+                    let signs = MLX.where(
+                        MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
+                        MLXArray(Float(-0.0)), MLXArray(Float(0.0)))
+                    let zeros = MLX.where(
+                        MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
+                        signs, MLXRandom.normal([rows, e])
+                    ).asType(dtype)
+                    assertRouterMatchesChain(zeros, k: k, normalize: normalize, "±0 \(tag)")
+
+                    // NaN rows: sort.h's LessThan puts NaN above everything
+                    // and ties all NaNs; order must match, scores exempt.
+                    var nans = MLX.where(
+                        MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.05,
+                        MLXArray(Float.nan), MLXRandom.normal([rows, e])
+                    ).asType(dtype)
+                    nans[0] = MLX.full([e], values: MLXArray(Float.nan)).asType(dtype)
+                    assertRouterMatchesChain(
+                        nans, k: k, normalize: normalize, "NaN \(tag)", indicesOnly: true)
+                }
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
@@ -1,13 +1,8 @@
 // Copyright © 2026 Apple Inc.
 //
-// CI pin for the bitwise contract behind the fused router top-k kernel:
-// it replaces the argPartition/takeAlong/normalise chain and must
-// reproduce the stable sort's selection order (ties, signed zeros,
-// NaN-above-everything) and the K-wide sequential in-dtype sum, bit for
-// bit, including the `uint32` index dtype argPartition produces. If an
-// MLX bump changes the sort's tie-breaking or the reduce's accumulation,
-// this fails a unit test instead of silently splitting decode (fused
-// kernel) from prefill (chain).
+// Pins fusedRouterTopK bitwise-equal to chainRouterTopK. If an MLX bump
+// changes the sort's tie-breaking or the reduce's accumulation, this
+// fails instead of decode (fused) silently splitting from prefill (chain).
 
 import MLX
 import XCTest
@@ -16,9 +11,8 @@ import XCTest
 
 final class Qwen35RouterTopKBitwiseTests: XCTestCase {
 
-    /// Bitwise equality, dtype and shape included. The f32 upcast is exact
-    /// and injective for f16/bf16/f32 finite values, so bit-comparing the
-    /// upcast compares the originals.
+    /// Bitwise equality, dtype and shape included; the f32 upcast is exact
+    /// for f16/bf16/f32, so comparing upcast bits compares the originals.
     private func assertBitIdentical(
         _ got: MLXArray, _ want: MLXArray, _ label: String,
         file: StaticString = #filePath, line: UInt = #line
@@ -49,9 +43,8 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
         let b = fusedInds.reshaped(-1).asArray(UInt32.self)
         XCTAssertEqual(a, b, "\(label): expert selection order", file: file, line: line)
 
-        // NaN score payloads are propagation-order-dependent and not part of
-        // the contract (production gates are softmax outputs, NaN-free); the
-        // NaN cases pin the *ordering* only.
+        // NaN score payloads are propagation-order-dependent and out of
+        // contract (production gates are softmax outputs, NaN-free).
         if !indicesOnly {
             assertBitIdentical(
                 fusedScores.reshaped(-1, k), chainScores.reshaped(-1, k),
@@ -81,8 +74,7 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
                     let equal = MLX.full([rows, e], values: MLXArray(Float(0.25))).asType(dtype)
                     assertRouterMatchesChain(equal, k: k, normalize: normalize, "all-equal \(tag)")
 
-                    // Signed zeros compare equal but differ bitwise; the tie
-                    // class must merge and the surviving values keep their sign.
+                    // Signed zeros: compare equal, differ bitwise.
                     let signs = MLX.where(
                         MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
                         MLXArray(Float(-0.0)), MLXArray(Float(0.0)))
@@ -92,8 +84,7 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
                     ).asType(dtype)
                     assertRouterMatchesChain(zeros, k: k, normalize: normalize, "±0 \(tag)")
 
-                    // NaN rows: sort.h's LessThan puts NaN above everything
-                    // and ties all NaNs; order must match, scores exempt.
+                    // NaN above everything, all NaNs tie; indices only.
                     var nans = MLX.where(
                         MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.05,
                         MLXArray(Float.nan), MLXRandom.normal([rows, e])


### PR DESCRIPTION
Independent of #467 and #468, applies directly on main.

ArgPartition::eval_gpu carries the comment "We direct arg partition to sort for now" and delegates to gpu_merge_sort. So every MoE layer, every decode token, the router fully sorts all 256 expert scores to pick the top 8, then does a gather, a sum and a divide on top. Three serial dispatches and three encoder-wide hazard barriers for a 256 to 8 selection. This PR replaces all three with one small Metal kernel on the single-row decode path.

The kernel is bit-identical to the chain by construction, with each piece derived from the MLX source it replaces rather than assumed:

- order: sort.h's LessThan compares values only, ThreadSort swaps on strict less-than, and merge_step takes from A on ties, so the sort is stable. Element i's ascending position is therefore exactly its rank count with index tie-break. Packing the index into the low 32 bits of a monotone bit key folds the value comparison and the tie-break into one 64-bit compare.
- sum: reduce.metal instantiates float16 with U = float16_t, and a row of 8 takes thread_reduce, meaning sequential accumulation in the output dtype from zero in slot order. The kernel does the same.
- divide: elementwise, same dtype.
- indices come out uint32, same as argPartition.

Two edge cases needed explicit handling: NaN maps above +inf and all NaNs tie (LessThan is explicitly NaN-aware), and the sign of zero is normalised because -0.0 and +0.0 compare equal under < but have different bit patterns.

A new test holds the fused kernel against the chain over softmax rows, heavy ties, all-equal rows, signed zeros and NaN rows, in f16, bf16 and f32, with dtypes and bit patterns asserted. So if a future MLX bump changes the sort's tie-breaking or the reduce's accumulation, CI fails a unit test instead of decode silently diverging from prefill.

Decode only. At prefill the block sort's O(E log^2 E) beats this kernel's O(E^2) rank count and there is no barrier to save, so many-row callers keep the original chain.

Measured on the 35B-A3B MoE hybrid (4-bit, M3 Max): decode +1.91% at 128 context (10 of 10 pairs) and +0.47% at 8K, prefill and peak memory flat, 32 of 32 A/B pairs token-identical. Dispatches per token went 1914 to 1827.

Two notes for reviewers. The kernel lives in the Qwen3.5 model file for now; it would generalise to every SwitchGLU-style router, happy to move it somewhere shared if you'd prefer that. And the MLXVLM copy of this MoE block still has the original chain, we did not touch it because we could not A/B it with our models.

Part of the perf batch in #466.

