### PR TITLE
Fix gated delta recurrence precision

### DIFF
--- a/Libraries/MLXLMCommon/GatedDelta.swift
+++ b/Libraries/MLXLMCommon/GatedDelta.swift
@@ -56,10 +56,20 @@ private func makeGatedDeltaKernel(hasMask: Bool) -> MLXFast.MLXFastKernel? {
             for (int t = 0; t < T; ++t) {
               if (\(maskSource)) {
                 float kv_mem = 0.0f;
-                for (int i = 0; i < n_per_t; ++i) {
-                  auto s_idx = n_per_t * dk_idx + i;
-                  state[i] = state[i] * g_[hv_idx];
-                  kv_mem += state[i] * k_[s_idx];
+                {
+                  // Preserve Kahan summation under Metal's default fast math.
+                  #pragma clang fp reassociate(off)
+                  #pragma clang fp contract(off)
+                  float kv_compensation = 0.0f;
+                  for (int i = 0; i < n_per_t; ++i) {
+                    auto s_idx = n_per_t * dk_idx + i;
+                    state[i] = state[i] * g_[hv_idx];
+                    auto product = state[i] * k_[s_idx];
+                    auto corrected = product - kv_compensation;
+                    auto next_sum = kv_mem + corrected;
+                    kv_compensation = (next_sum - kv_mem) - corrected;
+                    kv_mem = next_sum;
+                  }
                 }
                 kv_mem = simd_sum(kv_mem);
 

--- a/Tests/MLXLMTests/GatedDeltaTests.swift
+++ b/Tests/MLXLMTests/GatedDeltaTests.swift
@@ -122,4 +122,38 @@ public class GatedDeltaTests: XCTestCase {
         )
     }
 
+    /// The recurrent state update must retain low-order terms in its k-state dot product.
+    ///
+    /// Each SIMD lane accumulates one large value followed by five unit values. A naive
+    /// FP32 sum drops all five units, shifting the recurrent state by one ULP. Compensated
+    /// summation recovers them and matches the correctly rounded reference result.
+    func testGatedDeltaCompensatesRecurrentDotProduct() throws {
+        let keyDimension = 192
+        let laneState: [Float] = [100_000_000, 1, 1, 1, 1, 1]
+        let stateValues = (0 ..< 32).flatMap { _ in laneState }
+
+        let q = MLXArray.zeros([1, 1, 1, keyDimension], dtype: .bfloat16)
+        let k = MLXArray.ones([1, 1, 1, keyDimension], dtype: .bfloat16)
+        let v = MLXArray.zeros([1, 1, 1, 1], dtype: .bfloat16)
+        let a = MLXArray.zeros([1, 1, 1], dtype: .bfloat16)
+        let b = MLXArray.zeros([1, 1, 1], dtype: .bfloat16)
+        let aLog = MLXArray([-100] as [Float])
+        let dtBias = MLXArray.zeros([1], dtype: .bfloat16)
+        let state = MLXArray(stateValues).reshaped(1, 1, 1, keyDimension)
+
+        let (_, nextState) = gatedDeltaUpdate(
+            q: q, k: k, v: v, a: a, b: b,
+            aLog: aLog, dtBias: dtBias, state: state)
+
+        let actual = nextState[0, 0, 0, 0].item(Float.self)
+        let exactDotProduct = 32.0 * (100_000_000.0 + 5.0)
+        let expected = Float(100_000_000.0 - 0.5 * exactDotProduct)
+
+        XCTAssertEqual(
+            actual.bitPattern, expected.bitPattern,
+            "GDN recurrent dot product rounded to \(actual), expected \(expected). "
+                + "Naive FP32 accumulation loses the unit terms and returns -1.5e9."
+        )
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Use Kahan compensated summation for the recurrent k-state dot product so low-order terms do not drift at long context. Disable Metal reassociation and contraction only inside this reduction to preserve the algorithm under default fast math.

Add an adversarial BF16-path regression that checks the FP32 recurrent state against the correctly rounded reference result.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
