### PR TITLE
Centralize tool-call authorization and output routing

### DIFF
--- a/Libraries/MLXFoundationModels/ToolCalling/AllowedToolOutputRouter.swift
+++ b/Libraries/MLXFoundationModels/ToolCalling/AllowedToolOutputRouter.swift
@@ -14,7 +14,6 @@ struct AllowedToolOutputRouter {
 
     private var reasoningEmitter: ReasoningEventEmitter?
     private let toolProcessor: ToolCallProcessor
-    private let allowedToolNames: Set<String>
 
     init(
         format: ToolCallFormat,
@@ -22,10 +21,6 @@ struct AllowedToolOutputRouter {
         reasoning: (config: ReasoningConfig, primedInside: Bool)? = nil
     ) {
         self.toolProcessor = ToolCallProcessor(format: format, tools: tools)
-        self.allowedToolNames = Set(
-            tools.compactMap { tool in
-                (tool["function"] as? [String: any Sendable])?["name"] as? String
-            })
         self.reasoningEmitter = reasoning.map {
             ReasoningEventEmitter(config: $0.config, primedInside: $0.primedInside)
         }
@@ -74,12 +69,12 @@ struct AllowedToolOutputRouter {
     }
 
     private func route(_ outputs: [ToolCallProcessor.Output]) -> [Event] {
-        outputs.compactMap { output in
+        outputs.map { output in
             switch output {
             case .response(let text):
                 .response(text)
             case .toolCall(let call):
-                allowedToolNames.contains(call.function.name) ? .toolCall(call) : nil
+                .toolCall(call)
             }
         }
     }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2433,18 +2433,8 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
             }
         }
 
-        if let bufferedText = toolCallProcessor.processEOS(returnBufferedText: true),
-            !bufferedText.isEmpty
-        {
-            if case .terminated = emit(.chunk(bufferedText)) {
-                return
-            }
-        }
-
-        for toolCall in toolCallProcessor.drainToolCalls() {
-            if case .terminated = emit(.toolCall(toolCall)) {
-                break
-            }
+        if case .cancelled = emitOutputs(toolCallProcessor.processEOSOutputs(), emit: emit) {
+            return
         }
     }
 
@@ -2460,14 +2450,20 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
             return .more
         }
 
-        if let textToYield = toolCallProcessor.processChunk(text) {
-            if case .terminated = emit(.chunk(textToYield)) {
-                return .cancelled
-            }
-        }
+        return emitOutputs(toolCallProcessor.processChunkOutputs(text), emit: emit)
+    }
 
