### PR TITLE
Prefill: balanced chunking behind a new PrefillParameters (~9% at 32K)

### DIFF
--- a/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
+++ b/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
@@ -75,6 +75,9 @@ public enum GuidedGenerationLoop {
     ///     Used by the run tracker to detect consecutive whitespace runs.
     ///   - diagnosticLog: When true, flush the grammar constraint's diagnostic
     ///     logs after the run completes. Defaults to false.
+    ///   - prefill: Prompt prefill parameters (step size, chunking strategy,
+    ///     progress callback). Defaults to a 512-token step with balanced
+    ///     chunking.
     ///   - emit: Callback for each text delta. Return `false` to stop.
     /// - Returns: Total number of tokens generated (including FF tokens).
     /// - Throws: `GuidedGenerationError.incompleteOutput` if maxTokens is

--- a/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
+++ b/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
@@ -98,6 +98,7 @@ public enum GuidedGenerationLoop {
         whitespaceBias: MLXArray? = nil,
         whitespaceTokenIDs: Set<Int> = [],
         diagnosticLog: Bool = false,
+        prefill: PrefillParameters = .init(stepSize: PrefillParameters.defaultStepSize),
         emit: (String) -> Bool
     ) throws -> Int {
         let model = context.model
@@ -123,7 +124,7 @@ public enum GuidedGenerationLoop {
         var logits: MLXArray
         let inputLength = input.text.cacheSequenceLength
         switch try model.prepare(
-            input, cache: cacheStorage.cache, state: nil, prefill: .init(stepSize: 512))
+            input, cache: cacheStorage.cache, state: nil, prefill: prefill)
         {
         case .tokens(let tokens):
             let remainingLength = tokens.cacheSequenceLength

--- a/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
+++ b/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
@@ -123,7 +123,7 @@ public enum GuidedGenerationLoop {
         var logits: MLXArray
         let inputLength = input.text.cacheSequenceLength
         switch try model.prepare(
-            input, cache: cacheStorage.cache, state: nil, windowSize: 512)
+            input, cache: cacheStorage.cache, state: nil, prefill: .init(stepSize: 512))
         {
         case .tokens(let tokens):
             let remainingLength = tokens.cacheSequenceLength

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -65,11 +65,11 @@ extension LLMModel {
     /// 1024 plus a straggler. `prefillStepSize` becomes a pure loop-efficiency knob,
     /// bounded only by the peak memory of one chunk.
     public func prepare(
-        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
-        let prefillStepSize = windowSize ?? 512
+        let prefillStepSize = prefill.stepSize ?? 512
         var y = input.text
 
         // A prompt that fits in one chunk is handed to the iterator whole, exactly

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -27,51 +27,38 @@ extension LLMModel {
     ) throws
         -> PrepareResult
     {
-        let stepSize = max(1, prefill.stepSize ?? 512)
-        var y = input.text
+        let stepSize = prefill.resolvedStepSize()
+        let y = input.text
         let total = y.tokens.size
 
-        // A prompt that fits in one chunk is handed to the iterator whole:
-        // chunking it would only add a second forward. `.unchunked` (a nil
-        // chunk length) takes the same path at any prompt length.
-        guard total > stepSize,
-            let chunkSize = prefill.chunkLength(forChunking: total - 1, defaultStepSize: stepSize)
-        else {
-            return .tokens(y)
-        }
-        let tail = prefill.chunking == .remainder ? stepSize : 1
+        // A prompt that fits in one chunk is handed to the iterator whole,
+        // keeping short prompts bitwise-identical to the pre-chunking path.
+        // `.unchunked` (forEachChunk processes nothing) takes the same route
+        // at any prompt length.
+        guard total > stepSize else { return .tokens(y) }
 
+        var processed = 0
         try withPreparedCache(cache, lengths: y.sequenceLengths) {
             // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
-            // chunk N.
+            // chunk N. Under .remainder the reserved tail is the legacy leftover
+            // (up to a full step) rather than a single token.
             var state: LMOutput.State? = state
-            while y.tokens.size > tail {
-                // Cooperative cancellation between prefill windows. On iOS, GPU work
-                // submitted after the app moves to the background is rejected by the
-                // system ("Insufficient Permission"), and the resulting command-buffer
-                // error is thrown from a Metal completion handler where it cannot be
-                // caught, aborting the process. Without this check a long prompt's
-                // prefill cannot be interrupted, so apps cannot stop GPU submissions
-                // in time when entering the background. See ml-explore/mlx-swift-examples#230.
-                try Task.checkCancellation()
-                // Pool per chunk: long prompts run hundreds of chunk forwards
-                // before returning to any autorelease boundary.
-                autoreleasepool {
-                    let n = min(chunkSize, y.tokens.size - 1)
-                    let input = y[.newAxis, ..<n]
-                    let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
-                    state = output.state
-                    asyncEval(cache)
-                    y = y[n...]
-                    prefill.progress?(total - y.tokens.size, total)
-                }
+            processed = try prefill.forEachChunk(
+                total: total, reserving: prefill.chunking == .remainder ? stepSize : 1
+            ) { range in
+                let input = y[.newAxis, range]
+                let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
+                state = output.state
+                asyncEval(cache)
             }
 
             // Single sync after the loop to flush any remaining async work.
-            eval(cache)
+            if processed > 0 {
+                eval(cache)
+            }
         }
 
-        return .tokens(y)
+        return .tokens(y[processed...])
     }
 
     public func messageGenerator(tokenizer: Tokenizer) -> MessageGenerator {

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -4,6 +4,34 @@ import Foundation
 import MLX
 import MLXLMCommon
 
+/// Runtime switch over ``LLMModel/prepare(_:cache:state:windowSize:)``'s chunking strategy.
+///
+/// Exists so an A/B can alternate strategies **inside one process**, sharing the
+/// loaded weights and the machine's thermal state. Separate-binary A/Bs of this
+/// change were confounded: the M3 Max throttles hard under sustained 35B prefill,
+/// and whichever arm ran second always measured on a hotter machine.
+///
+/// Production leaves this at ``balanced``. Not thread-safe by construction — set it
+/// before generation starts, from the benchmark harness only.
+public enum PrefillChunking: Sendable {
+    /// Equal chunks of at most `prefillStepSize`; the iterator gets one token.
+    case balanced
+    /// Upstream behaviour: chunks of exactly `prefillStepSize`, and the iterator
+    /// swallows `promptTokens mod prefillStepSize` in one forward.
+    case remainder
+    /// No chunking at all: the whole prompt in a single forward.
+    ///
+    /// This is the *reference* computation — the one chunking approximates. It is
+    /// not usable in production (the `[1, H, Lq, Lk]` score matrix is quadratic in
+    /// the prompt), but at a few thousand tokens it fits, and it is the only way to
+    /// ask whether a chunking scheme moves logits *toward or away from* the true
+    /// answer. Comparing two chunkings to each other cannot answer that: neither is
+    /// a ground truth.
+    case unchunked
+
+    nonisolated(unsafe) public static var strategy: PrefillChunking = .balanced
+}
+
 /// Marker protocol for LLMModels
 public protocol LLMModel: LanguageModel, LoRAModel {
 
@@ -17,8 +45,25 @@ extension LLMModel {
 
     /// Default prepare step for ``LLMModel``.
     ///
-    /// This will evaluate the prompt in chunks until there is a small number of
-    /// tokens left to feed into the `TokenIterator`.
+    /// Evaluates the prompt in equal chunks of at most `prefillStepSize`, leaving
+    /// exactly ``tokenIteratorTail`` tokens for the `TokenIterator`'s first forward.
+    ///
+    /// **Why the chunks are balanced.** The obvious loop —
+    /// `while y.tokens.size > prefillStepSize` — hands the iterator a remainder of
+    /// `promptTokens mod prefillStepSize`, which it swallows in one un-pipelined
+    /// forward at the largest `Lk` of the whole prefill. That forward is
+    /// disproportionately slow: it pays full attention cost against the entire
+    /// prompt while giving each MoE expert only `Lq × topK / numExperts` rows of
+    /// GEMM. Measured on Qwen3.6-35B-A3B at 32K, a 141-token
+    /// remainder cost **2.89 s** — three times a full 1024-token chunk — and the
+    /// remainder *grows with the step size* (141 → 1,165 → 3,213 tokens at
+    /// 1024 / 2048 / 4096), so raising `prefillStepSize` to speed the loop up made
+    /// the remainder worse by more than the loop gained.
+    ///
+    /// Balancing removes the remainder without splitting it into a second small
+    /// forward: 31,884 tokens at a 1024 ceiling become 32 chunks of ~997, not 31 of
+    /// 1024 plus a straggler. `prefillStepSize` becomes a pure loop-efficiency knob,
+    /// bounded only by the peak memory of one chunk.
     public func prepare(
         _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
     ) throws
@@ -27,12 +72,30 @@ extension LLMModel {
         let prefillStepSize = windowSize ?? 512
         var y = input.text
 
+        // A prompt that fits in one chunk is handed to the iterator whole, exactly
+        // as before: chunking it would only add a second forward.
+        let chunkSize: Int
+        let tail: Int
+        switch PrefillChunking.strategy {
+        case .unchunked:
+            return .tokens(y)
+        case .balanced:
+            guard
+                let balanced = Self.balancedChunkSize(
+                    promptTokens: y.tokens.size, prefillStepSize: prefillStepSize)
+            else {
+                return .tokens(y)
+            }
+            (chunkSize, tail) = (balanced, Self.tokenIteratorTail)
+        case .remainder:
+            (chunkSize, tail) = (prefillStepSize, prefillStepSize)
+        }
+
         try withPreparedCache(cache, lengths: y.sequenceLengths) {
-            // Prepare the prompt in chunks if larger than the prefill size.
             // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
             // chunk N.
             var state: LMOutput.State? = state
-            while y.tokens.size > prefillStepSize {
+            while y.tokens.size > tail {
                 // Cooperative cancellation between prefill windows. On iOS, GPU work
                 // submitted after the app moves to the background is rejected by the
                 // system ("Insufficient Permission"), and the resulting command-buffer
@@ -44,11 +107,12 @@ extension LLMModel {
                 // Pool per chunk: long prompts run hundreds of chunk forwards
                 // before returning to any autorelease boundary.
                 autoreleasepool {
-                    let input = y[.newAxis, ..<prefillStepSize]
+                    let n = min(chunkSize, y.tokens.size - Self.tokenIteratorTail)
+                    let input = y[.newAxis, ..<n]
                     let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
                     state = output.state
                     asyncEval(cache)
-                    y = y[prefillStepSize...]
+                    y = y[n...]
                 }
             }
 
@@ -57,6 +121,20 @@ extension LLMModel {
         }
 
         return .tokens(y)
+    }
+
+    /// Tokens left for the `TokenIterator`'s first forward, which is the step that
+    /// produces the first sampled logits. One token makes that step decode-shaped.
+    public static var tokenIteratorTail: Int { 1 }
+
+    /// The largest chunk size ≤ `prefillStepSize` that splits the prompt into equal
+    /// chunks leaving only ``tokenIteratorTail`` tokens over, or `nil` when the
+    /// prompt is short enough that the iterator should take all of it.
+    public static func balancedChunkSize(promptTokens: Int, prefillStepSize: Int) -> Int? {
+        guard prefillStepSize > 0, promptTokens > prefillStepSize else { return nil }
+        let toChunk = promptTokens - tokenIteratorTail
+        let chunkCount = (toChunk + prefillStepSize - 1) / prefillStepSize
+        return (toChunk + chunkCount - 1) / chunkCount
     }
 
     public func messageGenerator(tokenizer: Tokenizer) -> MessageGenerator {

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -4,34 +4,6 @@ import Foundation
 import MLX
 import MLXLMCommon
 
-/// Runtime switch over ``LLMModel/prepare(_:cache:state:windowSize:)``'s chunking strategy.
-///
-/// Exists so an A/B can alternate strategies **inside one process**, sharing the
-/// loaded weights and the machine's thermal state. Separate-binary A/Bs of this
-/// change were confounded: the M3 Max throttles hard under sustained 35B prefill,
-/// and whichever arm ran second always measured on a hotter machine.
-///
-/// Production leaves this at ``balanced``. Not thread-safe by construction — set it
-/// before generation starts, from the benchmark harness only.
-public enum PrefillChunking: Sendable {
-    /// Equal chunks of at most `prefillStepSize`; the iterator gets one token.
-    case balanced
-    /// Upstream behaviour: chunks of exactly `prefillStepSize`, and the iterator
-    /// swallows `promptTokens mod prefillStepSize` in one forward.
-    case remainder
-    /// No chunking at all: the whole prompt in a single forward.
-    ///
-    /// This is the *reference* computation — the one chunking approximates. It is
-    /// not usable in production (the `[1, H, Lq, Lk]` score matrix is quadratic in
-    /// the prompt), but at a few thousand tokens it fits, and it is the only way to
-    /// ask whether a chunking scheme moves logits *toward or away from* the true
-    /// answer. Comparing two chunkings to each other cannot answer that: neither is
-    /// a ground truth.
-    case unchunked
-
-    nonisolated(unsafe) public static var strategy: PrefillChunking = .balanced
-}
-
 /// Marker protocol for LLMModels
 public protocol LLMModel: LanguageModel, LoRAModel {
 
@@ -45,51 +17,29 @@ extension LLMModel {
 
     /// Default prepare step for ``LLMModel``.
     ///
-    /// Evaluates the prompt in equal chunks of at most `prefillStepSize`, leaving
-    /// exactly ``tokenIteratorTail`` tokens for the `TokenIterator`'s first forward.
-    ///
-    /// **Why the chunks are balanced.** The obvious loop —
-    /// `while y.tokens.size > prefillStepSize` — hands the iterator a remainder of
-    /// `promptTokens mod prefillStepSize`, which it swallows in one un-pipelined
-    /// forward at the largest `Lk` of the whole prefill. That forward is
-    /// disproportionately slow: it pays full attention cost against the entire
-    /// prompt while giving each MoE expert only `Lq × topK / numExperts` rows of
-    /// GEMM. Measured on Qwen3.6-35B-A3B at 32K, a 141-token
-    /// remainder cost **2.89 s** — three times a full 1024-token chunk — and the
-    /// remainder *grows with the step size* (141 → 1,165 → 3,213 tokens at
-    /// 1024 / 2048 / 4096), so raising `prefillStepSize` to speed the loop up made
-    /// the remainder worse by more than the loop gained.
-    ///
-    /// Balancing removes the remainder without splitting it into a second small
-    /// forward: 31,884 tokens at a 1024 ceiling become 32 chunks of ~997, not 31 of
-    /// 1024 plus a straggler. `prefillStepSize` becomes a pure loop-efficiency knob,
-    /// bounded only by the peak memory of one chunk.
+    /// Evaluates the prompt into the cache in chunks of at most
+    /// ``PrefillParameters/stepSize`` (default 512), leaving one token for the
+    /// `TokenIterator`'s first forward. With ``PrefillParameters/Chunking/balanced``
+    /// (the default) the chunks are equal-sized, so no forward is a small
+    /// remainder paying full attention cost against the whole prompt.
     public func prepare(
         _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
-        let prefillStepSize = prefill.stepSize ?? 512
+        let stepSize = max(1, prefill.stepSize ?? 512)
         var y = input.text
+        let total = y.tokens.size
 
-        // A prompt that fits in one chunk is handed to the iterator whole, exactly
-        // as before: chunking it would only add a second forward.
-        let chunkSize: Int
-        let tail: Int
-        switch PrefillChunking.strategy {
-        case .unchunked:
+        // A prompt that fits in one chunk is handed to the iterator whole:
+        // chunking it would only add a second forward. `.unchunked` (a nil
+        // chunk length) takes the same path at any prompt length.
+        guard total > stepSize,
+            let chunkSize = prefill.chunkLength(forChunking: total - 1, defaultStepSize: stepSize)
+        else {
             return .tokens(y)
-        case .balanced:
-            guard
-                let balanced = Self.balancedChunkSize(
-                    promptTokens: y.tokens.size, prefillStepSize: prefillStepSize)
-            else {
-                return .tokens(y)
-            }
-            (chunkSize, tail) = (balanced, Self.tokenIteratorTail)
-        case .remainder:
-            (chunkSize, tail) = (prefillStepSize, prefillStepSize)
         }
+        let tail = prefill.chunking == .remainder ? stepSize : 1
 
         try withPreparedCache(cache, lengths: y.sequenceLengths) {
             // asyncEval lets the CPU build chunk N+1's graph while the GPU evaluates
@@ -107,12 +57,13 @@ extension LLMModel {
                 // Pool per chunk: long prompts run hundreds of chunk forwards
                 // before returning to any autorelease boundary.
                 autoreleasepool {
-                    let n = min(chunkSize, y.tokens.size - Self.tokenIteratorTail)
+                    let n = min(chunkSize, y.tokens.size - 1)
                     let input = y[.newAxis, ..<n]
                     let output = self(input, cache: cache.isEmpty ? nil : cache, state: state)
                     state = output.state
                     asyncEval(cache)
                     y = y[n...]
+                    prefill.progress?(total - y.tokens.size, total)
                 }
             }
 
@@ -121,20 +72,6 @@ extension LLMModel {
         }
 
         return .tokens(y)
-    }
-
-    /// Tokens left for the `TokenIterator`'s first forward, which is the step that
-    /// produces the first sampled logits. One token makes that step decode-shaped.
-    public static var tokenIteratorTail: Int { 1 }
-
-    /// The largest chunk size ≤ `prefillStepSize` that splits the prompt into equal
-    /// chunks leaving only ``tokenIteratorTail`` tokens over, or `nil` when the
-    /// prompt is short enough that the iterator should take all of it.
-    public static func balancedChunkSize(promptTokens: Int, prefillStepSize: Int) -> Int? {
-        guard prefillStepSize > 0, promptTokens > prefillStepSize else { return nil }
-        let toChunk = promptTokens - tokenIteratorTail
-        let chunkCount = (toChunk + prefillStepSize - 1) / prefillStepSize
-        return (toChunk + chunkCount - 1) / chunkCount
     }
 
     public func messageGenerator(tokenizer: Tokenizer) -> MessageGenerator {

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -18,8 +18,8 @@ extension LLMModel {
     /// Default prepare step for ``LLMModel``.
     ///
     /// Evaluates the prompt into the cache in chunks of at most
-    /// ``PrefillParameters/stepSize`` (default 512), leaving one token for the
-    /// `TokenIterator`'s first forward. With ``PrefillParameters/Chunking/balanced``
+    /// `PrefillParameters.stepSize` (default 512), leaving one token for the
+    /// `TokenIterator`'s first forward. With `PrefillParameters.Chunking.balanced`
     /// (the default) the chunks are equal-sized, so no forward is a small
     /// remainder paying full attention cost against the whole prompt.
     public func prepare(

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -433,7 +433,7 @@ public class Gemma3TextModel: Module, LLMModel {
     /// Handles prompt processing for sequences
     public func prepare(
         _ input: LMInput, cache: [KVCache], state _: LMOutput.State? = nil,
-        windowSize: Int? = nil
+        prefill: PrefillParameters = .init()
     ) throws -> PrepareResult {
         let promptTokens = input.text.tokens
         let promptCount = promptTokens.dim(0)
@@ -448,7 +448,7 @@ public class Gemma3TextModel: Module, LLMModel {
         // the last token to the TokenIterator — skipping the 262k-vocab lm_head over every
         // prompt position is the speedup. Chunk = explicit windowSize, else a tuned 128.
         let prefillStepSize = Swift.min(
-            windowSize ?? Self.defaultPrefillChunkSize, config.slidingWindow)
+            prefill.stepSize ?? Self.defaultPrefillChunkSize, config.slidingWindow)
         var y = input.text
         while y.tokens.size > 1 {
             let n = Swift.min(prefillStepSize, y.tokens.size - 1)

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -446,15 +446,21 @@ public class Gemma3TextModel: Module, LLMModel {
 
         // Prefill through the inner model (no lm_head) to fill the KV cache, handing only
         // the last token to the TokenIterator — skipping the 262k-vocab lm_head over every
-        // prompt position is the speedup. Chunk = explicit windowSize, else a tuned 128.
-        let prefillStepSize = Swift.min(
-            prefill.stepSize ?? Self.defaultPrefillChunkSize, config.slidingWindow)
+        // prompt position is the speedup. Tuned 128 default, capped at the sliding window.
         var y = input.text
-        while y.tokens.size > 1 {
-            let n = Swift.min(prefillStepSize, y.tokens.size - 1)
-            _ = model(y[.newAxis, ..<n].tokens, mask: nil, cache: cache)
-            asyncEval(cache)
-            y = y[n...]
+        let total = y.tokens.size
+        if let chunkLength = prefill.chunkLength(
+            forChunking: total - 1,
+            defaultStepSize: Self.defaultPrefillChunkSize,
+            maximumStepSize: config.slidingWindow)
+        {
+            while y.tokens.size > 1 {
+                let n = Swift.min(chunkLength, y.tokens.size - 1)
+                _ = model(y[.newAxis, ..<n].tokens, mask: nil, cache: cache)
+                asyncEval(cache)
+                y = y[n...]
+                prefill.progress?(total - y.tokens.size, total)
+            }
         }
         return .tokens(y)
     }

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -447,22 +447,16 @@ public class Gemma3TextModel: Module, LLMModel {
         // Prefill through the inner model (no lm_head) to fill the KV cache, handing only
         // the last token to the TokenIterator — skipping the 262k-vocab lm_head over every
         // prompt position is the speedup. Tuned 128 default, capped at the sliding window.
-        var y = input.text
-        let total = y.tokens.size
-        if let chunkLength = prefill.chunkLength(
-            forChunking: total - 1,
+        let y = input.text
+        let processed = try prefill.forEachChunk(
+            total: y.tokens.size,
             defaultStepSize: Self.defaultPrefillChunkSize,
-            maximumStepSize: config.slidingWindow)
-        {
-            while y.tokens.size > 1 {
-                let n = Swift.min(chunkLength, y.tokens.size - 1)
-                _ = model(y[.newAxis, ..<n].tokens, mask: nil, cache: cache)
-                asyncEval(cache)
-                y = y[n...]
-                prefill.progress?(total - y.tokens.size, total)
-            }
+            maximumStepSize: config.slidingWindow
+        ) { range in
+            _ = model(y[.newAxis, range].tokens, mask: nil, cache: cache)
+            asyncEval(cache)
         }
-        return .tokens(y)
+        return .tokens(y[processed...])
     }
 
     /// Prefill chunk size when the caller sets none, tuned for this path on Apple Silicon.

--- a/Libraries/MLXLLM/Models/Gemma3nText.swift
+++ b/Libraries/MLXLLM/Models/Gemma3nText.swift
@@ -998,7 +998,7 @@ public class Gemma3nTextModel: Module, LLMModel {
     /// Handles prompt processing for sequences
     public func prepare(
         _ input: LMInput, cache: [KVCache], state _: LMOutput.State? = nil,
-        windowSize: Int? = nil
+        prefill _: PrefillParameters = .init()
     ) throws -> PrepareResult {
         let promptTokens = input.text.tokens
         let promptCount = promptTokens.dim(0)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -53,9 +53,17 @@ public protocol LogitProcessor {
 /// for the `TokenIterator`.
 public struct GenerateParameters: Sendable {
 
+    /// How the prompt is prefilled into the cache: step size, chunking strategy,
+    /// and progress observation. See ``PrefillParameters``.
+    public var prefill: PrefillParameters
+
     /// Step size for processing the prompt. `nil` lets each model pick its own prefill
     /// chunk (the Gemma 3 text path uses a smaller chunk than the generic 512 default).
-    public var prefillStepSize: Int?
+    @available(*, deprecated, renamed: "prefill.stepSize")
+    public var prefillStepSize: Int? {
+        get { prefill.stepSize }
+        set { prefill.stepSize = newValue }
+    }
 
     /// Maximum tokens to generate
     public var maxTokens: Int?
@@ -154,7 +162,7 @@ public struct GenerateParameters: Sendable {
         presenceContextSize: Int = 20,
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
-        prefillStepSize: Int? = nil,
+        prefill: PrefillParameters = .init(),
         seed: UInt64? = nil
     ) {
         self.maxTokens = maxTokens
@@ -174,8 +182,43 @@ public struct GenerateParameters: Sendable {
         self.presenceContextSize = presenceContextSize
         self.frequencyPenalty = frequencyPenalty
         self.frequencyContextSize = frequencyContextSize
-        self.prefillStepSize = prefillStepSize
+        self.prefill = prefill
         self.seed = seed
+    }
+
+    @available(
+        *, deprecated,
+        renamed:
+            "init(maxTokens:maxKVSize:kvBits:kvGroupSize:quantizedKVStart:kvScheme:temperature:topP:topK:minP:repetitionPenalty:repetitionContextSize:presencePenalty:presenceContextSize:frequencyPenalty:frequencyContextSize:prefill:seed:)"
+    )
+    public init(
+        maxTokens: Int? = nil,
+        maxKVSize: Int? = nil,
+        kvBits: Int? = nil,
+        kvGroupSize: Int = 64,
+        quantizedKVStart: Int = 0,
+        kvScheme: String? = nil,
+        temperature: Float = 0.6,
+        topP: Float = 1.0,
+        topK: Int = 0,
+        minP: Float = 0.0,
+        repetitionPenalty: Float? = nil,
+        repetitionContextSize: Int = 20,
+        presencePenalty: Float? = nil,
+        presenceContextSize: Int = 20,
+        frequencyPenalty: Float? = nil,
+        frequencyContextSize: Int = 20,
+        prefillStepSize: Int?,
+        seed: UInt64? = nil
+    ) {
+        self.init(
+            maxTokens: maxTokens, maxKVSize: maxKVSize, kvBits: kvBits,
+            kvGroupSize: kvGroupSize, quantizedKVStart: quantizedKVStart, kvScheme: kvScheme,
+            temperature: temperature, topP: topP, topK: topK, minP: minP,
+            repetitionPenalty: repetitionPenalty, repetitionContextSize: repetitionContextSize,
+            presencePenalty: presencePenalty, presenceContextSize: presenceContextSize,
+            frequencyPenalty: frequencyPenalty, frequencyContextSize: frequencyContextSize,
+            prefill: .init(stepSize: prefillStepSize), seed: seed)
     }
 
     public func sampler() -> LogitSampler {
@@ -664,7 +707,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// Initialize a `TokenIterator` with the given input.
     ///
     /// If more control is needed over the generation,
-    /// ``init(input:model:cache:state:processor:sampler:prefillStepSize:maxTokens:)``
+    /// ``init(input:model:cache:state:processor:sampler:prefill:maxTokens:)``
     /// allows a caller to specify ``LogitProcessor`` and ``LogitSampler``
     /// directly.
     ///
@@ -709,7 +752,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.maxTokens = parameters.maxTokens
 
         self.promptPrefillTime = try measure {
-            try prepare(input: input, windowSize: parameters.prefillStepSize)
+            try prepare(input: input, prefill: parameters.prefill)
         }
     }
 
@@ -723,12 +766,13 @@ public struct TokenIterator: TokenIteratorProtocol {
     ///     evaluation against `cache` (e.g. by a caller resuming a session)
     ///   - processor: the logit processor
     ///   - sampler: the logit sampler
-    ///   - prefillStepSize: optional prefill step size
+    ///   - prefill: prefill parameters (step size, chunking, progress)
     ///   - maxTokens: maximum number of tokens to generate
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
         state: LMOutput.State? = nil,
-        processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int? = nil,
+        processor: LogitProcessor?, sampler: LogitSampler,
+        prefill: PrefillParameters = .init(),
         maxTokens: Int? = nil
     ) throws {
         self.model = model
@@ -742,15 +786,30 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.maxTokens = maxTokens
 
         self.promptPrefillTime = try measure {
-            try prepare(input: input, windowSize: prefillStepSize)
+            try prepare(input: input, prefill: prefill)
         }
     }
 
-    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+    @available(
+        *, deprecated, renamed: "init(input:model:cache:state:processor:sampler:prefill:maxTokens:)"
+    )
+    public init(
+        input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
+        state: LMOutput.State? = nil,
+        processor: LogitProcessor?, sampler: LogitSampler, prefillStepSize: Int?,
+        maxTokens: Int? = nil
+    ) throws {
+        try self.init(
+            input: input, model: model, cache: cache, state: state,
+            processor: processor, sampler: sampler,
+            prefill: .init(stepSize: prefillStepSize), maxTokens: maxTokens)
+    }
+
+    mutating func prepare(input: LMInput, prefill: PrefillParameters = .init()) throws {
         processor?.prompt(input.text.tokens)
         let inputLength = input.text.cacheSequenceLength
 
-        switch try model.prepare(input, cache: cache, state: state, windowSize: windowSize) {
+        switch try model.prepare(input, cache: cache, state: state, prefill: prefill) {
         case .tokens(let tokens):
             let remainingLength = tokens.cacheSequenceLength
             precondition(
@@ -988,18 +1047,18 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         self.numDraftTokens = numDraftTokens
 
         self.promptPrefillTime = try measure {
-            try prepare(input: input, windowSize: parameters.prefillStepSize)
+            try prepare(input: input, prefill: parameters.prefill)
         }
     }
 
     /// Prefill both main and draft models with the prompt, priming caches for generation
-    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+    mutating func prepare(input: LMInput, prefill: PrefillParameters = .init()) throws {
         processor?.prompt(input.text.tokens)
         let inputLength = input.text.cacheSequenceLength
 
         // Prefill main model
         switch try mainModel.prepare(
-            input, cache: mainCache, state: mainState, windowSize: windowSize)
+            input, cache: mainCache, state: mainState, prefill: prefill)
         {
         case .tokens(let tokens):
             let remainingLength = tokens.cacheSequenceLength
@@ -1019,7 +1078,11 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         // Prefill draft model, don't call didSample here -- processor tracks main model's accepted sequence only
-        switch try draftModel.prepare(input, cache: draftCache, state: nil, windowSize: windowSize)
+        // The draft prefill gets no progress callback: the main model's prefill
+        // already reported the prompt, and a second pass would double-count it.
+        var draftPrefill = prefill
+        draftPrefill.progress = nil
+        switch try draftModel.prepare(input, cache: draftCache, state: nil, prefill: draftPrefill)
         {
         case .tokens(let tokens):
             let remainingLength = tokens.cacheSequenceLength

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -57,8 +57,7 @@ public struct GenerateParameters: Sendable {
     /// and progress observation. See ``PrefillParameters``.
     public var prefill: PrefillParameters
 
-    /// Step size for processing the prompt. `nil` lets each model pick its own prefill
-    /// chunk (the Gemma 3 text path uses a smaller chunk than the generic 512 default).
+    /// See ``PrefillParameters/stepSize``.
     @available(*, deprecated, renamed: "prefill.stepSize")
     public var prefillStepSize: Int? {
         get { prefill.stepSize }
@@ -189,7 +188,9 @@ public struct GenerateParameters: Sendable {
     @available(
         *, deprecated,
         renamed:
-            "init(maxTokens:maxKVSize:kvBits:kvGroupSize:quantizedKVStart:kvScheme:temperature:topP:topK:minP:repetitionPenalty:repetitionContextSize:presencePenalty:presenceContextSize:frequencyPenalty:frequencyContextSize:prefill:seed:)"
+            "init(maxTokens:maxKVSize:kvBits:kvGroupSize:quantizedKVStart:kvScheme:temperature:topP:topK:minP:repetitionPenalty:repetitionContextSize:presencePenalty:presenceContextSize:frequencyPenalty:frequencyContextSize:prefill:seed:)",
+        message:
+            "prefill now defaults to balanced chunking; use prefill.chunking = .remainder for the legacy chunk boundaries"
     )
     public init(
         maxTokens: Int? = nil,
@@ -791,7 +792,10 @@ public struct TokenIterator: TokenIteratorProtocol {
     }
 
     @available(
-        *, deprecated, renamed: "init(input:model:cache:state:processor:sampler:prefill:maxTokens:)"
+        *, deprecated,
+        renamed: "init(input:model:cache:state:processor:sampler:prefill:maxTokens:)",
+        message:
+            "prefill now defaults to balanced chunking; use prefill.chunking = .remainder for the legacy chunk boundaries"
     )
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -823,6 +823,11 @@ public struct TokenIterator: TokenIteratorProtocol {
             y = .init(tokens: token)
             asyncEval(y.tokens)
 
+            // the model reported per-chunk progress; the remainder it left to us
+            // completes the prompt (models returning .logits report their own terminal)
+            let total = input.text.tokens.size
+            prefill.progress?(total, total)
+
         case .logits(let result):
             cacheStorage.commitProcessedTokens(inputLength)
             // carry the prefill state into decode, as step(previous:) does for later steps
@@ -1067,6 +1072,10 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
                 "Main model prepare returned more tokens than it received")
             mainCacheStorage.commitProcessedTokens(inputLength - remainingLength)
             y = tokens
+            // the remaining tokens are consumed by the first verify pass; the
+            // prompt is as processed as prefill will make it
+            let total = input.text.tokens.size
+            prefill.progress?(total, total)
         case .logits(let result):
             mainCacheStorage.commitProcessedTokens(inputLength)
             var logits = result.logits[0..., -1, 0...]

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -257,6 +257,14 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
     /// This can return:
     /// - ``PrepareResult/tokens(_:)`` if the caller should evaluate the (remaining) tokens normally
     /// - ``PrepareResult/logits(_:)`` to produce the next token from the prompt
+    ///
+    /// Implementations that chunk the prompt should drive the loop with
+    /// ``PrefillParameters/forEachChunk(total:reserving:defaultStepSize:maximumStepSize:_:)``,
+    /// which owns cancellation, pooling, and per-chunk progress. An
+    /// implementation returning `.logits` owns its whole
+    /// ``PrefillParameters/progress`` sequence, including the terminal
+    /// `(total, total)`; one returning `.tokens` reports only its own chunks —
+    /// the iterator that evaluates the remainder completes the sequence.
     func prepare(
         _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
     )
@@ -275,7 +283,11 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 }
 
 extension LanguageModel {
-    @available(*, deprecated, renamed: "prepare(_:cache:state:prefill:)")
+    @available(
+        *, deprecated, renamed: "prepare(_:cache:state:prefill:)",
+        message:
+            "prefill now defaults to balanced chunking; use prefill.chunking = .remainder for the legacy chunk boundaries"
+    )
     public func prepare(
         _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
     ) throws -> PrepareResult {

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -225,7 +225,7 @@ public struct LMOutput {
     }
 }
 
-/// The result of the call to ``LanguageModel/prepare(_:cache:state:windowSize:)``
+/// The result of the call to ``LanguageModel/prepare(_:cache:state:prefill:)``
 public enum PrepareResult {
     /// tokens to process by the ``TokenIterator``
     case tokens(LMInput.Text)
@@ -239,7 +239,7 @@ public enum PrepareResult {
 /// The language model is typically called by the ``TokenIterator`` and it:
 ///
 /// - consumes the ``LMInput``
-/// - calls ``prepare(_:cache:state:windowSize:)`` to initialize the KVCache and consume the prompt
+/// - calls ``prepare(_:cache:state:prefill:)`` to initialize the KVCache and consume the prompt
 /// - calls ``callAsFunction(_:cache:state:)-9kuvf`` for each token, producing an ``LMOutput``
 /// - the ``TokenIterator`` accumulates this information into a ``GenerateResult``
 public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
@@ -257,7 +257,9 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
     /// This can return:
     /// - ``PrepareResult/tokens(_:)`` if the caller should evaluate the (remaining) tokens normally
     /// - ``PrepareResult/logits(_:)`` to produce the next token from the prompt
-    func prepare(_ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?)
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    )
         throws -> PrepareResult
 
     /// Primary entry point to produce a step (single token) from the model
@@ -273,6 +275,13 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 }
 
 extension LanguageModel {
+    @available(*, deprecated, renamed: "prepare(_:cache:state:prefill:)")
+    public func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
+    ) throws -> PrepareResult {
+        try prepare(input, cache: cache, state: state, prefill: .init(stepSize: windowSize))
+    }
+
     public func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
         -> LMOutput
     {

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -188,6 +188,11 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             // equivalent autoregressive run, violating speculative
             // decoding's bit-exact-equivalence-to-greedy guarantee.
             pendingTokens.append(token.item(Int.self))
+
+            // the model reported per-chunk progress; the bonus forward above
+            // consumed the remainder of the prompt
+            let total = input.text.tokens.size
+            prefill.progress?(total, total)
         case .logits(let prefillResult):
             mainCacheStorage.commitProcessedTokens(inputLength)
             // Some `prepare` implementations evaluate the final position

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -136,7 +136,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         self.blockSize = blockSize
 
         let prefillStart = Date.timeIntervalSinceReferenceDate
-        try prepare(input: input, windowSize: parameters.prefillStepSize)
+        try prepare(input: input, prefill: parameters.prefill)
         self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
 
         // The guard above ran against a fresh, zero-offset cache, where a
@@ -153,7 +153,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
     /// Prefill the main model with the prompt. The drafter has no cache to
     /// prime; its first-round inputs come from the prefill's `LMOutput.state`.
-    mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+    mutating func prepare(input: LMInput, prefill: PrefillParameters = .init()) throws {
         processor?.prompt(input.text.tokens)
         let inputLength = input.text.cacheSequenceLength
 
@@ -164,7 +164,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         // passing `prefillState` into `prepare` — the emit flag is meant for
         // exactly one position, not the whole prompt.
 
-        switch try mainModel.prepare(input, cache: mainCache, state: nil, windowSize: windowSize)
+        switch try mainModel.prepare(input, cache: mainCache, state: nil, prefill: prefill)
         {
         case .tokens(let tokens):
             let remainingLength = tokens.cacheSequenceLength

--- a/Libraries/MLXLMCommon/PrefillParameters.swift
+++ b/Libraries/MLXLMCommon/PrefillParameters.swift
@@ -22,12 +22,17 @@ public struct PrefillParameters: Sendable {
     /// How the prompt is divided into forwards. See ``Chunking``.
     public var chunking: Chunking
 
-    /// Called after each prefill chunk with `(processedTokens, totalTokens)`.
+    /// Called after each prefill chunk with `(processedPositions, totalPositions)`.
     ///
-    /// A terminal `(total, total)` is delivered once the prompt is fully consumed,
-    /// for every model — including those that prefill in a single forward. Because
-    /// chunks are pipelined with `asyncEval`, intermediate calls report graph
-    /// submission, slightly ahead of GPU completion.
+    /// Positions are the units the model prefills: prompt tokens for text
+    /// models, merged embedding positions (after image expansion) for VLMs. A
+    /// terminal `(total, total)` is delivered once the prompt is fully
+    /// consumed, for every model — including those that prefill in a single
+    /// forward. Because chunks are pipelined with `asyncEval`, intermediate
+    /// calls report graph submission, slightly ahead of GPU completion.
+    ///
+    /// The closure is retained for as long as the containing parameters (e.g.
+    /// by a stored `GenerateParameters`) — capture weakly anything long-lived.
     public var progress: (@Sendable (_ processed: Int, _ total: Int) -> Void)?
 
     /// Strategy dividing the prompt into prefill forwards.
@@ -36,14 +41,17 @@ public struct PrefillParameters: Sendable {
         /// forward is disproportionately small at large KV length (the default).
         case balanced
 
-        /// Legacy stride: chunks of exactly the step size, with the remainder
-        /// riding along with the final forward. An escape hatch back to the
-        /// pre-``balanced`` chunk boundaries and their exact outputs.
+        /// Legacy stride: chunks of exactly the step size. An escape hatch back
+        /// to each model's pre-``balanced`` chunk boundaries and their exact
+        /// outputs — on the default `LLMModel` path the remainder rides along
+        /// with the `TokenIterator`'s first forward; models that reserve one
+        /// position for the logits keep that shape and stride the rest.
         case remainder
 
         /// The whole prompt in one forward — the reference computation that any
         /// chunking approximates. Attention scores are quadratic in the prompt
-        /// length, so this is for validation at short lengths, not production.
+        /// length and the logits materialize at `[1, L, vocab]`, so this is for
+        /// validation at short lengths, not production.
         case unchunked
     }
 
@@ -57,6 +65,17 @@ public struct PrefillParameters: Sendable {
         self.progress = progress
     }
 
+    /// The step size used when neither ``stepSize`` nor a model default applies.
+    public static let defaultStepSize = 512
+
+    /// The effective step-size ceiling: ``stepSize`` if set, else the model's
+    /// `defaultStepSize`, clamped to `maximumStepSize` and floored at 1.
+    public func resolvedStepSize(
+        defaultStepSize: Int = PrefillParameters.defaultStepSize, maximumStepSize: Int? = nil
+    ) -> Int {
+        max(1, min(stepSize ?? defaultStepSize, maximumStepSize ?? Int.max))
+    }
+
     /// The per-forward chunk length for prefilling `count` positions, or `nil`
     /// when the prompt should go through in a single forward (``Chunking/unchunked``).
     ///
@@ -65,9 +84,12 @@ public struct PrefillParameters: Sendable {
     /// `defaultStepSize` (used when ``stepSize`` is `nil`) and, if they have one,
     /// a `maximumStepSize` cap such as a sliding-window size.
     public func chunkLength(
-        forChunking count: Int, defaultStepSize: Int = 512, maximumStepSize: Int? = nil
+        forChunking count: Int,
+        defaultStepSize: Int = PrefillParameters.defaultStepSize,
+        maximumStepSize: Int? = nil
     ) -> Int? {
-        let step = max(1, min(stepSize ?? defaultStepSize, maximumStepSize ?? Int.max))
+        let step = resolvedStepSize(
+            defaultStepSize: defaultStepSize, maximumStepSize: maximumStepSize)
         switch chunking {
         case .unchunked:
             return nil
@@ -78,5 +100,48 @@ public struct PrefillParameters: Sendable {
             let chunkCount = (count + step - 1) / step
             return (count + chunkCount - 1) / chunkCount
         }
+    }
+
+    /// Drives a chunked prefill over `total` positions and returns the number
+    /// of positions processed.
+    ///
+    /// Computes the chunk length once, then calls `body` with each chunk's
+    /// range. The driver owns the loop's shared obligations: cooperative
+    /// cancellation between chunks (a long prompt must be interruptible — see
+    /// the note in `LLMModel.prepare`), an autorelease pool per chunk (long
+    /// prompts run hundreds of forwards before any autorelease boundary), and
+    /// the per-chunk ``progress`` report. `body` performs the model's forward
+    /// and its own cache fencing (`asyncEval`/`eval`).
+    ///
+    /// `reserving` positions are left unprocessed for the caller's final
+    /// forward — the one that produces logits (1 for every current caller).
+    /// Under ``Chunking/unchunked`` no chunking happens and 0 is returned:
+    /// the caller's final forward takes the whole prompt.
+    public func forEachChunk(
+        total: Int,
+        reserving: Int = 1,
+        defaultStepSize: Int = PrefillParameters.defaultStepSize,
+        maximumStepSize: Int? = nil,
+        _ body: (Range<Int>) -> Void
+    ) throws -> Int {
+        guard
+            let chunkLength = chunkLength(
+                forChunking: total - reserving,
+                defaultStepSize: defaultStepSize, maximumStepSize: maximumStepSize)
+        else {
+            return 0
+        }
+        let slack = min(reserving, 1)
+        var processed = 0
+        while total - processed > reserving {
+            try Task.checkCancellation()
+            autoreleasepool {
+                let n = min(chunkLength, total - processed - slack)
+                body(processed ..< processed + n)
+                processed += n
+                progress?(processed, total)
+            }
+        }
+        return processed
     }
 }

--- a/Libraries/MLXLMCommon/PrefillParameters.swift
+++ b/Libraries/MLXLMCommon/PrefillParameters.swift
@@ -1,0 +1,82 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Parameters controlling how a prompt is prefilled into the ``KVCache``.
+///
+/// Set via ``GenerateParameters/prefill`` and passed to
+/// ``LanguageModel/prepare(_:cache:state:prefill:)``:
+///
+/// ```swift
+/// var parameters = GenerateParameters()
+/// parameters.prefill.stepSize = 1024
+/// parameters.prefill.progress = { processed, total in ... }
+/// ```
+public struct PrefillParameters: Sendable {
+
+    /// Ceiling on tokens evaluated per prefill forward. `nil` lets each model pick
+    /// its own default (512 for the generic path; the Gemma 3 text path uses a
+    /// smaller, tuned chunk).
+    public var stepSize: Int?
+
+    /// How the prompt is divided into forwards. See ``Chunking``.
+    public var chunking: Chunking
+
+    /// Called after each prefill chunk with `(processedTokens, totalTokens)`.
+    ///
+    /// A terminal `(total, total)` is delivered once the prompt is fully consumed,
+    /// for every model — including those that prefill in a single forward. Because
+    /// chunks are pipelined with `asyncEval`, intermediate calls report graph
+    /// submission, slightly ahead of GPU completion.
+    public var progress: (@Sendable (_ processed: Int, _ total: Int) -> Void)?
+
+    /// Strategy dividing the prompt into prefill forwards.
+    public enum Chunking: Sendable {
+        /// The fewest equal chunks that respect the step-size ceiling, so no
+        /// forward is disproportionately small at large KV length (the default).
+        case balanced
+
+        /// Legacy stride: chunks of exactly the step size, with the remainder
+        /// riding along with the final forward. An escape hatch back to the
+        /// pre-``balanced`` chunk boundaries and their exact outputs.
+        case remainder
+
+        /// The whole prompt in one forward — the reference computation that any
+        /// chunking approximates. Attention scores are quadratic in the prompt
+        /// length, so this is for validation at short lengths, not production.
+        case unchunked
+    }
+
+    public init(
+        stepSize: Int? = nil,
+        chunking: Chunking = .balanced,
+        progress: (@Sendable (_ processed: Int, _ total: Int) -> Void)? = nil
+    ) {
+        self.stepSize = stepSize
+        self.chunking = chunking
+        self.progress = progress
+    }
+
+    /// The per-forward chunk length for prefilling `count` positions, or `nil`
+    /// when the prompt should go through in a single forward (``Chunking/unchunked``).
+    ///
+    /// `count` is the number of positions the caller intends to chunk — excluding
+    /// any tail it reserves for the first sampled forward. Models pass their own
+    /// `defaultStepSize` (used when ``stepSize`` is `nil`) and, if they have one,
+    /// a `maximumStepSize` cap such as a sliding-window size.
+    public func chunkLength(
+        forChunking count: Int, defaultStepSize: Int = 512, maximumStepSize: Int? = nil
+    ) -> Int? {
+        let step = max(1, min(stepSize ?? defaultStepSize, maximumStepSize ?? Int.max))
+        switch chunking {
+        case .unchunked:
+            return nil
+        case .remainder:
+            return step
+        case .balanced:
+            guard count > step else { return max(count, 1) }
+            let chunkCount = (count + step - 1) / step
+            return (count + chunkCount - 1) / chunkCount
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -163,7 +163,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: tokenCount,
-            prefillStepSize: parameters.prefill.stepSize ?? 512
+            prefillStepSize: parameters.prefill.resolvedStepSize()
         )
     }
 
@@ -207,7 +207,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: input.text.tokens.size,
-            prefillStepSize: parameters.prefill.stepSize ?? 512
+            prefillStepSize: parameters.prefill.resolvedStepSize()
         )
     }
 

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -97,7 +97,7 @@ public enum WiredMemoryUtils {
         var cache = try kvCachePlan.validated(model.newCache(parameters: parameters))
 
         switch try model.prepare(
-            input, cache: cache, state: nil, windowSize: parameters.prefillStepSize)
+            input, cache: cache, state: nil, prefill: parameters.prefill)
         {
         case .tokens(let tokens):
             let result = model(
@@ -163,7 +163,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: tokenCount,
-            prefillStepSize: parameters.prefillStepSize ?? 512
+            prefillStepSize: parameters.prefill.stepSize ?? 512
         )
     }
 
@@ -207,7 +207,7 @@ public enum WiredMemoryUtils {
             workspaceBytes: workspace,
             peakActiveBytes: peakActive,
             tokenCount: input.text.tokens.size,
-            prefillStepSize: parameters.prefillStepSize ?? 512
+            prefillStepSize: parameters.prefill.stepSize ?? 512
         )
     }
 

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1137,19 +1137,22 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: input.image?.pixels,
             mask: input.text.mask
         )
-        let prefillStepSize = prefill.stepSize ?? 512
         let totalPositions = embeddings.dim(1)
         var processed = 0
-        while totalPositions - processed > 1 {
-            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-            let range = processed ..< (processed + chunkLength)
-            _ = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., range, 0...])
-            asyncEval(cache)
-            processed += chunkLength
+        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+            while totalPositions - processed > 1 {
+                let n = min(chunkLength, totalPositions - processed - 1)
+                let range = processed ..< (processed + n)
+                _ = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., range, 0...])
+                asyncEval(cache)
+                processed += n
+                prefill.progress?(processed, totalPositions)
+            }
+            eval(cache)
         }
-        eval(cache)
         let result = languageModel(
             nil, cache: cache, inputEmbedding: embeddings[0..., processed..., 0...])
+        prefill.progress?(totalPositions, totalPositions)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1128,7 +1128,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -1137,7 +1137,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: input.image?.pixels,
             mask: input.text.mask
         )
-        let prefillStepSize = windowSize ?? 512
+        let prefillStepSize = prefill.stepSize ?? 512
         let totalPositions = embeddings.dim(1)
         var processed = 0
         while totalPositions - processed > 1 {

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1138,18 +1138,11 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
             mask: input.text.mask
         )
         let totalPositions = embeddings.dim(1)
-        var processed = 0
-        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-            while totalPositions - processed > 1 {
-                let n = min(chunkLength, totalPositions - processed - 1)
-                let range = processed ..< (processed + n)
-                _ = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., range, 0...])
-                asyncEval(cache)
-                processed += n
-                prefill.progress?(processed, totalPositions)
-            }
-            eval(cache)
+        let processed = try prefill.forEachChunk(total: totalPositions) { range in
+            _ = languageModel(nil, cache: cache, inputEmbedding: embeddings[0..., range, 0...])
+            asyncEval(cache)
         }
+        if processed > 0 { eval(cache) }
         let result = languageModel(
             nil, cache: cache, inputEmbedding: embeddings[0..., processed..., 0...])
         prefill.progress?(totalPositions, totalPositions)

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -993,19 +993,12 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
             var tokens = input.text.tokens
             if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
             let totalPositions = tokens.dim(1)
-            var processed = 0
-            if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-                while totalPositions - processed > 1 {
-                    let n = min(chunkLength, totalPositions - processed - 1)
-                    _ = languageModel(
-                        tokens[0..., processed ..< (processed + n)],
-                        cache: convertedCache, inputEmbedding: nil, mask: nil)
-                    asyncEval(cache)
-                    processed += n
-                    prefill.progress?(processed, totalPositions)
-                }
-                eval(cache)
+            let processed = try prefill.forEachChunk(total: totalPositions) { range in
+                _ = languageModel(
+                    tokens[0..., range], cache: convertedCache, inputEmbedding: nil, mask: nil)
+                asyncEval(cache)
             }
+            if processed > 0 { eval(cache) }
             let result = languageModel(
                 tokens[0..., processed...], cache: convertedCache, inputEmbedding: nil, mask: nil)
             prefill.progress?(totalPositions, totalPositions)
@@ -1020,20 +1013,13 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
 
         let maskMode: MLXFast.ScaledDotProductAttentionMaskMode = .causal
         let totalPositions = inputEmbeddings.dim(1)
-        var processed = 0
-        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-            while totalPositions - processed > 1 {
-                let n = min(chunkLength, totalPositions - processed - 1)
-                let range = processed ..< (processed + n)
-                _ = languageModel(
-                    nil, cache: convertedCache,
-                    inputEmbedding: inputEmbeddings[0..., range, 0...], mask: maskMode)
-                asyncEval(cache)
-                processed += n
-                prefill.progress?(processed, totalPositions)
-            }
-            eval(cache)
+        let processed = try prefill.forEachChunk(total: totalPositions) { range in
+            _ = languageModel(
+                nil, cache: convertedCache,
+                inputEmbedding: inputEmbeddings[0..., range, 0...], mask: maskMode)
+            asyncEval(cache)
         }
+        if processed > 0 { eval(cache) }
         let result = languageModel(
             nil, cache: convertedCache,
             inputEmbedding: inputEmbeddings[0..., processed..., 0...], mask: maskMode)

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -987,7 +987,6 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
     ) throws
         -> PrepareResult
     {
-        let prefillStepSize = prefill.stepSize ?? 512
         let convertedCache = cache.compactMap { $0 as KVCache }
 
         guard let imagePixels = input.image?.pixels else {
@@ -995,17 +994,21 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
             if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
             let totalPositions = tokens.dim(1)
             var processed = 0
-            while totalPositions - processed > 1 {
-                let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-                _ = languageModel(
-                    tokens[0..., processed ..< (processed + chunkLength)],
-                    cache: convertedCache, inputEmbedding: nil, mask: nil)
-                asyncEval(cache)
-                processed += chunkLength
+            if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+                while totalPositions - processed > 1 {
+                    let n = min(chunkLength, totalPositions - processed - 1)
+                    _ = languageModel(
+                        tokens[0..., processed ..< (processed + n)],
+                        cache: convertedCache, inputEmbedding: nil, mask: nil)
+                    asyncEval(cache)
+                    processed += n
+                    prefill.progress?(processed, totalPositions)
+                }
+                eval(cache)
             }
-            eval(cache)
             let result = languageModel(
                 tokens[0..., processed...], cache: convertedCache, inputEmbedding: nil, mask: nil)
+            prefill.progress?(totalPositions, totalPositions)
             return .logits(result)
         }
 
@@ -1018,19 +1021,23 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         let maskMode: MLXFast.ScaledDotProductAttentionMaskMode = .causal
         let totalPositions = inputEmbeddings.dim(1)
         var processed = 0
-        while totalPositions - processed > 1 {
-            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-            let range = processed ..< (processed + chunkLength)
-            _ = languageModel(
-                nil, cache: convertedCache,
-                inputEmbedding: inputEmbeddings[0..., range, 0...], mask: maskMode)
-            asyncEval(cache)
-            processed += chunkLength
+        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+            while totalPositions - processed > 1 {
+                let n = min(chunkLength, totalPositions - processed - 1)
+                let range = processed ..< (processed + n)
+                _ = languageModel(
+                    nil, cache: convertedCache,
+                    inputEmbedding: inputEmbeddings[0..., range, 0...], mask: maskMode)
+                asyncEval(cache)
+                processed += n
+                prefill.progress?(processed, totalPositions)
+            }
+            eval(cache)
         }
-        eval(cache)
         let result = languageModel(
             nil, cache: convertedCache,
             inputEmbedding: inputEmbeddings[0..., processed..., 0...], mask: maskMode)
+        prefill.progress?(totalPositions, totalPositions)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -983,11 +983,11 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
-        let prefillStepSize = windowSize ?? 512
+        let prefillStepSize = prefill.stepSize ?? 512
         let convertedCache = cache.compactMap { $0 as KVCache }
 
         guard let imagePixels = input.image?.pixels else {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2098,7 +2098,7 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -2120,7 +2120,8 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             return .logits(result)
         } else {
             return gemma4PrepareTextOnly(
-                input, cache: convertedCache, windowSize: windowSize, languageModel: languageModel)
+                input, cache: convertedCache, windowSize: prefill.stepSize,
+                languageModel: languageModel)
         }
     }
 
@@ -2560,13 +2561,13 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
         if input.image == nil, input.video == nil, input.audio == nil {
             return gemma4PrepareTextOnly(
-                input, cache: cache, windowSize: windowSize, languageModel: languageModel)
+                input, cache: cache, windowSize: prefill.stepSize, languageModel: languageModel)
         }
 
         let (inputsEmbeds, perLayerInputs) = try getInputEmbeddings(

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -244,27 +244,31 @@ private func gemma4TextOnlyPromptTokens(_ input: LMInput) -> MLXArray {
 private func gemma4PrepareTextOnly(
     _ input: LMInput,
     cache: [any KVCache],
-    windowSize: Int?,
+    prefill: PrefillParameters,
     languageModel: Gemma4TextLanguageModel
 ) -> PrepareResult {
-    let prefillStepSize = max(windowSize ?? 512, 1)
     let y = gemma4TextOnlyPromptTokens(input).expandedDimensions(axis: 0)
     let convertedCache = cache.map { $0 }
     let totalPositions = y.dim(1)
 
     var processed = 0
-    while totalPositions - processed > 1 {
-        let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-        _ = languageModel(
-            y[0..., processed ..< (processed + chunkLength)],
-            cache: convertedCache
-        )
-        asyncEval(cache)
-        processed += chunkLength
-    }
+    if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+        while totalPositions - processed > 1 {
+            let n = min(chunkLength, totalPositions - processed - 1)
+            _ = languageModel(
+                y[0..., processed ..< (processed + n)],
+                cache: convertedCache
+            )
+            asyncEval(cache)
+            processed += n
+            prefill.progress?(processed, totalPositions)
+        }
 
-    eval(cache)
-    return .logits(languageModel(y[0..., processed...], cache: convertedCache))
+        eval(cache)
+    }
+    let result = languageModel(y[0..., processed...], cache: convertedCache)
+    prefill.progress?(totalPositions, totalPositions)
+    return .logits(result)
 }
 
 private func gemma4BlockSequenceIdsForMask(_ tokenTypeIds: MLXArray) -> MLXArray {
@@ -2117,10 +2121,12 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
                     videoTokenId: config.videoTokenId,
                     audioTokenId: config.audioTokenId)
             )
+            let total = inputsEmbeds.dim(1)
+            prefill.progress?(total, total)
             return .logits(result)
         } else {
             return gemma4PrepareTextOnly(
-                input, cache: convertedCache, windowSize: prefill.stepSize,
+                input, cache: convertedCache, prefill: prefill,
                 languageModel: languageModel)
         }
     }
@@ -2567,7 +2573,7 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
     {
         if input.image == nil, input.video == nil, input.audio == nil {
             return gemma4PrepareTextOnly(
-                input, cache: cache, windowSize: prefill.stepSize, languageModel: languageModel)
+                input, cache: cache, prefill: prefill, languageModel: languageModel)
         }
 
         let (inputsEmbeds, perLayerInputs) = try getInputEmbeddings(
@@ -2592,6 +2598,8 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
             perLayerInputs: perLayerInputs,
             tokenTypeIds: tokenTypeIds
         )
+        let total = inputsEmbeds.dim(1)
+        prefill.progress?(total, total)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -246,26 +246,16 @@ private func gemma4PrepareTextOnly(
     cache: [any KVCache],
     prefill: PrefillParameters,
     languageModel: Gemma4TextLanguageModel
-) -> PrepareResult {
+) throws -> PrepareResult {
     let y = gemma4TextOnlyPromptTokens(input).expandedDimensions(axis: 0)
     let convertedCache = cache.map { $0 }
     let totalPositions = y.dim(1)
 
-    var processed = 0
-    if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-        while totalPositions - processed > 1 {
-            let n = min(chunkLength, totalPositions - processed - 1)
-            _ = languageModel(
-                y[0..., processed ..< (processed + n)],
-                cache: convertedCache
-            )
-            asyncEval(cache)
-            processed += n
-            prefill.progress?(processed, totalPositions)
-        }
-
-        eval(cache)
+    let processed = try prefill.forEachChunk(total: totalPositions) { range in
+        _ = languageModel(y[0..., range], cache: convertedCache)
+        asyncEval(cache)
     }
+    if processed > 0 { eval(cache) }
     let result = languageModel(y[0..., processed...], cache: convertedCache)
     prefill.progress?(totalPositions, totalPositions)
     return .logits(result)
@@ -2125,7 +2115,7 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             prefill.progress?(total, total)
             return .logits(result)
         } else {
-            return gemma4PrepareTextOnly(
+            return try gemma4PrepareTextOnly(
                 input, cache: convertedCache, prefill: prefill,
                 languageModel: languageModel)
         }
@@ -2572,7 +2562,7 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
         -> PrepareResult
     {
         if input.image == nil, input.video == nil, input.audio == nil {
-            return gemma4PrepareTextOnly(
+            return try gemma4PrepareTextOnly(
                 input, cache: cache, prefill: prefill, languageModel: languageModel)
         }
 

--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -1017,7 +1017,8 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?,
+        prefill _: PrefillParameters
     ) throws
         -> PrepareResult
     {

--- a/Libraries/MLXVLM/Models/GlmOcr.swift
+++ b/Libraries/MLXVLM/Models/GlmOcr.swift
@@ -1018,7 +1018,7 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
 
     public func prepare(
         _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?,
-        prefill _: PrefillParameters
+        prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -1043,6 +1043,8 @@ public class GlmOcr: Module, VLMModel, KVCacheDimensionProvider {
         let result = languageModel(
             nil, cache: cache, state: state, inputEmbedding: inputEmbeddings)
 
+        let total = inputEmbeddings.dim(1)
+        prefill.progress?(total, total)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -736,7 +736,7 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
     {
         let inputIds = input.text.tokens
         let pixelValues = input.image?.pixels
-        var embeddings = getInputEmbeddings(
+        let embeddings = getInputEmbeddings(
             inputIds: inputIds,
             pixelValues: pixelValues
         )
@@ -745,27 +745,15 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
         // (and `LLMModel.prepare`'s token chunking): evaluate the KV cache
         // between chunks, leaving the last embedding for the logits.
         let totalTokens = embeddings.dim(1)
-
-        var processed = 0
-        if let chunkLength = prefill.chunkLength(forChunking: totalTokens - 1) {
-            while embeddings.dim(1) > 1 {
-                let nToProcess = min(chunkLength, embeddings.dim(1) - 1)
-                let chunk = embeddings[0..., ..<nToProcess]
-                _ = languageModel(nil, cache: cache, inputs_embeds: chunk)
-                eval(cache)
-                embeddings = embeddings[0..., nToProcess...]
-                processed += nToProcess
-                prefill.progress?(processed, totalTokens)
-            }
-
-            // The prefix is now in the KV cache; the final embedding yields the
-            // first-token logits.
-            precondition(
-                processed == totalTokens - 1,
-                "Idefics3 chunked prefill: expected one residual embedding, processed "
-                    + "\(processed) of \(totalTokens)")
+        let processed = try prefill.forEachChunk(total: totalTokens) { range in
+            _ = languageModel(nil, cache: cache, inputs_embeds: embeddings[0..., range])
+            eval(cache)
         }
-        let result = languageModel(nil, cache: cache, inputs_embeds: embeddings)
+
+        // The prefix is now in the KV cache; the final embedding(s) yield the
+        // first-token logits.
+        let result = languageModel(
+            nil, cache: cache, inputs_embeds: embeddings[0..., processed...])
         prefill.progress?(totalTokens, totalTokens)
         return .logits(result)
     }

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -730,7 +730,7 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -744,7 +744,7 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
         // Prefill the merged image+text embeddings in windowSize-sized chunks,
         // matching mlx-vlm (and `LLMModel.prepare`'s token chunking): evaluate
         // the KV cache between chunks, leaving the last embedding for the logits.
-        let prefillStepSize = windowSize ?? 512
+        let prefillStepSize = prefill.stepSize ?? 512
         let totalTokens = embeddings.dim(1)
 
         var processed = 0

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -741,29 +741,32 @@ public class Idefics3: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: pixelValues
         )
 
-        // Prefill the merged image+text embeddings in windowSize-sized chunks,
-        // matching mlx-vlm (and `LLMModel.prepare`'s token chunking): evaluate
-        // the KV cache between chunks, leaving the last embedding for the logits.
-        let prefillStepSize = prefill.stepSize ?? 512
+        // Prefill the merged image+text embeddings in chunks, matching mlx-vlm
+        // (and `LLMModel.prepare`'s token chunking): evaluate the KV cache
+        // between chunks, leaving the last embedding for the logits.
         let totalTokens = embeddings.dim(1)
 
         var processed = 0
-        while embeddings.dim(1) > 1 {
-            let nToProcess = min(prefillStepSize, embeddings.dim(1) - 1)
-            let chunk = embeddings[0..., ..<nToProcess]
-            _ = languageModel(nil, cache: cache, inputs_embeds: chunk)
-            eval(cache)
-            embeddings = embeddings[0..., nToProcess...]
-            processed += nToProcess
-        }
+        if let chunkLength = prefill.chunkLength(forChunking: totalTokens - 1) {
+            while embeddings.dim(1) > 1 {
+                let nToProcess = min(chunkLength, embeddings.dim(1) - 1)
+                let chunk = embeddings[0..., ..<nToProcess]
+                _ = languageModel(nil, cache: cache, inputs_embeds: chunk)
+                eval(cache)
+                embeddings = embeddings[0..., nToProcess...]
+                processed += nToProcess
+                prefill.progress?(processed, totalTokens)
+            }
 
-        // The prefix is now in the KV cache; the final embedding yields the
-        // first-token logits.
-        precondition(
-            processed == totalTokens - 1,
-            "Idefics3 chunked prefill: expected one residual embedding, processed "
-                + "\(processed) of \(totalTokens)")
+            // The prefix is now in the KV cache; the final embedding yields the
+            // first-token logits.
+            precondition(
+                processed == totalTokens - 1,
+                "Idefics3 chunked prefill: expected one residual embedding, processed "
+                    + "\(processed) of \(totalTokens)")
+        }
         let result = languageModel(nil, cache: cache, inputs_embeds: embeddings)
+        prefill.progress?(totalTokens, totalTokens)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -1036,21 +1036,14 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
             pixelAttentionMask: pixelAttentionMask
         )
 
-        let result = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
+        let result = try withPreparedCache(cache, lengths: input.text.sequenceLengths) {
             let totalPositions = inputEmbeddings.dim(1)
-            var processed = 0
-            if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-                while totalPositions - processed > 1 {
-                    let n = min(chunkLength, totalPositions - processed - 1)
-                    let range = processed ..< (processed + n)
-                    _ = languageModel(
-                        nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
-                    asyncEval(cache)
-                    processed += n
-                    prefill.progress?(processed, totalPositions)
-                }
-                eval(cache)
+            let processed = try prefill.forEachChunk(total: totalPositions) { range in
+                _ = languageModel(
+                    nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
+                asyncEval(cache)
             }
+            if processed > 0 { eval(cache) }
 
             let result = languageModel(
                 nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., processed..., 0...])

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -980,7 +980,7 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -1037,7 +1037,7 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
         )
 
         let result = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
-            let prefillStepSize = windowSize ?? 512
+            let prefillStepSize = prefill.stepSize ?? 512
             let totalPositions = inputEmbeddings.dim(1)
             var processed = 0
             while totalPositions - processed > 1 {

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -1037,21 +1037,24 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
         )
 
         let result = withPreparedCache(cache, lengths: input.text.sequenceLengths) {
-            let prefillStepSize = prefill.stepSize ?? 512
             let totalPositions = inputEmbeddings.dim(1)
             var processed = 0
-            while totalPositions - processed > 1 {
-                let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-                let range = processed ..< (processed + chunkLength)
-                _ = languageModel(
-                    nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
-                asyncEval(cache)
-                processed += chunkLength
+            if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+                while totalPositions - processed > 1 {
+                    let n = min(chunkLength, totalPositions - processed - 1)
+                    let range = processed ..< (processed + n)
+                    _ = languageModel(
+                        nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., range, 0...])
+                    asyncEval(cache)
+                    processed += n
+                    prefill.progress?(processed, totalPositions)
+                }
+                eval(cache)
             }
-            eval(cache)
 
             let result = languageModel(
                 nil, cache: cache, inputsEmbeds: inputEmbeddings[0..., processed..., 0...])
+            prefill.progress?(totalPositions, totalPositions)
             return result
         }
 

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -748,20 +748,13 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         var tokens = inputIds
         if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
         let totalPositions = embeddings.dim(1)
-        var processed = 0
-        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-            while totalPositions - processed > 1 {
-                let n = min(chunkLength, totalPositions - processed - 1)
-                let range = processed ..< (processed + n)
-                _ = languageModel(
-                    tokens[0..., range], cache: cache,
-                    inputsEmbeds: embeddings[0..., range, 0...])
-                asyncEval(cache)
-                processed += n
-                prefill.progress?(processed, totalPositions)
-            }
-            eval(cache)
+        let processed = try prefill.forEachChunk(total: totalPositions) { range in
+            _ = languageModel(
+                tokens[0..., range], cache: cache,
+                inputsEmbeds: embeddings[0..., range, 0...])
+            asyncEval(cache)
         }
+        if processed > 0 { eval(cache) }
         let logits = languageModel(
             tokens[0..., processed...], cache: cache,
             inputsEmbeds: embeddings[0..., processed..., 0...])

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -747,22 +747,25 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
 
         var tokens = inputIds
         if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
-        let prefillStepSize = prefill.stepSize ?? 512
         let totalPositions = embeddings.dim(1)
         var processed = 0
-        while totalPositions - processed > 1 {
-            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-            let range = processed ..< (processed + chunkLength)
-            _ = languageModel(
-                tokens[0..., range], cache: cache,
-                inputsEmbeds: embeddings[0..., range, 0...])
-            asyncEval(cache)
-            processed += chunkLength
+        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+            while totalPositions - processed > 1 {
+                let n = min(chunkLength, totalPositions - processed - 1)
+                let range = processed ..< (processed + n)
+                _ = languageModel(
+                    tokens[0..., range], cache: cache,
+                    inputsEmbeds: embeddings[0..., range, 0...])
+                asyncEval(cache)
+                processed += n
+                prefill.progress?(processed, totalPositions)
+            }
+            eval(cache)
         }
-        eval(cache)
         let logits = languageModel(
             tokens[0..., processed...], cache: cache,
             inputsEmbeds: embeddings[0..., processed..., 0...])
+        prefill.progress?(totalPositions, totalPositions)
         return .logits(.init(logits: logits))
     }
 

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -722,7 +722,7 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -747,7 +747,7 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
 
         var tokens = inputIds
         if tokens.ndim == 1 { tokens = tokens.expandedDimensions(axis: 0) }
-        let prefillStepSize = windowSize ?? 512
+        let prefillStepSize = prefill.stepSize ?? 512
         let totalPositions = embeddings.dim(1)
         var processed = 0
         while totalPositions - processed > 1 {

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -598,7 +598,8 @@ public class PaliGemma: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?,
+        prefill _: PrefillParameters
     ) throws
         -> PrepareResult
     {

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -599,7 +599,7 @@ public class PaliGemma: Module, VLMModel, KVCacheDimensionProvider {
 
     public func prepare(
         _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?,
-        prefill _: PrefillParameters
+        prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -613,6 +613,8 @@ public class PaliGemma: Module, VLMModel, KVCacheDimensionProvider {
         let result = languageModel(
             inputIds, cache: cache, inputEmbedding: inputEmbedding, mask: finalAttentionMask4d)
 
+        let total = inputEmbedding.dim(1)
+        prefill.progress?(total, total)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -883,22 +883,25 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: pixelValues
         )
 
-        let prefillStepSize = prefill.stepSize ?? 512
         let totalPositions = embeddings.dim(1)
         var processed = 0
-        while totalPositions - processed > 1 {
-            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-            let range = processed ..< (processed + chunkLength)
-            _ = languageModel(
-                inputIds[0..., range], cache: cache,
-                inputsEmbeds: embeddings[0..., range, 0...])
-            asyncEval(cache)
-            processed += chunkLength
+        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+            while totalPositions - processed > 1 {
+                let n = min(chunkLength, totalPositions - processed - 1)
+                let range = processed ..< (processed + n)
+                _ = languageModel(
+                    inputIds[0..., range], cache: cache,
+                    inputsEmbeds: embeddings[0..., range, 0...])
+                asyncEval(cache)
+                processed += n
+                prefill.progress?(processed, totalPositions)
+            }
+            eval(cache)
         }
-        eval(cache)
         let logits = languageModel(
             inputIds[0..., processed...], cache: cache,
             inputsEmbeds: embeddings[0..., processed..., 0...])
+        prefill.progress?(totalPositions, totalPositions)
         return .logits(.init(logits: logits))
     }
 

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -870,7 +870,7 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
@@ -883,7 +883,7 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
             pixelValues: pixelValues
         )
 
-        let prefillStepSize = windowSize ?? 512
+        let prefillStepSize = prefill.stepSize ?? 512
         let totalPositions = embeddings.dim(1)
         var processed = 0
         while totalPositions - processed > 1 {

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -884,20 +884,13 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
         )
 
         let totalPositions = embeddings.dim(1)
-        var processed = 0
-        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-            while totalPositions - processed > 1 {
-                let n = min(chunkLength, totalPositions - processed - 1)
-                let range = processed ..< (processed + n)
-                _ = languageModel(
-                    inputIds[0..., range], cache: cache,
-                    inputsEmbeds: embeddings[0..., range, 0...])
-                asyncEval(cache)
-                processed += n
-                prefill.progress?(processed, totalPositions)
-            }
-            eval(cache)
+        let processed = try prefill.forEachChunk(total: totalPositions) { range in
+            _ = languageModel(
+                inputIds[0..., range], cache: cache,
+                inputsEmbeds: embeddings[0..., range, 0...])
+            asyncEval(cache)
         }
+        if processed > 0 { eval(cache) }
         let logits = languageModel(
             inputIds[0..., processed...], cache: cache,
             inputsEmbeds: embeddings[0..., processed..., 0...])

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -978,7 +978,7 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
     {
         let inputIds = input.text.tokens
 
-        let window = prefill.stepSize ?? 512
+        let window = prefill.resolvedStepSize()
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
@@ -1042,31 +1042,26 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             visionStartTokenId: config.baseConfiguration.visionStartTokenId,
             positionOffset: positionOffset)
 
-        let step = prefill.chunkLength(forChunking: remainderLength) ?? remainderLength
-        var lastLogits = MLXArray(0)
-        var start = 0
-        repeat {
-            try Task.checkCancellation()
-            let end = min(start + step, remainderLength)
-            let chunkPositions = positionIds[0..., 0..., start ..< end]
-            let output: LMOutput
-            if let embeds {
-                let chunkEmbeds = embeds[0..., start ..< end, 0...]
-                output = languageModel(
-                    nil, cache: cache, state: nil, inputEmbedding: chunkEmbeds,
-                    positionIds: chunkPositions)
-            } else {
-                let chunkInputs = inputIds[0..., start ..< end]
-                output = languageModel(
-                    chunkInputs, cache: cache, state: nil, inputEmbedding: nil,
-                    positionIds: chunkPositions)
-            }
-            lastLogits = output.logits
+        let processed = try prefill.forEachChunk(total: remainderLength) { range in
+            let chunkEmbeds = embeds.map { $0[0..., range, 0...] }
+            _ = languageModel(
+                chunkEmbeds == nil ? inputIds[0..., range] : nil,
+                cache: cache, state: nil, inputEmbedding: chunkEmbeds,
+                positionIds: positionIds[0..., 0..., range])
             asyncEval(cache)
-            prefill.progress?(end, remainderLength)
-            start = end
-        } while start < remainderLength
-        eval(cache)
+        }
+        if processed > 0 {
+            eval(cache)
+        }
+
+        let tailRange = processed ..< remainderLength
+        let tailEmbeds = embeds.map { $0[0..., tailRange, 0...] }
+        let lastLogits = languageModel(
+            tailEmbeds == nil ? inputIds[0..., tailRange] : nil,
+            cache: cache, state: nil, inputEmbedding: tailEmbeds,
+            positionIds: positionIds[0..., 0..., tailRange]
+        ).logits
+        prefill.progress?(remainderLength, remainderLength)
 
         var resumeState = LMOutput.State()
         resumeState[ropeDeltasKey] = ropeDeltas - MLXArray(Int32(cacheOffset))

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -971,13 +971,14 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?,
+        prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
         let inputIds = input.text.tokens
 
-        let window = windowSize ?? 512
+        let window = prefill.stepSize ?? 512
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -982,7 +982,7 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
-            return try prepareContinuation(input, cache: cache, state: state, windowSize: window)
+            return try prepareContinuation(input, cache: cache, state: state, prefill: prefill)
         }
 
         let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
@@ -1007,11 +1007,13 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
         let result = languageModel(
             embeds == nil ? inputIds2D : nil, cache: cache, state: state, inputEmbedding: embeds)
 
+        let total = inputIds2D.dim(-1)
+        prefill.progress?(total, total)
         return .logits(result)
     }
 
     private func prepareContinuation(
-        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, prefill: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
         let remainderLength = inputIds.dim(-1)
@@ -1040,7 +1042,7 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             visionStartTokenId: config.baseConfiguration.visionStartTokenId,
             positionOffset: positionOffset)
 
-        let step = max(1, windowSize)
+        let step = prefill.chunkLength(forChunking: remainderLength) ?? remainderLength
         var lastLogits = MLXArray(0)
         var start = 0
         repeat {
@@ -1061,6 +1063,7 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
             }
             lastLogits = output.logits
             asyncEval(cache)
+            prefill.progress?(end, remainderLength)
             start = end
         } while start < remainderLength
         eval(cache)

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -978,13 +978,14 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?,
+        prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
         let inputIds = input.text.tokens
 
-        let window = windowSize ?? 512
+        let window = prefill.stepSize ?? 512
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -989,7 +989,7 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
-            return try prepareContinuation(input, cache: cache, state: state, windowSize: window)
+            return try prepareContinuation(input, cache: cache, state: state, prefill: prefill)
         }
 
         let inputIds2D = inputIds.ndim == 1 ? inputIds[.newAxis, 0...] : inputIds
@@ -1013,11 +1013,13 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
         let result = languageModel(
             embeds == nil ? inputIds2D : nil, cache: cache, state: state, inputEmbedding: embeds)
 
+        let total = inputIds2D.dim(-1)
+        prefill.progress?(total, total)
         return .logits(result)
     }
 
     private func prepareContinuation(
-        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, windowSize: Int
+        _ input: LMInput, cache: [any KVCache], state: LMOutput.State?, prefill: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
         let remainderLength = inputIds.dim(-1)
@@ -1045,7 +1047,7 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             videoTokenId: config.baseConfiguration.videoTokenId,
             positionOffset: positionOffset)
 
-        let step = max(1, windowSize)
+        let step = prefill.chunkLength(forChunking: remainderLength) ?? remainderLength
         var lastLogits = MLXArray(0)
         var start = 0
         repeat {
@@ -1066,6 +1068,7 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             }
             lastLogits = output.logits
             asyncEval(cache)
+            prefill.progress?(end, remainderLength)
             start = end
         } while start < remainderLength
         eval(cache)

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -985,7 +985,7 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
     {
         let inputIds = input.text.tokens
 
-        let window = prefill.stepSize ?? 512
+        let window = prefill.resolvedStepSize()
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
@@ -1047,31 +1047,26 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
             videoTokenId: config.baseConfiguration.videoTokenId,
             positionOffset: positionOffset)
 
-        let step = prefill.chunkLength(forChunking: remainderLength) ?? remainderLength
-        var lastLogits = MLXArray(0)
-        var start = 0
-        repeat {
-            try Task.checkCancellation()
-            let end = min(start + step, remainderLength)
-            let chunkPositions = positionIds[0..., 0..., start ..< end]
-            let output: LMOutput
-            if let embeds {
-                let chunkEmbeds = embeds[0..., start ..< end, 0...]
-                output = languageModel(
-                    nil, cache: cache, state: nil, inputEmbedding: chunkEmbeds,
-                    positionIds: chunkPositions)
-            } else {
-                let chunkInputs = inputIds[0..., start ..< end]
-                output = languageModel(
-                    chunkInputs, cache: cache, state: nil, inputEmbedding: nil,
-                    positionIds: chunkPositions)
-            }
-            lastLogits = output.logits
+        let processed = try prefill.forEachChunk(total: remainderLength) { range in
+            let chunkEmbeds = embeds.map { $0[0..., range, 0...] }
+            _ = languageModel(
+                chunkEmbeds == nil ? inputIds[0..., range] : nil,
+                cache: cache, state: nil, inputEmbedding: chunkEmbeds,
+                positionIds: positionIds[0..., 0..., range])
             asyncEval(cache)
-            prefill.progress?(end, remainderLength)
-            start = end
-        } while start < remainderLength
-        eval(cache)
+        }
+        if processed > 0 {
+            eval(cache)
+        }
+
+        let tailRange = processed ..< remainderLength
+        let tailEmbeds = embeds.map { $0[0..., tailRange, 0...] }
+        let lastLogits = languageModel(
+            tailEmbeds == nil ? inputIds[0..., tailRange] : nil,
+            cache: cache, state: nil, inputEmbedding: tailEmbeds,
+            positionIds: positionIds[0..., 0..., tailRange]
+        ).logits
+        prefill.progress?(remainderLength, remainderLength)
 
         var resumeState = LMOutput.State()
         resumeState[ropeDeltasKey] = ropeDeltas - MLXArray(Int32(cacheOffset))

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1025,7 +1025,7 @@ public class Qwen35: Module, VLMModel {
         _ input: LMInput,
         cache: [any KVCache],
         state: LMOutput.State?,
-        windowSize: Int?
+        prefill: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
 
@@ -1038,7 +1038,7 @@ public class Qwen35: Module, VLMModel {
         // the cache offset plus the rope delta carried in `state` — never
         // back at zero. The windowed forward is single-sequence; batched
         // inputs keep the single-shot path below.
-        let window = windowSize ?? 512
+        let window = prefill.stepSize ?? 512
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1043,7 +1043,7 @@ public class Qwen35: Module, VLMModel {
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
             return try prepareContinuation(
-                input, cache: cache, state: state, windowSize: window)
+                input, cache: cache, state: state, prefill: prefill)
         }
 
         let (pixelValues, imageFrames, videoFrames, inputEmbeddings) =
@@ -1064,6 +1064,8 @@ public class Qwen35: Module, VLMModel {
             )
         }
 
+        let total = inputIds.dim(-1)
+        prefill.progress?(total, total)
         return .logits(output)
     }
 
@@ -1081,7 +1083,7 @@ public class Qwen35: Module, VLMModel {
     /// remainder, computes the new image's M-RoPE positions **once** from the
     /// seeded **Position Anchor** (so the image's diverging t/h/w indices
     /// start at the anchor, not zero), then drives the language-model forward
-    /// in chunks of `windowSize`. The full-attention scratch is bounded to
+    /// in chunks from the prefill parameters. The full-attention scratch is bounded to
     /// `[heads, chunk, L]` instead of `[heads, L, L]`, so it cannot crash on
     /// a long prefix or a large image.
     ///
@@ -1096,7 +1098,7 @@ public class Qwen35: Module, VLMModel {
         _ input: LMInput,
         cache: [any KVCache],
         state: LMOutput.State?,
-        windowSize: Int
+        prefill: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
         let remainderLength = inputIds.dim(-1)
@@ -1139,7 +1141,7 @@ public class Qwen35: Module, VLMModel {
         // while letting the GPU run window i as the CPU builds window i+1
         // (same shape as the sibling chunked prefills, e.g. Gemma3).
         let typedCache = castCache(cache)
-        let step = max(1, windowSize)
+        let step = prefill.chunkLength(forChunking: remainderLength) ?? remainderLength
         var lastLogits: MLXArray
         var start = 0
         repeat {
@@ -1163,6 +1165,7 @@ public class Qwen35: Module, VLMModel {
             if let typedCache {
                 asyncEval(typedCache)
             }
+            prefill.progress?(end, remainderLength)
             start = end
         } while start < remainderLength
         if let typedCache {

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1031,14 +1031,14 @@ public class Qwen35: Module, VLMModel {
 
         // Windowed (chunked) prefill — the remaining #344 deferred item for
         // Qwen3.5 — with the same default as the sibling chunked prefills
-        // (Gemma3/LLMModel: `prefill.stepSize ?? 512`). The windowed forward also
+        // (Gemma3/LLMModel: `prefill.resolvedStepSize()`). The windowed forward also
         // owns every warm continuation (multi-turn chat, tool restart,
         // restored prompt cache): a cold cache is just a continuation
         // anchored at offset 0, and a warm one anchors M-RoPE positions at
         // the cache offset plus the rope delta carried in `state` — never
         // back at zero. The windowed forward is single-sequence; batched
         // inputs keep the single-shot path below.
-        let window = prefill.stepSize ?? 512
+        let window = prefill.resolvedStepSize()
         if inputIds.ndim == 2, inputIds.dim(0) == 1, inputIds.dim(-1) > 0,
             faCacheOffset(cache) > 0 || inputIds.dim(-1) > window
         {
@@ -1135,42 +1135,46 @@ public class Qwen35: Module, VLMModel {
 
         // Chunk the forward. Each window forwards `chunk` query tokens against
         // the growing cache, so the full-attention scratch stays `[heads,
-        // chunk, L]`. Intermediate logits are dropped un-evaluated (only the
-        // cache is realized between windows), so `lm_head` never materializes a
-        // `[1, L, vocab]` tensor. `asyncEval` bounds the un-evaluated graph
-        // while letting the GPU run window i as the CPU builds window i+1
-        // (same shape as the sibling chunked prefills, e.g. Gemma3).
+        // chunk, L]`. Chunk logits are dropped un-evaluated (only the cache is
+        // realized between windows) and the logits the iterator samples come
+        // from the reserved final position, so `lm_head` materializes
+        // `[1, 1, vocab]`, never `[1, L, vocab]`. `asyncEval` bounds the
+        // un-evaluated graph while letting the GPU run window i as the CPU
+        // builds window i+1 (same shape as the sibling chunked prefills).
         let typedCache = castCache(cache)
-        let step = prefill.chunkLength(forChunking: remainderLength) ?? remainderLength
-        var lastLogits: MLXArray
-        var start = 0
-        repeat {
-            try Task.checkCancellation()
-            let end = min(start + step, remainderLength)
-            let chunkInputs = inputIds[0..., start ..< end]
-            let chunkEmbeds = inputEmbeddings.map { $0[0..., start ..< end, 0...] }
-            let chunkPositions = positionIds[0..., 0..., start ..< end]
-            let output = languageModel(
-                chunkInputs,
-                inputsEmbeds: chunkEmbeds,
+        let processed = try prefill.forEachChunk(total: remainderLength) { range in
+            _ = languageModel(
+                inputIds[0..., range],
+                inputsEmbeds: inputEmbeddings.map { $0[0..., range, 0...] },
                 cache: typedCache,
                 state: nil,
                 mask: nil,
-                positionIds: chunkPositions,
+                positionIds: positionIds[0..., 0..., range],
                 pixelValues: nil,
                 imageGridTHW: nil,
                 videoGridTHW: nil
             )
-            lastLogits = output.logits
             if let typedCache {
                 asyncEval(typedCache)
             }
-            prefill.progress?(end, remainderLength)
-            start = end
-        } while start < remainderLength
-        if let typedCache {
+        }
+        if processed > 0, let typedCache {
             eval(typedCache)
         }
+
+        let tailRange = processed ..< remainderLength
+        let lastLogits = languageModel(
+            inputIds[0..., tailRange],
+            inputsEmbeds: inputEmbeddings.map { $0[0..., tailRange, 0...] },
+            cache: typedCache,
+            state: nil,
+            mask: nil,
+            positionIds: positionIds[0..., 0..., tailRange],
+            pixelValues: nil,
+            imageGridTHW: nil,
+            videoGridTHW: nil
+        ).logits
+        prefill.progress?(remainderLength, remainderLength)
 
         // Seed the post-image text tail's anchor. The vendor's flat-continuation
         // branch positions tail token j at `tailCacheOffset + ropeDeltas + j`;

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1031,7 +1031,7 @@ public class Qwen35: Module, VLMModel {
 
         // Windowed (chunked) prefill — the remaining #344 deferred item for
         // Qwen3.5 — with the same default as the sibling chunked prefills
-        // (Gemma3/LLMModel: `windowSize ?? 512`). The windowed forward also
+        // (Gemma3/LLMModel: `prefill.stepSize ?? 512`). The windowed forward also
         // owns every warm continuation (multi-turn chat, tool restart,
         // restored prompt cache): a cold cache is just a continuation
         // anchored at offset 0, and a warm one anchors M-RoPE positions at

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1743,7 +1743,7 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
         _ input: LMInput,
         cache: [any KVCache],
         state: LMOutput.State?,
-        windowSize _: Int?
+        prefill _: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
 

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1743,7 +1743,7 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
         _ input: LMInput,
         cache: [any KVCache],
         state: LMOutput.State?,
-        prefill _: PrefillParameters
+        prefill: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
 
@@ -1820,6 +1820,8 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
             imageGridTHW: imageFrames,
             videoGridTHW: videoFrames)
 
+        let total = inputIds.dim(-1)
+        prefill.progress?(total, total)
         return .logits(languageOutput)
     }
 

--- a/Libraries/MLXVLM/Models/Qwen3VLMoE.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VLMoE.swift
@@ -654,7 +654,7 @@ public final class Qwen3VLMoE: Module, VLMModel, KVCacheDimensionProvider {
         _ input: LMInput,
         cache: [any KVCache],
         state: LMOutput.State?,
-        windowSize _: Int?
+        prefill: PrefillParameters
     ) throws -> PrepareResult {
         let inputIds = input.text.tokens
 
@@ -728,6 +728,8 @@ public final class Qwen3VLMoE: Module, VLMModel, KVCacheDimensionProvider {
             imageGridTHW: imageFrames,
             videoGridTHW: videoFrames)
 
+        let total = inputIds.dim(-1)
+        prefill.progress?(total, total)
         return .logits(languageOutput)
     }
 

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -271,13 +271,14 @@ public class YourModel: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func prepare(
-        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?, windowSize: Int?
+        _ input: LMInput, cache: [any KVCache], state _: LMOutput.State?,
+        prefill: PrefillParameters
     ) throws
         -> PrepareResult
     {
         // Merge image and text embeddings, then prefill the KV cache in
-        // windowSize-sized chunks. Single-pass prefill allocates transient
-        // buffers proportional to prompt length and causes OOM on long prompts.
+        // chunks. Single-pass prefill allocates transient buffers
+        // proportional to prompt length and causes OOM on long prompts.
         guard let image = input.image else { throw VLMError.imageRequired }
         guard let mask = input.text.mask else { throw VLMError.maskRequired }
         var inputIds = input.text.tokens
@@ -286,21 +287,24 @@ public class YourModel: Module, VLMModel, KVCacheDimensionProvider {
         let allEmbeds = inputEmbeddings(
             inputIds: inputIds, pixelValues: image.pixels, mask: mask)
 
-        let prefillStepSize = windowSize ?? 512
         let totalPositions = allEmbeds.dim(1)
         var processed = 0
-        while totalPositions - processed > 1 {
-            let chunkLength = min(prefillStepSize, totalPositions - processed - 1)
-            let range = processed ..< (processed + chunkLength)
-            _ = languageModel(inputIds[0..., range], cache: cache,
-                              inputEmbedding: allEmbeds[0..., range, 0...], mask: mask)
-            asyncEval(cache)
-            processed += chunkLength
+        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
+            while totalPositions - processed > 1 {
+                let n = min(chunkLength, totalPositions - processed - 1)
+                let range = processed ..< (processed + n)
+                _ = languageModel(inputIds[0..., range], cache: cache,
+                                  inputEmbedding: allEmbeds[0..., range, 0...], mask: mask)
+                asyncEval(cache)
+                processed += n
+                prefill.progress?(processed, totalPositions)
+            }
+            eval(cache)
         }
-        eval(cache)
         let result = languageModel(
             inputIds[0..., processed...], cache: cache,
             inputEmbedding: allEmbeds[0..., processed..., 0...], mask: mask)
+        prefill.progress?(totalPositions, totalPositions)
         return .logits(result)
     }
 

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -288,19 +288,12 @@ public class YourModel: Module, VLMModel, KVCacheDimensionProvider {
             inputIds: inputIds, pixelValues: image.pixels, mask: mask)
 
         let totalPositions = allEmbeds.dim(1)
-        var processed = 0
-        if let chunkLength = prefill.chunkLength(forChunking: totalPositions - 1) {
-            while totalPositions - processed > 1 {
-                let n = min(chunkLength, totalPositions - processed - 1)
-                let range = processed ..< (processed + n)
-                _ = languageModel(inputIds[0..., range], cache: cache,
-                                  inputEmbedding: allEmbeds[0..., range, 0...], mask: mask)
-                asyncEval(cache)
-                processed += n
-                prefill.progress?(processed, totalPositions)
-            }
-            eval(cache)
+        let processed = try prefill.forEachChunk(total: totalPositions) { range in
+            _ = languageModel(inputIds[0..., range], cache: cache,
+                              inputEmbedding: allEmbeds[0..., range, 0...], mask: mask)
+            asyncEval(cache)
         }
+        if processed > 0 { eval(cache) }
         let result = languageModel(
             inputIds[0..., processed...], cache: cache,
             inputEmbedding: allEmbeds[0..., processed..., 0...], mask: mask)

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -147,13 +147,13 @@ public class ChatSessionTests: XCTestCase {
         }
 
         func prepare(
-            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
         ) throws -> PrepareResult {
             try base.prepare(
                 LMInput(tokens: input.text.tokens),
                 cache: cache,
                 state: state,
-                windowSize: windowSize)
+                prefill: prefill)
         }
 
         func callAsFunction(

--- a/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
@@ -10,7 +10,7 @@ import Testing
 /// Unit tests for `Gemma4.prepare(_:cache:state:prefill:)` chunked prefill.
 ///
 /// The core property under test is **chunk-size invariance**: prefilling the
-/// same prompt with a small `windowSize` (many chunks) and a `windowSize`
+/// same prompt with a small step size (many chunks) and a step size
 /// larger than the prompt (single pass) must agree on the final logits and
 /// leave the KV caches at the same offsets. The synthetic config deliberately
 /// covers Gemma 4's tricky structures: sliding-window layers whose rotating
@@ -125,6 +125,25 @@ struct Gemma4ChunkedPrefillTests {
         let result = try Self.prefillLogits(model: model, tokens: tokens, windowSize: 512)
         #expect(result.cacheOffsets.allSatisfy { $0 == tokens.count })
         #expect(result.logits.shape == [1, 200])
+    }
+
+    @Test("A .logits model reports monotone progress ending at (total, total)")
+    func logitsModelProgressContract() throws {
+        let model = try Self.makeTinyModel()
+        let tokens = Self.makePrompt(count: 37)
+
+        final class Log: @unchecked Sendable { var events: [[Int]] = [] }
+        let log = Log()
+        var prefill = PrefillParameters(stepSize: 8)
+        prefill.progress = { log.events.append([$0, $1]) }
+
+        let input = LMInput(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
+        _ = try model.prepare(
+            input, cache: model.newCache(parameters: nil), state: nil, prefill: prefill)
+
+        #expect(log.events.last == [tokens.count, tokens.count])
+        #expect(log.events.map { $0[0] } == log.events.map { $0[0] }.sorted())
+        #expect(log.events.allSatisfy { $0[1] == tokens.count })
     }
 
     @Test("Unbatched (1-D) token input is accepted on the text path")

--- a/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 @testable import MLXVLM
 
-/// Unit tests for `Gemma4.prepare(_:cache:state:windowSize:)` chunked prefill.
+/// Unit tests for `Gemma4.prepare(_:cache:state:prefill:)` chunked prefill.
 ///
 /// The core property under test is **chunk-size invariance**: prefilling the
 /// same prompt with a small `windowSize` (many chunks) and a `windowSize`
@@ -74,7 +74,8 @@ struct Gemma4ChunkedPrefillTests {
     ) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
         let cache = model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
-        let result = try model.prepare(input, cache: cache, state: nil, windowSize: windowSize)
+        let result = try model.prepare(
+            input, cache: cache, state: nil, prefill: .init(stepSize: windowSize))
         guard case .logits(let output) = result else {
             Issue.record("Expected .logits from Gemma4.prepare, got .tokens")
             return (MLXArray(0), [])
@@ -133,7 +134,7 @@ struct Gemma4ChunkedPrefillTests {
 
         let cache = model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray(tokens))  // 1-D, no batch axis
-        let result = try model.prepare(input, cache: cache, state: nil, windowSize: 6)
+        let result = try model.prepare(input, cache: cache, state: nil, prefill: .init(stepSize: 6))
         guard case .logits(let output) = result else {
             Issue.record("Expected .logits from Gemma4.prepare")
             return

--- a/Tests/MLXLMTests/Gemma4UnifiedTests.swift
+++ b/Tests/MLXLMTests/Gemma4UnifiedTests.swift
@@ -113,7 +113,7 @@ struct Gemma4UnifiedTests {
         let input = LMInput(tokens: MLXArray([0, 2, 3, 4, 5, 1]).expandedDimensions(axis: 0))
 
         let result = try model.prepare(
-            input, cache: cache, state: nil, windowSize: 2)
+            input, cache: cache, state: nil, prefill: .init(stepSize: 2))
 
         guard case .logits(let output) = result else {
             Issue.record("Expected text-only Gemma4Unified.prepare to return logits")
@@ -138,7 +138,8 @@ struct Gemma4UnifiedTests {
 
         func prefill(windowSize: Int) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
             let cache = model.newCache(parameters: nil)
-            let result = try model.prepare(input, cache: cache, state: nil, windowSize: windowSize)
+            let result = try model.prepare(
+                input, cache: cache, state: nil, prefill: .init(stepSize: windowSize))
             guard case .logits(let output) = result else {
                 Issue.record("Expected text-only Gemma4Unified.prepare to return logits")
                 return (MLXArray.zeros([1, 32]), [])
@@ -291,7 +292,7 @@ struct Gemma4UnifiedTests {
         )
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil, windowSize: nil)
+            input, cache: model.newCache(parameters: nil), state: nil, prefill: .init())
 
         guard case .logits(let output) = result else {
             Issue.record("Expected Gemma4Unified.prepare to return logits")

--- a/Tests/MLXLMTests/Gemma4VideoInputTests.swift
+++ b/Tests/MLXLMTests/Gemma4VideoInputTests.swift
@@ -54,7 +54,8 @@ struct Gemma4VideoInputTests {
                 ? LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
                 : LMInput(text: text, image: LMInput.ProcessedImage(pixels: pixels))
             let result = try model.prepare(
-                input, cache: model.newCache(parameters: nil), state: nil, windowSize: 1024)
+                input, cache: model.newCache(parameters: nil), state: nil,
+                prefill: .init(stepSize: 1024))
             guard case .logits(let out) = result else {
                 Issue.record("Expected .logits from Gemma4.prepare (multimodal branch)")
                 return MLXArray(0)
@@ -93,7 +94,8 @@ struct Gemma4VideoInputTests {
         let input = LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil, windowSize: 1024)
+            input, cache: model.newCache(parameters: nil), state: nil,
+            prefill: .init(stepSize: 1024))
         guard case .logits(let out) = result else {
             Issue.record("Expected .logits from Gemma4.prepare")
             return

--- a/Tests/MLXLMTests/KVCacheConfigurationTests.swift
+++ b/Tests/MLXLMTests/KVCacheConfigurationTests.swift
@@ -458,10 +458,8 @@ struct KVCacheConfigurationTests {
 
     private final class HybridProgressModel: Module, LanguageModel {
         func prepare(
-            _ input: LMInput,
-            cache: [KVCache],
-            state: LMOutput.State?,
-            windowSize: Int?
+            _ input: MLXLMCommon.LMInput, cache: [any MLXLMCommon.KVCache],
+            state: MLXLMCommon.LMOutput.State?, prefill: MLXLMCommon.PrefillParameters
         ) throws -> PrepareResult {
             .tokens(input.text)
         }

--- a/Tests/MLXLMTests/MTPDrafterModelTests.swift
+++ b/Tests/MLXLMTests/MTPDrafterModelTests.swift
@@ -83,7 +83,9 @@ func testMTPDrafterContainerPerform() async {
 private final class DummyLanguageModel: Module, LanguageModel, KVCacheDimensionProvider {
     var kvHeads: [Int] { [] }
 
-    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    )
         throws -> PrepareResult
     {
         .tokens(input.text)

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -69,7 +69,9 @@ private final class MockMainModel: Module, LanguageModel, KVCacheDimensionProvid
         super.init()
     }
 
-    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    )
         throws -> PrepareResult
     {
         // Return `.tokens(...)`; the iterator's `prepare` will follow up with

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -56,7 +56,8 @@ final class NanbeigeTests: XCTestCase {
         _ model: NanbeigeModel, _ tokens: MLXArray, cache: [KVCache]
     ) throws -> MLXArray {
         let result = try model.prepare(
-            LMInput(text: .init(tokens: tokens)), cache: cache, state: nil, windowSize: 16)
+            LMInput(text: .init(tokens: tokens)), cache: cache, state: nil,
+            prefill: .init(stepSize: 16))
         switch result {
         case .tokens(let remainder):
             let out = model(remainder.tokens[.newAxis], cache: cache)

--- a/Tests/MLXLMTests/PrefillParametersTests.swift
+++ b/Tests/MLXLMTests/PrefillParametersTests.swift
@@ -1,0 +1,183 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+/// Unit tests for ``PrefillParameters``: the chunk-length arithmetic, the
+/// chunk schedule the default `LLMModel.prepare` derives from it, and the
+/// progress-callback sequence observed through a real `TokenIterator`.
+struct PrefillParametersTests {
+
+    // MARK: - chunkLength arithmetic
+
+    @Test("balanced chunk length: minimal equal chunks under the ceiling")
+    func balancedArithmetic() {
+        let prefill = PrefillParameters(stepSize: nil, chunking: .balanced)
+        for (count, step) in [(31884, 1024), (5000, 512), (1025, 1024), (7, 3), (100, 100)] {
+            let chunk = prefill.chunkLength(forChunking: count, defaultStepSize: step)!
+            #expect(chunk <= step)
+            // the chunk count the ceiling dictates is not exceeded
+            let minimalCount = (count + step - 1) / step
+            #expect((count + chunk - 1) / chunk == minimalCount)
+            // near-equal: the smallest chunk is within chunkCount-1 of the largest
+            let lastChunk = count - (minimalCount - 1) * chunk
+            #expect(lastChunk > chunk - minimalCount)
+            #expect(lastChunk <= chunk)
+        }
+    }
+
+    @Test("balanced degenerates safely: fits-in-one, empty, non-positive step")
+    func balancedDegenerates() {
+        let prefill = PrefillParameters(chunking: .balanced)
+        // count at or under the step: one chunk of exactly count
+        #expect(prefill.chunkLength(forChunking: 24, defaultStepSize: 128) == 24)
+        #expect(prefill.chunkLength(forChunking: 512, defaultStepSize: 512) == 512)
+        // empty and non-positive floor to 1
+        #expect(prefill.chunkLength(forChunking: 0, defaultStepSize: 512) == 1)
+        #expect(
+            PrefillParameters(stepSize: 0).chunkLength(forChunking: 10, defaultStepSize: 512) == 1)
+    }
+
+    @Test("stepSize overrides the default; maximumStepSize caps both")
+    func stepResolution() {
+        // explicit stepSize wins over the model default
+        #expect(
+            PrefillParameters(stepSize: 8, chunking: .remainder)
+                .chunkLength(forChunking: 100, defaultStepSize: 512) == 8)
+        // the cap clamps an explicit stepSize
+        #expect(
+            PrefillParameters(stepSize: 512, chunking: .remainder)
+                .chunkLength(forChunking: 100, defaultStepSize: 128, maximumStepSize: 64) == 64)
+        // and clamps the default too
+        #expect(
+            PrefillParameters(chunking: .remainder)
+                .chunkLength(forChunking: 100, defaultStepSize: 128, maximumStepSize: 64) == 64)
+    }
+
+    @Test("unchunked resolves to nil at any length")
+    func unchunkedIsNil() {
+        let prefill = PrefillParameters(chunking: .unchunked)
+        #expect(prefill.chunkLength(forChunking: 5) == nil)
+        #expect(prefill.chunkLength(forChunking: 31884) == nil)
+    }
+
+    // MARK: - default-prepare chunk schedule
+
+    /// Mirrors the chunk schedule of the default `LLMModel.prepare` loop:
+    /// returns the per-forward chunk lengths and the tokens left to the
+    /// `TokenIterator`.
+    private static func schedule(promptTokens: Int, prefill: PrefillParameters) -> (
+        chunks: [Int], iteratorTokens: Int
+    ) {
+        let stepSize = max(1, prefill.stepSize ?? 512)
+        var remaining = promptTokens
+        guard promptTokens > stepSize,
+            let chunkSize = prefill.chunkLength(
+                forChunking: promptTokens - 1, defaultStepSize: stepSize)
+        else {
+            return ([], remaining)
+        }
+        let tail = prefill.chunking == .remainder ? stepSize : 1
+        var chunks: [Int] = []
+        while remaining > tail {
+            let n = min(chunkSize, remaining - 1)
+            chunks.append(n)
+            remaining -= n
+        }
+        return (chunks, remaining)
+    }
+
+    /// Pins the exact schedule of the banked measurement (31,885 tokens at a
+    /// 1024 ceiling on Qwen3.6-35B-A3B): balanced runs 32 near-equal chunks
+    /// and hands the iterator one token, where the legacy stride ran 31 full
+    /// chunks and left a degenerate 141-token remainder.
+    @Test("schedule pin: 31,885 tokens @ 1024")
+    func schedulePin() {
+        let balanced = Self.schedule(
+            promptTokens: 31885, prefill: .init(stepSize: 1024, chunking: .balanced))
+        #expect(balanced.chunks == Array(repeating: 997, count: 31) + [977])
+        #expect(balanced.iteratorTokens == 1)
+
+        let legacy = Self.schedule(
+            promptTokens: 31885, prefill: .init(stepSize: 1024, chunking: .remainder))
+        #expect(legacy.chunks == Array(repeating: 1024, count: 31))
+        #expect(legacy.iteratorTokens == 141)
+    }
+
+    @Test("schedule: fits-in-one-chunk prompts go to the iterator whole")
+    func scheduleShortPrompt() {
+        for chunking in [PrefillParameters.Chunking.balanced, .remainder, .unchunked] {
+            let result = Self.schedule(
+                promptTokens: 300, prefill: .init(stepSize: 512, chunking: chunking))
+            #expect(result.chunks.isEmpty)
+            #expect(result.iteratorTokens == 300)
+        }
+    }
+
+    // MARK: - progress through a real TokenIterator
+
+    private final class ProgressLog: @unchecked Sendable {
+        var events: [[Int]] = []
+    }
+
+    private static func makeModel() -> LlamaModel {
+        let config = LlamaConfiguration(
+            hiddenSize: 32, hiddenLayers: 2, intermediateSize: 64, attentionHeads: 4,
+            rmsNormEps: 0.00001, vocabularySize: 100, kvHeads: 2)
+        return LlamaModel(config)
+    }
+
+    private static func prefillEvents(
+        promptTokens: Int, prefill: PrefillParameters
+    ) throws -> (events: [[Int]], cacheOffsets: [Int]) {
+        let model = makeModel()
+        let log = ProgressLog()
+        var parameters = GenerateParameters(temperature: 0)
+        parameters.prefill = prefill
+        parameters.prefill.progress = { processed, total in
+            log.events.append([processed, total])
+        }
+        let prompt = MLXArray((0 ..< promptTokens).map { Int32($0 % 100) })
+        let cache = model.newCache(parameters: parameters)
+        _ = try TokenIterator(
+            input: LMInput(tokens: prompt), model: model, cache: cache, parameters: parameters)
+        return (log.events, cache.map { $0.offset })
+    }
+
+    @Test("balanced progress: equal chunk boundaries, then the terminal call")
+    func progressBalanced() throws {
+        let result = try Self.prefillEvents(
+            promptTokens: 25, prefill: .init(stepSize: 8, chunking: .balanced))
+        #expect(result.events == [[8, 25], [16, 25], [24, 25], [25, 25]])
+        #expect(result.cacheOffsets.allSatisfy { $0 == 25 })
+
+        // a non-divisible count balances below the ceiling: ceil(24/4) = 6 per chunk
+        let uneven = try Self.prefillEvents(
+            promptTokens: 25, prefill: .init(stepSize: 7, chunking: .balanced))
+        #expect(uneven.events == [[6, 25], [12, 25], [18, 25], [24, 25], [25, 25]])
+    }
+
+    @Test("remainder progress: stride boundaries, remainder finishes at the terminal")
+    func progressRemainder() throws {
+        let result = try Self.prefillEvents(
+            promptTokens: 26, prefill: .init(stepSize: 8, chunking: .remainder))
+        #expect(result.events == [[8, 26], [16, 26], [24, 26], [26, 26]])
+        #expect(result.cacheOffsets.allSatisfy { $0 == 26 })
+    }
+
+    @Test("unchunked and fits-in-one-chunk prompts report only the terminal call")
+    func progressSingleForward() throws {
+        let unchunked = try Self.prefillEvents(
+            promptTokens: 25, prefill: .init(stepSize: 8, chunking: .unchunked))
+        #expect(unchunked.events == [[25, 25]])
+        #expect(unchunked.cacheOffsets.allSatisfy { $0 == 25 })
+
+        let short = try Self.prefillEvents(
+            promptTokens: 5, prefill: .init(stepSize: 512, chunking: .balanced))
+        #expect(short.events == [[5, 5]])
+        #expect(short.cacheOffsets.allSatisfy { $0 == 5 })
+    }
+}

--- a/Tests/MLXLMTests/PrefillParametersTests.swift
+++ b/Tests/MLXLMTests/PrefillParametersTests.swift
@@ -64,57 +64,52 @@ struct PrefillParametersTests {
         #expect(prefill.chunkLength(forChunking: 31884) == nil)
     }
 
-    // MARK: - default-prepare chunk schedule
+    // MARK: - forEachChunk schedule
 
-    /// Mirrors the chunk schedule of the default `LLMModel.prepare` loop:
-    /// returns the per-forward chunk lengths and the tokens left to the
-    /// `TokenIterator`.
-    private static func schedule(promptTokens: Int, prefill: PrefillParameters) -> (
-        chunks: [Int], iteratorTokens: Int
-    ) {
-        let stepSize = max(1, prefill.stepSize ?? 512)
-        var remaining = promptTokens
-        guard promptTokens > stepSize,
-            let chunkSize = prefill.chunkLength(
-                forChunking: promptTokens - 1, defaultStepSize: stepSize)
-        else {
-            return ([], remaining)
+    /// Collects the chunk ranges `forEachChunk` drives: the schedule the
+    /// shipping code produces, plus the positions left for the caller's final
+    /// forward.
+    private static func schedule(
+        total: Int, reserving: Int = 1, prefill: PrefillParameters
+    ) throws -> (chunks: [Range<Int>], tail: Int) {
+        var chunks: [Range<Int>] = []
+        let processed = try prefill.forEachChunk(total: total, reserving: reserving) {
+            chunks.append($0)
         }
-        let tail = prefill.chunking == .remainder ? stepSize : 1
-        var chunks: [Int] = []
-        while remaining > tail {
-            let n = min(chunkSize, remaining - 1)
-            chunks.append(n)
-            remaining -= n
-        }
-        return (chunks, remaining)
+        return (chunks, total - processed)
     }
 
     /// Pins the exact schedule of the banked measurement (31,885 tokens at a
     /// 1024 ceiling on Qwen3.6-35B-A3B): balanced runs 32 near-equal chunks
     /// and hands the iterator one token, where the legacy stride ran 31 full
-    /// chunks and left a degenerate 141-token remainder.
+    /// chunks and left a degenerate 141-token remainder. `reserving` values
+    /// mirror `LLMModel.prepare`'s calls.
     @Test("schedule pin: 31,885 tokens @ 1024")
-    func schedulePin() {
-        let balanced = Self.schedule(
-            promptTokens: 31885, prefill: .init(stepSize: 1024, chunking: .balanced))
-        #expect(balanced.chunks == Array(repeating: 997, count: 31) + [977])
-        #expect(balanced.iteratorTokens == 1)
+    func schedulePin() throws {
+        let balanced = try Self.schedule(
+            total: 31885, prefill: .init(stepSize: 1024, chunking: .balanced))
+        #expect(balanced.chunks.map(\.count) == Array(repeating: 997, count: 31) + [977])
+        #expect(balanced.chunks.first?.lowerBound == 0)
+        #expect(balanced.chunks.last?.upperBound == 31884)
+        #expect(balanced.tail == 1)
 
-        let legacy = Self.schedule(
-            promptTokens: 31885, prefill: .init(stepSize: 1024, chunking: .remainder))
-        #expect(legacy.chunks == Array(repeating: 1024, count: 31))
-        #expect(legacy.iteratorTokens == 141)
+        let legacy = try Self.schedule(
+            total: 31885, reserving: 1024, prefill: .init(stepSize: 1024, chunking: .remainder))
+        #expect(legacy.chunks.map(\.count) == Array(repeating: 1024, count: 31))
+        #expect(legacy.tail == 141)
     }
 
-    @Test("schedule: fits-in-one-chunk prompts go to the iterator whole")
-    func scheduleShortPrompt() {
-        for chunking in [PrefillParameters.Chunking.balanced, .remainder, .unchunked] {
-            let result = Self.schedule(
-                promptTokens: 300, prefill: .init(stepSize: 512, chunking: chunking))
-            #expect(result.chunks.isEmpty)
-            #expect(result.iteratorTokens == 300)
-        }
+    @Test("schedule: fits-in-one-chunk totals become a single chunk; unchunked, none")
+    func scheduleShortPrompt() throws {
+        let balanced = try Self.schedule(
+            total: 300, prefill: .init(stepSize: 512, chunking: .balanced))
+        #expect(balanced.chunks.map(\.count) == [299])
+        #expect(balanced.tail == 1)
+
+        let unchunked = try Self.schedule(
+            total: 300, prefill: .init(stepSize: 512, chunking: .unchunked))
+        #expect(unchunked.chunks.isEmpty)
+        #expect(unchunked.tail == 300)
     }
 
     // MARK: - progress through a real TokenIterator

--- a/Tests/MLXLMTests/Qwen25VLContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen25VLContinuationTests.swift
@@ -165,12 +165,12 @@ final class Qwen25VLContinuationTests: XCTestCase {
         let (logitsF, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1))),
-                cache: cacheF, state: nil, windowSize: nil))
+                cache: cacheF, state: nil, prefill: .init()))
 
         let cacheD = model.newCache(parameters: nil)
         let (_, s0) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: cacheD, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t1)), cache: cacheD, state: nil, prefill: .init()))
         var state = s0
         var logitsD = MLXArray(0)
         for j in 0 ..< t2.dim(1) {
@@ -184,10 +184,10 @@ final class Qwen25VLContinuationTests: XCTestCase {
         let cacheW = model.newCache(parameters: nil)
         _ = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, prefill: .init()))
         let (logitsW, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: cacheW, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: nil, prefill: .init()))
 
         let drift = maxAbsDiff(logitsW, logitsF)
         XCTAssertLessThanOrEqual(
@@ -210,16 +210,16 @@ final class Qwen25VLContinuationTests: XCTestCase {
         let (logitsF, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
-                windowSize: nil))
+                prefill: .init()))
 
         let cacheW = model.newCache(parameters: nil)
         let (_, s1) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
-                windowSize: nil))
+                prefill: .init()))
         let (logitsW, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, windowSize: nil))
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, prefill: .init()))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsW, logitsF), 1e-3,
@@ -242,19 +242,19 @@ final class Qwen25VLContinuationTests: XCTestCase {
         let (logitsF, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
-                windowSize: nil))
+                prefill: .init()))
 
         let cacheW = model.newCache(parameters: nil)
         let (_, s1) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, prefill: .init()))
         let (_, s2) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t2), image: image), cache: cacheW, state: s1,
-                windowSize: nil))
+                prefill: .init()))
         let (logitsW, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t3)), cache: cacheW, state: s2, windowSize: nil))
+                LMInput(text: .init(tokens: t3)), cache: cacheW, state: s2, prefill: .init()))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsW, logitsF), 1e-3,
@@ -270,12 +270,13 @@ final class Qwen25VLContinuationTests: XCTestCase {
         let cacheS = model.newCache(parameters: nil)
         let (logitsS, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: prompt)), cache: cacheS, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: prompt)), cache: cacheS, state: nil, prefill: .init()))
 
         let cacheC = model.newCache(parameters: nil)
         let (logitsC, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: prompt)), cache: cacheC, state: nil, windowSize: 8))
+                LMInput(text: .init(tokens: prompt)), cache: cacheC, state: nil,
+                prefill: .init(stepSize: 8)))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsC, logitsS), 1e-3,
@@ -296,13 +297,13 @@ final class Qwen25VLContinuationTests: XCTestCase {
         let (logitsS, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: prompt), image: image), cache: cacheS, state: nil,
-                windowSize: nil))
+                prefill: .init()))
 
         let cacheC = model.newCache(parameters: nil)
         let (logitsC, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: prompt), image: image), cache: cacheC, state: nil,
