### PR TITLE
Stand down from MTP speculation before the sliding cache wraps

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1746,7 +1746,12 @@ public func generateTokens(
 ///   - mtpDrafter: the ``MTPDrafterModel``. The target is threaded through
 ///     ``MTPDrafterModel/draftBlock(target:lastToken:lastHidden:sharedKV:queryOffset:blockSize:sampler:)``
 ///     per round; drafter instances hold no target-derived state and are safe
-///     to share across iterators.
+///     to share across iterators. Speculation requires a rewindable KV cache,
+///     so on a sliding-window model it is available only while total context
+///     (prompt plus generation) stays inside the window. Past that the
+///     iterator logs once, reports
+///     ``GenerateCompletionInfo/passthroughReason``, and finishes the stream
+///     with ordinary single-token generation.
 ///   - blockSize: total tokens per round (`blockSize - 1` drafted plus the
 ///     bonus from the previous verify). Mirrors mlx-vlm's
 ///     `draft_block_size`. Default 4 matches mlx-vlm's example configs.
@@ -1791,6 +1796,12 @@ public func generate(
 /// ``generateTokens(input:cache:parameters:context:draftModel:draftCache:numDraftTokens:wiredMemoryTicket:)``
 /// but for MTP drafters. Yields raw token IDs instead of decoded text or
 /// tool calls.
+///
+/// Speculation requires a rewindable KV cache, so on a sliding-window model it
+/// is available only while total context (prompt plus generation) stays inside
+/// the window. Past that the iterator logs once, reports
+/// ``GenerateCompletionInfo/passthroughReason`` on the emitted `.info` event,
+/// and finishes the stream with ordinary single-token generation.
 public func generateTokens(
     input: LMInput,
     cache: [KVCache]? = nil,

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -65,6 +65,13 @@ public protocol KVCache: Evaluatable {
     /// whether this cache can be trimmed
     var isTrimmable: Bool { get }
 
+    /// Predict whether this cache can still be trimmed after appending `positions`.
+    ///
+    /// - Parameter positions: The nonnegative number of sequence positions that
+    ///   would be appended.
+    /// - Returns: `true` when a subsequent rewind would remain valid.
+    func isTrimmable(after positions: Int) -> Bool
+
     /// trim n tokens from the cache, returning actual number trimmed
     @discardableResult
     func trim(_ n: Int) -> Int
@@ -99,6 +106,10 @@ public protocol KVCache: Evaluatable {
 extension KVCache {
     public var ropeOffset: RoPEOffset {
         .scalar(offset)
+    }
+
+    public func isTrimmable(after positions: Int) -> Bool {
+        isTrimmable
     }
 
     public func prepare(lengths: [Int]?) {}
@@ -203,6 +214,10 @@ open class BaseKVCache: KVCache {
     }
 
     open var isTrimmable: Bool { false }
+
+    open func isTrimmable(after positions: Int) -> Bool {
+        isTrimmable
+    }
 
     @discardableResult
     open func trim(_ n: Int) -> Int { 0 }
@@ -719,7 +734,11 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public override var isTrimmable: Bool {
-        return offset < maxCacheSize
+        isTrimmable(after: 0)
+    }
+
+    public override func isTrimmable(after positions: Int) -> Bool {
+        offset + positions < maxCacheSize
     }
 
     @discardableResult
@@ -1487,7 +1506,11 @@ public class CacheList: BaseKVCache {
     }
 
     public override var isTrimmable: Bool {
-        caches.allSatisfy { $0.isTrimmable }
+        isTrimmable(after: 0)
+    }
+
+    public override func isTrimmable(after positions: Int) -> Bool {
+        caches.allSatisfy { $0.isTrimmable(after: positions) }
     }
 
     @discardableResult

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -408,24 +408,23 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
     /// Stand down to passthrough if the main cache cannot absorb `positions`
     /// more tokens and still be rewound.
     ///
-    /// MTP's accept/reject step depends on `trimPromptCache`, and
-    /// ``RotatingKVCache/isTrimmable`` is `offset < maxCacheSize` — a sliding
-    /// window cache is untrimmable forever once it wraps. The wrap happens
-    /// *inside* the verify pass, so a check that merely asks "has it wrapped?"
-    /// fires a round too late: that round's rewind silently returns 0 (the
-    /// guard in `trimPromptCache` is all-or-nothing over the array, so even the
-    /// trimmable full-attention entries are skipped) and its rejected drafts
-    /// stay welded into every layer's cache. Standing down while headroom
-    /// remains keeps every rewind valid, so a passthrough-crossing stream
-    /// stays bit-exact to a plain autoregressive run.
+    /// MTP's accept/reject step depends on `trimPromptCache`, so each cache
+    /// predicts whether it will remain trimmable after the verify positions
+    /// are appended. The append happens *inside* the verify pass, so a check
+    /// that merely asks "is it trimmable now?" fires a round too late: that
+    /// round's rewind silently returns 0 (the guard in `trimPromptCache` is
+    /// all-or-nothing over the array, so even the trimmable full-attention
+    /// entries are skipped) and its rejected drafts stay welded into every
+    /// layer's cache. Standing down while headroom remains keeps every rewind
+    /// valid, so a passthrough-crossing stream stays bit-exact to a plain
+    /// autoregressive run.
     @discardableResult
     private mutating func standDownIfNoTrimHeadroom(
         positions: Int, reason: String
     ) -> Bool {
         guard !passthrough else { return false }
-        let hasHeadroom = mainCache.allSatisfy { cache in
-            guard let maxSize = cache.maxSize else { return true }
-            return cache.offset + positions < maxSize
+        let hasHeadroom = mainCache.allSatisfy {
+            $0.isTrimmable(after: positions)
         }
         guard !hasHeadroom else { return false }
         switchToPassthrough(reason: reason)

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -135,6 +135,17 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         let prefillStart = Date.timeIntervalSinceReferenceDate
         try prepare(input: input, windowSize: parameters.prefillStepSize)
         self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
+
+        // The guard above ran against a fresh, zero-offset cache, where a
+        // rotating cache is trimmable vacuously. Re-check now that the prompt
+        // is in: one whose length leaves no room for a speculative round can
+        // never be rewound, so speculation is unavailable for this stream.
+        // `blockSize` bounds the first round's width.
+        standDownIfNoTrimHeadroom(
+            positions: blockSize,
+            reason:
+                "prompt fills the sliding window — MTP rewind unavailable; generating without speculation"
+        )
     }
 
     /// Prefill the main model with the prompt. The drafter has no cache to
@@ -241,6 +252,18 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             let sharedKV = state[mtpSharedKVStatesKey]
         else {
             switchToPassthrough(reason: "main model did not emit drafter state")
+            return
+        }
+
+        // This round's verify pass commits `numDraft + 1` positions. If that
+        // would carry the sliding cache past its window, the rewind below
+        // would no-op and strand this round's rejected drafts in the cache —
+        // stand down now, while the cache is still rewindable.
+        if standDownIfNoTrimHeadroom(
+            positions: numDraft + 1,
+            reason:
+                "sliding cache wrapped mid-stream — MTP rewind unavailable; continuing without speculation"
+        ) {
             return
         }
 
@@ -382,6 +405,37 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         passthrough = true
     }
 
+    /// Stand down to passthrough if the main cache cannot absorb `positions`
+    /// more tokens and still be rewound.
+    ///
+    /// MTP's accept/reject step depends on `trimPromptCache`, and
+    /// ``RotatingKVCache/isTrimmable`` is `offset < maxCacheSize` — a sliding
+    /// window cache is untrimmable forever once it wraps. The wrap happens
+    /// *inside* the verify pass, so a check that merely asks "has it wrapped?"
+    /// fires a round too late: that round's rewind silently returns 0 (the
+    /// guard in `trimPromptCache` is all-or-nothing over the array, so even the
+    /// trimmable full-attention entries are skipped) and its rejected drafts
+    /// stay welded into every layer's cache. Standing down while headroom
+    /// remains keeps every rewind valid, so a passthrough-crossing stream
+    /// stays bit-exact to a plain autoregressive run.
+    @discardableResult
+    private mutating func standDownIfNoTrimHeadroom(
+        positions: Int, reason: String
+    ) -> Bool {
+        guard !passthrough else { return false }
+        let hasHeadroom = mainCache.allSatisfy { cache in
+            guard let maxSize = cache.maxSize else { return true }
+            return cache.offset + positions < maxSize
+        }
+        guard !hasHeadroom else { return false }
+        switchToPassthrough(reason: reason)
+        // Release the emitted snapshot: passthrough passes `state: nil` and
+        // never reads it again, and its sliding entries can span up to
+        // `maxCacheSize + S - 1` per layer.
+        mainState = nil
+        return true
+    }
+
     /// One single-token forward step against the main model, used in
     /// passthrough mode. The drafter is not invoked.
     private mutating func passthroughStep() -> Int? {
@@ -404,20 +458,26 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             return nil
         }
 
+        // Drain the pending buffer first — before the passthrough branch. A
+        // stand-down at the end of `init` leaves the prepare-time bonus
+        // sitting here, already committed to the cache (`y` is the token
+        // after it). Short-circuiting to `passthroughStep()` would drop it and
+        // start the stream one position ahead of an equivalent autoregressive
+        // run. Rounds that flip passthrough mid-stream always clear the buffer
+        // first, so this reordering is a no-op for them.
+        if pendingIndex < pendingTokens.count {
+            let token = pendingTokens[pendingIndex]
+            pendingIndex += 1
+            telemetry.recordGeneratedToken()
+            return token
+        }
+
         if passthrough {
             if let token = passthroughStep() {
                 telemetry.recordGeneratedToken()
                 return token
             }
             return nil
-        }
-
-        // Drain the pending buffer first.
-        if pendingIndex < pendingTokens.count {
-            let token = pendingTokens[pendingIndex]
-            pendingIndex += 1
-            telemetry.recordGeneratedToken()
-            return token
         }
 
         // Run a new speculation round (may transition to passthrough).

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -51,6 +51,102 @@ private final class LifecycleRecordingCache: BaseKVCache {
     }
 }
 
+/// A direct protocol conformer that deliberately relies on the
+/// `KVCache.isTrimmable(after:)` extension default.
+private final class ProtocolDefaultTrimmabilityCache: KVCache {
+    var offset = 0
+    var maxSize: Int? { nil }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        (keys, values)
+    }
+
+    var state: [MLXArray] {
+        get { [] }
+        set {}
+    }
+
+    var metaState: [String] {
+        get { [] }
+        set {}
+    }
+
+    var isTrimmable: Bool { true }
+
+    @discardableResult
+    func trim(_ n: Int) -> Int {
+        let trimmed = min(offset, n)
+        offset -= trimmed
+        return trimmed
+    }
+
+    func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        .none
+    }
+
+    func copy() -> any KVCache {
+        let copy = ProtocolDefaultTrimmabilityCache()
+        copy.offset = offset
+        return copy
+    }
+
+    func innerState() -> [MLXArray] { [] }
+}
+
+// MARK: - Predictive trimmability
+
+@Test func testRotatingKVCachePredictsStrictTrimBoundary() {
+    let cache = RotatingKVCache(maxSize: 8)
+    cache.offset = 3
+
+    #expect(cache.isTrimmable(after: 4))
+    #expect(!cache.isTrimmable(after: 5))
+}
+
+@Test func testRotatingKVCacheIsNotTrimmableAtOrPastWindow() {
+    let cache = RotatingKVCache(maxSize: 8)
+
+    cache.offset = 8
+    #expect(!cache.isTrimmable)
+    #expect(!cache.isTrimmable(after: 0))
+
+    cache.offset = 9
+    #expect(!cache.isTrimmable)
+    #expect(!cache.isTrimmable(after: 0))
+}
+
+@Test func testRotatingPredictiveTrimOverrideDispatchesThroughKVCache() {
+    let rotating = RotatingKVCache(maxSize: 8)
+    rotating.offset = 3
+    let cache: any KVCache = rotating
+
+    #expect(cache.isTrimmable(after: 4))
+    #expect(!cache.isTrimmable(after: 5))
+}
+
+@Test func testUnboundedCacheRemainsTrimmableAfterPositiveLookAhead() {
+    let cache: any KVCache = KVCacheSimple()
+
+    #expect(cache.isTrimmable(after: 1_000))
+}
+
+@Test func testCacheListDelegatesPredictiveTrimmabilityToChildren() {
+    let rotating = RotatingKVCache(maxSize: 8)
+    rotating.offset = 3
+    let cache: any KVCache = CacheList(KVCacheSimple(), rotating)
+
+    #expect(cache.isTrimmable(after: 4))
+    #expect(!cache.isTrimmable(after: 5))
+}
+
+@Test func testDirectKVCacheConformerUsesPredictiveTrimDefault() {
+    let cache: any KVCache = ProtocolDefaultTrimmabilityCache()
+
+    #expect(cache.isTrimmable(after: 1_000))
+}
+
 // MARK: - Original parameterized test (updated with value assertions)
 
 @Test(

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -150,9 +150,8 @@ private final class MockMainModel: Module, LanguageModel, KVCacheDimensionProvid
 ///
 /// `wrapAt` is opt-in and defaults to nil (unbounded, always trimmable), which
 /// is the behavior every pre-existing test relies on. Setting it mirrors
-/// `RotatingKVCache`: `maxSize` reports the window and `isTrimmable` becomes
-/// `offset < wrapAt`, so a mock stream can cross the window the same way a real
-/// sliding-window cache does.
+/// `RotatingKVCache` through the predictive trimmability query, so a mock stream
+/// can cross the window the same way a real sliding-window cache does.
 private final class CountingKVCache: KVCache {
     var offset: Int = 0
     let wrapAt: Int?
@@ -172,8 +171,11 @@ private final class CountingKVCache: KVCache {
         set {}
     }
     var isTrimmable: Bool {
+        isTrimmable(after: 0)
+    }
+    func isTrimmable(after positions: Int) -> Bool {
         guard let wrapAt else { return true }
-        return offset < wrapAt
+        return offset + positions < wrapAt
     }
     @discardableResult
     func trim(_ n: Int) -> Int {
@@ -615,13 +617,12 @@ func testTrimSharedKVStateNoOpOnNilStateAndAbsentKey() {
 // MARK: - Stand-down when the sliding cache runs out of trim headroom
 //
 // MTP's accept/reject step rewinds the main cache with `trimPromptCache`, and
-// `RotatingKVCache.isTrimmable` is `offset < maxCacheSize` — a sliding-window
-// cache is untrimmable forever once it wraps. Before the stand-down existed the
-// iterator only checked trimmability at init, against a fresh zero-offset cache
-// where the check is vacuously true, so any stream whose total context crossed
-// the window kept drafting: the verify pass's sliding K/V grew to
-// `maxCacheSize + S - 1`, flowed into `sharedKV`, and the next `draftBlock`
-// tripped `precondition(slidingKvLen <= textCfg.slidingWindow)`.
+// `RotatingKVCache.isTrimmable(after:)` owns the strict sliding-window boundary.
+// Before the stand-down existed the iterator only checked trimmability at init,
+// against a fresh zero-offset cache where the check is vacuously true, so any
+// stream whose total context crossed the window kept drafting: the verify pass's
+// sliding K/V grew to `maxCacheSize + S - 1`, flowed into `sharedKV`, and the next
+// `draftBlock` tripped `precondition(slidingKvLen <= textCfg.slidingWindow)`.
 //
 // `CountingKVCache(wrapAt:)` mirrors that regime; the checks below pin both
 // entry points and the equivalence-to-greedy guarantee across the transition.

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -147,9 +147,19 @@ private final class MockMainModel: Module, LanguageModel, KVCacheDimensionProvid
 /// Minimal `KVCache` that satisfies the protocol's trimmable interface; the
 /// mock model adjusts `offset` directly. Inherits the default
 /// `ropeOffset = .scalar(offset)` from the `KVCache` protocol extension.
+///
+/// `wrapAt` is opt-in and defaults to nil (unbounded, always trimmable), which
+/// is the behavior every pre-existing test relies on. Setting it mirrors
+/// `RotatingKVCache`: `maxSize` reports the window and `isTrimmable` becomes
+/// `offset < wrapAt`, so a mock stream can cross the window the same way a real
+/// sliding-window cache does.
 private final class CountingKVCache: KVCache {
     var offset: Int = 0
-    var maxSize: Int? { nil }
+    let wrapAt: Int?
+    init(wrapAt: Int? = nil) {
+        self.wrapAt = wrapAt
+    }
+    var maxSize: Int? { wrapAt }
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
         (keys, values)
     }
@@ -161,9 +171,13 @@ private final class CountingKVCache: KVCache {
         get { [] }
         set {}
     }
-    var isTrimmable: Bool { true }
+    var isTrimmable: Bool {
+        guard let wrapAt else { return true }
+        return offset < wrapAt
+    }
     @discardableResult
     func trim(_ n: Int) -> Int {
+        guard isTrimmable else { return 0 }
         let removed = Swift.min(n, offset)
         offset -= removed
         return removed
@@ -174,7 +188,7 @@ private final class CountingKVCache: KVCache {
         .none
     }
     func copy() -> any KVCache {
-        let c = CountingKVCache()
+        let c = CountingKVCache(wrapAt: wrapAt)
         c.offset = offset
         return c
     }
@@ -596,4 +610,164 @@ func testTrimSharedKVStateNoOpOnNilStateAndAbsentKey() {
     trimSharedKVState(&keylessState, numTokens: 3)
     #expect(keylessState?[mtpSharedKVStatesKey] == nil)
     #expect(keylessState?[mtpEmitFlagKey] == true)
+}
+
+// MARK: - Stand-down when the sliding cache runs out of trim headroom
+//
+// MTP's accept/reject step rewinds the main cache with `trimPromptCache`, and
+// `RotatingKVCache.isTrimmable` is `offset < maxCacheSize` — a sliding-window
+// cache is untrimmable forever once it wraps. Before the stand-down existed the
+// iterator only checked trimmability at init, against a fresh zero-offset cache
+// where the check is vacuously true, so any stream whose total context crossed
+// the window kept drafting: the verify pass's sliding K/V grew to
+// `maxCacheSize + S - 1`, flowed into `sharedKV`, and the next `draftBlock`
+// tripped `precondition(slidingKvLen <= textCfg.slidingWindow)`.
+//
+// `CountingKVCache(wrapAt:)` mirrors that regime; the checks below pin both
+// entry points and the equivalence-to-greedy guarantee across the transition.
+
+/// A prompt that leaves no room for a speculative round stands down during
+/// `init` — the drafter is never called, and the stream still completes.
+///
+/// The first-token assertion is the load-bearing one: `prepare` has already
+/// queued the prefill bonus in `pendingTokens` by the time the stand-down
+/// fires, and that token is already committed to the cache (`y` is the token
+/// after it). If `next()` short-circuits into `passthroughStep()` without
+/// draining the buffer, the bonus vanishes and the whole stream shifts a
+/// position relative to an equivalent autoregressive run.
+@Test
+func testMTPIteratorStandsDownWhenPromptFillsSlidingWindow() throws {
+    // Prompt of 8 against a window of 6: the cache is already past the window
+    // when prefill returns, so no rewind is possible for the rest of the run.
+    let mainLogitTokens: [Int32] = [
+        // Prefill follow-up call (length 8): only the final position is
+        // sampled; the rest are inert placeholders (< vocab=20).
+        0, 0, 0, 0, 0, 0, 0, 5,
+        // Passthrough single-token steps.
+        11, 12, 13,
+    ]
+    let main = MockMainModel(nextLogitTokens: mainLogitTokens)
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let input = LMInput(tokens: MLXArray([Int32(1), 2, 3, 4, 5, 6, 7, 8]))
+    let cache = CountingKVCache(wrapAt: 6)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: input, mainModel: main, drafter: drafter, mainCache: [cache],
+        parameters: GenerateParameters(maxTokens: 4, temperature: 0), blockSize: 4
+    )
+
+    let tokens = [iter.next(), iter.next(), iter.next(), iter.next(), iter.next()]
+
+    // The prefill bonus must be yielded first, then passthrough tokens.
+    #expect(tokens[0] == 5, "prefill bonus was dropped by the init-time stand-down")
+    #expect(tokens[1] == 11)
+    #expect(tokens[2] == 12)
+    #expect(tokens[3] == 13)
+    #expect(tokens[4] == nil)
+    #expect(iter.tokenCount == 4)
+
+    #expect(
+        iter.passthroughReason
+            == "prompt fills the sliding window — MTP rewind unavailable; generating without speculation"
+    )
+    // Never speculated: no draft was ever requested.
+    #expect(drafter.draftBlockCallCount == 0)
+    #expect(iter.proposedCount == 0)
+    #expect(iter.acceptedCount == 0)
+}
+
+/// A stream that speculates successfully and only later runs out of headroom
+/// stands down mid-stream, after real speculation has happened.
+@Test
+func testMTPIteratorStandsDownWhenSlidingCacheWrapsMidStream() throws {
+    // window=8, prompt=3, blockSize=4. Prefill leaves offset=3, so round 1 has
+    // headroom (3 + 4 < 8) and runs; its verify pass carries offset to 7, so
+    // round 2 (3 more positions) does not, and the iterator stands down before
+    // drafting rather than after the cache has already wrapped.
+    let mainLogitTokens: [Int32] = [
+        // Prefill follow-up (length 3): bonus 7.
+        0, 0, 7,
+        // Verify pass (length 4): all three drafts match, then correction 9.
+        7, 7, 7, 9,
+        // Passthrough single-token steps.
+        11, 12, 13,
+    ]
+    let main = MockMainModel(nextLogitTokens: mainLogitTokens)
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let input = LMInput(tokens: MLXArray([Int32(1), 2, 3]))
+    let cache = CountingKVCache(wrapAt: 8)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: input, mainModel: main, drafter: drafter, mainCache: [cache],
+        parameters: GenerateParameters(maxTokens: 8, temperature: 0), blockSize: 4
+    )
+
+    var tokens: [Int] = []
+    while let token = iter.next() { tokens.append(token) }
+
+    #expect(tokens == [7, 7, 7, 7, 9, 11, 12, 13])
+
+    // It really speculated before standing down.
+    #expect(drafter.draftBlockCallCount == 1)
+    #expect(iter.proposedCount == 3)
+    #expect(iter.acceptedCount == 3)
+
+    #expect(
+        iter.passthroughReason
+            == "sliding cache wrapped mid-stream — MTP rewind unavailable; continuing without speculation"
+    )
+}
+
+/// Bit-exact equivalence to greedy survives the stand-down: a stream that
+/// speculates, crosses the window, and finishes in passthrough emits exactly
+/// the tokens a plain `TokenIterator` emits from the same model.
+///
+/// Note on the harness: `MockMainModel` addresses its script by a running
+/// per-forward-call index, not by absolute sequence position, and a rejected
+/// draft rewinds the cache without rewinding that index. The two arms
+/// therefore only stay in step while every draft is accepted — which is the
+/// regime scripted here (`MockDrafter` emits one constant value, and the
+/// verify positions hold that same value). A rejection would desynchronize the
+/// script rather than reveal a real divergence.
+@Test
+func testMTPIteratorMatchesGreedyAcrossMidStreamStandDown() throws {
+    let mainLogitTokens: [Int32] = [
+        0, 0, 7,
+        7, 7, 7, 9,
+        11, 12, 13,
+        // Greedy consumes one script entry per emitted token, so it reads one
+        // position further than the speculative arm on the final step.
+        0,
+    ]
+    let promptTokens = MLXArray([Int32(1), 2, 3])
+    let parameters = GenerateParameters(maxTokens: 8, temperature: 0)
+
+    var mtpTokens: [Int] = []
+    do {
+        let main = MockMainModel(nextLogitTokens: mainLogitTokens)
+        var iter = try MTPSpeculativeTokenIterator(
+            input: LMInput(tokens: promptTokens), mainModel: main,
+            drafter: MockDrafter(draftedTokenValue: 7),
+            mainCache: [CountingKVCache(wrapAt: 8)],
+            parameters: parameters, blockSize: 4
+        )
+        while let token = iter.next() { mtpTokens.append(token) }
+        #expect(iter.passthroughReason != nil, "the run must actually cross the window")
+        #expect(iter.acceptedCount > 0, "the run must actually speculate first")
+    }
+
+    var greedyTokens: [Int] = []
+    do {
+        let main = MockMainModel(nextLogitTokens: mainLogitTokens)
+        var iter = try TokenIterator(
+            input: LMInput(tokens: promptTokens), model: main,
+            cache: [CountingKVCache(wrapAt: 8)],
+            parameters: parameters
+        )
+        while let token = iter.next() { greedyTokens.append(token) }
+    }
+
+    #expect(
+        mtpTokens == greedyTokens,
+        "MTP diverged from greedy across the stand-down: \(mtpTokens) vs \(greedyTokens)")
 }


### PR DESCRIPTION
## Proposed changes

cc @davidkoski

Fixes #505. Follow-up to #308.

With an `mtpDrafter`, total context was effectively capped at the model's sliding
window: once prompt plus generation crossed it, `draftBlock → forwardHidden` hit
`precondition(slidingKvLen <= textCfg.slidingWindow)` and the process died.

MTP's accept/reject step rewinds the main cache with `trimPromptCache`, and
`RotatingKVCache.isTrimmable` is `offset < maxCacheSize` — a sliding-window cache
is untrimmable forever once it wraps. The iterator checked `canTrimPromptCache`
only in `init`, against a fresh zero-offset cache where it is vacuously true, and
never again; meanwhile every verify pass goes through `updateConcat`, whose
allowance returns sliding K/V up to `maxCacheSize + S - 1`, and the emit hook
hands exactly those arrays to the drafter on the following round.

This adds `KVCache.isTrimmable(after:)` as a cache-owned look-ahead query. The
private helper, `standDownIfNoTrimHeadroom(positions:reason:)`, asks each
main-cache entry whether it remains trimmable after the coming round. It is called
at two points: at the end of `init` once the prompt is in, and at the top of each
speculative round before any `draftBlock`. When the cache cannot absorb the
coming round and still be rewound, the iterator switches to its existing
sticky-passthrough regime — the same mechanism already used when the target stops
emitting drafter state — with a one-time log line and a `passthroughReason` on
`GenerateCompletionInfo`. Nothing throws, and generation completes.

`RotatingKVCache` owns the strict sliding-window calculation,
`offset + positions < maxCacheSize`.
The predicate asks whether the cache has *headroom* for the round rather than
whether it has *already wrapped*, which matters for correctness rather than just
crash-avoidance: the wrap happens inside the verify pass, so an after-the-fact
check would let the boundary round run, and that round's `trimPromptCache` returns
0 (its guard is all-or-nothing over the array, so even the trimmable
full-attention entries go untrimmed). Its rejected drafts would stay in the cache
and every later token would be conditioned on tokens the target had rejected.
Standing down while headroom remains keeps every rewind valid.

One ordering change comes with it: `next()` now drains `pendingTokens` before
testing `passthrough`. The prefill bonus is queued there by `prepare`, and a
stand-down that fires at the end of `init` would otherwise skip it and start the
stream a position ahead of an equivalent greedy run. Every pre-existing
passthrough transition happens inside `speculateRound`, which `next()` reaches
only after clearing that buffer, so the reordering is a no-op for them.

The precondition, `updateConcat`'s overflow allowance, the emit hook, and the
classic `SpeculativeDecoding` path are all untouched. The precondition is correct
and doing its job — it turned what would have been a silently wrong attention
pattern into a precise report.

Two notes for reviewers. Speculative-decoding telemetry now describes only the
pre-stand-down prefix of such a stream while `emittedTokenCount` keeps climbing,
so `acceptanceRate` skews on runs that cross the window; happy to gate or annotate
that if you'd prefer. And the classic `SpeculativeTokenIterator` has the same
init-only trimmability check and degrades silently rather than crashing — left
alone here to keep this diff to the reported bug, but I can follow up.

## Verification

Run on macOS (Apple silicon), `swift-format` via pre-commit, against
`main` @ `cd1ab3d`.

```
xcodebuild build-for-testing -scheme mlx-swift-lm-Package -destination 'platform=macOS'
xcrun xctest .../Build/Products/Debug/MLXLMTests.xctest
  → Test run with 317 tests in 31 suites passed after 44.302 seconds

pre-commit run --all-files
  → swift-format ... Passed
```

Three regression tests were added to `MTPSpeculativeTokenIteratorTests`, all
CI-scoped against the existing synthetic mocks (no checkpoint required). Each was
confirmed to fail with the production change reverted and pass with it:

- `testMTPIteratorStandsDownWhenPromptFillsSlidingWindow` — a prompt past the
  window stands down during `init`; the stream still completes to `maxTokens`, the
  drafter is never invoked, and the prefill bonus is still the first token emitted.
- `testMTPIteratorStandsDownWhenSlidingCacheWrapsMidStream` — a stream that
  speculates a full round first and only then runs out of headroom stands down
  mid-stream with `acceptedCount > 0`.
- `testMTPIteratorMatchesGreedyAcrossMidStreamStandDown` — the wrap-crossing
  stream emits exactly the tokens a plain `TokenIterator` emits from the same
  model.

`CountingKVCache` gained an opt-in `wrapAt:` parameter and mirrors
`RotatingKVCache.isTrimmable(after:)` through the same strict
`offset + positions < wrapAt` boundary. `maxSize` still reports the window. It
defaults to nil — unbounded and always trimmable — so every pre-existing test
is unaffected.

Not run: the `IntegrationTesting` suites, which need checkpoints from the HF cache
and do not run in CI.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed) — the window bound on speculation is now documented on both public `generate(mtpDrafter:)` overloads.

