### PR TITLE
Qwen2.5-VL: accumulate vision cuSeqlens across temporal slices

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -326,6 +326,25 @@ private enum Language {
 
 // MARK: - Vision
 
+/// Cumulative patch-row boundaries, one per temporal slice, used to build the
+/// block-diagonal vision attention mask.
+///
+/// Each frame contributes `t` blocks of `h * w` rows, so the boundaries must be a
+/// running total across every slice of every frame. Internal rather than nested in
+/// `Vision` so that `t > 1` (video) grids can be covered directly by tests.
+func visionCuSeqlens(_ frames: [THW]) -> [Int] {
+    var cuSeqlens = [0]
+    for frame in frames {
+        let seqLen = frame.h * frame.w
+        var running = cuSeqlens.last!
+        for _ in 0 ..< frame.t {
+            running += seqLen
+            cuSeqlens.append(running)
+        }
+    }
+    return cuSeqlens
+}
+
 private enum Vision {
 
     static fileprivate func applyMultimodalRotaryPositionEmbedding(
@@ -664,15 +683,7 @@ private enum Vision {
 
             // prepare attention masks
             let seqLen = hiddenStates.dim(0)
-            var cuSeqlens = [0]
-            for frame in frames {
-                let seqLen = frame.h * frame.w
-                cuSeqlens.append(
-                    contentsOf: Array(repeating: seqLen, count: frame.t).map {
-                        cuSeqlens.last! + $0
-                    })
-            }
-            let cuSeqlensArray = MLXArray(cuSeqlens)
+            let cuSeqlensArray = MLXArray(visionCuSeqlens(frames))
 
             let fullAttentionMaskBool = attentionMask(
                 sequenceLength: seqLen, cuSeqlens: cuSeqlensArray)

--- a/Tests/MLXLMTests/Qwen25VLVisionMaskTests.swift
+++ b/Tests/MLXLMTests/Qwen25VLVisionMaskTests.swift
@@ -1,0 +1,63 @@
+// Copyright © 2026 Apple Inc.
+//
+// Coverage for the cumulative patch-row boundaries behind the Qwen2.5-VL vision
+// attention mask, on grids with a temporal extent (`t > 1`), i.e. video.
+//
+// The boundaries drive `attentionMask(sequenceLength:cuSeqlens:)`, which marks
+// `[start..<end, start..<end]` attendable for each temporal slice. If they are not
+// a running total the covered range stops short of the patch buffer, and the
+// uncovered rows attend uniformly across every frame instead of within their own —
+// the mask bias is a finite `-10000`, not `-inf`, so this corrupts values silently
+// rather than surfacing as NaN. Asserting the boundaries directly is therefore the
+// reliable check.
+//
+// `t == 1` (still images) collapses to one block per frame and is unaffected.
+
+import Foundation
+import MLXLMCommon
+import XCTest
+
+@testable import MLXVLM
+
+final class Qwen25VLVisionMaskTests: XCTestCase {
+
+    /// A single still image: one block, unchanged behaviour.
+    func testVisionCuSeqlensSingleImage() {
+        XCTAssertEqual(visionCuSeqlens([THW(1, 4, 4)]), [0, 16])
+    }
+
+    /// Several still images: one block each, boundaries accumulate across frames.
+    func testVisionCuSeqlensMultipleImages() {
+        XCTAssertEqual(visionCuSeqlens([THW(1, 4, 4), THW(1, 2, 4)]), [0, 16, 24])
+    }
+
+    /// Video: every temporal slice is its own block.
+    ///
+    /// `THW(3, 4, 4)` contributes three blocks of 16 rows, `THW(2, 2, 4)` two blocks
+    /// of 8 — 64 patch rows in total. Reading the accumulator inside a `map` instead
+    /// of carrying it forward yields `[0, 16, 16, 16, 24, 24]`, which covers 24 of
+    /// the 64 rows and leaves rows 24...63 outside every attendable block.
+    func testVisionCuSeqlensTemporalGridsAccumulateAcrossSlices() {
+        let frames = [THW(3, 4, 4), THW(2, 2, 4)]
+
+        let boundaries = visionCuSeqlens(frames)
+
+        XCTAssertEqual(boundaries, [0, 16, 32, 48, 56, 64])
+
+        let patchRows = frames.reduce(0) { $0 + $1.t * $1.h * $1.w }
+        XCTAssertEqual(
+            boundaries.last, patchRows,
+            "boundaries must cover every patch row, otherwise the tail attends outside its frame")
+    }
+
+    /// The boundaries must be strictly increasing — a repeated value is an empty
+    /// block, which is exactly how the accumulator bug manifests.
+    func testVisionCuSeqlensIsStrictlyIncreasing() {
+        let boundaries = visionCuSeqlens([THW(4, 2, 2), THW(1, 4, 4)])
+        for i in 1 ..< boundaries.count {
+            XCTAssertGreaterThan(
+                boundaries[i], boundaries[i - 1],
+                "empty block at index \(i): \(boundaries)")
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fixes #503.

### Problem

`Qwen25VL.swift` builds the vision full-attention mask from cumulative per-frame
boundaries:

```swift
cuSeqlens.append(
    contentsOf: Array(repeating: seqLen, count: frame.t).map {
        cuSeqlens.last! + $0
    })
```

`map` builds its entire result before `append(contentsOf:)` runs, so `cuSeqlens.last!`
is the same value for every element of a frame's chunk rather than a running total.

For `frames = [THW(3, 4, 4), THW(2, 2, 4)]` — 64 patch rows — the boundaries come out
`[0, 16, 16, 16, 24, 24]` instead of `[0, 16, 32, 48, 56, 64]`. `attentionMask(sequenceLength:cuSeqlens:)`
marks `[start..<end, start..<end]` attendable per boundary pair, so rows 24...63 fall
outside every block.

Worth being precise about the consequence: the boolean mask becomes an additive
`-10000` bias, not `-inf`, so those rows do not produce NaN — their softmax converges
to a uniform distribution over every patch in the payload, across frame boundaries.
The failure is silent.

Still images are unaffected: `t == 1` makes the chunk single-element, so
`cuSeqlens.last! + seqLen` is already correct.

### Fix

Carry the accumulator explicitly, one block per temporal slice.

The computation is extracted to `visionCuSeqlens(_:)` at internal visibility for one
reason: the original sits inside `private enum Vision`, which tests cannot reach even
with `@testable`, and `git grep "THW(" Tests/` showed only `THW(1, …)` — the `t > 1`
path had no coverage at all. Because the mask bias is finite, a downstream numeric
assertion does not reliably surface the bug; the boundaries themselves do. Happy to
re-house the helper wherever you'd prefer.

### Tests

Four cases in `Qwen25VLVisionMaskTests`: single image, multiple images, a multi-frame
video grid, and a strict-monotonicity check (a repeated boundary is an empty block,
which is exactly how the bug manifests).

Against the previous logic the two temporal tests fail with
`[0, 16, 16, 16, 24, 24]` vs `[0, 16, 32, 48, 56, 64]`; the still-image tests pass
either way.

Full `MLXLMTests` passes apart from the pre-existing `TurboQuantIntegrationTests`
flake (`cos 0.944` against a `0.97` bar), which is unrelated to this change.
