### PR TITLE
Make MambaCache rewindable so speculative decoding can run on hybrid SSM/attention models

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1400,7 +1400,56 @@ public class ArraysCache: BaseKVCache {
 }
 
 /// Simple cache for Mamba-style state space models
+///
+/// ## Rewindability
+///
+/// A recurrent state has no rows to drop: token `t`'s contribution has already
+/// been folded into token `t+1`'s state, so there is nothing to slice off the
+/// end. `trim(_:)` therefore cannot be implemented the way `KVCacheSimple`
+/// implements it, and `MambaCache` reports `isTrimmable == false` by default.
+///
+/// That default is what blocks speculative decoding on hybrid SSM/attention
+/// models: ``MTPSpeculativeTokenIterator`` requires
+/// ``canTrimPromptCache(_:)``, which is an `allSatisfy` over every layer's
+/// cache, so a single non-trimmable entry disables speculation for the whole
+/// model.
+///
+/// Opting in to ``rewindDepth`` makes the cache rewindable by keeping a bounded
+/// history of past states and restoring one on `trim`. With `rewindDepth == 0`
+/// — the default — nothing is recorded, nothing is allocated, and behaviour is
+/// identical to before this capability existed.
+///
+/// Callers must set `rewindDepth` to at least the deepest rewind they will
+/// request (for speculative decoding, `blockSize - 1`).
 public class MambaCache: ArraysCache {
+
+    /// Bounded history of past cache slots, oldest first, tagged with the token
+    /// position each snapshot represents.
+    ///
+    /// The slots are stored rather than ``state`` because `state` drops empty
+    /// slots: a `MambaCache` whose conv slot is unused (`convKernelSize == 1`)
+    /// has `state == [ssm]`, and restoring that through the `state` setter would
+    /// resize the cache from two slots to one.
+    private var rewindHistory: [(position: Int, slots: [MLXArray?])] = []
+
+    /// Token position this cache has advanced to, maintained independently of
+    /// ``BaseKVCache/offset``.
+    ///
+    /// `ArraysCache` never advances `offset` — `advance(_:)` only decrements
+    /// `lengths`/`leftPadding` — and models using this cache do not maintain it
+    /// either. Tracking position here keeps rewind self-contained instead of
+    /// making it depend on a field nothing currently sets.
+    private var rewindPosition: Int = 0
+
+    /// How many tokens of rewind history to retain. `0` (the default) disables
+    /// rewinding entirely.
+    ///
+    /// Memory cost is `rewindDepth + 1` copies of the cache slots. For
+    /// Qwen3.5/3.6 GDN that is ~2.06 MiB per linear-attention layer
+    /// (recurrent `[1, 32, 128, 128]` f32 plus conv `[1, 4, 8192]` bf16), so
+    /// ~61.9 MiB per retained step across 30 such layers.
+    public var rewindDepth: Int = 0
+
     public init(leftPadding: [Int]? = nil) {
         super.init(size: 2, leftPadding: leftPadding)
     }
@@ -1408,7 +1457,59 @@ public class MambaCache: ArraysCache {
     public override func copy() -> any KVCache {
         let new = MambaCache()
         copyContents(to: new)
+        new.rewindDepth = rewindDepth
+        new.rewindHistory = rewindHistory
+        new.rewindPosition = rewindPosition
         return new
+    }
+
+    /// Advance the cache position and snapshot the new state if rewinding is
+    /// enabled.
+    ///
+    /// Call this once per forward pass, after the new state has been written,
+    /// passing the number of tokens the pass consumed. With `rewindDepth == 0`
+    /// this is a single branch and records nothing.
+    ///
+    /// A prefill pass of `S` tokens produces one snapshot at position `S`, so a
+    /// rewind can land on any decode step but not inside a prefill — which is
+    /// the only granularity speculative decoding needs.
+    public func checkpoint(advancing tokens: Int) {
+        rewindPosition += tokens
+        guard rewindDepth > 0 else { return }
+        rewindHistory.append((rewindPosition, cache.map { $0?[.ellipsis] }))
+        let capacity = rewindDepth + 1
+        if rewindHistory.count > capacity {
+            rewindHistory.removeFirst(rewindHistory.count - capacity)
+        }
+    }
+
+    /// `true` only when a rewind has been opted into and a snapshot exists.
+    ///
+    /// Deliberately conservative: `trimPromptCache(_:numTokens:)` does not treat
+    /// a `0` return as an error, so advertising trimmability without the history
+    /// to honour it would leave rejected tokens folded into the SSM state — a
+    /// silent correctness bug rather than a slow path.
+    public override var isTrimmable: Bool {
+        rewindDepth > 0 && !rewindHistory.isEmpty
+    }
+
+    /// Restore the state as it was `n` tokens ago.
+    ///
+    /// Returns `n` on success and `0` if no snapshot lands exactly on the target
+    /// position, leaving the cache untouched. The rewind is exact or refused —
+    /// never approximate — because an SSM state that disagrees with the
+    /// attention caches by even one token yields wrong output with no error.
+    @discardableResult
+    public override func trim(_ n: Int) -> Int {
+        guard n > 0, rewindDepth > 0 else { return 0 }
+        let target = rewindPosition - n
+        guard target >= 0,
+            let index = rewindHistory.lastIndex(where: { $0.position == target })
+        else { return 0 }
+        cache = rewindHistory[index].slots
+        rewindPosition = target
+        rewindHistory.removeSubrange(rewindHistory.index(after: index)...)
+        return n
     }
 }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -564,6 +564,10 @@ enum Qwen35Language {
             if let cache {
                 cache[1] = state
                 cache.advance(S)
+                // Advances the cache position, and snapshots the new state when
+                // the caller has opted into `rewindDepth`. A no-op branch
+                // otherwise, which is the default.
+                cache.checkpoint(advancing: S)
             }
 
             out = norm(out, gate: z)

--- a/Tests/MLXLMTests/MambaCacheRewindTests.swift
+++ b/Tests/MLXLMTests/MambaCacheRewindTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+// Rewindability for `MambaCache`.
+//
+// A recurrent state cannot be trimmed by dropping rows, so `MambaCache` reports
+// `isTrimmable == false` and that disables speculative decoding for every hybrid
+// SSM/attention model: `canTrimPromptCache` is an `allSatisfy`, and
+// `MTPSpeculativeTokenIterator.init` throws without it.
+//
+// These tests pin the opt-in rewind path, and — just as importantly — pin that
+// the default path is untouched.
+
+/// Distinct, cheap slot payloads so a restored snapshot is identifiable by value.
+private func slots(_ step: Int) -> (conv: MLXArray, ssm: MLXArray) {
+    (conv: MLXArray([Float(step), Float(step) + 0.5]), ssm: MLXArray([Float(step) * 10]))
+}
+
+/// Advance a cache one decode step, writing both slots.
+private func step(_ cache: MambaCache, _ n: Int) {
+    let s = slots(n)
+    cache[0] = s.conv
+    cache[1] = s.ssm
+    cache.checkpoint(advancing: 1)
+}
+
+private func expectSlots(_ cache: MambaCache, matches n: Int, _ label: String = "") {
+    let want = slots(n)
+    #expect(cache[0]?.asArray(Float.self) == want.conv.asArray(Float.self), "conv slot \(label)")
+    #expect(cache[1]?.asArray(Float.self) == want.ssm.asArray(Float.self), "ssm slot \(label)")
+}
+
+// MARK: - the default path must not change
+
+@Test func testMambaCacheIsNotTrimmableByDefault() {
+    let cache = MambaCache()
+    for n in 1 ... 4 { step(cache, n) }
+    #expect(cache.rewindDepth == 0, "rewinding must be opt-in")
+    #expect(!cache.isTrimmable, "the historical default is untrimmable and must stay that way")
+    #expect(cache.trim(1) == 0, "a disabled rewind must refuse, not guess")
+    expectSlots(cache, matches: 4, "after a refused trim")
+}
+
+@Test func testHybridCacheListIsUntrimmableUntilEveryMambaOptsIn() {
+    // The actual gate: one `false` in the layer list disables speculation for
+    // the whole model, which is why this defaults matter.
+    let attention = KVCacheSimple()
+    let mamba = MambaCache()
+    #expect(canTrimPromptCache([attention]), "attention caches are trimmable")
+    #expect(!canTrimPromptCache([attention, mamba]), "one untrimmable entry poisons the list")
+
+    mamba.rewindDepth = 1
+    step(mamba, 1)
+    #expect(canTrimPromptCache([attention, mamba]), "opting in unlocks the list")
+}
+
+// MARK: - the property that makes speculation sound
+
+@Test func testRewindRestoresStateExactly() {
+    let cache = MambaCache()
+    cache.rewindDepth = 2
+    for n in 1 ... 5 { step(cache, n) }
+
+    #expect(cache.isTrimmable)
+    #expect(cache.trim(2) == 2, "an in-history rewind returns the amount asked for")
+    expectSlots(cache, matches: 3, "state must be exactly as it was two tokens ago")
+
+    // And the cache is usable afterwards: the next step continues from there.
+    step(cache, 42)
+    expectSlots(cache, matches: 42, "cache must accept writes after a rewind")
+}
+
+@Test func testRewindIsRepeatable() {
+    let cache = MambaCache()
+    cache.rewindDepth = 3
+    for n in 1 ... 4 { step(cache, n) }
+
+    #expect(cache.trim(1) == 1)
+    expectSlots(cache, matches: 3, "first rewind")
+    #expect(cache.trim(1) == 1, "history must survive an earlier rewind")
+    expectSlots(cache, matches: 2, "second rewind")
+}
+
+// MARK: - refusal, not approximation
+
+@Test func testTrimBeyondHistoryRefusesAndLeavesStateUntouched() {
+    let cache = MambaCache()
+    cache.rewindDepth = 1
+    for n in 1 ... 3 { step(cache, n) }
+
+    // depth 1 retains 2 snapshots, so a 2-token rewind has no exact target.
+    #expect(cache.trim(2) == 0, "an out-of-history rewind must refuse")
+    expectSlots(cache, matches: 3, "a refused trim must not mutate state")
+    #expect(cache.trim(1) == 1, "and must not damage the history it does have")
+    expectSlots(cache, matches: 2, "in-history rewind still works")
+}
+
+@Test func testTrimBeforeTheStartRefuses() {
+    let cache = MambaCache()
+    cache.rewindDepth = 4
+    step(cache, 1)
+    #expect(cache.trim(5) == 0, "cannot rewind past position zero")
+    expectSlots(cache, matches: 1, "state untouched")
+}
+
+@Test func testNonPositiveTrimIsANoOp() {
+    let cache = MambaCache()
+    cache.rewindDepth = 2
+    for n in 1 ... 2 { step(cache, n) }
+    #expect(cache.trim(0) == 0)
+    #expect(cache.trim(-3) == 0)
+    expectSlots(cache, matches: 2, "state untouched")
+}
+
+@Test func testRewindCannotLandInsideAPrefill() {
+    // A prefill of S tokens is one snapshot at position S. Rewinding to a
+    // position interior to it has no exact target, so it must refuse rather
+    // than silently restore the wrong state.
+    let cache = MambaCache()
+    cache.rewindDepth = 4
+    let prefill = slots(100)
+    cache[0] = prefill.conv
+    cache[1] = prefill.ssm
+    cache.checkpoint(advancing: 8)
+    step(cache, 9)
+
+    #expect(cache.trim(1) == 1, "rewinding the decode step is exact")
+    expectSlots(cache, matches: 100, "back to the end of the prefill")
+    #expect(cache.trim(3) == 0, "a position inside the prefill is not a valid target")
+    expectSlots(cache, matches: 100, "state untouched")
+    // The prefill snapshot is the earliest one there is: nothing recorded the
+    // state before it, so position 0 is not a rewind target either. The floor
+    // is the oldest retained snapshot, not zero.
+    #expect(cache.trim(8) == 0, "cannot rewind past the earliest snapshot")
+    expectSlots(cache, matches: 100, "state untouched")
+}
+
+// MARK: - bounds and bookkeeping
+
+@Test func testHistoryIsBoundedByRewindDepth() {
+    let cache = MambaCache()
+    cache.rewindDepth = 2
+    for n in 1 ... 50 { step(cache, n) }
+    // Bounded memory is the whole reason `rewindDepth` exists, so assert the
+    // bound behaviourally: depth is available, depth+1 is not.
+    #expect(cache.trim(2) == 2, "the full declared depth must be available")
+    expectSlots(cache, matches: 48)
+    for n in 51 ... 100 { step(cache, n) }
+    #expect(cache.trim(3) == 0, "history must not grow past the declared depth")
+}
+
+@Test func testRewindPreservesEmptySlots() {
+    // `state` drops empty slots, so a snapshot taken through `state` would
+    // resize a two-slot cache to one. Models with `convKernelSize == 1` never
+    // populate slot 0, so this is a real configuration, not a synthetic one.
+    let cache = MambaCache()
+    cache.rewindDepth = 1
+    cache[1] = MLXArray([Float(1)])
+    cache.checkpoint(advancing: 1)
+    cache[1] = MLXArray([Float(2)])
+    cache.checkpoint(advancing: 1)
+
+    #expect(cache.state.count == 1, "only one slot is populated")
+    #expect(cache.trim(1) == 1)
+    #expect(cache[0] == nil, "the empty slot must stay empty, not vanish")
+    #expect(cache[1]?.asArray(Float.self) == [1], "the populated slot rewinds")
+    // The slot count itself must survive, or the next `cache[1]` write traps.
+    cache[1] = MLXArray([Float(3)])
+    #expect(cache[1]?.asArray(Float.self) == [3])
+}
+
+@Test func testCopyPreservesRewindability() throws {
+    let cache = MambaCache()
+    cache.rewindDepth = 2
+    for n in 1 ... 3 { step(cache, n) }
+
+    let copied = try #require(cache.copy() as? MambaCache)
+    #expect(copied.rewindDepth == 2, "a copy must stay rewindable")
+    #expect(copied.isTrimmable)
+    #expect(copied.trim(2) == 2, "the copy carries its own history")
+    expectSlots(copied, matches: 1, "copy rewinds to the right state")
+    // The original is independent.
+    expectSlots(cache, matches: 3, "rewinding a copy must not disturb the original")
+}
+
+@Test func testTrimPromptCacheDrivesTheRewind() {
+    // End to end through the public helper speculative decoding actually calls.
+    let mamba = MambaCache()
+    mamba.rewindDepth = 2
+    for n in 1 ... 4 { step(mamba, n) }
+    let caches: [KVCache] = [mamba]
+    #expect(canTrimPromptCache(caches))
+    #expect(trimPromptCache(caches, numTokens: 2) == 2)
+    expectSlots(mamba, matches: 2, "restored through trimPromptCache")
+}


### PR DESCRIPTION
## The problem

`MTPSpeculativeTokenIterator` refuses to initialise without a trimmable main cache — `MLXLMCommon/MTPSpeculativeTokenIterator.swift:115`:

```swift
guard canTrimPromptCache(self.mainCache) else {
    throw KVCacheError(
        message: "MTP speculative decoding requires a trimmable main KV cache.")
}
```

`canTrimPromptCache` is an `allSatisfy` over every layer's cache (`KVCache.swift:1883`), and `MambaCache` never overrides `isTrimmable`, so it inherits `BaseKVCache`'s `false` (`KVCache.swift:205`). Neither does its parent `ArraysCache`.

So **one linear-attention layer disables speculative decoding for the entire model.** For hybrid Qwen3.5/3.6 GDN, `layer_types` with `full_attention_interval: 4` gives 30 `MambaCache` instances out of 40 layers. `Evaluate.swift:880` and `ChatSession.swift:851` gate the same way.

This is not Qwen-specific. Ten models in this repo construct a `MambaCache`: Qwen35, Mamba2, Jamba, NemotronH, GraniteMoeHybrid, BaichuanM1, LFM2, LFM2MoE, LFM2VL. None of them can speculate today.

There is also no way to fix this from outside the module: `MambaCache` is `public`, not `open`, so it cannot be subclassed downstream — and substituting a different `KVCache` fails *silently*, because `Qwen35.swift:670` and `:729` use `cache as? MambaCache`, which yields `nil` and makes the GDN layer run with no cache at all.

## The approach

A recurrent state has no rows to drop — token `t`'s contribution is already folded into `t+1`'s state — so `trim(_:)` cannot be implemented the way `KVCacheSimple.trim` is. What it *can* mean is "restore the state as it was `n` tokens ago", which needs history.

`rewindDepth` opts in to keeping a bounded history:

- **Default `0` means nothing changes.** Nothing is recorded, nothing is allocated, `isTrimmable` stays `false`, and `MTPSpeculativeTokenIterator` still throws for callers who have not opted in. This is deliberately not on by default — see the performance note below.
- `checkpoint(advancing:)` advances the position and snapshots. Models call it once per forward pass; with `rewindDepth == 0` it is a single branch.
- Memory is `rewindDepth + 1` copies of the slots — for Qwen3.6 GDN, ~2.06 MiB per linear layer (recurrent `[1,32,128,128]` f32 + conv `[1,4,8192]` bf16), so ~61.9 MiB per retained step across 30 layers.

Three details that are easy to get wrong, and are the reason the diff looks the way it does:

1. **Snapshots store the raw slots, not `state`.** `ArraysCache.state` drops empty slots, so a model with `convKernelSize == 1` (slot 0 never populated) has `state == [ssm]`, and restoring through the `state` setter would resize the cache from two slots to one — the next `cache[1]` write then traps.

2. **Position is tracked inside the cache, not via `offset`.** `ArraysCache.advance(_:)` only decrements `lengths`/`leftPadding` and never touches `offset` (`KVCache.swift:1301`), and no model using `MambaCache` maintains it. Keying checkpoints on `offset` would silently record position 0 every step and make `trim` a no-op. Keeping position local also means this change cannot perturb anything that reads `offset`.

3. **`trim` is exact or refused, never approximate.** Over-rewinding is not a safe fallback: if the attention caches rewind `n` and the SSM state rewinds `n+2`, the next forward runs at the attention position with a state from two tokens earlier and produces wrong output with no error. Since `trimPromptCache` does not treat a `0` return as failure, `isTrimmable` is `true` only when a snapshot actually exists to honour.

The floor is the oldest retained snapshot. A rewind past it — including to before a prefill, which nothing snapshots — refuses and leaves state untouched.

## Performance: this is a key, not a speedup

I want to be straight about this, because the obvious reading of "trimmable SSM state" is a throughput claim and that claim is weak:

- vLLM's own batch-1 column reports **0.99×** for Qwen3.5-4B GDN.
- SGLang reports "slightly slower at batch 1".
- On my own per-token byte accounting the SSM-state term is 125.83 MB of 1,795.39 MB/token = **7.0%**, so a **1.07× ceiling even if the SSM kernel were free**.

All three are right and this PR does not dispute any of them. The value here is that MTP speculative decoding currently **cannot start at all** on these models, and this is what unblocks measuring it.

My own projection for MTP on a 24 GB M4 (103 GB/s measured streaming, 90.09 ms/token) brackets **0.93× to 1.48×** depending on two unknowns I cannot resolve without this change landing: which acceptance metric applies (published MTP numbers for this family report the same runs as both ~79–85% exact-match and ~46–47% probabilistic), and how much the routed-expert set overlaps between adjacent positions at `blockSize = 2`. **The bracket includes a loss.** That is precisely why `rewindDepth` defaults to off, and why I have framed this as unblocking a measurement rather than delivering a speedup.

## Tests

`Tests/MLXLMTests/MambaCacheRewindTests.swift`, 12 tests, no model download:

- the default path stays untrimmable, and `trim` refuses rather than guessing
- a hybrid list is untrimmable until the `MambaCache` opts in — the actual gate
- rewind restores state exactly, is repeatable, and the cache is usable after
- out-of-history, before-the-start, and non-positive trims all refuse and leave state untouched
- a rewind cannot land inside a prefill
- history is bounded by `rewindDepth`
- empty slots survive a rewind (detail 1 above)
- `copy()` preserves rewindability, independently of the original
- end to end through `trimPromptCache`

Existing suites pass unchanged. On an M4 / macOS, via the path CONTRIBUTING documents:

```
xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' \
  -skipPackagePluginValidation -only-testing:MLXLMTests
→ ** TEST SUCCEEDED **   Executed 291 tests, with 0 failures (0 unexpected)
```

That includes the pre-existing `MambaCache` round-trip and batch-metadata tests, and the Qwen3.5 chunked-prefill and cache suites.

## Open question for maintainers

I chose **exact-or-refuse** for `trim`. The alternative is to return the actual amount rewound and require callers to honour the return value — `trimPromptCache` already propagates it, but the MTP iterator's use of it would need auditing, and a mismatch there is silent. If you would rather have that shape, I am happy to switch.

I also left `MambaCache` as `public` rather than `open`. `open` does not compile here — `error: superclass 'ArraysCache' of open class must be open` — so opening it up for downstream subclassing means opening `ArraysCache` too. Fixing `MambaCache` itself makes that unnecessary for this use case, but say the word if you want both opened as a follow-up.