-                windowSize: 8))
+                prefill: .init(stepSize: 8)))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsC, logitsS), 1e-3,

--- a/Tests/MLXLMTests/Qwen35ContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen35ContinuationTests.swift
@@ -109,14 +109,14 @@ final class Qwen35ContinuationTests: XCTestCase {
         let cacheF = model.newCache(parameters: nil)
         let (logitsF, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: full)), cache: cacheF, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: full)), cache: cacheF, state: nil, prefill: .init()))
 
         // Control: decode path, token by token, state threaded. Correct by
         // construction; its divergence from F is the numerical noise floor.
         let cacheD = model.newCache(parameters: nil)
         let (_, s0) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: cacheD, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t1)), cache: cacheD, state: nil, prefill: .init()))
         var state = s0
         var logitsD = MLXArray(0)
         for j in 0 ..< t2.dim(1) {
@@ -133,10 +133,10 @@ final class Qwen35ContinuationTests: XCTestCase {
         let cacheW = model.newCache(parameters: nil)
         _ = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, prefill: .init()))
         let (logitsW, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: cacheW, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: nil, prefill: .init()))
 
         let drift = maxAbsDiff(logitsW, logitsF)
         XCTAssertLessThanOrEqual(
@@ -168,17 +168,17 @@ final class Qwen35ContinuationTests: XCTestCase {
         let (logitsF, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
-                windowSize: nil))
+                prefill: .init()))
 
         // Two turns with the prefill state threaded, as ChatSession does.
         let cacheW = model.newCache(parameters: nil)
         let (_, s1) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
