### PR TITLE
Fix Qwen3.5 hybrid cache offset accounting

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -341,6 +341,7 @@ final class Qwen35GatedDeltaNet: Module {
             cache[0] = newConvState
             cache[1] = newRecState
             cache.advance(inputs.dim(1))
+            cache.offset += inputs.dim(1)
         }
         return out
     }
@@ -744,6 +745,7 @@ final class Qwen35DecoderLayer: Module {
         cache[0] = out[1]
         cache[1] = out[2]
         cache.advance(1)
+        cache.offset += 1
         return out[0]
     }
 
@@ -1020,6 +1022,7 @@ public class Qwen35TextModelInner: Module {
                 mambaCache[0] = outputs[1 + 2 * i]
                 mambaCache[1] = outputs[2 + 2 * i]
                 mambaCache.advance(1)
+                mambaCache.offset += 1
             }
 
             pendingAttention = []

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -564,6 +564,7 @@ enum Qwen35Language {
             if let cache {
                 cache[1] = state
                 cache.advance(S)
+                cache.offset += S
             }
 
             out = norm(out, gate: z)

--- a/Tests/MLXLMTests/Qwen35CompiledDecodeLifecycleTests.swift
+++ b/Tests/MLXLMTests/Qwen35CompiledDecodeLifecycleTests.swift
@@ -46,6 +46,18 @@ final class Qwen35CompiledDecodeLifecycleTests: XCTestCase {
             Qwen35TextConfiguration.self, from: Data(json.utf8))
     }
 
+    private func assertCacheOffsets(
+        _ cache: [KVCache], equal expected: Int,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            cache.allSatisfy { $0.offset == expected },
+            "expected every cache offset to equal \(expected), got \(cache.map(\.offset))",
+            file: file,
+            line: line
+        )
+    }
+
     /// Runs two decode steps (the first installs the compiled closures, the
     /// second replays them), releases the model, and asserts the
     /// closure-owning blocks deallocate.
@@ -84,6 +96,35 @@ final class Qwen35CompiledDecodeLifecycleTests: XCTestCase {
         // traces.
         try assertBlocksDeallocate(headDim: 32) { caches in
             caches.map { $0 is MambaCache ? $0 : QuantizedKVCache(groupSize: 32, bits: 8) }
+        }
+    }
+
+    func testCacheOffsetsAdvanceAcrossPrefillAndWholeStepDecode() throws {
+        let model = Qwen35TextModel(try tinyMoEConfiguration(headDim: 8))
+        let cache = model.newCache(parameters: nil)
+        let prompt = MLXArray([Int32(1), 2, 3, 4]).reshaped(1, 4)
+
+        eval(model(prompt, cache: cache))
+        assertCacheOffsets(cache, equal: 4)
+
+        let nextToken = MLXArray([Int32(5)]).reshaped(1, 1)
+        eval(model(nextToken, cache: cache))
+        assertCacheOffsets(cache, equal: 5)
+    }
+
+    func testCacheOffsetsAdvanceAcrossFallbackDecode() throws {
+        let model = Qwen35TextModel(try tinyMoEConfiguration(headDim: 32))
+        let cache = model.newCache(parameters: nil).map { cache in
+            cache is MambaCache
+                ? cache
+                : QuantizedKVCache(groupSize: 32, bits: 8)
+        }
+
+        // Quantized attention caches make the whole-step decode schedule
+        // ineligible. This exercises Qwen35DecoderLayer.decodeLinearLayer.
+        for (token, expectedOffset) in [(Int32(1), 1), (Int32(2), 2)] {
+            eval(model(MLXArray([token]).reshaped(1, 1), cache: cache))
+            assertCacheOffsets(cache, equal: expectedOffset)
         }
     }
 }

--- a/Tests/MLXLMTests/Qwen35ContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen35ContinuationTests.swift
@@ -144,6 +144,26 @@ final class Qwen35ContinuationTests: XCTestCase {
             "warm continuation diverged from full prefill (noise floor \(noiseFloor))")
     }
 
+    func testWarmTextContinuationKeepsCacheOffsetsAligned() throws {
+        MLXRandom.seed(17)
+        let model = try makeTinyModel()
+        let prefix = textTokens(40)
+        let suffix = textTokens(8, seed: 3)
+        let cache = model.newCache(parameters: nil)
+
+        _ = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: prefix)), cache: cache, state: nil,
+                windowSize: nil))
+        XCTAssertTrue(cache.allSatisfy { $0.offset == 40 })
+
+        _ = try lastLogits(
+            model.prepare(
+                LMInput(text: .init(tokens: suffix)), cache: cache, state: nil,
+                windowSize: nil))
+        XCTAssertTrue(cache.allSatisfy { $0.offset == 48 })
+    }
+
     /// With an image in turn 1, the rope delta the image accumulated must be
     /// carried into turn 2's prefill (the ChatSession cross-turn state
     /// threading): two-turn with threaded state ≡ one-shot full prefill.


### PR DESCRIPTION
## Proposed changes

Qwen3.5/Qwen3.6 hybrid models use both recurrent and KV caches. In the compiled prefill and decode paths, the recurrent cache state was advanced manually, but its token offset was not updated. This caused the recurrent and KV cache offsets to drift apart, breaking cache validation and potentially causing failures when continuing generation from a warmed cache.
The fix increments the recurrent cache offset by the number of processed tokens whenever its state is advanced, covering prefill, compiled decode, fallback decode, and the corresponding vision-language path.
This keeps all cache layers synchronized, makes cached continuation reliable, and adds regression tests for text and vision-language models to prevent future offset-accounting regressions.
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
