### PR TITLE
Let models declare chat conventions via ChatConventionsProviding

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -616,16 +616,21 @@ public final class LLMModelFactory: GenericModelFactory {
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
+        // Chat conventions: registry override wins (config already non-nil);
+        // otherwise ask the model, then fall back to model_type inference.
         if mutableConfiguration.toolCallFormat == nil {
-            mutableConfiguration.toolCallFormat = ToolCallFormat.infer(
-                from: baseConfig.modelType, configData: configData)
+            mutableConfiguration.toolCallFormat =
+                model.declaredToolCallFormat
+                ?? ToolCallFormat.infer(from: baseConfig.modelType, configData: configData)
         }
-        // Reasoning protocol: registry override wins; otherwise infer from
-        // model_type + repo id. `modelId` is load-bearing — R1-Distill reports a
-        // base model_type (qwen2/llama) and is only recognizable by id.
+        // Reasoning protocol falls back to inference from model_type + repo id.
+        // `modelId` is load-bearing — R1-Distill reports a base model_type
+        // (qwen2/llama) and is only recognizable by id.
         if mutableConfiguration.reasoningConfig == nil {
-            mutableConfiguration.reasoningConfig = ReasoningConfig.infer(
-                from: baseConfig.modelType, modelId: configuration.name, configData: configData)
+            mutableConfiguration.reasoningConfig =
+                model.declaredReasoningConfig
+                ?? ReasoningConfig.infer(
+                    from: baseConfig.modelType, modelId: configuration.name, configData: configData)
         }
 
         // Load tokenizer and weights in parallel

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -620,7 +620,7 @@ public final class LLMModelFactory: GenericModelFactory {
         // otherwise ask the model, then fall back to model_type inference.
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat =
-                model.declaredToolCallFormat
+                model.toolCallFormat
                 ?? ToolCallFormat.infer(from: baseConfig.modelType, configData: configData)
         }
         // Reasoning protocol falls back to inference from model_type + repo id.
@@ -628,7 +628,7 @@ public final class LLMModelFactory: GenericModelFactory {
         // (qwen2/llama) and is only recognizable by id.
         if mutableConfiguration.reasoningConfig == nil {
             mutableConfiguration.reasoningConfig =
-                model.declaredReasoningConfig
+                model.reasoningConfig
                 ?? ReasoningConfig.infer(
                     from: baseConfig.modelType, modelId: configuration.name, configData: configData)
         }

--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -353,7 +353,7 @@ extension NanbeigeModel: LoRAModel {
 
 // MARK: - Chat conventions
 
-extension NanbeigeModel: ChatConventionsProviding {
+extension NanbeigeModel {
     // XML is the trained default / model-card recommendation for agentic use;
     // the chat template also supports JSON.
     public var toolCallFormat: ToolCallFormat? { .xmlFunction }

--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -350,3 +350,20 @@ extension NanbeigeModel: LoRAModel {
         model.layers
     }
 }
+
+// MARK: - Chat conventions
+
+extension NanbeigeModel: ChatConventionsProviding {
+    // XML is the trained default / model-card recommendation for agentic use;
+    // the chat template also supports JSON.
+    public var toolCallFormat: ToolCallFormat? { .xmlFunction }
+
+    // <think>/</think>, toggled via `enable_thinking` (template default true),
+    // same contract as the Qwen3 family.
+    public var reasoningConfig: ReasoningConfig? {
+        ReasoningConfig(
+            startDelimiter: "<think>", endDelimiter: "</think>",
+            promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
+            isSpecialToken: true)
+    }
+}

--- a/Libraries/MLXLMCommon/ChatConventions.swift
+++ b/Libraries/MLXLMCommon/ChatConventions.swift
@@ -1,0 +1,49 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+
+// MARK: - ChatConventionsProviding
+
+/// A model's chat conventions: how it encodes tool calls and how it reasons.
+///
+/// Adopted by the model so this knowledge lives with the model definition rather
+/// than in centralized `model_type` string tables (``ToolCallFormat/infer(from:configData:)``
+/// and ``ReasoningConfig/infer(from:modelId:configData:)``). The model factories
+/// probe this protocol before falling back to those inference chains.
+///
+/// Opt-in: the protocol extension defaults both properties to `nil`, so a
+/// conforming type overrides only the property that applies to it. This mirrors
+/// the ``ModelConfigurationValidating`` opt-in pattern.
+public protocol ChatConventionsProviding {
+    /// The tool-call format this model emits, or `nil` for the JSON default.
+    var toolCallFormat: ToolCallFormat? { get }
+
+    /// The model's reasoning protocol, or `nil` for non-reasoning models.
+    var reasoningConfig: ReasoningConfig? { get }
+}
+
+extension ChatConventionsProviding {
+    public var toolCallFormat: ToolCallFormat? { nil }
+    public var reasoningConfig: ReasoningConfig? { nil }
+}
+
+// MARK: - LanguageModel probe
+
+extension LanguageModel {
+    /// The tool-call format this model declares via ``ChatConventionsProviding``,
+    /// or `nil` if it does not conform / declares no format.
+    ///
+    /// Exposed as a method on the model so factories read it by borrowing `self`
+    /// and receiving a `Sendable` result, rather than downcasting the model
+    /// inline (which would taint the model's region and block returning it as a
+    /// `sending` result).
+    public var declaredToolCallFormat: ToolCallFormat? {
+        (self as? ChatConventionsProviding)?.toolCallFormat
+    }
+
+    /// The reasoning config this model declares via ``ChatConventionsProviding``,
+    /// or `nil` if it does not conform / declares none.
+    public var declaredReasoningConfig: ReasoningConfig? {
+        (self as? ChatConventionsProviding)?.reasoningConfig
+    }
+}

--- a/Libraries/MLXLMCommon/ChatConventions.swift
+++ b/Libraries/MLXLMCommon/ChatConventions.swift
@@ -6,14 +6,13 @@ import Foundation
 
 /// A model's chat conventions: how it encodes tool calls and how it reasons.
 ///
-/// Adopted by the model so this knowledge lives with the model definition rather
-/// than in centralized `model_type` string tables (``ToolCallFormat/infer(from:configData:)``
-/// and ``ReasoningConfig/infer(from:modelId:configData:)``). The model factories
-/// probe this protocol before falling back to those inference chains.
-///
-/// Opt-in: the protocol extension defaults both properties to `nil`, so a
-/// conforming type overrides only the property that applies to it. This mirrors
-/// the ``ModelConfigurationValidating`` opt-in pattern.
+/// This knowledge lives with the model definition rather than in centralized
+/// `model_type` string tables (``ToolCallFormat/infer(from:configData:)`` and
+/// ``ReasoningConfig/infer(from:modelId:configData:)``). ``LanguageModel``
+/// conforms with `nil` defaults, so the model factories read `model.toolCallFormat`
+/// / `model.reasoningConfig` directly and fall back to the inference chains when a
+/// model declares nothing. A model opts in by overriding either property in an
+/// extension.
 public protocol ChatConventionsProviding {
     /// The tool-call format this model emits, or `nil` for the JSON default.
     var toolCallFormat: ToolCallFormat? { get }
@@ -25,25 +24,4 @@ public protocol ChatConventionsProviding {
 extension ChatConventionsProviding {
     public var toolCallFormat: ToolCallFormat? { nil }
     public var reasoningConfig: ReasoningConfig? { nil }
-}
-
-// MARK: - LanguageModel probe
-
-extension LanguageModel {
-    /// The tool-call format this model declares via ``ChatConventionsProviding``,
-    /// or `nil` if it does not conform / declares no format.
-    ///
-    /// Exposed as a method on the model so factories read it by borrowing `self`
-    /// and receiving a `Sendable` result, rather than downcasting the model
-    /// inline (which would taint the model's region and block returning it as a
-    /// `sending` result).
-    public var declaredToolCallFormat: ToolCallFormat? {
-        (self as? ChatConventionsProviding)?.toolCallFormat
-    }
-
-    /// The reasoning config this model declares via ``ChatConventionsProviding``,
-    /// or `nil` if it does not conform / declares none.
-    public var declaredReasoningConfig: ReasoningConfig? {
-        (self as? ChatConventionsProviding)?.reasoningConfig
-    }
 }

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -235,7 +235,7 @@ public enum PrepareResult {
 /// - calls ``prepare(_:cache:state:windowSize:)`` to initialize the KVCache and consume the prompt
 /// - calls ``callAsFunction(_:cache:state:)-9kuvf`` for each token, producing an ``LMOutput``
 /// - the ``TokenIterator`` accumulates this information into a ``GenerateResult``
-public protocol LanguageModel: BaseLanguageModel {
+public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 
     /// Prepare the cache state and consume the ``LMInput``.
     ///

--- a/Libraries/MLXLMCommon/ReasoningConfig.swift
+++ b/Libraries/MLXLMCommon/ReasoningConfig.swift
@@ -147,15 +147,6 @@ public struct ReasoningConfig: Sendable, Equatable {
                 isSpecialToken: true)
         }
 
-        // Nanbeige4.2+: <think>/</think>, thinking toggled via `enable_thinking`
-        // (template default true), same contract as the Qwen3 family.
-        if type.hasPrefix("nanbeige") {
-            return ReasoningConfig(
-                startDelimiter: "<think>", endDelimiter: "</think>",
-                promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
-                isSpecialToken: true)
-        }
-
         // DeepSeek-R1 (and R1-Distill): always-on <think>/</think>.
         //
         // R1-Distill reports its *base* model_type ("qwen2"/"llama"), so it must

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -216,12 +216,6 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .xmlFunction
         }
 
-        // Nanbeige4.2+ — chat template supports XML and JSON; XML is the trained
-        // default and the model card's recommendation for agentic use
-        if type.hasPrefix("nanbeige") {
-            return .xmlFunction
-        }
-
         // Mistral3 family (mistral3, mistral3_text, etc.)
         if type.hasPrefix("mistral3") {
             return .mistral

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -387,6 +387,13 @@ public final class VLMModelFactory: GenericModelFactory {
                 model.toolCallFormat
                 ?? ToolCallFormat.infer(from: baseConfig.modelType)
         }
+        // Reasoning protocol: ask the model, then fall back to model_type + repo id.
+        if mutableConfiguration.reasoningConfig == nil {
+            mutableConfiguration.reasoningConfig =
+                model.reasoningConfig
+                ?? ReasoningConfig.infer(
+                    from: baseConfig.modelType, modelId: configuration.name, configData: configData)
+        }
 
         // Load tokenizer from model directory (or alternate tokenizer repo),
         // processor config, and weights in parallel using async let.
@@ -441,7 +448,8 @@ public final class VLMModelFactory: GenericModelFactory {
             extraEOSTokens: mutableConfiguration.extraEOSTokens,
             stopStrings: mutableConfiguration.stopStrings,
             eosTokenIds: mutableConfiguration.eosTokenIds,
-            toolCallFormat: mutableConfiguration.toolCallFormat)
+            toolCallFormat: mutableConfiguration.toolCallFormat,
+            reasoningConfig: mutableConfiguration.reasoningConfig)
 
         return .init(
             configuration: modelConfig, model: model, processor: processor,

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -381,9 +381,11 @@ public final class VLMModelFactory: GenericModelFactory {
         mutableConfiguration.eosTokenIds = eosTokenIds
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
 
-        // Auto-detect tool call format from model type if not explicitly set
+        // Auto-detect tool call format: ask the model, then fall back to model type
         if mutableConfiguration.toolCallFormat == nil {
-            mutableConfiguration.toolCallFormat = ToolCallFormat.infer(from: baseConfig.modelType)
+            mutableConfiguration.toolCallFormat =
+                model.declaredToolCallFormat
+                ?? ToolCallFormat.infer(from: baseConfig.modelType)
         }
 
         // Load tokenizer from model directory (or alternate tokenizer repo),

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -384,7 +384,7 @@ public final class VLMModelFactory: GenericModelFactory {
         // Auto-detect tool call format: ask the model, then fall back to model type
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat =
-                model.declaredToolCallFormat
+                model.toolCallFormat
                 ?? ToolCallFormat.infer(from: baseConfig.modelType)
         }
 

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -190,14 +190,12 @@ final class NanbeigeTests: XCTestCase {
     func testDeclaresXMLFunctionToolCallFormat() throws {
         let model = NanbeigeModel(try makeConfig())
         XCTAssertEqual(model.toolCallFormat, .xmlFunction)
-        // ...and reachable through the factory-facing accessor on LanguageModel.
-        XCTAssertEqual(model.declaredToolCallFormat, .xmlFunction)
     }
 
     /// <think>/</think>, toggled via `enable_thinking` (template default true).
     func testDeclaresQwen3StyleReasoningConfig() throws {
         let model = NanbeigeModel(try makeConfig())
-        let config = try XCTUnwrap(model.declaredReasoningConfig)
+        let config = try XCTUnwrap(model.reasoningConfig)
         XCTAssertEqual(config.startDelimiter, "<think>")
         XCTAssertEqual(config.endDelimiter, "</think>")
         XCTAssertEqual(

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -181,4 +181,27 @@ final class NanbeigeTests: XCTestCase {
             maxAbsDiff(logitsW, logitsF), 1e-3,
             "warm continuation diverged from cold full prefill")
     }
+
+    // MARK: - Chat conventions
+
+    /// Nanbeige declares its own tool-call format and reasoning config via
+    /// `ChatConventionsProviding`, rather than the centralized `model_type`
+    /// inference chains. XML is the trained default for agentic use.
+    func testDeclaresXMLFunctionToolCallFormat() throws {
+        let model = NanbeigeModel(try makeConfig())
+        XCTAssertEqual(model.toolCallFormat, .xmlFunction)
+        // ...and reachable through the factory-facing accessor on LanguageModel.
+        XCTAssertEqual(model.declaredToolCallFormat, .xmlFunction)
+    }
+
+    /// <think>/</think>, toggled via `enable_thinking` (template default true).
+    func testDeclaresQwen3StyleReasoningConfig() throws {
+        let model = NanbeigeModel(try makeConfig())
+        let config = try XCTUnwrap(model.declaredReasoningConfig)
+        XCTAssertEqual(config.startDelimiter, "<think>")
+        XCTAssertEqual(config.endDelimiter, "</think>")
+        XCTAssertEqual(
+            config.promptStrategy, .templateFlag(key: "enable_thinking", defaultOn: true))
+        XCTAssertTrue(config.isSpecialToken)
+    }
 }

--- a/Tests/MLXLMTests/ReasoningConfigTests.swift
+++ b/Tests/MLXLMTests/ReasoningConfigTests.swift
@@ -17,14 +17,6 @@ struct ReasoningConfigTests {
         #expect(config?.promptStrategy == .templateFlag(key: "enable_thinking", defaultOn: true))
     }
 
-    @Test func inferNanbeige() {
-        let config = ReasoningConfig.infer(
-            from: "nanbeige", modelId: "Nanbeige/Nanbeige4.2-3B")
-        #expect(config?.startDelimiter == "<think>")
-        #expect(config?.endDelimiter == "</think>")
-        #expect(config?.promptStrategy == .templateFlag(key: "enable_thinking", defaultOn: true))
-    }
-
     @Test func inferDeepSeekV3IsAlwaysOn() {
         let config = ReasoningConfig.infer(
             from: "deepseek_v3", modelId: "mlx-community/DeepSeek-R1-4bit")

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -3,6 +3,13 @@ import MLXLMCommon
 import Testing
 
 struct ToolTests {
+    @Test("ChatConventionsProviding defaults to nil for both properties")
+    func chatConventionsOptInDefaults() {
+        struct Bare: ChatConventionsProviding {}
+        #expect(Bare().toolCallFormat == nil)
+        #expect(Bare().reasoningConfig == nil)
+    }
+
     @Test("ToolCallProcessor drains calls once in parse order")
     func toolCallProcessorPublicDrain() {
         let processor = ToolCallProcessor(format: .json)
@@ -1064,10 +1071,6 @@ struct ToolTests {
         #expect(ToolCallFormat.infer(from: "qwen3_next") == .xmlFunction)
         #expect(ToolCallFormat.infer(from: "qwen3_next_moe") == .xmlFunction)
         #expect(ToolCallFormat.infer(from: "QWEN3_NEXT") == .xmlFunction)
-
-        // Nanbeige models (prefix matching)
-        #expect(ToolCallFormat.infer(from: "nanbeige") == .xmlFunction)
-        #expect(ToolCallFormat.infer(from: "NANBEIGE") == .xmlFunction)
 
         // Mistral3 models (prefix matching)
         #expect(ToolCallFormat.infer(from: "mistral3") == .mistral)


### PR DESCRIPTION
## Proposed changes

Introduce an opt-in ChatConventionsProviding protocol so a model declares its own tool-call format and reasoning config next to its definition, rather than via the centralized model_type hasPrefix chains in ToolCallFormat.infer / ReasoningConfig.infer. The model factories ask the model first (through the region-safe LanguageModel.declared* accessors) and fall back to the existing inference for models not yet migrated.

Migrate Nanbeige as the first slice: it now declares .xmlFunction and its <think>/enable_thinking reasoning config, and the nanbeige branches are removed from both infer methods. Tests relocated onto the model conformance.

Addresses davidkoski's review note on PR #460.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