-                windowSize: nil))
+                prefill: .init()))
         let (logitsW, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, windowSize: nil))
+                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, prefill: .init()))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsW, logitsF), 1e-3,
@@ -209,20 +209,20 @@ final class Qwen35ContinuationTests: XCTestCase {
         let (logitsF, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: full), image: image), cache: cacheF, state: nil,
-                windowSize: nil))
+                prefill: .init()))
 
         // Three turns, state threaded turn-to-turn: text, then image, then text.
         let cacheW = model.newCache(parameters: nil)
         let (_, s1) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: t1)), cache: cacheW, state: nil, prefill: .init()))
         let (_, s2) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t2), image: image), cache: cacheW, state: s1,
-                windowSize: nil))
+                prefill: .init()))
         let (logitsW, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: t3)), cache: cacheW, state: s2, windowSize: nil))
+                LMInput(text: .init(tokens: t3)), cache: cacheW, state: s2, prefill: .init()))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsW, logitsF), 1e-3,
@@ -240,12 +240,13 @@ final class Qwen35ContinuationTests: XCTestCase {
         let cacheS = model.newCache(parameters: nil)
         let (logitsS, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: prompt)), cache: cacheS, state: nil, windowSize: nil))
+                LMInput(text: .init(tokens: prompt)), cache: cacheS, state: nil, prefill: .init()))
 
         let cacheC = model.newCache(parameters: nil)
         let (logitsC, _) = try lastLogits(
             model.prepare(
-                LMInput(text: .init(tokens: prompt)), cache: cacheC, state: nil, windowSize: 8))
+                LMInput(text: .init(tokens: prompt)), cache: cacheC, state: nil,
+                prefill: .init(stepSize: 8)))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsC, logitsS), 1e-3,
@@ -269,13 +270,13 @@ final class Qwen35ContinuationTests: XCTestCase {
         let (logitsS, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: prompt), image: image), cache: cacheS, state: nil,
