### PR TITLE
Integration tests: scope down heavy suites, fix flakes and memory pressure

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/CoherenceIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/CoherenceIntegrationTests.swift
@@ -3,6 +3,7 @@
 import Foundation
 import HuggingFace
 import IntegrationTestHelpers
+import MLX
 import MLXHuggingFace
 import MLXLLM
 import MLXLMCommon
@@ -14,99 +15,115 @@ private let models = IntegrationTestModels(
     tokenizerLoader: #huggingFaceTokenizerLoader()
 )
 
+/// Load `configuration`, run the planets coherence check, then release the
+/// model. Each coherence test uses a distinct model exactly once, so we evict
+/// it from the shared cache and clear the GPU buffer pool afterwards: loading
+/// ~20 multi-GB models in one serialized run otherwise accumulates resident
+/// weights until the process is jetsammed (Metal compiler XPC crashes).
+private func runCoherence(_ configuration: ModelConfiguration) async throws {
+    let container = try await models.llmContainer(for: configuration)
+    do {
+        try await ChatSessionTests.planetsCoherence(container: container)
+    } catch {
+        await releaseModel(configuration)
+        throw error
+    }
+    await releaseModel(configuration)
+}
+
+private func releaseModel(_ configuration: ModelConfiguration) async {
+    await models.evictLLM(configuration)
+    Stream.gpu.synchronize()
+    GPU.clearCache()
+}
+
+/// Fast, reliable, architecturally-diverse subset that runs by default so the
+/// nightly/manual job stays well under the job time limit. The full model
+/// matrix lives in `CoherenceFullIntegrationTests` (opt-in).
 @Suite(.serialized)
 struct CoherenceIntegrationTests {
 
-    @Test func bitnet_b1_58_2B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.bitnet_b1_58_2b_4t_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func exaone_4_0_1_2B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.exaone_4_0_1_2b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func gemma3_1B_qat() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.gemma3_1B_qat_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func gemma3n_E2B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.gemma3n_E2B_it_lm_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func gemma4_e2b() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.gemma4_e2b_it_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func glm4_9B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.glm4_9b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func granite3_3_2B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.granite3_3_2b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func granite4_0_H_tiny() async throws {
-        let container = try await models.llmContainer(
-            for: LLMRegistry.granite_4_0_h_tiny_4bit_dwq)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func jamba_3B_4bit() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.jamba_3b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func lfm2_1_2B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.lfm2_1_2b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
     @Test func llama3_2_1B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.llama3_2_1B_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func mistral_7B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.mistral7B4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func olmo2_7B() async throws {
-        let container = try await models.llmContainer(
-            for: LLMRegistry.olmo_2_1124_7B_Instruct_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func olmoe_1B_7B() async throws {
-        let container = try await models.llmContainer(
-            for: LLMRegistry.olmoe_1b_7b_0125_instruct_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
-    }
-
-    @Test func phi3_5() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.phi3_5_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
+        try await runCoherence(LLMRegistry.llama3_2_1B_4bit)
     }
 
     @Test func qwen3_1_7B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.qwen3_1_7b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
+        try await runCoherence(LLMRegistry.qwen3_1_7b_4bit)
+    }
+
+    @Test func gemma3_1B_qat() async throws {
+        try await runCoherence(LLMRegistry.gemma3_1B_qat_4bit)
+    }
+
+    @Test func phi3_5() async throws {
+        try await runCoherence(LLMRegistry.phi3_5_4bit)
+    }
+
+    @Test func granite3_3_2B() async throws {
+        try await runCoherence(LLMRegistry.granite3_3_2b_4bit)
+    }
+}
+
+/// The remaining coherence models — larger, slower, or otherwise not needed for
+/// the default signal. Opt in with `MLX_RUN_FULL_COHERENCE=1`.
+@Suite(
+    .serialized,
+    .enabled(if: ProcessInfo.processInfo.environment["MLX_RUN_FULL_COHERENCE"] == "1"))
+struct CoherenceFullIntegrationTests {
+
+    @Test func bitnet_b1_58_2B() async throws {
+        try await runCoherence(LLMRegistry.bitnet_b1_58_2b_4t_4bit)
+    }
+
+    @Test func exaone_4_0_1_2B() async throws {
+        try await runCoherence(LLMRegistry.exaone_4_0_1_2b_4bit)
+    }
+
+    @Test func gemma3n_E2B() async throws {
+        try await runCoherence(LLMRegistry.gemma3n_E2B_it_lm_4bit)
+    }
+
+    @Test func gemma4_e2b() async throws {
+        try await runCoherence(LLMRegistry.gemma4_e2b_it_4bit)
+    }
+
+    @Test func glm4_9B() async throws {
+        try await runCoherence(LLMRegistry.glm4_9b_4bit)
+    }
+
+    @Test func granite4_0_H_tiny() async throws {
+        try await runCoherence(LLMRegistry.granite_4_0_h_tiny_4bit_dwq)
+    }
+
+    @Test func jamba_3B_4bit() async throws {
+        try await runCoherence(LLMRegistry.jamba_3b_4bit)
+    }
+
+    @Test func lfm2_1_2B() async throws {
+        try await runCoherence(LLMRegistry.lfm2_1_2b_4bit)
+    }
+
+    @Test func mistral_7B() async throws {
+        try await runCoherence(LLMRegistry.mistral7B4bit)
+    }
+
+    @Test func olmo2_7B() async throws {
+        try await runCoherence(LLMRegistry.olmo_2_1124_7B_Instruct_4bit)
+    }
+
+    // OLMoE ships a GPTNeoXTokenizer, which the tokenizer loader does not yet
+    // support (fails with `.unsupportedTokenizer("GPTNeoXTokenizer")`), so this
+    // model cannot currently pass the coherence check.
+    @Test(.disabled("OLMoE uses GPTNeoXTokenizer, unsupported by the tokenizer loader"))
+    func olmoe_1B_7B() async throws {
+        try await runCoherence(LLMRegistry.olmoe_1b_7b_0125_instruct_4bit)
     }
 
     @Test func qwen3_5_2B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.qwen3_5_2b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
+        try await runCoherence(LLMRegistry.qwen3_5_2b_4bit)
     }
 
     @Test func smollm3_3B() async throws {
-        let container = try await models.llmContainer(for: LLMRegistry.smollm3_3b_4bit)
-        try await ChatSessionTests.planetsCoherence(container: container)
+        try await runCoherence(LLMRegistry.smollm3_3b_4bit)
     }
 }

--- a/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
@@ -57,6 +57,15 @@ private let drafter31BModelId = "mlx-community/gemma-4-31B-it-assistant-bf16"
 private let target31BRevision = "fe92291011fc698452920c0b558b52f790dff711"
 private let drafter31BRevision = "28e92270316e89288579ec59c17939541d9ca433"
 
+/// The 31B target+drafter pair is ~35GB. These diagnostics only run when both
+/// snapshots are already in the local HF cache, matching the gating in
+/// `MTPAcceptanceRateTests` / `MTPQuantizationOnsetTests`. This keeps a cold CI
+/// run from spending its entire time budget downloading the pair; warm the
+/// cache out-of-band (or run locally after a first fetch) to exercise them.
+private let has31BPair: Bool =
+    hfSnapshotDir(modelId: target31BModelId, revision: target31BRevision) != nil
+    && hfSnapshotDir(modelId: drafter31BModelId, revision: drafter31BRevision) != nil
+
 /// Shared downloader for the 31B target+drafter pair. Fetches to the local
 /// HF cache on first use (~35GB); subsequent tests and runs reuse the cache.
 private let downloader: any Downloader = #hubDownloader()
@@ -113,7 +122,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// No acceptance-rate floor is asserted here; the first successful run
     /// logs the observed rate and a floor is added in a follow-up commit
     /// after a real number is on the table.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BPairProducesAcceptedDrafts() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -200,7 +209,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// aligned with the autoregressive baseline. The maxTokens=64
     /// measurement here is the more stable rate over a larger sample
     /// (n=66 vs n=29) and is the better regression gate.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BBlockSize4AcceptanceLifted() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -269,7 +278,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// Post-fix measurement: 29.8% acceptance, 8.60 tok/s — +11.9pp,
     /// +1.50 tok/s. The 25% floor below catches a regression toward the
     /// pre-fix baseline while leaving ~8pp headroom for variance.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BBlockSize6AcceptanceLifted() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -335,7 +344,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// commit ee86bff (Phase 4b): the iterator's prepare(input:) sampled one
     /// or two bonus tokens but never appended them to pendingTokens, so the
     /// output stream silently started 1 or 2 positions ahead of baseline.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BMatchesBaselineByteIdentical() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -411,7 +420,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// doesn't prove that empirically. This test extends the bit-exact-
     /// equivalence check to a second prompt whose acceptance profile differs
     /// from sky-blue (46% acceptance per v1.1 §5.2 sweep).
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BMatchesBaselineRainbowsPrompt() async throws {
         try await runMTPVsBaselineByteIdentityCheck(
             prompt: "Write a paragraph about how rainbows form.",
@@ -424,7 +433,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// acceptance means more correction-token positions per stream, which
     /// exercises the speculation/verify/accept boundary differently from the
     /// rainbows prompt.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BMatchesBaselineSwiftPrompt() async throws {
         try await runMTPVsBaselineByteIdentityCheck(
             prompt: "What's the best way to learn Swift?",
@@ -459,7 +468,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// stream lengths. The 64-token prefix-identity assertion
     /// captures the empirical boundary on this hardware + model
     /// configuration.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BLongerStreamProducesValidContinuation() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -588,7 +597,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// upheld and the Phase B divergence is genuinely MTP-vs-baseline drift.
     /// If they differ, the byte-identity framework's premise is broken at
     /// this stream length and the Phase B "failure" is reframed.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testBaselineSelfDeterminism128() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -649,7 +658,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// rounds (sky-blue chat-template prompt ≈ 30 tokens; +3-4 cache positions
     /// per blockSize=4 round) complete on the regular cache before
     /// quantization triggers around round 3.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTP31BQuantizationOnsetEngagesPassthrough() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,
@@ -745,7 +754,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
     /// the emitted token stream. Equivalently, the recorded count is no
     /// more than the emitted count, and the contents match position-by-
     /// position from the recorded-sequence start.
-    @Test
+    @Test(.enabled(if: has31BPair))
     func testMTPLogitProcessorReceivesOnlyEmittedTokens() async throws {
         let loaded = try await loadTargetAndDrafter(
             targetModelId: target31BModelId,

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -31,6 +31,43 @@ private func check(_ condition: Bool, _ message: String) throws {
     guard condition else { throw IntegrationTestFailure(message) }
 }
 
+// MARK: - Network Retry
+
+/// Transient network failures worth retrying on a flaky CI network — chiefly
+/// `-1005 networkConnectionLost`, which surfaced mid-download in CI.
+private func isTransientNetworkError(_ error: Error) -> Bool {
+    guard let urlError = error as? URLError else { return false }
+    switch urlError.code {
+    case .networkConnectionLost, .timedOut, .cannotConnectToHost,
+        .notConnectedToInternet, .dnsLookupFailed, .cannotFindHost,
+        .resourceUnavailable, .badServerResponse:
+        return true
+    default:
+        return false
+    }
+}
+
+/// Run `operation`, retrying a few times with linear backoff on transient
+/// network errors. Non-network errors (and the final attempt) rethrow.
+private func withNetworkRetry<T>(
+    _ label: String, attempts: Int = 3, _ operation: () async throws -> T
+) async throws -> T {
+    var lastError: Error?
+    for attempt in 1...attempts {
+        do {
+            return try await operation()
+        } catch {
+            lastError = error
+            guard isTransientNetworkError(error), attempt < attempts else { throw error }
+            print(
+                "Transient network error loading \(label) "
+                    + "(attempt \(attempt)/\(attempts)): \(error). Retrying…")
+            try? await Task.sleep(nanoseconds: UInt64(attempt) * 2_000_000_000)
+        }
+    }
+    throw lastError ?? IntegrationTestFailure("\(label): retry loop exited unexpectedly")
+}
+
 // MARK: - Model IDs
 
 public enum IntegrationTestModelIDs {
@@ -72,16 +109,27 @@ public actor IntegrationTestModels {
         let tokenizerLoader = self.tokenizerLoader
         let task = Task {
             print("Loading LLM: \(key)")
-            let container = try await LLMModelFactory.shared.loadContainer(
-                from: downloader, using: tokenizerLoader,
-                configuration: configuration,
-                progressHandler: logProgress(key)
-            )
+            let container = try await withNetworkRetry(key) {
+                try await LLMModelFactory.shared.loadContainer(
+                    from: downloader, using: tokenizerLoader,
+                    configuration: configuration,
+                    progressHandler: logProgress(key)
+                )
+            }
             print("Loaded LLM: \(key)")
             return container
         }
         llmTasksByName[key] = task
         return try await task.value
+    }
+
+    /// Drop the cached container for `configuration` so ARC can free its
+    /// GPU-resident weights between tests. Pair with `GPU.clearCache()` at the
+    /// call site to release the freed buffers back to the system — without this,
+    /// loading many large models in one serialized run accumulates weights until
+    /// the process is jetsammed (Metal compiler XPC failures / crashes).
+    public func evictLLM(_ configuration: ModelConfiguration) {
+        llmTasksByName[configuration.name] = nil
     }
 
     /// Load an arbitrary VLM container, cached by `configuration.name` so the same

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -53,7 +53,7 @@ private func withNetworkRetry<T>(
     _ label: String, attempts: Int = 3, _ operation: () async throws -> T
 ) async throws -> T {
     var lastError: Error?
-    for attempt in 1...attempts {
+    for attempt in 1 ... attempts {
         do {
             return try await operation()
         } catch {


### PR DESCRIPTION
## Proposed changes

The Xcode-26 job compiled and ran but was cancelled at the 2h cap and showed instability. Root causes and fixes:

Timeout: MTPIteratorEndToEndDiagnosticTests auto-downloads a ~35GB 31B target+drafter pair with no gate; a cold run spent ~83 min on one test. Gate the ten 31B-dependent tests on both snapshots already being cached (has31BPair, mirroring MTPAcceptanceRateTests / MTPQuantizationOnsetTests). The E4B/E2B tests keep their own env gates.

Scope: split CoherenceIntegrationTests into a fast default subset (llama3.2-1B, qwen3-1.7B, gemma3-1B-qat, phi3.5, granite3.3-2B) and an opt-in CoherenceFullIntegrationTests suite (MLX_RUN_FULL_COHERENCE=1) for the rest.

Memory/crash: loading ~20 multi-GB models in one serialized run accumulated resident weights until the process was jetsammed (Metal compiler XPC crashes, e.g. the gemma3n_E2B hang). Route every coherence test through a helper that evicts the model (IntegrationTestModels.evictLLM) and calls GPU.clearCache() after each, bounding residency to one model.

Failures: disable olmoe_1B_7B (GPTNeoXTokenizer unsupported by the loader); add transient-network retry to IntegrationTestModels.llmContainer for the granite -1005 'network connection lost' flake.

Validated: build-for-testing succeeds on Xcode 27; the default coherence subset runs green (5/5) locally with the per-model release path.
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
