### PR TITLE
Fix tied quantized Qwen3 MoE head sanitization

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -255,7 +255,9 @@ public class Qwen3MoEModel: Module, LLMModel, KVCacheDimensionProvider {
         var sanitizedWeights = weights
 
         if configuration.tieWordEmbeddings {
-            sanitizedWeights["lm_head.weight"] = nil
+            sanitizedWeights = sanitizedWeights.filter { key, _ in
+                !key.hasPrefix("lm_head.")
+            }
         }
 
         if sanitizedWeights["model.layers.0.mlp.experts.0.up_proj.weight"] == nil {

--- a/Tests/MLXLMTests/Qwen3MoESanitizeTests.swift
+++ b/Tests/MLXLMTests/Qwen3MoESanitizeTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLLM
+
+final class Qwen3MoESanitizeTests: XCTestCase {
+    private func makeConfig(tieWordEmbeddings: Bool) throws -> Qwen3MoEConfiguration {
+        let json = """
+            {
+                "model_type": "qwen3_moe",
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "intermediate_size": 16,
+                "num_attention_heads": 1,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "num_experts": 2,
+                "num_experts_per_tok": 1,
+                "decoder_sparse_step": 1,
+                "mlp_only_layers": [],
+                "moe_intermediate_size": 8,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 32,
+                "tie_word_embeddings": \(tieWordEmbeddings)
+            }
+            """
+        return try JSONDecoder().decode(
+            Qwen3MoEConfiguration.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    func testTiedEmbeddingsRemoveEveryQuantizedLMHeadTensor() throws {
+        let model = Qwen3MoEModel(try makeConfig(tieWordEmbeddings: true))
+        let value = MLXArray.zeros([1])
+        let sanitized = model.sanitize(weights: [
+            "lm_head.weight": value,
+            "lm_head.scales": value,
+            "lm_head.biases": value,
+            "model.embed_tokens.weight": value,
+        ])
+
+        XCTAssertFalse(sanitized.keys.contains { $0.hasPrefix("lm_head.") })
+        XCTAssertNotNil(sanitized["model.embed_tokens.weight"])
+    }
+
+    func testUntiedEmbeddingsPreserveQuantizedLMHeadTensors() throws {
+        let model = Qwen3MoEModel(try makeConfig(tieWordEmbeddings: false))
+        let value = MLXArray.zeros([1])
+        let sanitized = model.sanitize(weights: [
+            "lm_head.weight": value,
+            "lm_head.scales": value,
+            "lm_head.biases": value,
+        ])
+
+        XCTAssertNotNil(sanitized["lm_head.weight"])
+        XCTAssertNotNil(sanitized["lm_head.scales"])
+        XCTAssertNotNil(sanitized["lm_head.biases"])
+    }
+}


### PR DESCRIPTION
When `tie_word_embeddings` is enabled, converted quantized checkpoints can contain `lm_head.weight`, `lm_head.scales`, and `lm_head.biases`. Qwen3MoE currently removes only `lm_head.weight`, leaving the quantization metadata to load into the absent optional module and failing with `Unable to set lm_head on Qwen3MoEModel`.

Remove every `lm_head.*` tensor for tied embeddings, matching the model's use of `embed_tokens` as the output projection. Preserve all head tensors for untied configurations.

Adds focused tests for both tied and untied quantized heads.

Validation: `swift test --filter Qwen3MoESanitizeTests` (2 passed). Real model that exposed this: `justneedsomeavailableusername/Qwen3-MOE-4x0.6B-2.4B-Writing-Thunder-V1.2-mlx-4Bit`.