-                windowSize: nil))
+                prefill: .init()))
 
         let cacheC = model.newCache(parameters: nil)
         let (logitsC, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: prompt), image: image), cache: cacheC, state: nil,
-                windowSize: 8))
+                prefill: .init(stepSize: 8)))
 
         XCTAssertLessThanOrEqual(
             maxAbsDiff(logitsC, logitsS), 1e-3,

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -275,9 +275,10 @@ private final class CacheTrackingTransitionModel: Module, LanguageModel,
         super.init()
     }
 
-    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
-        throws -> PrepareResult
-    {
+    func prepare(
+        _ input: MLXLMCommon.LMInput, cache: [any MLXLMCommon.KVCache],
+        state: MLXLMCommon.LMOutput.State?, prefill: MLXLMCommon.PrefillParameters
+    ) throws -> PrepareResult {
         .tokens(input.text)
     }
 

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -314,7 +314,9 @@ private final class StableTransitionLanguageModel: Module, LanguageModel, KVCach
         super.init()
     }
 
-    func prepare(_ input: LMInput, cache: [KVCache], state _: LMOutput.State?, windowSize: Int?)
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    )
         throws -> PrepareResult
     {
         .tokens(input.text)


### PR DESCRIPTION
`LLMModel.prepare` used to chunk the prompt in fixed strides of `prefillStepSize` and hand the TokenIterator the leftover, up to stepSize − 1 tokens, evaluated in one forward at the largest Lk of the whole prefill. That forward is disproportionately expensive. On Qwen3.6-35B-A3B at 32K (warm, Release, M3 Max), a 1024-token chunk in the pipelined loop costs 0.98 s while the 141-token remainder costs 2.94 s. The fix divides the prompt into the fewest equal chunks that respect the ceiling (32 × 997 instead of 31 × 1024 + 141), so no degenerate forward exists. Measured on full production prefill, in-process and ABBA-alternated so thermal drift loads neither arm: 51.0 s → 46.2 s, about 9%; all five ABBA blocks across two runs favor balanced (sign test p = 0.031). Splitting the remainder off instead (140 + 1) measured neutral — the tokens have to be absorbed into the interior of the pipeline.

On outputs: any chunking reorders floating-point accumulation, so both chunkings were probed against the unchunked single forward as reference. Neither is closer to the truth — at 3K and 8K each flips the same single token out of 64, at a reference top-two margin of 0.03 against a median margin of 12.4; at 5K neither flips anything. The old chunking is an approximation of exactly the same magnitude, not a ground truth.

## The API

Following the review discussion, the strategy is now per-request rather than a global, and the `windowSize: Int?` in `LanguageModel.prepare` is replaced by a `PrefillParameters` struct:

- `stepSize` — the per-forward ceiling; `nil` keeps each model's own default.
- `chunking` — `.balanced` (default), `.remainder` (the legacy boundaries, for anyone with pinned outputs), `.unchunked` (the reference computation; quadratic memory, for validation).
- `progress` — a `(processed, total)` callback with the same semantics as mlx-lm's `prompt_progress_callback`, including the terminal `(total, total)`.

Future prefill knobs become additive fields instead of protocol breaks.

The chunked-prefill loop itself lives on the struct: `forEachChunk(total:reserving:defaultStepSize:maximumStepSize:_:)` computes the balanced chunk length and owns the loop's shared obligations — cooperative cancellation between chunks, a per-chunk autorelease pool, and the progress report — so every `prepare()` drives it against its own defaults and caps. This is the honest version of "hoist it so all models benefit": the TokenIterator can't compute the schedule because the nil-`stepSize` default is per-model (512 generic; Gemma3Text's tuned `min(128, slidingWindow)`), and the M-RoPE models can't chunk at all. A side effect worth naming: the cancellation check and pooling previously existed only in the default LLM path; every chunked prefill now has them.

## Per-model adoption

Gemma3Text, Gemma3, Gemma4 (text-only), Idefics3, FastVLM, LFM2VL, Pixtral, Mistral3, and the Qwen3.5 windowed continuation now chunk balanced and report progress (the continuation additionally reserves the final position, so lm_head materializes `[1, 1, vocab]` rather than a full last chunk). Qwen2VL, Qwen25VL, Qwen3VL, GlmOcr, and Paligemma stay single-shot — M-RoPE position lockstep or fused multimodal masks — and fire the terminal progress call. The ~9% is measured on the default path; the other loops get the same arithmetic on the same shape argument, unmeasured.

## Compatibility

`GenerateParameters.prefillStepSize` (from #439) and the inits that took it still work as deprecated forwarders, as does a deprecated `prepare(windowSize:)` method for out-of-tree callers; their deprecation messages note that they forward into the balanced default (`.remainder` restores the legacy boundaries). Out-of-tree `LanguageModel` implementers get a compile error pointing at the new signature. The one silent corner: an out-of-tree `LLMModel` conformer that customized `prepare` with the old signature would fall back to the default implementation — Swift gives no way to diagnose that, hence this note.

## Tests

Chunk-length properties; pinned schedules at the measured operating point (31,885 @ 1024 → 32 near-equal chunks + 1 vs 31 strides + 141), collected from `forEachChunk` itself so the pin holds the shipping code; `.remainder` legacy-boundary reproduction; exact progress sequences through a real `TokenIterator`; and the `.logits`-model progress contract on a tiny Gemma4.
