### PR TITLE
Fix TF32 test-oracle flakiness in the Gemma4 chunk-invariance tests

### DIFF
--- a/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
@@ -54,7 +54,14 @@ struct Gemma4ChunkedPrefillTests {
             """
         let config = try JSONDecoder().decode(
             Gemma4Configuration.self, from: Data(json.utf8))
-        return Gemma4(config)
+        // Pin the initializer weights. Task-local rather than MLXRandom.seed:
+        // tests in this suite run concurrently and share the global RNG.
+        let model = withRandomState(MLXRandom.RandomState(seed: 42)) {
+            Gemma4(config)
+        }
+        // Run in f16, as real models do.
+        model.apply { $0.dtype.isFloatingPoint ? $0.asType(.float16) : $0 }
+        return model
     }
 
     /// Token ids well inside the tiny vocabulary.
@@ -94,15 +101,18 @@ struct Gemma4ChunkedPrefillTests {
         #expect(chunked.cacheOffsets == singlePass.cacheOffsets)
         #expect(chunked.cacheOffsets.allSatisfy { $0 == tokens.count })
 
-        let close = allClose(
-            chunked.logits, singlePass.logits, rtol: 1e-4, atol: 1e-5
-        ).item(Bool.self)
+        // Max absolute difference, not allClose: relative error is meaningless
+        // here because logits pass through zero.
+        let drift = abs(
+            chunked.logits.asType(.float32) - singlePass.logits.asType(.float32)
+        ).max()
+        eval(drift)
         #expect(
-            close,
+            drift.item(Float.self) < 5e-2,
             """
             Final-position logits differ between windowSize=\(chunkSize) and \
-            single-pass prefill — chunked prefill must be numerically \
-            equivalent under causal masking.
+            single-pass prefill by \(drift.item(Float.self)) — chunked prefill \
+            must be numerically equivalent under causal masking.
             """)
     }
 
@@ -131,11 +141,16 @@ struct Gemma4ChunkedPrefillTests {
         eval(output.logits)
         #expect(cache.allSatisfy { $0.offset == tokens.count })
 
-        // And it matches the batched run.
+        // And it matches the batched run. Same shapes and same chunking, so the
+        // two runs are bitwise equal; the tolerance only covers one f16 ulp,
+        // which is ~2e-3 at these logit magnitudes.
         let batched = try Self.prefillLogits(model: model, tokens: tokens, windowSize: 6)
-        let close = allClose(
-            output.logits[0..., -1, 0...], batched.logits, rtol: 1e-4, atol: 1e-5
-        ).item(Bool.self)
-        #expect(close, "1-D and [1, N] token inputs must produce identical logits.")
+        let drift = abs(
+            output.logits[0..., -1, 0...].asType(.float32) - batched.logits.asType(.float32)
+        ).max()
+        eval(drift)
+        #expect(
+            drift.item(Float.self) < 5e-3,
+            "1-D and [1, N] token inputs must produce identical logits.")
     }
 }

--- a/Tests/MLXLMTests/Gemma4UnifiedTests.swift
+++ b/Tests/MLXLMTests/Gemma4UnifiedTests.swift
@@ -126,7 +126,14 @@ struct Gemma4UnifiedTests {
 
     @Test("Gemma4 Unified text-only prefill is chunk-size invariant")
     func textOnlyPrefillChunkSizeInvariant() throws {
-        let model = Gemma4Unified(try tinyTextConfig())
+        // Pin the initializer weights. Task-local rather than MLXRandom.seed:
+        // tests in this suite run concurrently and share the global RNG.
+        let config = try tinyTextConfig()
+        let model = withRandomState(MLXRandom.RandomState(seed: 42)) {
+            Gemma4Unified(config)
+        }
+        // Run in f16, as real models do.
+        model.apply { $0.dtype.isFloatingPoint ? $0.asType(.float16) : $0 }
         let input = LMInput(tokens: MLXArray([0, 2, 3, 4, 5, 1]).expandedDimensions(axis: 0))
 
         func prefill(windowSize: Int) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
@@ -147,7 +154,9 @@ struct Gemma4UnifiedTests {
         let diff = abs(full.logits.asType(.float32) - chunked.logits.asType(.float32)).max()
         eval(diff)
 
-        #expect(diff.item(Float.self) < 1e-4)
+        #expect(
+            diff.item(Float.self) < 1e-4,
+            "Chunked and single-pass prefill logits differ by \(diff.item(Float.self)).")
     }
 
     @Test("Gemma4 Unified processor emits model patches and position ids")


### PR DESCRIPTION
## Proposed changes

Fixes #357. On devices with a NAX, `Gemma4ChunkedPrefillTests.chunkSizeInvariance` and `Gemma4UnifiedTests.textOnlyPrefillChunkSizeInvariant` fail.

Both tests build a synthetic model from a JSON config, which leaves the MLXNN `Linear`/`Embedding` weights at their random float32 defaults, then assert that chunked and single-pass prefill agree to a tolerance calibrated for exact float32. Those two paths are mathematically equivalent, but with TF32 enabled the GPU can select different matmul/attention kernels and reduction orders depending on shape, so the logits drift past that tolerance. This is the test oracle, not the chunking logic — as diagnosed by @aleroot and @davidkoski on the issue.

Per that discussion:

- **Cast both synthetic models to f16**, matching what #326 did for `SpeculativeDecodingTests`. Real models never run float32.
- **Pin the initializer weights** so the drift is reproducible.
- **Compare max absolute difference** instead of `allClose` in `Gemma4ChunkedPrefillTests` — these logits pass through zero, where relative error is meaningless — and widen that bound to `5e-2`.

The exact cache-offset assertions are unchanged throughout. Those are the half of the oracle that catches real chunk-boundary bugs, and they are not precision-sensitive.

### Pinning uses `withRandomState`, not `MLXRandom.seed`

Worth calling out, because the obvious version does not work. `MLXRandom.seed` mutates process-global state, and swift-testing runs these tests concurrently — all four `chunkSize` cases plus the sibling tests build their models at overlapping times, so their seeding and their draws interleave on one stream. Measured with a global seed: **0.0** drift running the test alone, **4.0** with one sibling test running alongside (max |logit| is ~3.0). It also leaks a fixed key into every other suite drawing from that stream.

`withRandomState` is task-local, so each model construction gets its own stream and nothing escapes the closure.

### Tolerance

With the weights actually pinned, the drift is deterministic — identical on every run, and unchanged with `MLX_ENABLE_TF32=0`:

| chunk size | 16 | 8 | 5 | 3 |
|---|---|---|---|---|
| max abs drift | 6.2e-3 | **8.4e-3** | 6.4e-3 | 6.2e-3 |

`5e-2` leaves ~6× margin over the worst case. For the other direction — that the oracle still discriminates — injecting cache/mask defects into the 37-token model moves the logits by 1.0 (token just outside the sliding window flipped), 1.7 (two in-window tokens swapped), and 2.4 (first token dropped), i.e. 20–48× the bound.

`Gemma4UnifiedTests` keeps its original `1e-4`. With the model in f16 that test is bitwise equal, so only the cast was needed there and widening it would only lower the bar.

### One assertion the cast affected indirectly

`unbatchedTokensAccepted` shares `makeTinyModel()` and so silently started comparing f16 output at `rtol: 1e-4, atol: 1e-5` — a budget of ~4e-4 where one f16 ulp at these magnitudes is ~2e-3, i.e. finer than the dtype can represent. It passes only because the 1-D and `[1, N]` paths are bitwise identical. Converted to the same max-abs-diff form with a bound above one ulp.

## Verification

On an M5 Max (the affected hardware):

- `xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -skipPackagePluginValidation` — full suite green: 282 XCTest, 314 swift-testing, 0 failures.
- The two affected suites specifically: **5/5 runs pass with TF32 on, 5/5 with `MLX_ENABLE_TF32=0`.**
- `pre-commit run --all-files` — passes (swift-format 603.0.0, matching the CI pin).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
