### PR TITLE
Fix structured ChatSession continuations

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/ToolCallIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/ToolCallIntegrationTests.swift
@@ -94,6 +94,12 @@ struct ToolCallIntegrationTests {
         try await ToolCallTests.qwen35EndToEndGeneration(container: container)
     }
 
+    @Test func qwen35StructuredToolContinuation() async throws {
+        let container = try await models.llmContainer(
+            for: .init(id: IntegrationTestModelIDs.qwen35))
+        try await ChatSessionTests.structuredToolContinuation(container: container)
+    }
+
     @Test func qwen35MultiTool() async throws {
         let container = try await models.llmContainer(
             for: .init(id: IntegrationTestModelIDs.qwen35))

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -257,6 +257,69 @@ public enum ChatSessionTests {
         }
     }
 
+    /// Exercises the structured continuation path used by clients that execute
+    /// tool calls outside `ChatSession` and feed the results back afterward.
+    ///
+    /// Conversation-aware templates must receive the original user query and
+    /// assistant tool call again on the result turn. Rendering only the new
+    /// `.tool` message reproduces the Qwen Jinja "No user query found" failure.
+    public static func structuredToolContinuation(container: LLModelContainer) async throws {
+        let session = ChatSession(
+            container,
+            instructions:
+                "Use the weather tool whenever weather is requested. After receiving its result, answer the user briefly.",
+            generateParameters: GenerateParameters(maxTokens: 150, temperature: 0),
+            additionalContext: ["enable_thinking": false],
+            tools: [weatherToolSchema]
+        )
+
+        var firstPassCalls: [ToolCall] = []
+        for try await generation in session.streamDetails(
+            to: "What's the weather in Tokyo? Use the weather tool.",
+            images: [],
+            videos: [])
+        {
+            if case .toolCall(let call) = generation {
+                firstPassCalls.append(call)
+            }
+        }
+
+        guard let call = firstPassCalls.first else {
+            throw IntegrationTestFailure("Expected the first pass to call get_weather")
+        }
+        try check(
+            call.function.name == "get_weather",
+            "Expected get_weather, got \(call.function.name)")
+
+        var followUpText = ""
+        var followUpCalls: [ToolCall] = []
+        var completion: GenerateCompletionInfo?
+        for try await generation in session.streamDetails(to: [
+            .tool(
+                #"{"location":"Tokyo","temperature_celsius":24,"conditions":"clear"}"#,
+                id: call.id)
+        ]) {
+            switch generation {
+            case .chunk(let text):
+                followUpText += text
+            case .toolCall(let call):
+                followUpCalls.append(call)
+            case .info(let info):
+                completion = info
+            }
+        }
+
+        try check(
+            completion != nil,
+            "Expected structured tool continuation to complete generation")
+        try check(
+            !followUpText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            "Expected a final text response after the tool result")
+        try check(
+            followUpCalls.isEmpty,
+            "Expected the tool result to resolve the request, got another tool call")
+    }
+
     public static func toolInvocation(container: LLModelContainer) async throws {
         struct EmptyInput: Codable {}
 

--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -68,10 +68,23 @@ if !toolResults.isEmpty {
 }
 ```
 
-When a session is initialized with history, the first generation must tokenize
-and prefill that history to create a KV cache. Reuse the same `ChatSession` and
-continue with structured messages to avoid paying that full prefill cost on
-each tool turn.
+When `ChatSession` builds its cache from messages, it retains the structured
+transcript and renders the complete conversation for every continuation, as
+required by conversation-aware chat templates. When the rendered tokens extend
+the tokens already represented by the session's KV cache, only the new suffix
+is prefetched. If a template rewrites an earlier part of the prompt, the session
+rewinds to a verified common prefix when the cache and input can be trimmed
+safely. Otherwise, it rebuilds the cache rather than combining stale model state
+with a mismatched prompt.
+
+The low-level initializers that accept an existing raw KV cache cannot recover
+the messages used to create it. Those initializers preserve fragment-based
+continuation behavior; use the history initializer when a structured
+conversation must be resumed.
+
+When a session is initialized with history, the first generation must prefill
+that history to create a KV cache. Reuse the same `ChatSession` so later tool
+turns can take the suffix-only fast path.
 
 ## VLMs (Vision Language Models)
 

--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -72,10 +72,12 @@ When `ChatSession` builds its cache from messages, it retains the structured
 transcript and renders the complete conversation for every continuation, as
 required by conversation-aware chat templates. When the rendered tokens extend
 the tokens already represented by the session's KV cache, only the new suffix
-is prefetched. If a template rewrites an earlier part of the prompt, the session
-rewinds to a verified common prefix when the cache and input can be trimmed
-safely. Otherwise, it rebuilds the cache rather than combining stale model state
-with a mismatched prompt.
+is prefilled. Both the string-and-role overloads and the structured-message
+overloads use this same retained-conversation and cache-reuse path. If a
+template rewrites an earlier part of the prompt, the session rewinds to a
+verified common prefix when the cache and input can be trimmed safely.
+Otherwise, it rebuilds the cache rather than combining stale model state with a
+mismatched prompt.
 
 The low-level initializers that accept an existing raw KV cache cannot recover
 the messages used to create it. Those initializers preserve fragment-based

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -157,18 +157,19 @@ public final class ChatSession {
         /// cache offset is an invalidated ledger and forces a rebuild.
         var cachedTokens: [Int]
 
+        @discardableResult
         mutating func record(
             _ assistant: AssistantGeneration,
             generatedTokens: [Int],
             cacheOffset: Int?
-        ) {
+        ) -> Bool {
             guard assistant.shouldRecord else {
                 // A cancelled or semantically empty generation has no
                 // assistant turn to replay. Its cache may nevertheless
                 // contain generated or lookahead tokens, so invalidate
                 // the ledger and rebuild from the retained messages.
                 cachedTokens.removeAll()
-                return
+                return false
             }
 
             let cachedTokenCount = cachedTokens.count
@@ -189,6 +190,7 @@ public final class ChatSession {
                 .assistant(
                     assistant.content,
                     toolCalls: assistant.toolCalls.isEmpty ? nil : assistant.toolCalls))
+            return true
         }
     }
 
@@ -745,11 +747,15 @@ public final class ChatSession {
                     // loop can restart on tool calls
                     restart: while !pendingMessages.isEmpty {
                         let templateMessages: [Chat.Message]
+                        let conversationMessageCountBeforePending: Int?
                         if var currentConversation = conversation {
+                            conversationMessageCountBeforePending =
+                                currentConversation.messages.count
                             currentConversation.messages.append(contentsOf: pendingMessages)
                             templateMessages = leadingMessages + currentConversation.messages
                             conversation = currentConversation
                         } else {
+                            conversationMessageCountBeforePending = nil
                             // A cache restored without its transcript cannot be reconciled
                             // against a complete chat template. Preserve the legacy prefix
                             // continuation behavior for this explicitly low-level API.
@@ -1064,10 +1070,20 @@ public final class ChatSession {
                         let generatedTokens = await generation.task.value
 
                         if var currentConversation = conversation {
-                            currentConversation.record(
+                            let recordedAssistant = currentConversation.record(
                                 assistant,
                                 generatedTokens: generatedTokens,
                                 cacheOffset: kvCache.first?.offset)
+                            if !recordedAssistant,
+                                let conversationMessageCountBeforePending
+                            {
+                                // A cancelled or empty generation did not commit an
+                                // assistant turn. Roll back this restart's pending input
+                                // so a later request cannot produce invalid role sequences
+                                // such as user/user on strict chat templates.
+                                currentConversation.messages.removeSubrange(
+                                    conversationMessageCountBeforePending...)
+                            }
                             conversation = currentConversation
                         }
 

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -145,15 +145,97 @@ public struct SpeculativeDecodingConfig: Sendable {
 /// - Note: `ChatSession` is not thread-safe. Each session should be used from a single
 ///   task/thread at a time. The underlying `ModelContainer` handles thread safety for
 ///   model operations.
+/// - Note: A session retains its structured transcript, including referenced media,
+///   until ``clear()`` is called. Long-running VLM sessions should clear or replace
+///   the session when that retained context is no longer needed.
 public final class ChatSession {
 
-    enum Cache {
+    private struct Conversation {
+        var messages: [Chat.Message]
+        /// Exact tokens represented by the main KV cache when its count
+        /// matches the cache offset. An empty value paired with a nonzero
+        /// cache offset is an invalidated ledger and forces a rebuild.
+        var cachedTokens: [Int]
+
+        mutating func record(
+            _ assistant: AssistantGeneration,
+            generatedTokens: [Int],
+            cacheOffset: Int?
+        ) {
+            guard assistant.shouldRecord else {
+                // A cancelled or semantically empty generation has no
+                // assistant turn to replay. Its cache may nevertheless
+                // contain generated or lookahead tokens, so invalidate
+                // the ledger and rebuild from the retained messages.
+                cachedTokens.removeAll()
+                return
+            }
+
+            let cachedTokenCount = cachedTokens.count
+            if let cacheOffset,
+                cacheOffset >= cachedTokenCount,
+                cacheOffset - cachedTokenCount <= generatedTokens.count
+            {
+                cachedTokens.append(
+                    contentsOf: generatedTokens.prefix(cacheOffset - cachedTokenCount))
+            } else {
+                // The iterator/cache relationship could not be proven
+                // (for example, a speculative iterator retained
+                // un-emitted lookahead).
+                cachedTokens.removeAll()
+            }
+
+            messages.append(
+                .assistant(
+                    assistant.content,
+                    toolCalls: assistant.toolCalls.isEmpty ? nil : assistant.toolCalls))
+        }
+    }
+
+    private struct GenerationRun {
+        let stream: AsyncStream<Generation>
+        let task: Task<[Int], Never>
+
+        init(_ pair: (AsyncStream<Generation>, Task<[Int], Never>)) {
+            (stream, task) = pair
+        }
+    }
+
+    private struct AssistantGeneration {
+        var content = ""
+        var toolCalls: [ToolCall] = []
+        var stopReason: GenerateStopReason?
+        var wasTerminatedByConsumer = false
+
+        var shouldRecord: Bool {
+            (!content.isEmpty || !toolCalls.isEmpty)
+                && !wasTerminatedByConsumer
+                && stopReason != .cancelled
+        }
+
+        mutating func consume(_ item: Generation) {
+            if let chunk = item.chunk {
+                content += chunk
+            }
+            if let toolCall = item.toolCall {
+                toolCalls.append(toolCall)
+            }
+            if let info = item.info {
+                stopReason = info.stopReason
+            }
+        }
+    }
+
+    private enum Cache {
         /// `state` is the per-call model state (e.g. M-RoPE rope deltas)
         /// from the last prefill against this cache. It must survive across
         /// turns: without it, a model that anchors positions on carried
         /// state re-derives them from a cold start on the next turn.
         case empty
-        case kvcache([KVCache], draftKVCache: [KVCache]?, state: LMOutput.State?)
+        case kvcache(
+            [KVCache], draftKVCache: [KVCache]?, state: LMOutput.State?,
+            conversation: Conversation?
+        )
         case history([Chat.Message])
     }
 
@@ -321,6 +403,10 @@ public final class ChatSession {
     /// > re-tokenized on each call to ``respond(to:role:images:videos:audios:)`` without matching
     /// > KV state, producing incoherent output.
     ///
+    /// > Important: A raw cache does not carry the structured chat transcript.
+    /// > This initializer therefore preserves fragment-based continuation behavior.
+    /// > Use a history initializer when later turns must re-render the full conversation.
+    ///
     /// - Parameters:
     ///   - model: the ``ModelContainer``
     ///   - instructions: optional system instructions for the session — leave `nil` if the
@@ -346,7 +432,8 @@ public final class ChatSession {
     ) {
         self.model = model
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil, state: nil))
+        self.cache = .init(
+            .kvcache(cache, draftKVCache: nil, state: nil, conversation: nil))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
@@ -366,6 +453,10 @@ public final class ChatSession {
     /// > instructions, do not pass the same `instructions` here — they would be
     /// > re-tokenized on each call to ``respond(to:role:images:videos:audios:)`` without matching
     /// > KV state, producing incoherent output.
+    ///
+    /// > Important: A raw cache does not carry the structured chat transcript.
+    /// > This initializer therefore preserves fragment-based continuation behavior.
+    /// > Use a history initializer when later turns must re-render the full conversation.
     ///
     /// - Parameters:
     ///   - model: the ``ModelContext``
@@ -392,7 +483,8 @@ public final class ChatSession {
     ) {
         self.model = ModelContainer(context: model)
         self.instructions = instructions
-        self.cache = .init(.kvcache(cache, draftKVCache: nil, state: nil))
+        self.cache = .init(
+            .kvcache(cache, draftKVCache: nil, state: nil, conversation: nil))
         self.loadedDraftModel = .init(speculativeDecoding?.draftModel)
         self.processing = processing
         self.generateParameters = generateParameters
@@ -595,9 +687,9 @@ public final class ChatSession {
                     let tokenizer = await model.tokenizer
                     let modelConfiguration = await model.configuration
 
-                    var messages: [Chat.Message] = []
+                    var leadingMessages: [Chat.Message] = []
                     if let instructions {
-                        messages.append(.system(instructions))
+                        leadingMessages.append(.system(instructions))
                     }
 
                     // prepare the cache, if needed.  note:
@@ -623,40 +715,196 @@ public final class ChatSession {
                     // across turns alongside the KV cache; updated after each
                     // prefill and stored back at the end of the turn.
                     var lmState: LMOutput.State?
+                    var conversation: Conversation?
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil, state: nil)
+                        conversation = Conversation(messages: [], cachedTokens: [])
+                        cache = .kvcache(
+                            kvCache, draftKVCache: nil, state: nil, conversation: conversation)
 
-                    case .kvcache(let array, let storedDraftCache, let storedState):
-                        kvCache = array
+                    case .kvcache(
+                        let storedCache, let storedDraftCache, let storedState,
+                        let storedConversation
+                    ):
+                        kvCache = storedCache
                         draftKVCache = storedDraftCache
                         lmState = storedState
+                        conversation = storedConversation
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
                         kvCache = model.newCache(parameters: generateParameters)
-                        cache = .kvcache(kvCache, draftKVCache: nil, state: nil)
-                        messages.append(contentsOf: history)
+                        conversation = Conversation(messages: history, cachedTokens: [])
+                        cache = .kvcache(
+                            kvCache, draftKVCache: nil, state: nil, conversation: conversation)
                     }
 
-                    // prepare the input
-                    messages.append(contentsOf: inputMessages.consume())
+                    var pendingMessages = inputMessages.consume()
 
                     // loop can restart on tool calls
-                    restart: while !messages.isEmpty {
+                    restart: while !pendingMessages.isEmpty {
+                        let templateMessages: [Chat.Message]
+                        if var currentConversation = conversation {
+                            currentConversation.messages.append(contentsOf: pendingMessages)
+                            templateMessages = leadingMessages + currentConversation.messages
+                            conversation = currentConversation
+                        } else {
+                            // A cache restored without its transcript cannot be reconciled
+                            // against a complete chat template. Preserve the legacy prefix
+                            // continuation behavior for this explicitly low-level API.
+                            templateMessages = leadingMessages + pendingMessages
+                        }
+                        let containsNewMedia = pendingMessages.contains {
+                            !$0.images.isEmpty || !$0.videos.isEmpty || !$0.audios.isEmpty
+                        }
+
                         let userInput = UserInput(
-                            chat: messages,
+                            chat: templateMessages,
                             processing: processing,
                             tools: tools, additionalContext: additionalContext)
-                        let input = try await processor.prepare(input: userInput)
-                        messages.removeAll()
+                        let preparedInput = try await processor.prepare(input: userInput)
+                        var input = preparedInput
+                        pendingMessages.removeAll()
+
+                        let speculativeMemoryEvaluation: SpeculativeDecodingMemoryEvaluation?
+                        if let speculativeDecoding,
+                            let memoryPolicy = speculativeDecoding.memoryPolicy,
+                            let draftModelBytes = speculativeDecoding.estimatedDraftModelBytes
+                        {
+                            speculativeMemoryEvaluation = memoryPolicy.evaluate(
+                                mainModelBytes:
+                                    SpeculativeDecodingMemoryPolicy.modelWeightBytes(model),
+                                draftModelBytes: draftModelBytes)
+                        } else {
+                            speculativeMemoryEvaluation = nil
+                        }
+                        let willFallBackBeforeLoadingDraft =
+                            speculativeMemoryEvaluation.map {
+                                !$0.shouldUseSpeculativeDecoding && $0.action != .fail
+                            } ?? false
+
+                        var reusedMainCacheWithoutDraft = false
+                        if var currentConversation = conversation {
+                            let fullTokenIds = input.text.tokens.asArray(Int.self)
+                            let cachedTokenIds = currentConversation.cachedTokens
+                            let cacheOffset = kvCache.first?.offset
+                            let allMainCachesAreAligned =
+                                !kvCache.isEmpty
+                                && kvCache.allSatisfy { $0.offset == cachedTokenIds.count }
+                            let draftCacheIsAligned: Bool
+                            let allDraftCachesAreAligned: Bool
+                            if let draftKVCache {
+                                draftCacheIsAligned =
+                                    draftKVCache.first?.offset == cachedTokenIds.count
+                                allDraftCachesAreAligned =
+                                    !draftKVCache.isEmpty
+                                    && draftKVCache.allSatisfy {
+                                        $0.offset == cachedTokenIds.count
+                                    }
+                            } else {
+                                // Tentatively reuse the main cache. If speculative
+                                // decoding is admitted below, both caches are rebuilt
+                                // from `preparedInput`; a fallback can keep this suffix.
+                                draftCacheIsAligned = true
+                                allDraftCachesAreAligned = true
+                            }
+                            let extendsCachedPrefix =
+                                cacheOffset == cachedTokenIds.count
+                                && draftCacheIsAligned
+                                && fullTokenIds.starts(with: cachedTokenIds)
+
+                            if extendsCachedPrefix && !containsNewMedia
+                                && fullTokenIds.count > cachedTokenIds.count
+                                && input.text.mask == nil
+                            {
+                                let suffix = Array(fullTokenIds.dropFirst(cachedTokenIds.count))
+                                input = LMInput(tokens: MLXArray(suffix))
+                                reusedMainCacheWithoutDraft =
+                                    speculativeDecoding != nil
+                                    && !willFallBackBeforeLoadingDraft
+                                    && draftKVCache == nil
+                                    && !cachedTokenIds.isEmpty
+                            } else if cacheOffset != 0 {
+                                let commonPrefixCount = zip(fullTokenIds, cachedTokenIds)
+                                    .prefix { $0 == $1 }
+                                    .count
+                                let trimCount = cachedTokenIds.count - commonPrefixCount
+                                let hasPreparedMedia =
+                                    input.image != nil || input.video != nil || input.audio != nil
+                                let canReuseCommonPrefix =
+                                    commonPrefixCount > 0
+                                    && commonPrefixCount < fullTokenIds.count
+                                    && trimCount > 0
+                                    && allMainCachesAreAligned
+                                    && allDraftCachesAreAligned
+                                    && !containsNewMedia
+                                    && !hasPreparedMedia
+                                    && input.text.mask == nil
+                                    && lmState == nil
+                                    && canTrimPromptCache(kvCache)
+                                    && (draftKVCache.map(canTrimPromptCache) ?? true)
+
+                                if canReuseCommonPrefix {
+                                    let mainTrimmed = trimPromptCache(
+                                        kvCache, numTokens: trimCount)
+                                    let draftTrimmed = draftKVCache.map {
+                                        trimPromptCache($0, numTokens: trimCount)
+                                    }
+                                    let mainTrimIsAligned =
+                                        mainTrimmed == trimCount
+                                        && kvCache.allSatisfy {
+                                            $0.offset == commonPrefixCount
+                                        }
+                                    let draftTrimIsAligned: Bool
+                                    if let draftKVCache {
+                                        draftTrimIsAligned =
+                                            draftTrimmed == trimCount
+                                            && draftKVCache.allSatisfy {
+                                                $0.offset == commonPrefixCount
+                                            }
+                                    } else {
+                                        draftTrimIsAligned = true
+                                    }
+
+                                    if mainTrimIsAligned && draftTrimIsAligned {
+                                        input = LMInput(
+                                            tokens: MLXArray(
+                                                Array(
+                                                    fullTokenIds.dropFirst(
+                                                        commonPrefixCount))))
+                                        reusedMainCacheWithoutDraft =
+                                            speculativeDecoding != nil
+                                            && !willFallBackBeforeLoadingDraft
+                                            && draftKVCache == nil
+                                    } else {
+                                        kvCache = model.newCache(
+                                            parameters: generateParameters)
+                                        draftKVCache = nil
+                                        lmState = nil
+                                    }
+                                } else {
+                                    // The template changed an already-cached portion of the
+                                    // transcript, or this input carries state/media that cannot
+                                    // be rewound safely. Rebuild rather than combining a
+                                    // mismatched prompt with stale model state.
+                                    kvCache = model.newCache(parameters: generateParameters)
+                                    draftKVCache = nil
+                                    lmState = nil
+                                }
+                            }
+
+                            currentConversation.cachedTokens = fullTokenIds
+                            conversation = currentConversation
+                        }
+
+                        guard input.text.tokens.size > 0 else {
+                            throw ChatSessionError.emptyPreparedInput
+                        }
 
                         // Select the token iterator based on speculative decoding configuration.
-                        let (genStream, genTask): (AsyncStream<Generation>, Task<Void, Never>)
-                        func defaultGeneration() throws -> (
-                            AsyncStream<Generation>, Task<Void, Never>
-                        ) {
+                        let generation: GenerationRun
+                        func defaultGeneration() throws -> GenerationRun {
                             // Seed the iterator with the carried state; read
                             // back the post-prefill state (prefill runs in the
                             // iterator's init, and the rope delta does not
@@ -668,27 +916,19 @@ public final class ChatSession {
                                 parameters: generateParameters)
                             lmState = iterator.state
 
-                            return MLXLMCommon.generateTask(
-                                promptTokenCount: input.text.tokens.size,
-                                modelConfiguration: modelConfiguration,
-                                tokenizer: tokenizer,
-                                iterator: iterator,
-                                tools: tools
+                            return GenerationRun(
+                                MLXLMCommon.generateTaskRecordingTokens(
+                                    promptTokenCount: input.text.tokens.size,
+                                    modelConfiguration: modelConfiguration,
+                                    tokenizer: tokenizer,
+                                    iterator: iterator,
+                                    tools: tools)
                             )
                         }
 
                         if let speculativeDecoding {
                             var shouldFallBackBeforeLoadingDraft = false
-                            if let memoryPolicy = speculativeDecoding.memoryPolicy,
-                                let draftModelBytes =
-                                    speculativeDecoding.estimatedDraftModelBytes
-                            {
-                                let memoryEvaluation = memoryPolicy.evaluate(
-                                    mainModelBytes:
-                                        SpeculativeDecodingMemoryPolicy
-                                        .modelWeightBytes(model),
-                                    draftModelBytes: draftModelBytes
-                                )
+                            if let memoryEvaluation = speculativeMemoryEvaluation {
                                 if !memoryEvaluation.shouldUseSpeculativeDecoding {
                                     if memoryEvaluation.action == .fail {
                                         throw SpeculativeDecodingMemoryError(
@@ -700,7 +940,7 @@ public final class ChatSession {
                             }
 
                             if shouldFallBackBeforeLoadingDraft {
-                                (genStream, genTask) = try defaultGeneration()
+                                generation = try defaultGeneration()
                             } else {
                                 let cachedDraftContainer = await loadedDraftModel.read { $0 }
                                 let draftContainer: ModelContainer
@@ -710,15 +950,13 @@ public final class ChatSession {
                                     draftContainer = try await speculativeDecoding.loadDraftModel()
                                 }
 
-                                // Extract the draft model from its container (same pattern as the main model).
                                 let draftModel = await draftContainer.perform { context in
                                     SendableBox(context.model)
                                 }.consume()
-
                                 let memoryEvaluation = speculativeDecoding.memoryPolicy?.evaluate(
                                     mainModel: model,
-                                    draftModel: draftModel
-                                )
+                                    draftModel: draftModel)
+
                                 if let memoryEvaluation,
                                     !memoryEvaluation.shouldUseSpeculativeDecoding
                                 {
@@ -727,7 +965,7 @@ public final class ChatSession {
                                             evaluation: memoryEvaluation)
                                     }
 
-                                    (genStream, genTask) = try defaultGeneration()
+                                    generation = try defaultGeneration()
                                 } else {
                                     if cachedDraftContainer == nil {
                                         await loadedDraftModel.update { storedDraftModel in
@@ -737,15 +975,31 @@ public final class ChatSession {
                                         }
                                     }
 
+                                    if reusedMainCacheWithoutDraft {
+                                        // The main cache took a suffix-only path, but
+                                        // speculation was admitted without a matching
+                                        // draft cache. Rebuild both from the full input.
+                                        kvCache = model.newCache(
+                                            parameters: generateParameters)
+                                        draftKVCache = nil
+                                        lmState = nil
+                                        input = preparedInput
+                                    }
+
                                     // Allocate the draft KV cache once and reuse it across turns,
                                     // exactly like the main model's KV cache.
-                                    if draftKVCache == nil {
-                                        draftKVCache = draftModel.newCache(
+                                    let draftCache: [KVCache]
+                                    if let existingDraftCache = draftKVCache {
+                                        draftCache = existingDraftCache
+                                    } else {
+                                        let newDraftCache = draftModel.newCache(
                                             parameters: generateParameters)
+                                        draftKVCache = newDraftCache
                                         cache = .kvcache(
-                                            kvCache, draftKVCache: draftKVCache, state: lmState)
+                                            kvCache, draftKVCache: newDraftCache, state: lmState,
+                                            conversation: conversation)
+                                        draftCache = newDraftCache
                                     }
-                                    let draftCache = draftKVCache!
 
                                     let iterator = try SpeculativeTokenIterator(
                                         input: input,
@@ -757,23 +1011,26 @@ public final class ChatSession {
                                         numDraftTokens: speculativeDecoding.numDraftTokens
                                     )
 
-                                    (genStream, genTask) = MLXLMCommon.generateTask(
-                                        promptTokenCount: input.text.tokens.size,
-                                        modelConfiguration: modelConfiguration,
-                                        tokenizer: tokenizer,
-                                        iterator: iterator,
-                                        tools: tools
-                                    )
+                                    generation = GenerationRun(
+                                        MLXLMCommon.generateTaskRecordingTokens(
+                                            promptTokenCount: input.text.tokens.size,
+                                            modelConfiguration: modelConfiguration,
+                                            tokenizer: tokenizer,
+                                            iterator: iterator,
+                                            tools: tools))
                                 }
                             }
                         } else {
                             // Standard path with no speculative decoding.
-                            (genStream, genTask) = try defaultGeneration()
+                            generation = try defaultGeneration()
                         }
 
                         var pendingToolCalls: [ToolCall] = []
+                        var assistant = AssistantGeneration()
 
-                        for await item in genStream {
+                        for await item in generation.stream {
+                            assistant.consume(item)
+
                             // collect tool calls for dispatch; if no
                             // toolDispatch the caller handles them via
                             // the transform (streamDetails path)
@@ -781,7 +1038,8 @@ public final class ChatSession {
                                 pendingToolCalls.append(toolCall)
                             } else if let value = transform(item) {
                                 if case .terminated = continuation.yield(value) {
-                                    genTask.cancel()
+                                    assistant.wasTerminatedByConsumer = true
+                                    generation.task.cancel()
                                     break
                                 }
                             }
@@ -789,29 +1047,41 @@ public final class ChatSession {
 
                         // The generation task is unstructured, so cancellation of
                         // this task (stream onTermination) does not propagate to
-                        // it. Without an explicit cancel, `await genTask.value`
+                        // it. Without an explicit cancel, awaiting its value
                         // would wait for the FULL generation while holding the
                         // cache lock — deadlocking the session's next call (e.g.
                         // a caller that cancels mid-stream and immediately asks
                         // again). The generate loop checks Task.isCancelled per
                         // token, so this stops it promptly.
                         if Task.isCancelled {
-                            genTask.cancel()
+                            assistant.wasTerminatedByConsumer = true
+                            generation.task.cancel()
                         }
 
                         // wait for the task to complete -- this is important in
                         // the case where we broke the loop early as the generation
                         // work may continue (briefly) and use the KVCache
-                        await genTask.value
+                        let generatedTokens = await generation.task.value
+
+                        if var currentConversation = conversation {
+                            currentConversation.record(
+                                assistant,
+                                generatedTokens: generatedTokens,
+                                cacheOffset: kvCache.first?.offset)
+                            conversation = currentConversation
+                        }
 
                         // dispatch all tool calls from this generation pass
                         if let toolDispatch, !pendingToolCalls.isEmpty,
                             !Task.isCancelled
                         {
-                            messages.append(.assistant("", toolCalls: pendingToolCalls))
+                            if conversation == nil {
+                                pendingMessages.append(
+                                    .assistant("", toolCalls: pendingToolCalls))
+                            }
                             for toolCall in pendingToolCalls {
                                 let toolResult = try await toolDispatch(toolCall)
-                                messages.append(.tool(toolResult, id: toolCall.id))
+                                pendingMessages.append(.tool(toolResult, id: toolCall.id))
                             }
                             continue restart
                         }
@@ -819,7 +1089,9 @@ public final class ChatSession {
 
                     // Store the carried state back alongside the KV cache so
                     // the next turn resumes with correct position anchoring.
-                    cache = .kvcache(kvCache, draftKVCache: draftKVCache, state: lmState)
+                    cache = .kvcache(
+                        kvCache, draftKVCache: draftKVCache, state: lmState,
+                        conversation: conversation)
 
                     continuation.finish()
                 }
@@ -880,7 +1152,7 @@ public final class ChatSession {
     {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _, _):
+            case .kvcache(let cache, _, _, _):
                 return try await body(cache)
             default:
                 return try await body(nil)
@@ -893,13 +1165,19 @@ public final class ChatSession {
     /// Use one of the initializers that accept a `cache` parameter together with
     /// ``loadPromptCache(url:)`` to restore the saved cache in a future session.
     ///
+    /// > Important: This saves raw KV state only. It does not save the structured
+    /// > transcript retained by `ChatSession`. A restored raw cache therefore uses
+    /// > fragment-based continuation and is not suitable for conversation-aware
+    /// > structured tool continuations. Persist the messages separately and restore
+    /// > them with a history initializer when the transcript is required.
+    ///
     /// - Parameter url: the file URL to write the cache to
     /// - Throws: ``ChatSessionError/noCacheAvailable`` if no generation has occurred yet,
     ///   or any error thrown by the underlying file write
     public func saveCache(to url: URL) async throws {
         try await cache.read { cache in
             switch cache {
-            case .kvcache(let cache, _, _):
+            case .kvcache(let cache, _, _, _):
                 try savePromptCache(url: url, cache: cache)
             default:
                 throw ChatSessionError.noCacheAvailable
@@ -912,8 +1190,15 @@ public final class ChatSession {
 public enum ChatSessionError: LocalizedError {
     /// ``ChatSession/saveCache(to:)`` was called before any generation occurred.
     case noCacheAvailable
+    /// The processor produced no tokens for generation.
+    case emptyPreparedInput
 
     public var errorDescription: String? {
-        "No KV cache is available. Call respond() or streamResponse() before saveCache(to:)."
+        switch self {
+        case .noCacheAvailable:
+            "No KV cache is available. Call respond() or streamResponse() before saveCache(to:)."
+        case .emptyPreparedInput:
+            "The chat template produced no uncached tokens for generation."
+        }
     }
 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1619,6 +1619,32 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
     )
 }
 
+/// Internal variant used by `ChatSession` to keep its token-prefix record in
+/// lockstep with the KV cache.
+func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
+    promptTokenCount: Int,
+    modelConfiguration: ModelConfiguration,
+    tokenizer: Tokenizer,
+    iterator: consuming TOKEN,
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    tools: [[String: any Sendable]]? = nil
+) -> (AsyncStream<Generation>, Task<[Int], Never>) {
+    generateLoopTask(
+        promptTokenCount: promptTokenCount,
+        modelConfiguration: modelConfiguration,
+        tokenizer: tokenizer,
+        iterator: iterator,
+        wiredMemoryTicket: wiredMemoryTicket,
+        tokenCollector: RecordingGeneratedTokens(),
+        handler: TextToolTokenLoopHandler(
+            tokenizer: tokenizer,
+            stopStrings: modelConfiguration.effectiveStopStrings,
+            format: modelConfiguration.toolCallFormat ?? .json,
+            tools: tools
+        )
+    )
+}
+
 /// Generates raw token IDs asynchronously using the provided language model input, parameters, and context.
 ///
 /// This is similar to `generate(input:cache:parameters:context:)`, but yields raw token IDs instead of decoded text/tool calls.
@@ -1864,6 +1890,30 @@ public func generateTokenTask(
     )
 }
 
+private protocol GeneratedTokenCollector: Sendable {
+    associatedtype Result: Sendable
+
+    mutating func record(_ token: Int)
+    consuming func result() -> Result
+}
+
+private struct IgnoringGeneratedTokens: GeneratedTokenCollector {
+    mutating func record(_ token: Int) {}
+    consuming func result() {}
+}
+
+private struct RecordingGeneratedTokens: GeneratedTokenCollector {
+    private var tokens: [Int] = []
+
+    mutating func record(_ token: Int) {
+        tokens.append(token)
+    }
+
+    consuming func result() -> [Int] {
+        tokens
+    }
+}
+
 private func generateLoopTask<Handler: TokenLoopHandler>(
     promptTokenCount: Int,
     modelConfiguration: ModelConfiguration,
@@ -1873,17 +1923,41 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
     includeStopToken: Bool = false,
     handler: consuming Handler
 ) -> (AsyncStream<Handler.Output>, Task<Void, Never>) {
+    generateLoopTask(
+        promptTokenCount: promptTokenCount,
+        modelConfiguration: modelConfiguration,
+        tokenizer: tokenizer,
+        iterator: iterator,
+        wiredMemoryTicket: wiredMemoryTicket,
+        includeStopToken: includeStopToken,
+        tokenCollector: IgnoringGeneratedTokens(),
+        handler: handler)
+}
 
+private func generateLoopTask<
+    Handler: TokenLoopHandler, Collector: GeneratedTokenCollector
+>(
+    promptTokenCount: Int,
+    modelConfiguration: ModelConfiguration,
+    tokenizer: Tokenizer,
+    iterator: consuming any TokenIteratorProtocol,
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    includeStopToken: Bool = false,
+    tokenCollector: consuming Collector,
+    handler: consuming Handler
+) -> (AsyncStream<Handler.Output>, Task<Collector.Result, Never>) {
     let (stream, continuation) = AsyncStream<Handler.Output>.makeStream()
 
     let iterator = SendableBox(iterator)
     let handler = SendableBox(handler)
+    let tokenCollector = consume tokenCollector
 
     // Launch a Task to perform iteration asynchronously.
     let task = Task {
         let performIteration = {
             var iterator = iterator.consume()
             var handler = handler.consume()
+            var tokenCollector = tokenCollector
 
             var start = Date.timeIntervalSinceReferenceDate
             var promptTime: TimeInterval = 0
@@ -1904,6 +1978,7 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             // settles any in-flight evaluation at the end of the task body.
             tokenLoop: while !Task.isCancelled {
                 guard let token = autoreleasepool(invoking: { iterator.next() }) else { break }
+                tokenCollector.record(token)
 
                 if promptTime == 0 {
                     let now = Date.timeIntervalSinceReferenceDate
@@ -1979,14 +2054,16 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
 
             // Finalize the stream
             continuation.finish()
+
+            return tokenCollector.result()
         }
 
         if let ticket = wiredMemoryTicket {
-            await WiredMemoryTicket.withWiredLimit(ticket) {
+            return await WiredMemoryTicket.withWiredLimit(ticket) {
                 performIteration()
             }
         } else {
-            performIteration()
+            return performIteration()
         }
     }
 

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -363,7 +363,7 @@ public class ChatSessionTests: XCTestCase {
         XCTAssertFalse(calls[1].contains { $0.content == "first instruction" })
     }
 
-    func testEmptyGenerationDoesNotAppendAssistantMessage() async throws {
+    func testEmptyGenerationRollsBackIncompleteTurn() async throws {
         let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
         let processor = TestInputProcessor(
             tokenizer: TestTokenizer(),
@@ -386,10 +386,11 @@ public class ChatSessionTests: XCTestCase {
 
         XCTAssertEqual(calls.count, 2)
         XCTAssertEqual(calls[0].map(\.role), [.user])
-        XCTAssertEqual(calls[1].map(\.role), [.user, .user])
+        XCTAssertEqual(calls[1].map(\.role), [.user])
+        XCTAssertEqual(calls[1].first?.content, "second question")
     }
 
-    func testInterruptedGenerationDoesNotAppendPartialAssistantMessage() async throws {
+    func testInterruptedGenerationRollsBackIncompleteTurn() async throws {
         let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
         let processor = TestInputProcessor(
             tokenizer: TestTokenizer(),
@@ -415,7 +416,8 @@ public class ChatSessionTests: XCTestCase {
 
         XCTAssertEqual(calls.count, 2)
         XCTAssertEqual(calls[0].map(\.role), [.user])
-        XCTAssertEqual(calls[1].map(\.role), [.user, .user])
+        XCTAssertEqual(calls[1].map(\.role), [.user])
+        XCTAssertEqual(calls[1].first?.content, "second question")
     }
 
     func testEmptyPreparedInputThrowsClearError() async throws {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -479,7 +479,7 @@ public class ChatSessionTests: XCTestCase {
             history.map(\.role) + [.tool, .assistant, .tool, .assistant, .user])
     }
 
-    func testCompleteTranscriptContinuationPrefillsOnlyUncachedSuffix() async throws {
+    func testLegacyStringContinuationPrefillsOnlyUncachedSuffix() async throws {
         let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
         var lengthIterator = renderedLengths.makeAsyncIterator()
         let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
@@ -497,6 +497,38 @@ public class ChatSessionTests: XCTestCase {
 
         var completionInfo: GenerateCompletionInfo?
         for try await item in session.streamDetails(to: "second") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+
+        let info = try XCTUnwrap(completionInfo)
+        let secondRenderedLength = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(secondRenderedLength)
+        XCTAssertLessThan(info.promptTokenCount, fullSecondPromptLength)
+        XCTAssertEqual(
+            info.promptTokenCount,
+            fullSecondPromptLength - firstPromptLength - 3)
+    }
+
+    func testStructuredContinuationPrefillsOnlyUncachedSuffix() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(to: [.user("first")])
+        let firstRenderedLength = await lengthIterator.next()
+        let firstPromptLength = try XCTUnwrap(firstRenderedLength)
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: [.user("second")]) {
             if let info = item.info {
                 completionInfo = info
             }

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -27,6 +27,167 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
+    /// Produces a transcript token stream where a rendered follow-up is an
+    /// exact extension of the prompt and generated tokens from the prior turn.
+    private struct PrefixPreservingTokenizer: Tokenizer {
+        let renderedLengthContinuation: AsyncStream<Int>.Continuation
+        var rewritesPrefixOnContinuation = false
+        var rewritesCachedTailOnContinuation = false
+
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var unknownToken: String? = nil
+        var eosTokenId: Int? { 101 }
+        var unknownTokenId: Int? { 102 }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            text.unicodeScalars.map { scalar in
+                if (0xE000 ..< 0xE064).contains(Int(scalar.value)) {
+                    return Int(scalar.value) - 0xE000
+                }
+                return Int(scalar.value) % 80 + 1
+            }
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            String(
+                String.UnicodeScalarView(
+                    tokenIds.compactMap { UnicodeScalar(0xE000 + $0) }))
+        }
+
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? {
+            UnicodeScalar(0xE000 + id).map(String.init)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            var tokens: [Int] = []
+            for message in messages {
+                let role = message["role"] as? String
+                let content = message["content"] as? String ?? ""
+                switch role {
+                case "system":
+                    tokens.append(96)
+                case "user":
+                    tokens.append(97)
+                case "tool":
+                    tokens.append(98)
+                case "assistant":
+                    tokens.append(94)
+                default:
+                    tokens.append(99)
+                }
+                tokens.append(contentsOf: encode(text: content, addSpecialTokens: false))
+                if role != "assistant" {
+                    tokens.append(95)
+                }
+            }
+            tokens.append(94)  // assistant generation marker
+            if rewritesPrefixOnContinuation {
+                tokens.insert(messages.count > 1 ? 93 : 92, at: 0)
+            }
+            if rewritesCachedTailOnContinuation, let marker = tokens.firstIndex(of: 94) {
+                tokens[marker] = messages.count > 1 ? 93 : 92
+            }
+
+            renderedLengthContinuation.yield(tokens.count)
+            return tokens
+        }
+    }
+
+    private struct MediaAwareInputProcessor: UserInputProcessor {
+        let tokenizer: Tokenizer
+        let configuration = ModelConfiguration(id: "test")
+        let messageGenerator = DefaultMessageGenerator()
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = messageGenerator.generate(from: input)
+            let tokens = try tokenizer.applyChatTemplate(
+                messages: messages,
+                tools: input.tools,
+                additionalContext: input.additionalContext)
+            let image =
+                input.images.isEmpty
+                ? nil : LMInput.ProcessedImage(pixels: MLXArray([Float(0)]))
+            return LMInput(text: .init(tokens: MLXArray(tokens)), image: image)
+        }
+    }
+
+    private struct MaskedInputProcessor: UserInputProcessor {
+        let tokenizer: Tokenizer
+        let configuration = ModelConfiguration(id: "test")
+        let messageGenerator = DefaultMessageGenerator()
+
+        func prepare(input: UserInput) throws -> LMInput {
+            let messages = messageGenerator.generate(from: input)
+            let tokens = try tokenizer.applyChatTemplate(
+                messages: messages,
+                tools: input.tools,
+                additionalContext: input.additionalContext)
+            let mask = MLXArray(Array(repeating: 1, count: tokens.count))
+                .reshaped(1, tokens.count)
+            return LMInput(text: .init(tokens: MLXArray(tokens), mask: mask))
+        }
+    }
+
+    /// The synthetic text model does not consume attention masks itself.
+    /// Strip the mask only after `ChatSession` has made its cache-reuse
+    /// decision so the regression test can exercise that decision with a
+    /// valid masked processor input.
+    private final class MaskTolerantLanguageModel: Module, LanguageModel {
+        let base: any LanguageModel
+
+        init(_ base: any LanguageModel) {
+            self.base = base
+            super.init()
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, windowSize: Int?
+        ) throws -> PrepareResult {
+            try base.prepare(
+                LMInput(tokens: input.text.tokens),
+                cache: cache,
+                state: state,
+                windowSize: windowSize)
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            base(input, cache: cache, state: state)
+        }
+
+        func newCache(parameters: GenerateParameters?) -> [KVCache] {
+            base.newCache(parameters: parameters)
+        }
+    }
+
+    private struct EmptyChatTemplateTokenizer: Tokenizer {
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var unknownToken: String? = nil
+        var eosTokenId: Int? { 101 }
+        var unknownTokenId: Int? { 102 }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            []
+        }
+    }
+
     private struct UnexpectedDraftModelLoadError: Error {}
 
     private actor DraftModelLoadCounter {
@@ -41,7 +202,11 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
-    private static func makeModel(processor: TestInputProcessor = TestInputProcessor())
+    private static func makeModel(
+        processor: any UserInputProcessor,
+        configuration: ModelConfiguration,
+        tokenizer: any Tokenizer
+    )
         -> ModelContext
     {
         let config = Gemma3TextConfiguration(
@@ -62,14 +227,55 @@ public class ChatSessionTests: XCTestCase {
         eval(model)
 
         return .init(
-            configuration: processor.configuration,
+            configuration: configuration,
             model: model,
             processor: processor,
+            tokenizer: tokenizer)
+    }
+
+    private static func makeModel(processor: TestInputProcessor = TestInputProcessor())
+        -> ModelContext
+    {
+        makeModel(
+            processor: processor,
+            configuration: processor.configuration,
             tokenizer: processor.tokenizer)
     }
 
     private func model(processor: TestInputProcessor = TestInputProcessor()) -> ModelContext {
         Self.makeModel(processor: processor)
+    }
+
+    private func model(processor: MediaAwareInputProcessor) -> ModelContext {
+        Self.makeModel(
+            processor: processor,
+            configuration: processor.configuration,
+            tokenizer: processor.tokenizer)
+    }
+
+    private func model(processor: MaskedInputProcessor) -> ModelContext {
+        var context = Self.makeModel(
+            processor: processor,
+            configuration: processor.configuration,
+            tokenizer: processor.tokenizer)
+        context.model = MaskTolerantLanguageModel(context.model)
+        return context
+    }
+
+    private func collectGeneration(
+        _ stream: AsyncThrowingStream<Generation, Error>
+    ) async throws -> (text: String, info: GenerateCompletionInfo) {
+        var text = ""
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in stream {
+            if let chunk = item.chunk {
+                text += chunk
+            }
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+        return (text, try XCTUnwrap(completionInfo))
     }
 
     private let generationParameters = GenerateParameters(maxTokens: 50)
@@ -128,7 +334,109 @@ public class ChatSessionTests: XCTestCase {
         XCTAssertGreaterThan(result.count, targetLength, result)
     }
 
-    func testStructuredContinuationAvoidsReplayingHistoryAcrossToolTurns() async throws {
+    func testChangingInstructionsUpdatesRetainedConversation() async throws {
+        let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: TestTokenizer(),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: RecordingMessageGenerator(continuation: continuation))
+        let session = ChatSession(
+            model(processor: processor),
+            instructions: "first instruction",
+            generateParameters: GenerateParameters(maxTokens: 1))
+
+        _ = try await session.respond(to: "first question")
+        session.instructions = "replacement instruction"
+        _ = try await session.respond(to: "second question")
+        continuation.finish()
+
+        var calls: [[RecordedMessage]] = []
+        for await call in recordedMessages {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls[0].map(\.role), [.system, .user])
+        XCTAssertEqual(calls[0].first?.content, "first instruction")
+        XCTAssertEqual(calls[1].map(\.role), [.system, .user, .assistant, .user])
+        XCTAssertEqual(calls[1].first?.content, "replacement instruction")
+        XCTAssertFalse(calls[1].contains { $0.content == "first instruction" })
+    }
+
+    func testEmptyGenerationDoesNotAppendAssistantMessage() async throws {
+        let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: TestTokenizer(),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: RecordingMessageGenerator(continuation: continuation))
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 0))
+
+        let firstResponse = try await session.respond(to: "first question")
+        let secondResponse = try await session.respond(to: "second question")
+        XCTAssertEqual(firstResponse, "")
+        XCTAssertEqual(secondResponse, "")
+        continuation.finish()
+
+        var calls: [[RecordedMessage]] = []
+        for await call in recordedMessages {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls[0].map(\.role), [.user])
+        XCTAssertEqual(calls[1].map(\.role), [.user, .user])
+    }
+
+    func testInterruptedGenerationDoesNotAppendPartialAssistantMessage() async throws {
+        let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let processor = TestInputProcessor(
+            tokenizer: TestTokenizer(),
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: RecordingMessageGenerator(continuation: continuation))
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 50))
+
+        for try await _ in session.streamResponse(to: "first question") {
+            break
+        }
+        await session.synchronize()
+
+        session.generateParameters = GenerateParameters(maxTokens: 1)
+        _ = try await session.respond(to: "second question")
+        continuation.finish()
+
+        var calls: [[RecordedMessage]] = []
+        for await call in recordedMessages {
+            calls.append(call)
+        }
+
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls[0].map(\.role), [.user])
+        XCTAssertEqual(calls[1].map(\.role), [.user, .user])
+    }
+
+    func testEmptyPreparedInputThrowsClearError() async throws {
+        let tokenizer = EmptyChatTemplateTokenizer()
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 1))
+
+        do {
+            _ = try await session.respond(to: "ignored")
+            XCTFail("expected ChatSessionError.emptyPreparedInput")
+        } catch ChatSessionError.emptyPreparedInput {
+            // expected
+        }
+    }
+
+    func testStructuredContinuationRendersCompleteTranscriptAcrossToolTurns() async throws {
         let (recordedMessages, continuation) = AsyncStream<[RecordedMessage]>.makeStream()
         let processor = TestInputProcessor(
             tokenizer: TestTokenizer(),
@@ -160,16 +468,200 @@ public class ChatSessionTests: XCTestCase {
             calls.append(call)
         }
 
-        XCTAssertEqual(calls.map(\.count), [history.count + 1, 1, 1])
+        XCTAssertEqual(
+            calls.map(\.count), [history.count + 1, history.count + 3, history.count + 5])
         XCTAssertEqual(calls[0].map(\.role), history.map(\.role) + [.tool])
-        XCTAssertEqual(calls[1].map(\.role), [.tool])
-        XCTAssertEqual(calls[2].map(\.role), [.user])
+        XCTAssertEqual(
+            calls[1].map(\.role),
+            history.map(\.role) + [.tool, .assistant, .tool])
+        XCTAssertEqual(
+            calls[2].map(\.role),
+            history.map(\.role) + [.tool, .assistant, .tool, .assistant, .user])
+    }
 
-        let actualPreparedMessageCount = calls.reduce(0) { $0 + $1.count }
-        let replayedHistoryPreparedMessageCount = continuations.indices.reduce(0) {
-            $0 + history.count + $1 + 1
+    func testCompleteTranscriptContinuationPrefillsOnlyUncachedSuffix() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(to: "first")
+        let firstRenderedLength = await lengthIterator.next()
+        let firstPromptLength = try XCTUnwrap(firstRenderedLength)
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "second") {
+            if let info = item.info {
+                completionInfo = info
+            }
         }
-        XCTAssertLessThan(actualPreparedMessageCount, replayedHistoryPreparedMessageCount)
+
+        let info = try XCTUnwrap(completionInfo)
+        let secondRenderedLength = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(secondRenderedLength)
+        XCTAssertLessThan(info.promptTokenCount, fullSecondPromptLength)
+        XCTAssertEqual(
+            info.promptTokenCount,
+            fullSecondPromptLength - firstPromptLength - 3)
+    }
+
+    func testExactPrefixReuseRebuildsWhenPreparedInputHasMask() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MaskedInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(to: "first")
+        _ = await lengthIterator.next()
+
+        let second = try await collectGeneration(session.streamDetails(to: "second"))
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+
+        XCTAssertEqual(second.info.promptTokenCount, secondRenderedLength)
+    }
+
+    func testContinuationRebuildsCacheWhenTemplateRewritesPrefix() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: continuation,
+            rewritesPrefixOnContinuation: true)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(to: "first")
+        _ = await lengthIterator.next()
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "second") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+
+        let secondRenderedLength = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(secondRenderedLength)
+        XCTAssertEqual(completionInfo?.promptTokenCount, fullSecondPromptLength)
+    }
+
+    func testContinuationTrimsCacheToLongestCommonPrefix() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: continuation,
+            rewritesCachedTailOnContinuation: true)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(to: "first")
+        let firstRenderedLengthValue = await lengthIterator.next()
+        let firstRenderedLength = try XCTUnwrap(firstRenderedLengthValue)
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "second") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+
+        let fullSecondPromptLengthValue = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(fullSecondPromptLengthValue)
+        let expectedCommonPrefixLength = firstRenderedLength - 1
+        XCTAssertEqual(
+            completionInfo?.promptTokenCount,
+            fullSecondPromptLength - expectedCommonPrefixLength)
+        XCTAssertLessThan(completionInfo?.promptTokenCount ?? .max, fullSecondPromptLength)
+    }
+
+    func testHistoricalMediaReusesSuffixButNewMediaRebuildsCache() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        let firstRenderedLengthValue = await lengthIterator.next()
+        let firstRenderedLength = try XCTUnwrap(firstRenderedLengthValue)
+
+        var textFollowUpInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "describe it") {
+            if let info = item.info {
+                textFollowUpInfo = info
+            }
+        }
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+        XCTAssertEqual(
+            textFollowUpInfo?.promptTokenCount,
+            secondRenderedLength - firstRenderedLength - 3)
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+        XCTAssertEqual(newMediaInfo?.promptTokenCount, thirdRenderedLength)
+    }
+
+    func testLongestCommonPrefixTrimmingFallsBackForHistoricalMedia() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: continuation,
+            rewritesCachedTailOnContinuation: true)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "describe it") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+
+        let fullSecondPromptLengthValue = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(fullSecondPromptLengthValue)
+        XCTAssertEqual(completionInfo?.promptTokenCount, fullSecondPromptLength)
     }
 
     func testChatSessionAsyncInterrupt() async throws {
@@ -290,6 +782,96 @@ public class ChatSessionTests: XCTestCase {
 
         let completionInfo = try XCTUnwrap(info)
         XCTAssertNil(completionInfo.speculativeDecodingTelemetry)
+    }
+
+    func testSpeculativeDecodingMemoryPolicyFallbackReusesMainCacheAcrossTurns() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                draftModel: ModelContainer(context: model()),
+                numDraftTokens: 2,
+                memoryPolicy: SpeculativeDecodingMemoryPolicy(
+                    limitBytes: 0,
+                    action: .fallbackToDefault)),
+            generateParameters: GenerateParameters(maxTokens: 3, temperature: 0))
+
+        _ = try await session.respond(to: "first")
+        let firstRenderedLengthValue = await lengthIterator.next()
+        let firstRenderedLength = try XCTUnwrap(firstRenderedLengthValue)
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "second") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+        XCTAssertEqual(
+            completionInfo?.promptTokenCount,
+            secondRenderedLength - firstRenderedLength - 3)
+        XCTAssertNil(completionInfo?.speculativeDecodingTelemetry)
+    }
+
+    func testActiveSpeculativeDecodingSafelyRebuildsAcrossTurns() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: continuation,
+            rewritesPrefixOnContinuation: true)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let container = ModelContainer(context: model(processor: processor))
+        let speculativeDecoding = SpeculativeDecodingConfig(
+            draftModel: container,
+            numDraftTokens: 2)
+        let parameters = GenerateParameters(maxTokens: 3, temperature: 0)
+        let session = ChatSession(
+            container,
+            speculativeDecoding: speculativeDecoding,
+            generateParameters: parameters)
+
+        let first = try await collectGeneration(session.streamDetails(to: "first"))
+        _ = await lengthIterator.next()
+        let firstTelemetry = try XCTUnwrap(first.info.speculativeDecodingTelemetry)
+        XCTAssertGreaterThan(firstTelemetry.roundCount, 0)
+        XCTAssertGreaterThan(firstTelemetry.draftTokenCount, 0)
+        XCTAssertEqual(firstTelemetry.emittedTokenCount, first.info.generationTokenCount)
+
+        let second = try await collectGeneration(session.streamDetails(to: "second"))
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+        let secondTelemetry = try XCTUnwrap(second.info.speculativeDecodingTelemetry)
+        XCTAssertGreaterThan(secondTelemetry.roundCount, 0)
+        XCTAssertGreaterThan(secondTelemetry.draftTokenCount, 0)
+        XCTAssertEqual(secondTelemetry.emittedTokenCount, second.info.generationTokenCount)
+        XCTAssertEqual(second.info.promptTokenCount, secondRenderedLength)
+
+        let cleanSession = ChatSession(
+            container,
+            history: [.user("first"), .assistant(first.text)],
+            speculativeDecoding: speculativeDecoding,
+            generateParameters: parameters)
+        let cleanSecond = try await collectGeneration(
+            cleanSession.streamDetails(to: "second"))
+        let cleanRenderedLengthValue = await lengthIterator.next()
+        let cleanRenderedLength = try XCTUnwrap(cleanRenderedLengthValue)
+
+        let cleanTelemetry = try XCTUnwrap(cleanSecond.info.speculativeDecodingTelemetry)
+        XCTAssertGreaterThan(cleanTelemetry.draftTokenCount, 0)
+        XCTAssertEqual(cleanTelemetry.emittedTokenCount, cleanSecond.info.generationTokenCount)
+        XCTAssertEqual(cleanSecond.info.promptTokenCount, cleanRenderedLength)
+        XCTAssertEqual(second.text, cleanSecond.text)
     }
 
     func testSpeculativeDecodingMemoryPolicyFailThrows() async throws {

--- a/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
+++ b/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
@@ -20,10 +20,22 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
     /// Stateful across passes, hence a class; calls are serialized by the
     /// session's generation task.
     private final class ScriptedToolCallTokenizer: MLXLMCommon.Tokenizer, @unchecked Sendable {
-        private let toolCallScript =
-            #"<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>"#
+        private struct MissingUserQuery: Error {}
+
+        private let requiresUserQuery: Bool
+        private let toolCallPrefix: String
         private let plainScript = "It is sunny in Paris today."
         private var pass = 0
+
+        init(requiresUserQuery: Bool = true, toolCallPrefix: String = "") {
+            self.requiresUserQuery = requiresUserQuery
+            self.toolCallPrefix = toolCallPrefix
+        }
+
+        private var toolCallScript: String {
+            toolCallPrefix
+                + #"<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>"#
+        }
 
         let vocabularySize = 100
         private let _eosTokenId = 101
@@ -40,6 +52,12 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
             tools: [[String: any Sendable]]?,
             additionalContext: [String: any Sendable]?
         ) throws -> [Int] {
+            guard
+                !requiresUserQuery
+                    || messages.contains(where: { $0["role"] as? String == "user" })
+            else {
+                throw MissingUserQuery()
+            }
             pass += 1
             return encode(text: "")
         }
@@ -128,6 +146,21 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
             tokenizer: tokenizer)
     }
 
+    private static let weatherTool: ToolSpec = [
+        "type": "function",
+        "function": [
+            "name": "get_weather",
+            "description": "Get the weather for a city",
+            "parameters": [
+                "type": "object",
+                "properties": [
+                    "city": ["type": "string"] as [String: any Sendable]
+                ] as [String: any Sendable],
+                "required": ["city"],
+            ] as [String: any Sendable],
+        ] as [String: any Sendable],
+    ]
+
     func testRestartedGenerationSeesAssistantToolCallsBeforeResults() async throws {
         let log = MessageLog()
         let dispatched = DispatchLog()
@@ -136,25 +169,10 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
             tokenizer: tokenizer,
             messageGenerator: RecordingMessageGenerator(log: log))
 
-        let weatherTool: ToolSpec = [
-            "type": "function",
-            "function": [
-                "name": "get_weather",
-                "description": "Get the weather for a city",
-                "parameters": [
-                    "type": "object",
-                    "properties": [
-                        "city": ["type": "string"] as [String: any Sendable]
-                    ] as [String: any Sendable],
-                    "required": ["city"],
-                ] as [String: any Sendable],
-            ] as [String: any Sendable],
-        ]
-
         let session = ChatSession(
             context,
             generateParameters: GenerateParameters(maxTokens: 24),
-            tools: [weatherTool],
+            tools: [Self.weatherTool],
             toolDispatch: { call in
                 dispatched.record(call)
                 return #"{"forecast": "sunny"}"#
@@ -174,6 +192,9 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
         let passes = log.all
         XCTAssertGreaterThanOrEqual(passes.count, 2)
         let restart = try XCTUnwrap(passes.last)
+        XCTAssertTrue(
+            restart.contains { $0.role == .user },
+            "conversation-aware templates must retain the user query on tool continuation")
 
         let toolIndex = try XCTUnwrap(
             restart.lastIndex { $0.role == .tool },
@@ -194,5 +215,43 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
         XCTAssertEqual(toolCalls.count, 1)
         let function = try XCTUnwrap(toolCalls.first?["function"] as? [String: any Sendable])
         XCTAssertEqual(function["name"] as? String, "get_weather")
+    }
+
+    func testRawCacheToolRestartPreservesLegacyFragmentShape() async throws {
+        let log = MessageLog()
+        let tokenizer = ScriptedToolCallTokenizer(
+            requiresUserQuery: false,
+            toolCallPrefix: "Checking the tool. ")
+        let context = Self.makeContext(
+            tokenizer: tokenizer,
+            messageGenerator: RecordingMessageGenerator(log: log))
+        let parameters = GenerateParameters(maxTokens: 40)
+        let rawCache = context.model.newCache(parameters: parameters)
+        let session = ChatSession(
+            context,
+            cache: rawCache,
+            generateParameters: parameters,
+            tools: [Self.weatherTool],
+            toolDispatch: { _ in #"{"forecast": "sunny"}"# })
+
+        _ = try await session.respond(to: "What's the weather in Paris?")
+
+        let passes = log.all
+        XCTAssertGreaterThanOrEqual(passes.count, 2)
+        let restart = try XCTUnwrap(passes.last)
+        XCTAssertFalse(
+            restart.contains { $0.role == .user },
+            "raw KV caches cannot reconstruct and replay their original transcript")
+
+        let toolIndex = try XCTUnwrap(restart.lastIndex { $0.role == .tool })
+        guard toolIndex > 0 else {
+            XCTFail("tool result was rendered with no preceding assistant message")
+            return
+        }
+        XCTAssertEqual(restart[toolIndex - 1].role, .assistant)
+        XCTAssertEqual(
+            restart[toolIndex - 1].content,
+            "",
+            "generated text is already represented by the raw cache and must not be replayed")
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR is a correctness follow-up to #313, which added support for continuing a cached `ChatSession` with structured messages such as tool results.

### Problem

`ChatSession` keeps a KV cache so the model does not need to process the entire conversation again on every turn. However, after #313, only the newly supplied messages were passed to the model’s chat template.

For example, after a tool call, the template could receive only:

```text
tool: <tool result>
```

The original user question and the assistant’s tool call existed in the model’s KV cache, but chat templates cannot inspect that cache. They can only inspect the structured messages provided to them.

Some conversation-aware templates, including Qwen templates, require the original user question to format a tool result correctly. When it was missing, generation failed with a Jinja error such as:

```text
No user query found in messages.
```

This made valid structured tool continuations fail in downstream agent applications, even though the tool itself completed successfully.

### Solution

`ChatSession` now retains the structured conversation together with its KV cache. For every continuation, it gives the chat template the complete conversation, including:

- The original user message
- The assistant response or tool call
- Tool results
- Later user and assistant messages

This allows conversation-aware templates to understand the relationship between a tool result and the user request that caused it.

The performance benefit introduced by #313 is preserved. Although the complete conversation is rendered, `ChatSession` compares the resulting tokens with those already represented by the KV cache. When the cached tokens are still an exact prefix, only the new token suffix is processed by the model.

If the template changes an earlier part of the prompt—for example, because the instructions changed—`ChatSession` safely rebuilds the cache instead of combining a new prompt with stale model state.

The implementation also:

- Preserves the existing behavior of low-level initializers that receive only a raw KV cache, because those initializers do not have enough information to reconstruct the original conversation.
- Handles standard and speculative decoding cache alignment.
- Rebuilds safely when a new turn introduces media that cannot be independently sliced from the prepared input.
- Records generated tokens inside the generation task using Swift 6 compiler-checked value semantics.

### Next step: message-boundary cache checkpoints

> This PR safely rebuilds the prompt whenever a rendered transcript changes an already-cached token region and the underlying cache cannot be trimmed.
>
> That is correct, but hybrid/recurrent models may lose cache-reuse performance because SSM/Mamba state cannot be rewound to an arbitrary longest-common-prefix offset. Wrapped rotating caches can have similar restrictions.
>
> A future optimization should retain bounded cache checkpoints at stable message boundaries particularly before assistant generation. When a chat template rewrites or removes part of the previous assistant response, `ChatSession` could restore the latest checkpoint that is still an exact prefix and prefill only the remaining suffix, without trimming recurrent state.
>
> The checkpoint should include:
>
> - Main and draft model caches.
> - Exact token prefix and offset.
> - Per-model continuation state such as M-RoPE state.
> - Compatibility information for media, masks, processing configuration, and cache parameters.
> - A bounded retention policy to control memory usage.
>
> Validation should compare checkpoint reuse against cold full-prefill logits for standard KV, rotating, and hybrid/SSM models, including Qwen templates that remove reasoning traces. Benchmarks should report cached-token count and TTFT at increasing conversation lengths.


## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
  - `pre-commit` is not installed on this machine. The configured Swift formatter was run manually on the changed files, formatter lint passed, and `git diff --check` is clean.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)