### PR TITLE
Run Integration Tests nightly and report failures on a tracking issue

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,10 +3,28 @@ name: Integration Tests
 # Heavy integration tests (Hugging Face model downloads, Metal GPU, long-running).
 # Kept out of the PR path so they never block merges
 on:
+  # Nightly at 09:17 UTC (02:17 PDT), so a regression is found by morning
+  # instead of whenever someone remembers to dispatch. Deliberately off the
+  # hour: GitHub queues :00 schedules behind everyone else's and delays them.
+  # Scheduled runs always use the default branch's copy of this file.
+  schedule:
+    - cron: '17 9 * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
+
+# One integration run at a time, repo-wide. There is a single self-hosted mac
+# with one on-disk Hugging Face cache, and the tests are already forced to a
+# single xctest worker for that reason (see below); two runs would race the
+# same cache. Deliberately ref-independent: a manual dispatch on a branch
+# contends for the same runner and cache as the nightly on main, so keeping
+# github.ref out of the group is what makes them serialize. cancel-in-progress
+# is false because a nightly that is 100 minutes into downloading models
+# should not be thrown away by a dispatch.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   integration_tests:
@@ -69,3 +87,117 @@ jobs:
             IntegrationTesting.xcresult
             ~/Library/Logs/DiagnosticReports/*
           retention-days: 7
+
+  # A red nightly has to land somewhere maintainers will see it. GitHub emails
+  # scheduled-workflow failures to exactly one account (whoever last edited the
+  # cron above), so instead we keep one tracking issue and comment on it.
+  notify:
+    needs: integration_tests
+    # No implicit success() here: any explicit job-level `if` replaces it, so
+    # this runs only when the guard below says so. failure() is true when a
+    # needed job failed, which includes blowing the 120-minute cap. Scheduled
+    # runs only: whoever pressed "Run workflow" is already watching that run,
+    # and a dispatch can target any branch, so a red WIP branch must not get
+    # filed as a nightly regression.
+    if: >-
+      failure()
+      && github.event_name == 'schedule'
+      && github.repository == 'ml-explore/mlx-swift-lm'
+    # Not the self-hosted mac: this is two REST calls, and it must not occupy
+    # the one machine that runs the tests.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    # Job-level permissions replace the workflow-level block outright rather
+    # than merging with it, so this job gets issues:write and nothing else.
+    # It never checks out the repo, so it needs no contents access.
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the nightly failure issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const label = 'ci-failure';
+            const title = 'Nightly integration tests are failing';
+            const { owner, repo } = context.repo;
+            const runUrl =
+              `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const attempt = process.env.GITHUB_RUN_ATTEMPT || '1';
+            // schedule events carry no head_commit payload; context.sha is the
+            // default branch head the run actually tested.
+            const sha = context.sha;
+            const shortSha = sha.slice(0, 7);
+            const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${sha}`;
+            const today = new Date().toISOString().slice(0, 10);
+
+            // Create the label up front. It does not exist in this repo yet, and
+            // it is not documented whether issues.create auto-creates labels
+            // passed in `labels`, so do not rely on that: the dedupe lookup
+            // below filters on the label and has to work on the very first run.
+            // Label writes are covered by the issues scope.
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: 'd73a4a',
+                description: 'Automated CI failure report (nightly integration tests)',
+              });
+            }
+
+            // listForRepo, not the Search API: search is a separate eventually
+            // consistent index with its own rate limit, so a freshly filed
+            // issue can be invisible to it and two nightlies in a row would
+            // each open their own. listForRepo also returns pull requests, so
+            // drop anything with a pull_request key.
+            const open = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              labels: label,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = open.data.find(
+              (issue) => !issue.pull_request && issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: `Still failing ${today}: [run #${context.runNumber}]`
+                  + `(${runUrl}) (attempt ${attempt}) at \`${shortSha}\`.`,
+              });
+              core.notice(`Commented on existing #${existing.number}`);
+              return;
+            }
+
+            const body = [
+              'The nightly `Integration Tests` run failed.',
+              '',
+              `- Run: ${runUrl} (attempt ${attempt})`,
+              `- Commit: [\`${shortSha}\`](${commitUrl}) on \`${context.ref}\``,
+              `- First seen: ${today}`,
+              '',
+              'The failing run uploads an `integration-test-results` artifact:',
+              'the `IntegrationTesting.xcresult` bundle plus anything in',
+              '`~/Library/Logs/DiagnosticReports` (crash logs). Artifacts are',
+              'kept for 7 days, so download it from the run page before it',
+              'expires, then open the `.xcresult` in Xcode.',
+              '',
+              'Consecutive failures comment on this issue instead of opening a',
+              'new one. Close it once the nightly is green again; the next',
+              'failure after that opens a fresh issue.',
+            ].join('\n');
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: [label],
+            });
+            core.notice(`Opened #${created.data.number}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,13 @@ xcodebuild test -scheme mlx-swift-lm-Package -destination 'platform=macOS' -skip
 ```
 
 Integration tests verify end-to-end model loading and generation. They require
-macOS with Metal and download models from Hugging Face Hub on first run. These
-tests do not run in CI.
+macOS with Metal and download models from Hugging Face Hub on first run. They
+are not part of the pull request checks, so they never block a merge. In
+`ml-explore/mlx-swift-lm` they run nightly on a self-hosted macOS runner
+(`.github/workflows/integration_tests.yml`), and failures are reported on a
+tracking issue labeled `ci-failure`. Because nothing runs them on your branch,
+run them locally when you change model loading, generation, or tokenizer
+behavior.
 
 Open `IntegrationTesting/IntegrationTesting.xcodeproj` in Xcode and run the
 test target (`Cmd+U` or via the Test Navigator), or use `xcodebuild`:


### PR DESCRIPTION
## Proposed changes

Closes #500.

`Integration Tests` is `workflow_dispatch`-only, so the suite only runs when someone remembers to trigger it, and dispatching needs admin rights on this repository (a non-admin `gh workflow run` gets `403 Must have admin rights to Repository`). Regressions go unnoticed between manual runs.

Three additions to `.github/workflows/integration_tests.yml`. **The `integration_tests` job itself is untouched** and the test scope is unchanged: no `MLX_RUN_*` env gate is added, so the nightly runs byte-for-byte what a manual dispatch runs today.

**1. Nightly cron at `17 9 * * *`** (09:17 UTC, 02:17 PDT). Off the hour on purpose, since GitHub queues `:00` schedules behind everyone else's and delays them. The existing `if: github.repository == 'ml-explore/mlx-swift-lm'` guard keeps scheduled runs off forks.

**2. A repo-wide `concurrency` group** so a manual dispatch cannot race the nightly. There is one self-hosted mac with one on-disk Hugging Face cache, and the tests are already forced to a single xctest worker for exactly that reason. The group deliberately omits `github.ref`: a dispatch on a branch contends for the same runner and cache as the nightly on `main`, so leaving the ref out is what makes them serialize. `cancel-in-progress: false`, because a nightly 100 minutes into downloading models should not be thrown away by a dispatch.

The group holds at most one in-progress plus one pending run; a third arrival cancels the older *pending* one, which shows up in the Actions list with a concurrency reason rather than being silently dropped. I did not add the same group to `pull_request.yml`'s `mac_build_and_test`, even though it shares the runner: it would queue every PR build behind a 36-minute nightly, and its unit tests do not download models, so they do not touch the cache.

**3. A `notify` job** that keeps one tracking issue labeled `ci-failure`, commenting on it for consecutive failures instead of filing a new issue every night. This is the part that makes the schedule useful: GitHub emails scheduled-workflow failures to exactly one account, whoever last edited the cron, not to maintainers or watchers. Without it, adding the cron would just make me the sole recipient of every nightly failure email. The job runs on `ubuntu-22.04` so it never occupies the mac, and its job-level `permissions` narrow the token to `issues: write` only (job-level permissions replace the workflow-level block rather than merging, and the job does no checkout, so it gets no `contents` access).

`CONTRIBUTING.md` said the integration tests "do not run in CI," which was already stale. It now describes the nightly and keeps the point that nothing runs them on your branch.

### One correction to the issue's premise

#500 is titled "restore nightly schedule" and says the trigger "was removed while the suite was still unstable." It was never actually committed: `git log -S"schedule"` and `-S"cron"` over `.github/` return zero commits. #458's commit message claimed a nightly schedule, but the YAML it added was `workflow_dispatch` only, so the message was aspirational. This is an addition, not a restore. No behavior change either way, just so the history reads straight.

### Please dispatch a fresh run before merging

`main` has moved three commits past the last green run (2026-07-31, ~36 min): Qwen3-VL-MoE, #502 (migrate all models to `ChatConventionsProviding`, delete the infer chains), and #401 (LogitProcessor injection). #502 rewrote chat-convention plumbing across every model, which is precisely what the tool-call, coherence, and vision suites exercise, so I would not assume the suite is still green.

```
gh workflow run integration_tests.yml --repo ml-explore/mlx-swift-lm --ref main
```

I cannot run this myself. It matters because of a specific failure mode: if the suite is already red, the very first nightly files a public tracking issue whose opening comment is a pre-existing regression, and a nightly that is red on day one gets written off as broken infrastructure, which is the outcome #500 exists to prevent. Merging without it is survivable, just noisier.

### How the notify script was validated

The script cannot be exercised in this repo before merge, so I ran it against the real API in my fork: a throwaway workflow with a one-line `exit 1` job on a hosted runner plus this notify job verbatim (guards relaxed), asserted byte-identical to the version in this PR. Two consecutive runs:

- Run 1: `GET /labels/ci-failure` returned `404`, the label was created, and one issue was opened.
- Run 2: the label lookup succeeded, `listForRepo` found the open issue, and it added a single terse comment. No second issue.

The fork's `default_workflow_permissions` is `read`, and `issues: write` was still granted, which confirms an explicit `permissions:` block escalates past a read-only default. The scratch branch, label, and issue have been cleaned up.

Two design points that came out of that:

- **Explicit label creation rather than relying on `issues.create`.** `ci-failure` does not exist in this repo, and whether passing an unknown name in `labels` creates it is undocumented. The docs do warn that labels are *silently dropped* without push access, and a silent drop would break the dedupe lookup invisibly. So the script does `getLabel` and catches the 404. Confirmed above that this is the path actually taken on first run.
- **`listForRepo` rather than the Search API for dedupe.** Search is a separate eventually consistent, rate-limited index, so a freshly filed issue can be invisible to the next night's query, which would produce one issue per night and defeat the whole feature. `listForRepo` reads the primary store; it also returns pull requests, hence the `!issue.pull_request` filter, plus an exact title match so an unrelated future use of the label cannot absorb the report.

### Deliberate gaps, if you would rather I close them

- **`cancelled` does not alert.** `failure()` is false for cancelled runs. On a self-hosted runner, cancelled usually means infrastructure (runner restart, agent upgrade, the concurrency rule above) rather than a regression, and an alert that cries wolf gets muted. A `timeout-minutes` overrun does report as `failure`, so the 120-minute cap is covered. A runner that dies mid-run may surface as `cancelled` and go unreported.
- **A missing nightly is invisible.** If the runner is offline at 09:17 UTC the run queues and expires with no `failure` conclusion, so nothing fires. Detecting "the nightly did not run" needs a separate heartbeat; I left it out.
- **Going green again is manual.** The issue body asks maintainers to close it. I did not auto-close on the first green nightly: the suite downloads models over a network and shares a mutable on-disk cache, so one green run is weak evidence the regression is fixed rather than that a flake did not reproduce, and auto-close would discard triage notes and churn open/close on intermittent failures. Easy to add a green-again *comment* without closing if you want the signal.
- **Scheduled workflows are auto-disabled after 60 days of repository inactivity**, silently. Not a practical concern at the current commit rate, but it means the nightly should not be treated as the only safety net.

Also worth knowing: `POST /repos/{owner}/{repo}/issues` now emits an octokit deprecation warning, scheduled for removal 2028-03-10. Nothing to do now; noting it so it is not a surprise later.

### Verification

- `actionlint` on the changed file reports only the pre-existing `SC2012` info on the untouched Xcode-selection step. I confirmed against the file at `HEAD` that this finding is unchanged, so the PR introduces no new lint findings.
- `yaml.safe_load` parses the file; triggers resolve to `['schedule', 'workflow_dispatch']`, the notify `if:` folds to the intended single expression.
- `node --check` on the extracted script body.
- `.pre-commit-config.yaml` has a single `swift-format` hook with `types: [swift]`, so neither the local hook nor the `lint` job inspects these files.

Post-merge, in order:

1. `gh api repos/ml-explore/mlx-swift-lm/actions/workflows/integration_tests.yml -q .state` should be `active`, with no "scheduled trigger disabled" banner.
2. After the next 09:17 UTC, `gh run list --workflow integration_tests.yml --event schedule` should show one run. Scheduled runs are best effort and can be delayed tens of minutes under load, so a late run is not a bug.
3. On the first red nightly: the `ci-failure` label is created, one issue is opened, and a second consecutive failure comments rather than opening a second issue. If notify fails with `403 Resource not accessible by integration`, that points at Settings, Actions, General, Workflow permissions.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit`. The only hook is `swift-format` with `types: [swift]`, so it skips both changed files.
- [ ] I have added tests that prove my fix is effective or that my feature works. There is no test harness for workflow YAML; the equivalent evidence is the fork validation and the lint/parse checks described above.
- [x] I have updated the necessary documentation (if needed)
