### PR TITLE
Integration tests CI: run on Xcode 26 only

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,28 +18,27 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode
+      - name: Select Xcode 26
         shell: bash
         run: |
-          # The FoundationModels integration tests only build against the macOS 27
-          # SDK (canImport(FoundationModels, _version: 2)); on the macOS 26 SDK the
-          # MLXFoundationModels adapter compiles out and those tests are skipped.
-          # Prefer Xcode 27 when the runner has it so the full suite runs; otherwise
-          # fall back to the default toolchain and run the SDK-agnostic tests.
+          # This job runs on Xcode 26 only. The MLXFoundationModels adapter and its
+          # integration tests are gated on canImport(FoundationModels, _version: 2)
+          # (macOS 27 SDK), so on Xcode 26 they compile out and only the SDK-agnostic
+          # suites (MTP, Qwen3VL/Qwen3.5 vision, Coherence, Gemma4, tool calls, masks)
+          # build and run — i.e. exactly the tests that compile on this SDK.
+          # Fail loudly if no Xcode 26 is installed rather than fall through to a 27
+          # toolchain (which would fail to compile against a moving FoundationModels beta).
+          version_of() { "$1/Contents/Developer/usr/bin/xcodebuild" -version 2>/dev/null | head -1; }
           dev=""
-          for app in /Applications/Xcode_27*.app /Applications/Xcode-27*.app /Applications/Xcode.app; do
-            [ -d "$app" ] || continue
-            v=$("$app/Contents/Developer/usr/bin/xcodebuild" -version 2>/dev/null | head -1)
-            case "$v" in "Xcode 27"*) dev="$app/Contents/Developer" ;; esac
-            [ -n "$dev" ] && break
+          for app in $(ls -d /Applications/Xcode_26*.app /Applications/Xcode-26*.app /Applications/Xcode.app 2>/dev/null | sort -Vr); do
+            case "$(version_of "$app")" in "Xcode 26"*) dev="$app/Contents/Developer"; break ;; esac
           done
-          if [ -n "$dev" ]; then
-            echo "Using Xcode 27 at $dev (full suite, incl. FoundationModels tests)"
-            echo "DEVELOPER_DIR=$dev" >> "$GITHUB_ENV"
-          else
-            echo "Xcode 27 not found; using default $(xcode-select -p)."
-            echo "FoundationModels tests will be compiled out (macOS 27 SDK required)."
+          if [ -z "$dev" ]; then
+            echo "::error::Xcode 26 not found on this runner."
+            exit 1
           fi
+          echo "Selected $(version_of "$(dirname "$(dirname "$dev")")") at $dev"
+          echo "DEVELOPER_DIR=$dev" >> "$GITHUB_ENV"
 
       - name: Verify MetalToolchain installed
         shell: bash


### PR DESCRIPTION
## Proposed changes

Support only Xcode 26 and run just the tests that compile there. The MLXFoundationModels adapter and its integration tests are gated on canImport(FoundationModels, _version: 2) (macOS 27 SDK), so on Xcode 26 they compile out automatically and the target builds only the SDK-agnostic suites (MTP, Qwen3VL/Qwen3.5 vision, Coherence, Gemma4, tool calls, masks) — no test filtering needed.

Replace the prefer-Xcode-27 selection with an explicit Xcode 26 pick that fails loudly if Xcode 26 is absent, so the job never lands on a 27 beta whose moving FoundationModels SDK breaks the build.
## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
