### PR TITLE
Add opt-in q4_0 lattice calibration to model conversion

### DIFF
--- a/Libraries/MLXLMCommon/ModelConversion.swift
+++ b/Libraries/MLXLMCommon/ModelConversion.swift
@@ -24,7 +24,7 @@ public enum ModelConversionQuantizationCalibration: Sendable, Equatable {
     /// Re-deriving a grid from such weights discards the alignment they were trained for;
     /// reproducing it keeps them on their intended lattice.
     ///
-    /// Requires 4 bits, a group size of 32, and ``QuantizationMode/affine``. Supplying a
+    /// Requires 4 bits, a group size of 32, and `QuantizationMode.affine`. Supplying a
     /// conflicting value throws ``ModelConversionError/incompatibleCalibration(_:_:)``
     /// rather than silently overriding it.
     ///

--- a/Libraries/MLXLMCommon/ModelConversion.swift
+++ b/Libraries/MLXLMCommon/ModelConversion.swift
@@ -9,6 +9,32 @@ package let modelConversionSidecarPatterns = [
 ]
 package let modelConversionDownloadPatterns = ["*.safetensors"] + modelConversionSidecarPatterns
 
+/// How the quantization grid is derived from the source weights.
+///
+/// This selects a *derivation*, not a storage format: every calibration produces ordinary
+/// quantized layers that load and run without any decode-side support.
+public enum ModelConversionQuantizationCalibration: Sendable, Equatable {
+    /// Derive the grid from the weights, as MLX does by default.
+    case standard
+
+    /// Reproduce the `Q4_0` grid: symmetric, 32-element groups, scaled by the signed
+    /// element of largest magnitude.
+    ///
+    /// Use this for checkpoints whose weights were already trained against that grid.
+    /// Re-deriving a grid from such weights discards the alignment they were trained for;
+    /// reproducing it keeps them on their intended lattice.
+    ///
+    /// Requires 4 bits, a group size of 32, and ``QuantizationMode/affine``. Supplying a
+    /// conflicting value throws ``ModelConversionError/incompatibleCalibration(_:_:)``
+    /// rather than silently overriding it.
+    ///
+    /// Only `Linear` layers are calibrated. Other quantizable layers are still quantized to
+    /// the same 4-bit/group-32 affine grid, but derive it the standard way, because
+    /// `QuantizedEmbedding` has no initializer accepting precomputed scales and biases.
+    /// The stored format is identical either way, so this affects accuracy, not loadability.
+    case q4Zero
+}
+
 /// Quantization settings for one conversion pass or layer.
 public struct ModelConversionQuantization: Sendable, Equatable {
     /// Quantization bit depth.
@@ -24,10 +50,17 @@ public struct ModelConversionQuantization: Sendable, Equatable {
     /// Quantization mode.
     public var mode: QuantizationMode
 
-    public init(bits: Int? = nil, groupSize: Int? = nil, mode: QuantizationMode = .affine) {
+    /// How the quantization grid is derived. Defaults to ``ModelConversionQuantizationCalibration/standard``.
+    public var calibration: ModelConversionQuantizationCalibration
+
+    public init(
+        bits: Int? = nil, groupSize: Int? = nil, mode: QuantizationMode = .affine,
+        calibration: ModelConversionQuantizationCalibration = .standard
+    ) {
         self.bits = bits
         self.groupSize = groupSize
         self.mode = mode
+        self.calibration = calibration
     }
 }
 
@@ -75,15 +108,22 @@ public struct ModelConversionOptions: Sendable {
         set { quantization.mode = newValue }
     }
 
+    public var calibration: ModelConversionQuantizationCalibration {
+        get { quantization.calibration }
+        set { quantization.calibration = newValue }
+    }
+
     public init(
         bits: Int? = nil,
         groupSize: Int? = nil,
         mode: QuantizationMode = .affine,
+        calibration: ModelConversionQuantizationCalibration = .standard,
         maxShardSize: Int64 = 5 * 1024 * 1024 * 1024,
         overwriteExistingOutput: Bool = false,
         quantizationPredicate: ModelConversionQuantizationPredicate? = nil
     ) {
-        self.quantization = .init(bits: bits, groupSize: groupSize, mode: mode)
+        self.quantization = .init(
+            bits: bits, groupSize: groupSize, mode: mode, calibration: calibration)
         self.maxShardSize = maxShardSize
         self.overwriteExistingOutput = overwriteExistingOutput
         self.quantizationPredicate = quantizationPredicate
@@ -152,6 +192,8 @@ public enum ModelConversionError: LocalizedError, Equatable {
     case unsupportedPyTorchWeights(URL)
     case sourceAlreadyQuantized(URL)
     case invalidShardSize(Int64)
+    case incompatibleCalibration(
+        ModelConversionQuantizationCalibration, ModelConversionQuantization)
 
     public var errorDescription: String? {
         switch self {
@@ -167,6 +209,8 @@ public enum ModelConversionError: LocalizedError, Equatable {
             "The source model in \(directory.path) is already quantized. Re-quantizing is not supported by this conversion helper."
         case .invalidShardSize(let shardSize):
             "Shard size must be greater than zero, got \(shardSize)."
+        case .incompatibleCalibration(let calibration, let quantization):
+            "\(calibration) calibration requires bits 4, group size 32, and affine mode, but got bits \(quantization.bits.map(String.init) ?? "default"), group size \(quantization.groupSize.map(String.init) ?? "default"), mode \(quantization.mode)."
         }
     }
 }
@@ -191,6 +235,12 @@ public func convert(
     if perLayerQuantization != nil {
         throw ModelConversionError.sourceAlreadyQuantized(modelDirectory)
     }
+    try validateModelConversionCalibration(options.quantization)
+    // Resolved once, before any filesystem mutation, and reused below. Re-running the
+    // predicate after the output exists would let a stateful one pass preflight and then
+    // fail with a half-written model on disk.
+    let quantizationDecisions = try modelConversionQuantizationDecisions(
+        model: model, options: options)
     try validateModelConversionOutputDirectory(
         outputDirectory,
         modelDirectory: modelDirectory,
@@ -212,7 +262,8 @@ public func convert(
         perLayerQuantization: perLayerQuantization)
 
     progressHandler(.init(stage: .quantizing))
-    let quantizationResult = quantizeForModelConversion(model: model, options: options)
+    let quantizationResult = quantizeForModelConversion(
+        model: model, options: options, decisions: quantizationDecisions)
     eval(model)
 
     progressHandler(.init(stage: .savingWeights))
@@ -554,18 +605,16 @@ private func removeModelConversionWeights(in outputDirectory: URL) throws {
 
 private func quantizeForModelConversion(
     model: BaseLanguageModel,
-    options: ModelConversionOptions
+    options: ModelConversionOptions,
+    decisions: [(String, Module, ModelConversionQuantizationDecision)]
 ) -> ModelConversionQuantizationResult {
     var layerQuantization = [String: ModelConversionQuantizationDecision]()
     let defaultQuantization = options.quantization
     var effectiveDefaultQuantization = effectiveModelConversionQuantization(defaultQuantization)
 
     let updates =
-        model
-        .leafModules()
-        .flattened()
-        .compactMap { path, module -> (String, Module)? in
-            let decision = options.quantizationPredicate?(path, module) ?? .quantize()
+        decisions
+        .compactMap { path, module, decision -> (String, Module)? in
             let quantization: ModelConversionQuantization
             let usesDefaultQuantization: Bool
             switch decision {
@@ -609,6 +658,94 @@ private func quantizeForModelConversion(
         layerQuantization: layerQuantization)
 }
 
+/// Bits, group size, and mode that ``ModelConversionQuantizationCalibration/q4Zero`` requires.
+private let q4ZeroBits = 4
+private let q4ZeroGroupSize = 32
+
+/// Magnitude of the most-negative representable code. The grid spans `[-8, 7]`, so the scale
+/// is `extremum / -8` and the affine bias that recentres it is `-8 * scale`.
+private let q4ZeroNegativeExtent: Float = 8
+
+/// Validates that a quantization request is consistent with its calibration.
+///
+/// Called before any output directory is created or removed so an unusable request fails
+/// without touching the filesystem.
+func validateModelConversionCalibration(_ quantization: ModelConversionQuantization) throws {
+    switch quantization.calibration {
+    case .standard:
+        return
+    case .q4Zero:
+        let compatible =
+            (quantization.bits ?? q4ZeroBits) == q4ZeroBits
+            && (quantization.groupSize ?? q4ZeroGroupSize) == q4ZeroGroupSize
+            && quantization.mode == .affine
+        if !compatible {
+            throw ModelConversionError.incompatibleCalibration(.q4Zero, quantization)
+        }
+    }
+}
+
+/// Resolves every layer's quantization decision and validates it.
+///
+/// Runs before the output directory is created or removed, so a conflicting per-layer
+/// override fails without leaving a half-written model behind.
+func modelConversionQuantizationDecisions(
+    model: BaseLanguageModel,
+    options: ModelConversionOptions
+) throws -> [(String, Module, ModelConversionQuantizationDecision)] {
+    var resolved = [(String, Module, ModelConversionQuantizationDecision)]()
+    for (path, module) in model.leafModules().flattened() {
+        let decision = options.quantizationPredicate?(path, module) ?? .quantize()
+        if case .quantize(let override) = decision, let override {
+            try validateModelConversionCalibration(override)
+        }
+        resolved.append((path, module, decision))
+    }
+    return resolved
+}
+
+/// Reproduces the `Q4_0` grid for one weight tensor.
+///
+/// Per 32-element group along the input axis the scale comes from the **signed** element of
+/// largest magnitude, `d = extremum / -8`. Using `-max(abs(w))/8` instead flips the sign on
+/// every group whose extremum is negative — close to half of them — which silently produces a
+/// different grid rather than an error. `codeSignedExtremumIsNotAbsMax` pins that apart.
+///
+/// Returns MLX's affine triplet: packed 4-bit codes, `scales = d`, and `biases = -8 * d`.
+func q4ZeroQuantized(_ weight: MLXArray) -> (weight: MLXArray, scales: MLXArray, biases: MLXArray) {
+    let rows = weight.dim(0)
+    let columns = weight.dim(-1)
+    let groups = columns / q4ZeroGroupSize
+
+    let grouped = weight.reshaped(rows * groups, q4ZeroGroupSize).asType(.float32)
+
+    // Signed element of largest magnitude, per group.
+    let magnitudes = MLX.abs(grouped)
+    let extremumIndex = MLX.argMax(magnitudes, axis: -1, keepDims: true)
+    let extremum = MLX.takeAlong(grouped, extremumIndex, axis: -1)
+
+    let scales = extremum / -q4ZeroNegativeExtent
+    let isZero = scales .== 0
+    let inverse = MLX.where(
+        isZero, MLXArray(Float(0)), 1 / MLX.where(isZero, MLXArray(Float(1)), scales))
+
+    // `grouped * inverse` lands in [-8, 8], so adding 8.5 is always positive and floor()
+    // equals the reference encoder's trunc(). Rounding half-to-even would disagree on ties.
+    let offset = grouped * inverse + (q4ZeroNegativeExtent + 0.5)
+    let codes = MLX.clip(MLX.floor(offset), min: 0, max: 15).asType(.uint32)
+
+    // Pack 8 consecutive codes per uint32, low nibble first. The nibbles never overlap, so
+    // summing the shifted codes is exactly a bitwise OR.
+    let codesPerWord = 32 / q4ZeroBits
+    let packedGroups = codes.reshaped(rows, columns / codesPerWord, codesPerWord)
+    let shifts = (MLXArray(0 ..< codesPerWord) * q4ZeroBits).asType(.uint32).reshaped(
+        1, 1, codesPerWord)
+    let packed = MLX.sum(packedGroups << shifts, axis: 2).asType(.uint32)
+
+    let scaleGrid = scales.reshaped(rows, groups).asType(weight.dtype)
+    return (packed, scaleGrid, (scaleGrid * -q4ZeroNegativeExtent).asType(weight.dtype))
+}
+
 private func isConvertibleQuantizationTarget(_ module: Module, groupSize: Int) -> Bool {
     if module is Quantized {
         return false
@@ -634,6 +771,24 @@ private func quantizeLayerForModelConversion(
     let mode = quantization.mode
 
     if let linear = layer as? Linear {
+        if quantization.calibration == .q4Zero {
+            guard linear.weight.dim(-1) % q4ZeroGroupSize == 0 else { return nil }
+            let (weight, scales, biases) = q4ZeroQuantized(linear.weight)
+            let resolved = EffectiveModelConversionQuantization(
+                bits: q4ZeroBits, groupSize: q4ZeroGroupSize, mode: .affine)
+            return (
+                QuantizedLinear(
+                    weight: weight,
+                    bias: linear.bias,
+                    scales: scales,
+                    biases: biases,
+                    groupSize: q4ZeroGroupSize,
+                    bits: q4ZeroBits,
+                    mode: .affine),
+                resolved
+            )
+        }
+
         let (weight, scales, biases) = MLX.quantized(
             linear.weight, groupSize: quantization.groupSize, bits: quantization.bits, mode: mode)
         let actualQuantization =
@@ -678,7 +833,7 @@ private func quantizeLayerForModelConversion(
     return (quantized, effectiveQuantization)
 }
 
-private struct EffectiveModelConversionQuantization: Equatable {
+struct EffectiveModelConversionQuantization: Equatable {
     var bits: Int
     var groupSize: Int
     var mode: QuantizationMode
@@ -695,14 +850,21 @@ private struct ModelConversionQuantizationResult {
 
 extension ModelConversionQuantization {
     fileprivate var hasUnresolvedDefaults: Bool {
-        bits == nil || groupSize == nil
+        guard calibration == .standard else { return false }
+        return bits == nil || groupSize == nil
     }
 }
 
-private func effectiveModelConversionQuantization(
+func effectiveModelConversionQuantization(
     _ quantization: ModelConversionQuantization
 ) -> EffectiveModelConversionQuantization {
-    .init(
+    // A calibration fixes its own grid geometry. Falling through to the mode defaults here
+    // would resolve q4Zero to group size 64 and then skip linears whose input width is a
+    // multiple of 32 but not 64.
+    if quantization.calibration == .q4Zero {
+        return .init(bits: q4ZeroBits, groupSize: q4ZeroGroupSize, mode: .affine)
+    }
+    return .init(
         bits: quantization.bits ?? defaultModelConversionBits(for: quantization.mode),
         groupSize: quantization.groupSize
             ?? defaultModelConversionGroupSize(for: quantization.mode),

--- a/Tests/MLXLMTests/ModelConversionTests.swift
+++ b/Tests/MLXLMTests/ModelConversionTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import MLX
+import MLXNN
 import XCTest
 
 @testable import MLXLMCommon
@@ -453,6 +454,266 @@ final class ModelConversionTests: XCTestCase {
         FileManager.default.fileExists(
             atPath: directory.appendingPathComponent(filename).path)
     }
+
+    // MARK: - q4Zero calibration
+
+    /// Unpacks MLX's 4-bit affine layout: 8 codes per uint32, low nibble first.
+    private func unpackCodes(_ packed: MLXArray) -> [Int] {
+        let words = packed.asArray(UInt32.self)
+        var codes = [Int]()
+        codes.reserveCapacity(words.count * 8)
+        for word in words {
+            for nibble in 0 ..< 8 {
+                codes.append(Int((word >> UInt32(nibble * 4)) & 0xF))
+            }
+        }
+        return codes
+    }
+
+    /// One 32-element group whose extremum is NEGATIVE, with hand-computable codes.
+    ///
+    /// extremum = -4, so d = -4 / -8 = 0.5 and code = floor(w / 0.5 + 8.5).
+    private func negativeExtremumGroup() -> (weights: [Float], expectedCodes: [Int]) {
+        var weights = [Float](repeating: 0, count: 32)
+        weights[0] = -4.0  // the signed extremum
+        weights[1] = 0.0
+        weights[2] = 0.5
+        weights[3] = -0.5
+        weights[4] = 3.5
+        var expected = [Int](repeating: 8, count: 32)  // w == 0 -> floor(8.5) == 8
+        expected[0] = 0  // floor(-8 + 8.5)
+        expected[1] = 8
+        expected[2] = 9  // floor(1 + 8.5)
+        expected[3] = 7  // floor(-1 + 8.5)
+        expected[4] = 15  // floor(7 + 8.5)
+        return (weights, expected)
+    }
+
+    func testQ4ZeroCalibrationDefaultsToStandard() {
+        XCTAssertEqual(ModelConversionQuantization().calibration, .standard)
+        XCTAssertEqual(ModelConversionOptions().calibration, .standard)
+    }
+
+    func testQ4ZeroProducesHandComputableCodesScalesAndBiases() {
+        let (weights, expected) = negativeExtremumGroup()
+        let weight = MLXArray(weights, [1, 32])
+
+        let (packed, scales, biases) = q4ZeroQuantized(weight)
+
+        XCTAssertEqual(unpackCodes(packed), expected)
+        XCTAssertEqual(scales.asArray(Float.self), [0.5])
+        XCTAssertEqual(biases.asArray(Float.self), [-4.0])
+        // First word packs codes 0,8,9,7,15,8,8,8 low-nibble-first.
+        XCTAssertEqual(packed.asArray(UInt32.self)[0], 0x888F_7980)
+    }
+
+    /// The regression that matters: `-max(abs(w))/8` flips the scale's sign on every group
+    /// whose extremum is negative, silently producing a different grid rather than an error.
+    func testQ4ZeroUsesSignedExtremumNotAbsMax() {
+        let (weights, _) = negativeExtremumGroup()
+        let weight = MLXArray(weights, [1, 32])
+
+        let (packed, scales, _) = q4ZeroQuantized(weight)
+
+        // Signed extremum is -4 -> d = +0.5 and the extremum encodes to code 0.
+        XCTAssertEqual(scales.asArray(Float.self), [0.5])
+        XCTAssertEqual(unpackCodes(packed)[0], 0)
+
+        // -absMax/8 would give d = -0.5, sending the same element to code 15.
+        let absMaxScale = -weights.map { abs($0) }.max()! / 8
+        XCTAssertEqual(absMaxScale, -0.5)
+        let wrongCode = min(15, max(0, Int((weights[0] / absMaxScale + 8.5).rounded(.down))))
+        XCTAssertEqual(wrongCode, 15)
+    }
+
+    func testQ4ZeroHandlesPositiveExtremumAndClipsAtBothEnds() {
+        // extremum = +4 -> d = -0.5. code = floor(w / -0.5 + 8.5).
+        var weights = [Float](repeating: 0, count: 32)
+        weights[0] = 4.0
+        weights[1] = -3.5
+        let weight = MLXArray(weights, [1, 32])
+
+        let (packed, scales, biases) = q4ZeroQuantized(weight)
+        let codes = unpackCodes(packed)
+
+        XCTAssertEqual(scales.asArray(Float.self), [-0.5])
+        XCTAssertEqual(biases.asArray(Float.self), [4.0])
+        XCTAssertEqual(codes[0], 0)  // floor(-8 + 8.5)
+        XCTAssertEqual(codes[1], 15)  // floor(7 + 8.5)
+        XCTAssertTrue(codes.allSatisfy { $0 >= 0 && $0 <= 15 })
+    }
+
+    func testQ4ZeroAllZeroGroupDoesNotDivideByZero() {
+        let weight = MLXArray([Float](repeating: 0, count: 32), [1, 32])
+
+        let (packed, scales, biases) = q4ZeroQuantized(weight)
+
+        XCTAssertEqual(scales.asArray(Float.self), [0])
+        XCTAssertEqual(biases.asArray(Float.self), [0])
+        // inverse is forced to 0, so every code is floor(0 + 8.5) == 8.
+        XCTAssertEqual(unpackCodes(packed), [Int](repeating: 8, count: 32))
+    }
+
+    func testQ4ZeroScalesPerGroupAcrossMultipleGroupsAndRows() {
+        // Two rows, two groups each: distinct extrema prove grouping follows the input axis
+        // rather than collapsing across rows or groups.
+        var values = [Float](repeating: 0, count: 2 * 64)
+        values[0] = -4.0  // row 0, group 0 -> d = 0.5
+        values[32] = 2.0  // row 0, group 1 -> d = -0.25
+        values[64] = 8.0  // row 1, group 0 -> d = -1.0
+        values[96] = -1.0  // row 1, group 1 -> d = 0.125
+        let weight = MLXArray(values, [2, 64])
+
+        let (_, scales, biases) = q4ZeroQuantized(weight)
+
+        XCTAssertEqual(scales.shape, [2, 2])
+        XCTAssertEqual(scales.asArray(Float.self), [0.5, -0.25, -1.0, 0.125])
+        XCTAssertEqual(biases.asArray(Float.self), [-4.0, 2.0, 8.0, -1.0])
+    }
+
+    func testQ4ZeroDequantizesOntoTheIntendedLattice() {
+        let (weights, expected) = negativeExtremumGroup()
+        let weight = MLXArray(weights, [1, 32])
+
+        let (packed, scales, biases) = q4ZeroQuantized(weight)
+        let restored = dequantized(
+            packed, scales: scales, biases: biases, groupSize: 32, bits: 4, mode: .affine)
+
+        let scale = scales.asArray(Float.self)[0]
+        let expectedValues = expected.map { (Float($0) - 8) * scale }
+        let actual = restored.asArray(Float.self)
+        XCTAssertEqual(actual.count, expectedValues.count)
+        for (lhs, rhs) in zip(actual, expectedValues) {
+            XCTAssertEqual(lhs, rhs, accuracy: 1e-6)
+        }
+    }
+
+    func testQ4ZeroCalibrationRejectsIncompatibleSettings() {
+        for quantization in [
+            ModelConversionQuantization(bits: 8, calibration: .q4Zero),
+            ModelConversionQuantization(groupSize: 64, calibration: .q4Zero),
+        ] {
+            XCTAssertThrowsError(try validateModelConversionCalibration(quantization)) { error in
+                guard case ModelConversionError.incompatibleCalibration = error else {
+                    return XCTFail("expected incompatibleCalibration, got \(error)")
+                }
+            }
+        }
+    }
+
+    func testQ4ZeroCalibrationAcceptsResolvedAndOmittedSettings() {
+        XCTAssertNoThrow(
+            try validateModelConversionCalibration(
+                ModelConversionQuantization(calibration: .q4Zero)))
+        XCTAssertNoThrow(
+            try validateModelConversionCalibration(
+                ModelConversionQuantization(bits: 4, groupSize: 32, calibration: .q4Zero)))
+    }
+
+    func testStandardCalibrationImposesNoConstraints() {
+        XCTAssertNoThrow(
+            try validateModelConversionCalibration(
+                ModelConversionQuantization(bits: 8, groupSize: 64)))
+    }
+
+    // MARK: - q4Zero wiring
+
+    /// Minimal model exposing one Linear and one Embedding for conversion-path tests.
+    private final class StubConversionModel: Module, BaseLanguageModel {
+        let linear: Linear
+        let embedding: Embedding
+
+        init(inputWidth: Int) {
+            self.linear = Linear(inputWidth, 8, bias: true)
+            self.embedding = Embedding(embeddingCount: 4, dimensions: inputWidth)
+        }
+
+        func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] { weights }
+    }
+
+    /// Regression: q4Zero must resolve its own geometry. Falling through to the affine mode
+    /// defaults yields group size 64, which then skips every linear whose input width is a
+    /// multiple of 32 but not 64.
+    func testQ4ZeroResolvesToFourBitsGroupThirtyTwo() {
+        let resolved = effectiveModelConversionQuantization(
+            ModelConversionQuantization(calibration: .q4Zero))
+
+        XCTAssertEqual(resolved.bits, 4)
+        XCTAssertEqual(resolved.groupSize, 32)
+        XCTAssertEqual(resolved.mode, .affine)
+
+        // Standard calibration keeps the mode-derived defaults.
+        let standard = effectiveModelConversionQuantization(ModelConversionQuantization())
+        XCTAssertEqual(standard.groupSize, 64)
+    }
+
+    /// Regression: an invalid per-layer override must throw, not be silently dropped.
+    func testInvalidPerLayerOverrideThrowsBeforeConversion() {
+        let model = StubConversionModel(inputWidth: 32)
+        let options = ModelConversionOptions(quantizationPredicate: { _, _ in
+            .quantize(ModelConversionQuantization(bits: 8, calibration: .q4Zero))
+        })
+
+        XCTAssertThrowsError(
+            try modelConversionQuantizationDecisions(model: model, options: options)
+        ) { error in
+            guard case ModelConversionError.incompatibleCalibration = error else {
+                return XCTFail("expected incompatibleCalibration, got \(error)")
+            }
+        }
+    }
+
+    func testValidPerLayerOverridesResolveForEveryLeaf() throws {
+        let model = StubConversionModel(inputWidth: 32)
+        let options = ModelConversionOptions(quantizationPredicate: { _, _ in
+            .quantize(ModelConversionQuantization(calibration: .q4Zero))
+        })
+
+        let decisions = try modelConversionQuantizationDecisions(model: model, options: options)
+
+        XCTAssertFalse(decisions.isEmpty)
+        XCTAssertTrue(
+            decisions.allSatisfy {
+                if case .quantize(let override) = $0.2 { return override?.calibration == .q4Zero }
+                return false
+            })
+    }
+
+    /// Regression: the predicate must be consulted exactly once per leaf. Resolving twice
+    /// would let a stateful predicate pass preflight and then fail after the output
+    /// directory has already been created and populated.
+    func testQuantizationPredicateIsInvokedOncePerLeaf() throws {
+        let model = StubConversionModel(inputWidth: 32)
+        let counts = LockedCounts()
+        let options = ModelConversionOptions(quantizationPredicate: { path, _ in
+            counts.increment(path)
+            return .quantize()
+        })
+
+        let decisions = try modelConversionQuantizationDecisions(model: model, options: options)
+
+        XCTAssertFalse(decisions.isEmpty)
+        XCTAssertEqual(counts.snapshot().count, decisions.count)
+        XCTAssertTrue(counts.snapshot().values.allSatisfy { $0 == 1 })
+    }
+
+    private final class LockedCounts: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage = [String: Int]()
+
+        func increment(_ key: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            storage[key, default: 0] += 1
+        }
+
+        func snapshot() -> [String: Int] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
 }
 
 private struct ConversionMockDownloader: Downloader {


### PR DESCRIPTION
## Proposed changes

Adds an opt-in **calibration** to model conversion that reproduces a checkpoint's existing `Q4_0` quantization grid instead of deriving a new one.

### The problem

Some checkpoints ship weights that were already trained against a specific quantization grid — Google's Gemma 4 QAT releases are the motivating case. `MLX.quantized` derives a fresh grid from those weights by min/max, which discards the alignment they were trained for. The result is a converted model that sits further from the original than it needs to, at the same bit width and the same file size.

The grid is recoverable: it is 32-element groups scaled by the **signed** element of largest magnitude, `d = extremum / -8`, which is expressible as ordinary affine `scales = d`, `biases = -8 * d`.

### What this changes

```swift
public enum ModelConversionQuantizationCalibration: Sendable, Equatable {
    case standard   // today's behaviour, unchanged and still the default
    case q4Zero     // reproduce the Q4_0 grid
}
```

`calibration` is added to `ModelConversionQuantization` and surfaced on `ModelConversionOptions`. `.q4Zero` resolves to 4 bits / group size 32 / affine, and **rejects** a conflicting explicit value rather than silently overriding it. Per-layer predicate overrides are validated on the same terms, before the output directory is created or removed.

**This is a derivation, not a storage format.** The output is ordinary affine 4-bit, so converted models load and run through the existing path with no decode-side change anywhere. The diff touches only `ModelConversion.swift` and its tests.

### Evidence

Each converted model was compared against its own bfloat16 reference over 200 chat-formatted prompts, teacher-forced, measuring mean KL divergence per token position (lower is better) and exact top-1 agreement. Stock group-32 conversion vs this calibration, **at identical file size**:

| model | KL, stock | KL, calibrated | top-1, stock | top-1, calibrated |
|---|---|---|---|---|
| Gemma 4 E2B | 0.0220 | **0.0175** | 95.7% | **96.2%** |
| Gemma 4 E4B | 0.0160 | **0.0112** | 96.6% | **97.2%** |
| Gemma 4 12B | 0.1219 | **0.0631** | 92.8% | **94.3%** |
| Gemma 4 31B | 0.0321 | **0.0205** | 96.5% | **96.9%** |

Correctness was established independently of those measurements: the derivation reproduces Google's own shipped `Q4_0` GGUF **exactly** — 100% of codes and scales matched across 721M weights on 12B — and this Swift implementation was then checked tensor-by-tensor against that verified artifact on E2B: **275 tensors, 0 mismatches**, bit-identical packed codes, scales and biases.

### Scope and limits, stated plainly

- **Only `Linear` is calibrated.** Other quantizable layers still land on the same 4-bit/group-32 affine grid but derive it the standard way, because `QuantizedEmbedding` has no initializer accepting precomputed scales and biases. That affects accuracy, not loadability, and is documented on the API. Happy to follow up if an upstream initializer would be welcome.
- **No benefit on mixture-of-experts.** The same measurement on Gemma 4 26B-A4B showed no significant change (0.0707 → 0.0680, overlapping confidence intervals), so no claim is made there.
- **Opt-in only.** No model-name or fingerprint auto-detection; callers ask for it explicitly.
- Measurements are single-run on one prompt corpus with a fixed seed.

### Notes for review

- The case is named `q4Zero` rather than `q4_0` to fit Swift naming; the format name `Q4_0` is kept in documentation.
- A mirrored change for `mlx-lm` is prepared, so the two conversion paths stay in step.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Tests: 14 added to `ModelConversionTests`, covering hand-computable codes/scales/biases, positive and negative extrema, truncation and clipping at both ends, degenerate all-zero groups, per-group scaling across multiple rows and groups, dequantization onto the intended lattice, rejection of incompatible settings and per-layer overrides, and one pinning the signed-extremum rule apart from `-absMax/8` — the error that silently produces a different grid on roughly half of all groups. Full `xcodebuild` suite passes.


---

**Published weights using this path** — 4-bit MLX conversions of the Gemma 4 QAT checkpoints, which load with released `mlx-lm` (they are ordinary affine 4-bit; none of this PR is needed to *use* them):

- [gemma-4-E2B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-E2B-it-qat-q4_0-mlx)
- [gemma-4-E4B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-E4B-it-qat-q4_0-mlx)
- [gemma-4-12B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-12B-it-qat-q4_0-mlx)
- [gemma-4-31B-it-qat-q4_0-mlx](https://huggingface.co/goodolclint/gemma-4-31B-it-qat-q4_0-mlx)

Each was produced by this branch and verified bit-identical to Google's shipped `Q4_0` grid before upload.