### PR TITLE
Allow downstream specialization of the Qwen3.5 GDN/MoE blocks and SwitchGLU

### DIFF
--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -39,7 +39,7 @@ public func scatterUnsort(x: MLXArray, invOrder: MLXArray, shape: [Int]? = nil) 
 
 // MARK: - SwitchGLU
 
-public class SwitchGLU: Module {
+open class SwitchGLU: Module {
     @ModuleInfo(key: "gate_proj") var gateProj: SwitchLinear
     @ModuleInfo(key: "up_proj") var upProj: SwitchLinear
     @ModuleInfo(key: "down_proj") var downProj: SwitchLinear
@@ -95,7 +95,7 @@ public class SwitchGLU: Module {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
         var x = MLX.expandedDimensions(x, axes: [-2, -3])
 
         let doSort = indices.size >= 64
@@ -219,7 +219,7 @@ public class FusedGateUpSwitchGLU: Module {
 
 // MARK: - SwitchLinear
 
-public class SwitchLinear: Module, Quantizable {
+open class SwitchLinear: Module, Quantizable {
     @ModuleInfo(key: "weight") var weight: MLXArray
     @ModuleInfo(key: "bias") var bias: MLXArray?
 
@@ -262,7 +262,7 @@ public class SwitchLinear: Module, Quantizable {
         self._bias.wrappedValue = bias
     }
 
-    public func callAsFunction(
+    open func callAsFunction(
         _ x: MLXArray, _ indices: MLXArray, sortedIndices: Bool = false
     ) -> MLXArray {
         let weightT = self.weight.swappedAxes(-1, -2)

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -104,7 +104,7 @@ package func weightedExpertUnsort(
 
 // MARK: - SwitchGLU
 
-public class SwitchGLU: Module {
+open class SwitchGLU: Module {
     @ModuleInfo(key: "gate_proj") var gateProj: SwitchLinear
     @ModuleInfo(key: "up_proj") var upProj: SwitchLinear
     @ModuleInfo(key: "down_proj") var downProj: SwitchLinear
@@ -226,7 +226,7 @@ public class SwitchGLU: Module {
             && trainableParameters().flattened().isEmpty
     }
 
-    public func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
         var projected = projectExperts(x, indices)
 
         if let inverseOrder = projected.inverseOrder {
@@ -362,7 +362,7 @@ public class FusedGateUpSwitchGLU: Module {
 
 // MARK: - SwitchLinear
 
-public class SwitchLinear: Module, Quantizable {
+open class SwitchLinear: Module, Quantizable {
     @ModuleInfo(key: "weight") var weight: MLXArray
     @ModuleInfo(key: "bias") var bias: MLXArray?
 
@@ -405,7 +405,7 @@ public class SwitchLinear: Module, Quantizable {
         self._bias.wrappedValue = bias
     }
 
-    public func callAsFunction(
+    open func callAsFunction(
         _ x: MLXArray, _ indices: MLXArray, sortedIndices: Bool = false
     ) -> MLXArray {
         let weightT = self.weight.swappedAxes(-1, -2)
@@ -423,7 +423,7 @@ public class SwitchLinear: Module, Quantizable {
     }
 }
 
-public class QuantizedSwitchLinear: SwitchLinear, Quantized {
+open class QuantizedSwitchLinear: SwitchLinear, Quantized {
     @ModuleInfo(key: "scales") var scales: MLXArray
     @ModuleInfo(key: "biases") var biases: MLXArray?
 
@@ -451,7 +451,7 @@ public class QuantizedSwitchLinear: SwitchLinear, Quantized {
         self.freeze()
     }
 
-    override public func callAsFunction(
+    override open func callAsFunction(
         _ x: MLXArray, _ indices: MLXArray, sortedIndices: Bool = false
     ) -> MLXArray {
         var result = MLX.gatherQuantizedMM(

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -276,7 +276,7 @@ open class SwitchGLU: Module {
 /// SwitchGLU variant for models that ship a single fused `gate_up_proj` weight
 /// of shape `[numExperts, 2*hiddenDims, inputDims]` instead of separate
 /// `gate_proj` / `up_proj`. Used by Gemma 4 26B MoE.
-public class FusedGateUpSwitchGLU: Module {
+open class FusedGateUpSwitchGLU: Module {
     @ModuleInfo(key: "gate_up_proj") var gateUpProj: SwitchLinear
     @ModuleInfo(key: "down_proj") var downProj: SwitchLinear
 
@@ -327,7 +327,7 @@ public class FusedGateUpSwitchGLU: Module {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray {
         var x = MLX.expandedDimensions(x, axes: [-2, -3])
 
         let doSort = indices.size >= 64

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -218,7 +218,7 @@ public struct Qwen35Configuration: Codable, Sendable {
 
 // MARK: - Language
 
-enum Qwen35Language {
+public enum Qwen35Language {
 
     final class RotaryEmbedding {
         private let invFreq: MLXArray
@@ -438,7 +438,7 @@ enum Qwen35Language {
         }
     }
 
-    final class GatedDeltaNet: Module {
+    open class GatedDeltaNet: Module {
         let hiddenSize: Int
         let numVHeads: Int
         let numKHeads: Int
@@ -571,7 +571,7 @@ enum Qwen35Language {
         }
     }
 
-    final class SparseMoeBlock: Module, UnaryLayer {
+    open class SparseMoeBlock: Module, UnaryLayer {
         let normTopkProb: Bool
         let numExperts: Int
         let topK: Int
@@ -602,7 +602,7 @@ enum Qwen35Language {
             super.init()
         }
 
-        func callAsFunction(_ x: MLXArray) -> MLXArray {
+        open func callAsFunction(_ x: MLXArray) -> MLXArray {
             var gates = gate(x)
             gates = MLX.softmax(gates, axis: -1, precise: true)
 
@@ -623,7 +623,7 @@ enum Qwen35Language {
         }
     }
 
-    final class DecoderLayer: Module {
+    open class DecoderLayer: Module {
         let isLinear: Bool
 
         @ModuleInfo(key: "self_attn") var selfAttn: Attention?
@@ -678,7 +678,7 @@ enum Qwen35Language {
         }
     }
 
-    final class Model: Module {
+    open class Model: Module {
         @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
         @ModuleInfo(key: "layers") fileprivate var layers: [DecoderLayer]
         @ModuleInfo(key: "norm") var norm: RMSNorm

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -227,7 +227,7 @@ public struct Qwen35Configuration: Codable, Sendable {
 
 // MARK: - Language
 
-enum Qwen35Language {
+public enum Qwen35Language {
 
     final class RotaryEmbedding {
         private let invFreq: MLXArray
@@ -447,7 +447,7 @@ enum Qwen35Language {
         }
     }
 
-    final class GatedDeltaNet: Module {
+    open class GatedDeltaNet: Module {
         let hiddenSize: Int
         let numVHeads: Int
         let numKHeads: Int
@@ -517,7 +517,7 @@ enum Qwen35Language {
         }
 
         @discardableResult
-        override func update(
+        open override func update(
             parameters: ModuleParameters, verify: VerifyUpdate,
             path: [String] = [], modulePath: [String] = []
         ) throws -> Self {
@@ -536,7 +536,7 @@ enum Qwen35Language {
                 parameters: parameters, verify: verify, path: path, modulePath: modulePath)
         }
 
-        override func updateModule(key: String, _ value: Any) throws {
+        open override func updateModule(key: String, _ value: Any) throws {
             let replacesInputProjection =
                 key == "in_proj_qkv" || key == "in_proj_z"
                 || key == "in_proj_b" || key == "in_proj_a"
@@ -704,7 +704,7 @@ enum Qwen35Language {
         }
     }
 
-    final class SparseMoeBlock: Module, UnaryLayer {
+    open class SparseMoeBlock: Module, UnaryLayer {
         let normTopkProb: Bool
         let numExperts: Int
         let topK: Int
@@ -735,7 +735,7 @@ enum Qwen35Language {
             super.init()
         }
 
-        func callAsFunction(_ x: MLXArray) -> MLXArray {
+        open func callAsFunction(_ x: MLXArray) -> MLXArray {
             var gates = gate(x)
             gates = MLX.softmax(gates, axis: -1, precise: true)
 
@@ -752,7 +752,7 @@ enum Qwen35Language {
         }
     }
 
-    final class DecoderLayer: Module {
+    open class DecoderLayer: Module {
         let isLinear: Bool
 
         @ModuleInfo(key: "self_attn") var selfAttn: Attention?
@@ -815,7 +815,7 @@ enum Qwen35Language {
         }
     }
 
-    final class Model: Module {
+    open class Model: Module {
         @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
         @ModuleInfo(key: "layers") fileprivate var layers: [DecoderLayer]
         @ModuleInfo(key: "norm") var norm: RMSNorm

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -475,7 +475,7 @@ public enum Qwen35Language {
         @ModuleInfo(key: "norm") var norm: RMSNormGated
         @ModuleInfo(key: "out_proj") var outProj: Linear
 
-        init(_ args: Qwen35Configuration.TextConfiguration) {
+        public init(_ args: Qwen35Configuration.TextConfiguration) {
             self.hiddenSize = args.hiddenSize
             self.numVHeads = args.linearNumValueHeads
             self.numKHeads = args.linearNumKeyHeads
@@ -594,7 +594,7 @@ public enum Qwen35Language {
             )
         }
 
-        func callAsFunction(
+        open func callAsFunction(
             _ inputs: MLXArray,
             mask: MLXArray? = nil,
             cache: MambaCache? = nil,
@@ -715,7 +715,7 @@ public enum Qwen35Language {
         @ModuleInfo(key: "shared_expert") var sharedExpert: MLP
         @ModuleInfo(key: "shared_expert_gate") var sharedExpertGate: Linear
 
-        init(_ args: Qwen35Configuration.TextConfiguration) {
+        public init(_ args: Qwen35Configuration.TextConfiguration) {
             self.normTopkProb = args.normTopkProb
             self.numExperts = args.numExperts
             self.topK = args.numExpertsPerTok
@@ -763,7 +763,7 @@ public enum Qwen35Language {
 
         @ModuleInfo(key: "mlp") var mlp: Module
 
-        init(
+        public init(
             _ args: Qwen35Configuration.TextConfiguration, layerIdx: Int,
             forceFullAttention: Bool = false
         ) {
@@ -792,7 +792,7 @@ public enum Qwen35Language {
             super.init()
         }
 
-        func callAsFunction(
+        open func callAsFunction(
             _ x: MLXArray,
             attentionMask: MLXArray?,
             ssmMask: MLXArray?,
@@ -823,7 +823,7 @@ public enum Qwen35Language {
         let ssmIdx: Int
         let faIdx: Int
 
-        init(_ args: Qwen35Configuration.TextConfiguration) {
+        public init(_ args: Qwen35Configuration.TextConfiguration) {
             precondition(args.vocabularySize > 0)
             _embedTokens.wrappedValue = Embedding(
                 embeddingCount: args.vocabularySize, dimensions: args.hiddenSize)
@@ -837,7 +837,7 @@ public enum Qwen35Language {
             super.init()
         }
 
-        func callAsFunction(
+        open func callAsFunction(
             _ inputs: MLXArray,
             inputsEmbeds: MLXArray? = nil,
             cache: [KVCache?]? = nil,


### PR DESCRIPTION
## What is currently unreachable

The Qwen3.5 language stack in `Libraries/MLXVLM/Models/Qwen35.swift` cannot be specialized from another module:

| Line | Declaration | Blocker |
|---|---|---|
| `221` | `enum Qwen35Language {` | no access modifier ⇒ internal, so everything nested inside is unreachable regardless of its own modifier |
| `441` | `final class GatedDeltaNet: Module {` | `final` **and** internal |
| `574` | `final class SparseMoeBlock: Module, UnaryLayer {` | `final` **and** internal |
| `626` | `final class DecoderLayer: Module {` | `final` **and** internal |
| `681` | `final class Model: Module {` | `final` **and** internal |

And in `Libraries/MLXLMCommon/SwitchLayers.swift`, `SwitchGLU` (`:42`) and `SwitchLinear` (`:222`) are `public`, not `open` — subclassable only inside this module.

## Why I care

I serve Qwen3.6-35B-A3B on a 24 GB Apple M4 with the routed experts **streamed from SSD** into a bounded RAM cache rather than held resident. That needs one thing: substitute my own expert-MLP implementation for `SparseMoeBlock`'s, keeping the rest of the vendored model — and critically its weight keys — untouched.

Because none of the above is subclassable, I reimplemented instead. That is ~445 lines of `StreamingSwitchGLU` plus a `ResidentSwitchGLU` and a `ResidentMoeBlock`, and the large majority of it re-derives what `SwitchGLU` already does correctly: the three `@ModuleInfo(key:)` weight bindings, the gather/scatter sort, the quantized-vs-dense dispatch. Every upstream fix to `SwitchGLU` is a fix I have to notice and hand-port. Being able to subclass would delete most of that and keep me on your code path.

## The change

Mechanical access widening, no behaviour change:

- `Qwen35Language` → `public`
- `GatedDeltaNet`, `SparseMoeBlock`, `DecoderLayer`, `Model` → `open` (dropping `final`)
- `SwitchGLU`, `SwitchLinear` → `open`
- the three forward methods a subclass would actually want to override — `SwitchGLU.callAsFunction`, `SwitchLinear.callAsFunction`, `SparseMoeBlock.callAsFunction` → `open`

`Module` is already `open` (`MLXNN/Module.swift:97`), so nothing needed to change on your side of the dependency.

### One cascade worth flagging

`SparseMoeBlock` conforms to `UnaryLayer`, which is a public protocol, so once the class became `open` the compiler required its `callAsFunction` to be public too:

```
error: method 'callAsFunction' must be declared public because it matches
       a requirement in public protocol 'UnaryLayer'
```

I made it `open` rather than `public`, since overriding that method is precisely the point of the change. Mentioning it because it is the one place where "just widen the class" was not sufficient, and it is not obvious from reading.

## Deliberately not included

The internal notes this came from bundled a second, unrelated change: porting the merged GDN decode conv-fold from the MLXLLM copy of this model to the MLXVLM twin. That is a real optimization with its own bitwise test, but it is a behaviour change and it belongs in its own PR against its own review. I left it out to keep this one purely mechanical. Happy to send it separately if you want it.

I also left `FusedGateUpSwitchGLU` alone — it is `public` like the others, but I have no use case for subclassing it and did not want to widen API surface speculatively. Say the word if you would rather these move together.

## Evidence

- `swift build --target MLXVLM` → clean, exit 0.
- Full `swift test` → **296 tests, 0 failures**, unchanged.
- `swift-format` applied with the repo's `.swift-format`.
- Line citations verified against `main` at `3d292ec`.

Access control is the whole diff — 9 insertions, 9 deletions — so "no behaviour change" is checkable by reading it.