-        for toolCall in toolCallProcessor.drainToolCalls() {
-            if case .terminated = emit(.toolCall(toolCall)) {
+    private func emitOutputs(
+        _ outputs: [ToolCallProcessor.Output],
+        emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
+    ) -> TokenLoopDisposition {
+        for output in outputs {
+            let result =
+                switch output {
+                case .response(let text): emit(.chunk(text))
+                case .toolCall(let call): emit(.toolCall(call))
+                }
+            if case .terminated = result {
                 return .cancelled
             }
         }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -30,26 +30,7 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
 
         let jsonStr = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let toolCall = parseToolCall(from: jsonStr) ?? parseRedundantOuterBraces(from: jsonStr)
-        guard let toolCall else { return nil }
-
-        // If tool schemas are provided, only accept calls to declared tools.
-        if let tools, !tools.isEmpty {
-            var isDeclaredTool = false
-            for tool in tools {
-                let functionSpec = tool["function"] as? [String: any Sendable]
-                if functionSpec?["name"] as? String == toolCall.function.name {
-                    isDeclaredTool = true
-                    break
-                }
-            }
-
-            guard isDeclaredTool else {
-                return nil
-            }
-        }
-
-        return toolCall
+        return parseToolCall(from: jsonStr) ?? parseRedundantOuterBraces(from: jsonStr)
     }
 
     /// Some Qwen chat templates emit an EOS-delimited JSON call with a

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -22,7 +22,8 @@ public protocol ToolCallParser: Sendable {
     /// Parse the content into a `ToolCall`.
     /// - Parameters:
     ///   - content: The text content to parse (may include tags)
-    ///   - tools: Optional tool schemas for type-aware parsing
+    ///   - tools: Optional tool schemas for type-aware argument parsing. Tool
+    ///     authorization is enforced by ``ToolCallProcessor`` after parsing.
     /// - Returns: A `ToolCall` if parsing succeeds, `nil` otherwise
     func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall?
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -35,6 +35,7 @@ public class ToolCallProcessor {
     private let format: ToolCallFormat
     private let parser: any ToolCallParser
     private let tools: [[String: any Sendable]]?
+    private let allowedToolNames: Set<String>?
     private let supportsBareJSONFallback: Bool
     private let maxJSONFallbackBufferLength = 32_768
     private let jsonObjectScanner = JSONLeadingObjectScanner(startCharacter: "{")
@@ -67,11 +68,20 @@ public class ToolCallProcessor {
     /// Initialize with a specific tool call format.
     /// - Parameters:
     ///   - format: The tool call format to use (defaults to `.json` for standard JSON format)
-    ///   - tools: Optional tool schemas for type-aware parsing
+    ///   - tools: Optional tool schemas for type-aware parsing and tool authorization.
+    ///     When schemas are present, calls to undeclared tools are consumed but not emitted.
     public init(format: ToolCallFormat = .json, tools: [[String: any Sendable]]? = nil) {
         self.format = format
         self.parser = format.createParser()
         self.tools = tools
+        if let tools, !tools.isEmpty {
+            self.allowedToolNames = Set(
+                tools.compactMap { tool in
+                    (tool["function"] as? [String: any Sendable])?["name"] as? String
+                })
+        } else {
+            self.allowedToolNames = nil
+        }
         self.supportsBareJSONFallback = format == .json
     }
 
@@ -210,11 +220,13 @@ public class ToolCallProcessor {
                 state = .collectingToolCall
 
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                    recordResponse(leading.replacingOccurrences(of: "<|python_tag|>", with: ""))
+                    let response =
+                        leading.replacingOccurrences(of: "<|python_tag|>", with: "")
+                    recordResponse(response)
                     appendToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
-                    return leading.isEmpty ? nil : leading
+                    return response.isEmpty ? nil : response
                 }
 
                 // Still collecting — check if the first JSON object is complete (would mean parse
@@ -367,8 +379,9 @@ public class ToolCallProcessor {
 
             let callText = String(remaining[..<argsRange.upperBound]) + split.object
             guard let call = parser.parse(content: callText, tools: tools) else { break }
-            appendToolCall(call)
-            outputs.append(.toolCall(toolCalls.removeLast()))
+            if isAuthorized(call) {
+                outputs.append(.toolCall(normalizedToolCall(call)))
+            }
             remaining = split.trailing
         }
 
@@ -400,8 +413,9 @@ public class ToolCallProcessor {
             let callText = String(remaining[startRange.lowerBound ... callEnd])
             guard let call = parser.parse(content: callText, tools: tools) else { break }
             appendResponse(stripProtocolSpans(from: responsePrefix), to: &outputs)
-            appendToolCall(call)
-            outputs.append(.toolCall(toolCalls.removeLast()))
+            if isAuthorized(call) {
+                outputs.append(.toolCall(normalizedToolCall(call)))
+            }
             remaining = String(remaining[remaining.index(after: callEnd)...])
         }
 
@@ -700,7 +714,12 @@ public class ToolCallProcessor {
         }
     }
 
+    private func isAuthorized(_ call: ToolCall) -> Bool {
+        allowedToolNames?.contains(call.function.name) ?? true
+    }
+
     private func appendToolCall(_ call: ToolCall) {
+        guard isAuthorized(call) else { return }
         let normalized = normalizedToolCall(call)
         toolCalls.append(normalized)
         if orderedOutputEnabled {

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -3,6 +3,12 @@ import MLXLMCommon
 import Testing
 
 struct ToolTests {
+    private func toolSchemas(_ names: String...) -> [[String: any Sendable]] {
+        names.map { name in
+            ["function": ["name": name] as [String: any Sendable]]
+        }
+    }
+
     @Test("ChatConventionsProviding defaults to nil for both properties")
     func chatConventionsOptInDefaults() {
         struct Bare: ChatConventionsProviding {}
@@ -140,6 +146,17 @@ struct ToolTests {
 
         #expect(toolCall.function.name == "get_weather")
         #expect(toolCall.function.arguments["location"] == .string("Paris"))
+    }
+
+    @Test("JSON parser leaves tool authorization to the processor")
+    func testJSONParserParsesUndeclaredTool() throws {
+        let parser = JSONToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content = #"<tool_call>{"name":"not_declared","arguments":{}}</tool_call>"#
+
+        let toolCall = try #require(
+            parser.parse(content: content, tools: toolSchemas("get_weather")))
+
+        #expect(toolCall.function.name == "not_declared")
     }
 
     @Test("Test JSON Tool Call Parser - Custom Tags")
@@ -364,10 +381,8 @@ struct ToolTests {
         #expect(processor.toolCalls.isEmpty)
     }
 
-    @Test(
-        "Test JSON Format via ToolCallProcessor - Unknown Tool Name Stays Text When Tools Are Provided"
-    )
-    func testJSONFormatProcessorUnknownToolNameStaysTextWithTools() {
+    @Test("Test JSON Format via ToolCallProcessor - Unknown Bare Tool Is Rejected")
+    func testJSONFormatProcessorUnknownBareToolIsRejected() {
         struct EmptyInput: Codable {}
         struct EmptyOutput: Codable { let ok: Bool }
 
@@ -385,7 +400,7 @@ struct ToolTests {
         let output = processor.processChunk(chunk)
         let eosOutput = processor.processEOS(returnBufferedText: true)
 
-        #expect(output == chunk)
+        #expect(output == nil)
         #expect(eosOutput == nil)
         #expect(processor.toolCalls.isEmpty)
     }
@@ -416,9 +431,9 @@ struct ToolTests {
     }
 
     @Test(
-        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool Preserved And Continues Parsing"
+        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool Rejected And Continues Parsing"
     )
-    func testJSONFormatProcessorUnknownTaggedToolPreservedAndContinuesParsing() throws {
+    func testJSONFormatProcessorUnknownTaggedToolRejectedAndContinuesParsing() throws {
         struct EmptyInput: Codable {}
         struct EmptyOutput: Codable { let ok: Bool }
 
@@ -437,7 +452,7 @@ struct ToolTests {
         let output = processor.processChunk(chunk)
         let eosOutput = processor.processEOS(returnBufferedText: true)
 
-        #expect(output == "<tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call>")
+        #expect(output == nil)
         #expect(eosOutput == nil)
         #expect(processor.toolCalls.count == 1)
 
@@ -446,9 +461,9 @@ struct ToolTests {
     }
 
     @Test(
-        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool With Leading Text Preserved"
+        "Test JSON Format via ToolCallProcessor - Unknown Tagged Tool Preserves Only Leading Text"
     )
-    func testJSONFormatProcessorUnknownTaggedToolWithLeadingTextPreserved() throws {
+    func testJSONFormatProcessorUnknownTaggedToolPreservesOnlyLeadingText() throws {
         struct EmptyInput: Codable {}
         struct EmptyOutput: Codable { let ok: Bool }
 
@@ -467,8 +482,7 @@ struct ToolTests {
         let output = processor.processChunk(chunk)
         let eosOutput = processor.processEOS(returnBufferedText: true)
 
-        #expect(
-            output == "Preface <tool_call>{\"name\":\"not_declared\",\"arguments\":{}}</tool_call>")
+        #expect(output == "Preface ")
         #expect(eosOutput == nil)
         #expect(processor.toolCalls.count == 1)
 
@@ -702,6 +716,17 @@ struct ToolTests {
         #expect(toolCall.function.arguments["expression"] == .string("2+2"))
     }
 
+    @Test("LFM2 EOS output consumes undeclared calls")
+    func testLFM2EOSOutputRejectsUndeclaredCall() {
+        let processor = ToolCallProcessor(format: .lfm2, tools: toolSchemas("calculator"))
+
+        #expect(
+            processor.processChunkOutputs(
+                "<|tool_call_start|>[not_declared()]after"
+            ).isEmpty)
+        #expect(processor.processEOSOutputs() == [.response("after")])
+    }
+
     // MARK: - XML Function Format Tests (Qwen3 Coder)
 
     @Test("Test XML Function Parser - Qwen3 Coder Format")
@@ -741,6 +766,17 @@ struct ToolTests {
         #expect(toolCall.function.name == "set_temperature")
         #expect(toolCall.function.arguments["value"] == .int(25))
         #expect(toolCall.function.arguments["enabled"] == .bool(true))
+    }
+
+    @Test("XML parser leaves tool authorization to the processor")
+    func testXMLFunctionParserParsesUndeclaredTool() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content = "<function=example_function_name></function>"
+
+        let toolCall = try #require(
+            parser.parse(content: content, tools: toolSchemas("get_weather")))
+
+        #expect(toolCall.function.name == "example_function_name")
     }
 
     @Test("Test XML Function Parser - Multiline Content (Qwen3.5 style)")
@@ -832,6 +868,42 @@ struct ToolTests {
         let toolCall = try #require(processor.toolCalls.first)
         #expect(toolCall.function.name == "get_current_datetime")
         #expect(toolCall.function.arguments.isEmpty)
+    }
+
+    @Test("XML processor rejects undeclared calls and continues parsing")
+    func testXMLProcessorRejectsUndeclaredCallAndContinuesParsing() throws {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction, tools: toolSchemas("get_weather"))
+        let content =
+            "<tool_call><function=example_function_name></function></tool_call>"
+            + "<tool_call><function=get_weather></function></tool_call>"
+
+        #expect(processor.processChunk(content) == nil)
+        #expect(processor.processEOS(returnBufferedText: true) == nil)
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "get_weather")
+    }
+
+    @Test("Ordered XML output removes malformed protocol but preserves surrounding text")
+    func testOrderedXMLOutputSuppressesMalformedProtocol() {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction, tools: toolSchemas("get_weather"))
+
+        #expect(
+            processor.processChunkOutputs(
+                "before <tool_call><function=broken></tool_call> after"
+            ) == [.response("before "), .response(" after")])
+        #expect(processor.processEOSOutputs().isEmpty)
+    }
+
+    @Test("Ordered XML output removes unfinished protocol at EOS")
+    func testOrderedXMLOutputSuppressesUnfinishedProtocolAtEOS() {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction, tools: toolSchemas("get_weather"))
+
+        #expect(
+            processor.processChunkOutputs("<tool_call><function=broken>").isEmpty)
+        #expect(processor.processEOSOutputs().isEmpty)
     }
 
     // MARK: - GLM4 Format Tests
@@ -1061,6 +1133,21 @@ struct ToolTests {
         #expect(toolCalls6[1].function.arguments["location"] == .string("London"))
     }
 
+    @Test("Inline processor consumes undeclared calls")
+    func testInlineProcessorRejectsUndeclaredCall() {
+        let content = #"<|python_tag|>{"name":"not_declared","arguments":{}}"#
+
+        let legacyProcessor = ToolCallProcessor(
+            format: .llama3, tools: toolSchemas("run_script"))
+        #expect(legacyProcessor.processChunk(content) == nil)
+        #expect(legacyProcessor.toolCalls.isEmpty)
+
+        let orderedProcessor = ToolCallProcessor(
+            format: .llama3, tools: toolSchemas("run_script"))
+        #expect(orderedProcessor.processChunkOutputs(content).isEmpty)
+        #expect(orderedProcessor.processEOSOutputs().isEmpty)
+    }
+
     // MARK: - ToolCallFormat Serialization Tests
 
     @Test("Test ToolCallFormat Raw Values for Serialization")
@@ -1243,6 +1330,17 @@ struct ToolTests {
         let toolCall = try #require(processor.toolCalls.first)
         #expect(toolCall.function.name == "get_weather")
         #expect(toolCall.function.arguments["location"] == .string("Berlin"))
+    }
+
+    @Test("Mistral EOS output consumes undeclared calls")
+    func testMistralEOSOutputRejectsUndeclaredCall() {
+        let processor = ToolCallProcessor(format: .mistral, tools: toolSchemas("get_weather"))
+
+        #expect(
+            processor.processChunkOutputs(
+                "[TOOL_CALLS]not_declared[ARGS]{}after"
+            ).isEmpty)
+        #expect(processor.processEOSOutputs() == [.response("after")])
     }
 
     @Test("Test Mistral Format Processor Multiple Tool Calls")


### PR DESCRIPTION
## Proposed changes

Tool-call syntax is now parsed independently from authorization, undeclared calls are consumed at the processor boundary, and generation uses ordered outputs so malformed or unfinished tool protocol is not emitted as assistant text or fed back into conversation history.

Rejects undeclared tool function names as `example_function_name` that the model sometimes may try to call by mistake.

I kept this PR focused on centralising declared-tool filtering and ordered output routing, but I can add an observable rejection outcome here or track it as a follow-up, depending on the preferred API direction.

*I am also aware that the stronger long-term approach is constrained generation, using XGrammar to restrict tool names and arguments while decoding. Even with constrained decoding, however, the processor would still need defensive handling for truncation, malformed output, unsupported models, and legacy string-based formats. I therefore see this PR as a necessary compatibility and safety layer, not as a replacement for constrained decoding.*

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
