### PR TITLE
Gate remaining FoundationModels integration tests behind the 27 SDK

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/ApplyChatTemplateProbeTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/ApplyChatTemplateProbeTests.swift
@@ -1,5 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
+
 import Foundation
 import MLXLMCommon
 import Testing
@@ -68,3 +70,5 @@ struct ApplyChatTemplateProbeTests {
         }
     }
 }
+
+#endif  // FoundationModelsIntegration

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/IntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/IntegrationTests.swift
@@ -1,5 +1,7 @@
 // Copyright © 2025 Apple Inc.
 
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
+
 import Foundation
 import FoundationModels
 import Testing
@@ -314,3 +316,5 @@ struct IntegrationTests {
         #expect(tokenCount >= 5, "Should have received at least 5 tokens before cancellation")
     }
 }
+
+#endif  // FoundationModelsIntegration

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/MultiTurnToolCallingTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/MultiTurnToolCallingTests.swift
@@ -1,6 +1,6 @@
 // Copyright © 2026 Apple Inc.
 
-#if FoundationModelsIntegration
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
 
 import Foundation
 import FoundationModels

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/StructuredToolOutputSessionTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/StructuredToolOutputSessionTests.swift
@@ -1,6 +1,6 @@
 // Copyright © 2026 Apple Inc.
 
-#if FoundationModelsIntegration
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
 
 import Foundation
 import FoundationModels

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallGrammarCharacterizationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallGrammarCharacterizationTests.swift
@@ -1,6 +1,6 @@
 // Copyright © 2026 Apple Inc.
 
-#if FoundationModelsIntegration
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
 
 import Foundation
 import FoundationModels


### PR DESCRIPTION
## Proposed changes

The Xcode-26 integration job still failed to compile: five FoundationModels test files were not covered by #464's SDK gating, so they referenced symbols (makeTestModel, MLXLanguageModel, executeResponse, ...) that compile out on the macOS 26 SDK.

- TextGeneration/IntegrationTests.swift and ApplyChatTemplateProbeTests.swift had no trait guard at all -> wrap the whole body in '#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)'.
- Three ToolCalling tests (added after #464) still had the bare '#if FoundationModelsIntegration' -> extend it with the same SDK check.

Now every FoundationModels test compiles out on Xcode 26, leaving only the SDK-agnostic suites, and stays active on Xcode 27.


## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
