### PR TITLE
Enforce and expose effective maxKVSize cache policy

### DIFF
--- a/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
+++ b/Libraries/MLXGuidedGeneration/GuidedGenerationLoop.swift
@@ -114,7 +114,7 @@ public enum GuidedGenerationLoop {
         let kvCachePlan = try generationParameters.kvCachePlan()
         let cacheStorage = try kvCachePlan.validated(
             KVCacheStorage(
-                model.newCache(parameters: generationParameters), plan: kvCachePlan))
+                try model.newCache(parameters: generationParameters), plan: kvCachePlan))
         var modelState: LMOutput.State?
 
         // Build EOS token set

--- a/Libraries/MLXLLM/Models/AfMoE.swift
+++ b/Libraries/MLXLLM/Models/AfMoE.swift
@@ -557,14 +557,14 @@ public class AfMoEModel: Module, LLMModel, KVCacheDimensionProvider {
         return sanitizedWeights
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        // Create cache based on layer type (rotating for sliding attention, simple for full attention)
-        layerUsesSliding.map { usesSliding in
-            if usesSliding {
-                RotatingKVCache(maxSize: slidingWindow)
-            } else {
-                KVCacheSimple()
-            }
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        // Sliding-window layers are capped by maxKVSize when requested;
+        // full-attention layers use the requested limit directly.
+        try layerUsesSliding.map { usesSliding in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: slidingWindow,
+                usesSlidingWindow: usesSliding)
         }
     }
 }

--- a/Libraries/MLXLLM/Models/BaichuanM1.swift
+++ b/Libraries/MLXLLM/Models/BaichuanM1.swift
@@ -262,12 +262,14 @@ public class BaichuanM1Model: Module, LLMModel, KVCacheDimensionProvider {
         return outputs
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        return model.layers.enumerated().map { (i, _) in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try model.layers.enumerated().map { (i, _) in
             let isSWA = configuration.slidingWindowLayers.contains(i)
             let convCache = MambaCache()
-            let kvCache: KVCache =
-                isSWA ? RotatingKVCache(maxSize: configuration.slidingWindow) : KVCacheSimple()
+            let kvCache = try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: configuration.slidingWindow,
+                usesSlidingWindow: isSWA)
             return CacheList(convCache, kvCache)
         }
     }

--- a/Libraries/MLXLLM/Models/Exaone4.swift
+++ b/Libraries/MLXLLM/Models/Exaone4.swift
@@ -216,13 +216,12 @@ public class Exaone4Model: Module, LLMModel, KVCacheDimensionProvider {
         return weights
     }
 
-    public func newCache(parameters: GenerateParameters? = nil) -> [KVCache] {
-        return model.layers.map { layer in
-            if layer.attention.isLocal, let slidingWindow = configuration.slidingWindow {
-                return RotatingKVCache(maxSize: slidingWindow, keep: 0)
-            } else {
-                return StandardKVCache()
-            }
+    public func newCache(parameters: GenerateParameters? = nil) throws -> [KVCache] {
+        try model.layers.map { layer in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: configuration.slidingWindow,
+                usesSlidingWindow: layer.attention.isLocal)
         }
     }
 }

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -796,17 +796,17 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
         return sanitizedWeights
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        let attentionCache = makeAttentionCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        let attentionCache = try makeAttentionCache(parameters: parameters)
         return model.layers.map { _ in CacheList(MambaCache(), attentionCache.copy()) }
     }
 
     /// Build the attention cache for a single layer, honoring ``GenerateParameters``
     /// memory controls while leaving the Mamba recurrent cache untouched.
-    private func makeAttentionCache(parameters: GenerateParameters?) -> any KVCache {
+    private func makeAttentionCache(parameters: GenerateParameters?) throws -> any KVCache {
         // Sliding-window attention: only the KV attention cache is bounded. The Mamba
         // recurrent state retains its full history because it cannot be safely windowed.
-        if let capacity = parameters?.effectiveKVCacheCapacity {
+        if let capacity = try parameters?.effectiveKVCacheCapacity() {
             return capacity.makeRotatingCache()
         }
 

--- a/Libraries/MLXLLM/Models/GPTOSS.swift
+++ b/Libraries/MLXLLM/Models/GPTOSS.swift
@@ -549,20 +549,13 @@ public class GPTOSSModel: Module, LLMModel, KVCacheDimensionProvider {
         GPTOSSMessageGenerator()
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        var caches: [KVCache] = []
-
-        for lt in model.layerTypes {
-            if lt == "full_attention" {
-                caches.append(StandardKVCache())
-            } else {
-                caches.append(
-                    RotatingKVCache(maxSize: configuration.slidingWindow, keep: 0)
-                )
-            }
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        try model.layerTypes.map { layerType in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: configuration.slidingWindow,
+                usesSlidingWindow: layerType != "full_attention")
         }
-
-        return caches
     }
 }
 

--- a/Libraries/MLXLLM/Models/Gemma3Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma3Text.swift
@@ -406,28 +406,25 @@ public class Gemma3TextModel: Module, LLMModel {
         return processedWeights
     }
 
-    public func newCache(parameters: GenerateParameters? = nil) -> [KVCache] {
-        var caches = [KVCache]()
+    public func newCache(parameters: GenerateParameters? = nil) throws -> [KVCache] {
         let slidingWindow = config.slidingWindow
         let slidingWindowPattern = config.slidingWindowPattern
 
-        for i in 0 ..< config.hiddenLayers {
+        return try (0 ..< config.hiddenLayers).map { i in
             let isGlobalLayer = (i % slidingWindowPattern == slidingWindowPattern - 1)
-
             if isGlobalLayer {
-                // For global layers, use standard cache but with reasonable step size for long sequences
-                let cache = StandardKVCache()
-                cache.step = 1024  // Larger step size for efficiency with long sequences
-                caches.append(cache)
+                // Global (full-attention) layers honor maxKVSize. When unbounded,
+                // use a larger allocation step for long-context efficiency.
+                let cache = try makeAttentionKVCache(parameters: parameters)
+                if let simple = cache as? StandardKVCache {
+                    simple.step = 1024
+                }
+                return cache
             } else {
-                // For sliding window layers, use rotating cache
-                caches.append(
-                    RotatingKVCache(maxSize: slidingWindow, keep: 0)
-                )
+                return try makeSlidingWindowKVCache(
+                    parameters: parameters, window: slidingWindow)
             }
         }
-
-        return caches
     }
 
     /// Handles prompt processing for sequences

--- a/Libraries/MLXLLM/Models/Gemma3nText.swift
+++ b/Libraries/MLXLLM/Models/Gemma3nText.swift
@@ -656,24 +656,24 @@ public class Gemma3nLanguageModel: Module {
 
     @ModuleInfo var norm: RMSNorm
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        var caches: [any KVCache] = []
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
         let slidingWindow = config.slidingWindow > 0 ? config.slidingWindow : 4096
         let firstKvSharedLayerIdx = config.numHiddenLayers - config.numKvSharedLayers
         let layerTypes =
             config.layerTypes ?? Array(repeating: "global_attention", count: config.numHiddenLayers)
 
-        for i in 0 ..< firstKvSharedLayerIdx {
+        return try (0 ..< firstKvSharedLayerIdx).map { i in
             let layerType = layerTypes[i]
-            if layerType == "full_attention" {
-                caches.append(StandardKVCache())
-            } else if layerType == "sliding_attention" {
-                caches.append(RotatingKVCache(maxSize: slidingWindow, keep: 0))
-            } else {
+            switch layerType {
+            case "full_attention", "global_attention":
+                return try makeAttentionKVCache(parameters: parameters)
+            case "sliding_attention":
+                return try makeSlidingWindowKVCache(
+                    parameters: parameters, window: slidingWindow)
+            default:
                 fatalError("Unknown layer type: \(layerType) for layer \(i)")
             }
         }
-        return caches
     }
 
     init(_ config: Gemma3nTextConfiguration) {
@@ -942,8 +942,8 @@ public class Gemma3nTextModel: Module, LLMModel {
         super.init()
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        return languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        return try languageModel.newCache(parameters: parameters)
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {

--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -96,8 +96,8 @@ public class Gemma4Model: Module, LLMModel, KVCacheDimensionProvider {
         return languageModel.sanitize(weights: sanitized)
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -923,18 +923,15 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
         return Int(digits)
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
         let firstKvShared = config.numHiddenLayers - config.numKvSharedLayers
 
-        var caches = [any KVCache]()
-        for i in 0 ..< firstKvShared {
-            if config.layerTypes[i] == "full_attention" {
-                caches.append(StandardKVCache())
-            } else {
-                caches.append(RotatingKVCache(maxSize: config.slidingWindow, keep: 0))
-            }
+        return try (0 ..< firstKvShared).map { i in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: config.slidingWindow,
+                usesSlidingWindow: config.layerTypes[i] != "full_attention")
         }
-        return caches
     }
 }
 

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -517,12 +517,12 @@ public class GraniteMoeHybridModel: Module, LLMModel, KVCacheDimensionProvider {
         return out / logitsScaling
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        configuration.layerTypes.map { layerType in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try configuration.layerTypes.map { layerType in
             if layerType == "mamba" {
                 return MambaCache()
             } else {
-                return KVCacheSimple()
+                return try makeAttentionKVCache(parameters: parameters)
             }
         }
     }

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -476,10 +476,10 @@ public class JambaModel: Module, LLMModel, KVCacheDimensionProvider {
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        return model.layers.map { layer in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try model.layers.map { layer in
             if layer.isAttn {
-                return KVCacheSimple()
+                return try makeAttentionKVCache(parameters: parameters)
             } else {
                 return MambaCache()
             }

--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -398,10 +398,10 @@ public class LFM2Model: Module, LLMModel, KVCacheDimensionProvider {
         return sanitizedWeights
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        (0 ..< configuration.hiddenLayers).map { layerIdx in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try (0 ..< configuration.hiddenLayers).map { layerIdx in
             if configuration.fullAttnIdxs.contains(layerIdx) {
-                KVCacheSimple()
+                try makeAttentionKVCache(parameters: parameters)
             } else {
                 MambaCache()
             }

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -492,10 +492,10 @@ public class LFM2MoEModel: Module, LLMModel, KVCacheDimensionProvider {
         return sanitized
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        (0 ..< configuration.hiddenLayers).map { layerIdx in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try (0 ..< configuration.hiddenLayers).map { layerIdx in
             if configuration.fullAttnIdxs.contains(layerIdx) {
-                KVCacheSimple()
+                try makeAttentionKVCache(parameters: parameters)
             } else {
                 MambaCache()
             }

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -458,13 +458,12 @@ public class MiMoV2FlashModel: Module, LLMModel, KVCacheDimensionProvider {
         }
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        return model.layers.map { layer in
-            if layer.isSlidingWindow {
-                return RotatingKVCache(maxSize: configuration.slidingWindowSize)
-            } else {
-                return KVCacheSimple()
-            }
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try model.layers.map { layer in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: configuration.slidingWindowSize,
+                usesSlidingWindow: layer.isSlidingWindow)
         }
     }
 }

--- a/Libraries/MLXLLM/Models/Mistral3Text.swift
+++ b/Libraries/MLXLLM/Models/Mistral3Text.swift
@@ -348,15 +348,14 @@ public class Mistral3TextModel: Module, LLMModel, KVCacheDimensionProvider {
 
     /// Create appropriate caches for each layer type.
     ///
-    /// Sliding window attention layers use RotatingKVCache,
-    /// full attention layers use standard KVCacheSimple.
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        return model.layers.map { layer in
-            if layer.useSliding, let slidingWindow = args.slidingWindow {
-                return RotatingKVCache(maxSize: slidingWindow)
-            } else {
-                return KVCacheSimple()
-            }
+    /// Sliding-window layers use the smaller of the architecture window and
+    /// `GenerateParameters.maxKVSize`; full-attention layers use the requested limit.
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try model.layers.map { layer in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: args.slidingWindow,
+                usesSlidingWindow: layer.useSliding)
         }
     }
 }

--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -213,14 +213,10 @@ public class NanbeigeModel: Module, LLMModel {
         return out
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
         let count = model.cacheSlotCount
-        if let maxKVSize = parameters?.maxKVSize {
-            return (0 ..< count).map { _ in
-                RotatingKVCache(maxSize: maxKVSize, keep: 4)
-            }
-        } else {
-            return (0 ..< count).map { _ in KVCacheSimple() }
+        return try (0 ..< count).map { _ in
+            try makeAttentionKVCache(parameters: parameters)
         }
     }
 

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -739,15 +739,15 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
         return out
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
         let pattern = Array(configuration.hybridOverridePattern)
-        return pattern.compactMap { char -> KVCache? in
+        return try pattern.compactMap { char -> KVCache? in
             let blockType = NemotronHBlockType(from: char)
             switch blockType {
             case .mamba:
                 return MambaCache()
             case .attention:
-                return KVCacheSimple()
+                return try makeAttentionKVCache(parameters: parameters)
             case .mlp, .moe:
                 return nil  // No cache needed for MLP/MoE layers
             }

--- a/Libraries/MLXLLM/Models/NemotronLabsDiffusion.swift
+++ b/Libraries/MLXLLM/Models/NemotronLabsDiffusion.swift
@@ -435,6 +435,9 @@ public struct NemotronLabsDiffusionConfiguration: Codable, Sendable {
 // MARK: - Generation Helpers
 
 extension NemotronLabsDiffusionModel {
+    private func makeUnboundedCache() -> [KVCache] {
+        kvHeads.map { _ in KVCacheSimple() }
+    }
 
     /// Number of tokens to commit per denoising step within a single block,
     /// distributed evenly with leftovers spread to the first few steps. Mirrors
@@ -502,7 +505,7 @@ extension NemotronLabsDiffusionModel {
         maxNewTokens: Int = 128,
         eosTokenId: Int? = nil
     ) -> (tokens: [Int], nfe: Int) {
-        let cache = newCache(parameters: nil)
+        let cache = makeUnboundedCache()
 
         let prompt = MLXArray(promptIds.map { Int32($0) })[.newAxis, 0...]
         var logits = self(prompt, cache: cache)
@@ -586,7 +589,7 @@ extension NemotronLabsDiffusionModel {
         var nfe = 0
 
         // Causal prefill of the prompt once. After this, cache.offset == promptIds.count.
-        let cache = newCache(parameters: nil)
+        let cache = makeUnboundedCache()
         let promptArr = MLXArray(promptIds.map { Int32($0) })[.newAxis, 0...]
         _ = self(promptArr, cache: cache)
         eval(cache)
@@ -734,7 +737,7 @@ extension NemotronLabsDiffusionModel {
     ) -> (tokens: [Int], nfe: Int) {
         let maskId = Int32(args.maskTokenId)
 
-        let cache = newCache(parameters: nil)
+        let cache = makeUnboundedCache()
 
         // Causal prefill: LoRA off so the cached prefix matches AR mode.
         setLoRAEnabledFast(false)

--- a/Libraries/MLXLLM/Models/Olmo3.swift
+++ b/Libraries/MLXLLM/Models/Olmo3.swift
@@ -223,16 +223,13 @@ public class Olmo3Model: Module, LLMModel, KVCacheDimensionProvider {
         weights.filter { !$0.key.contains("self_attn.rotary_emb.inv_freq") }
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        var caches: [KVCache] = []
-        for layerType in args.layerTypes {
-            if layerType == "full_attention" {
-                caches.append(KVCacheSimple())
-            } else {
-                caches.append(RotatingKVCache(maxSize: args.slidingWindow))
-            }
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try args.layerTypes.map { layerType in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: args.slidingWindow,
+                usesSlidingWindow: layerType != "full_attention")
         }
-        return caches
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1066,12 +1066,14 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
         return out
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        return model.layers.map { layer in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try model.layers.map { layer in
             if layer.isLinear {
                 return MambaCache()
             }
-            return KVCacheSimple()
+            // Full-attention layers honor maxKVSize; GDN / linear layers keep
+            // a fixed recurrent state that cannot be token-windowed.
+            return try makeAttentionKVCache(parameters: parameters)
         }
     }
 
@@ -1139,8 +1141,8 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
         languageModel(inputs, cache: cache)
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -498,17 +498,19 @@ public class Qwen3NextModel: Module, LLMModel, KVCacheDimensionProvider {
         return out
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        return model.layers.map { layer in
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try model.layers.map { layer in
             if layer.isLinear {
                 return MambaCache()
             }
-            return KVCacheSimple()
+            return try makeAttentionKVCache(parameters: parameters)
         }
     }
 
     public func makeCache() -> [KVCache] {
-        return newCache(parameters: nil)
+        model.layers.map { layer in
+            layer.isLinear ? MambaCache() : KVCacheSimple()
+        }
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXLMCommon/CacheConfiguration.swift
+++ b/Libraries/MLXLMCommon/CacheConfiguration.swift
@@ -1,0 +1,364 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Layer kinds
+
+/// How a single model layer retains state across generation steps.
+///
+/// This is the stable, descriptive counterpart to concrete ``KVCache`` instances.
+/// Obtain it through ``KVCacheStatus`` rather than inspecting or
+/// casting runtime cache objects.
+public enum CacheLayerKind: Sendable, Hashable {
+    /// Standard or implementation-defined attention KV.
+    ///
+    /// A `nil` `maxSize` is unbounded. A non-nil value describes a bounded
+    /// custom cache that is not a ``RotatingKVCache``.
+    case attention(maxSize: Int?)
+
+    /// Sliding / rotating attention window (``RotatingKVCache``).
+    ///
+    /// Used both for architecture-imposed sliding-window attention and for
+    /// caller-requested capacity limits on full-attention layers.
+    case rotatingAttention(maxSize: Int, keep: Int)
+
+    /// Fixed-size state-space / Mamba / GDN recurrent state (``MambaCache``).
+    ///
+    /// These caches are not token-windowed; a ``GenerateParameters/maxKVSize``
+    /// policy does not apply to them.
+    case stateSpace
+
+    /// Composite per-layer cache (``CacheList``), e.g. Mamba + attention.
+    case composite([CacheLayerKind])
+
+    /// Whether this kind stores attention keys/values that can be size-limited.
+    public var isAttention: Bool {
+        switch self {
+        case .attention, .rotatingAttention:
+            return true
+        case .composite(let children):
+            return children.contains(where: \.isAttention)
+        case .stateSpace:
+            return false
+        }
+    }
+
+    /// Whether this kind is a bounded attention window.
+    public var isBoundedAttention: Bool {
+        switch self {
+        case .attention(let maxSize):
+            return maxSize != nil
+        case .rotatingAttention:
+            return true
+        case .composite(let children):
+            return children.contains(where: \.isBoundedAttention)
+        case .stateSpace:
+            return false
+        }
+    }
+
+    /// Effective attention token budget, if any.
+    public var attentionMaxSize: Int? {
+        switch self {
+        case .attention(let maxSize):
+            return maxSize
+        case .rotatingAttention(let maxSize, _):
+            return maxSize
+        case .composite(let children):
+            return children.compactMap(\.attentionMaxSize).max()
+        case .stateSpace:
+            return nil
+        }
+    }
+
+    fileprivate var containsStateSpace: Bool {
+        switch self {
+        case .stateSpace:
+            return true
+        case .composite(let children):
+            return children.contains(where: \.containsStateSpace)
+        case .attention, .rotatingAttention:
+            return false
+        }
+    }
+}
+
+// MARK: - Unified status
+
+/// Authoritative planned or realized state of a model's KV / recurrent cache.
+///
+/// Obtain this through ``LanguageModel/cacheStatus(parameters:)``,
+/// ``ModelContainer/cacheStatus(parameters:)``, or ``ChatSession/cacheStatus()``.
+/// The same value describes topology, capacity, strategy application, and
+/// model-wide progress for both legacy and typed configuration entry points.
+public struct KVCacheStatus: Sendable, Hashable {
+    public enum Phase: Sendable, Hashable {
+        /// The cache layout has been constructed for inspection but has not run generation.
+        case planned
+        /// The status describes cache storage owned by an active session.
+        case realized
+    }
+
+    public enum RequestSource: Sendable, Hashable {
+        case legacy
+        case typed
+    }
+
+    /// Relationship between requested capacity and the attention layers to
+    /// which that request applies.
+    public enum CapacityDisposition: Sendable, Hashable {
+        case notRequested
+        case fullyApplied
+        case partiallyApplied
+        case unsupported
+        case ignored
+    }
+
+    public let phase: Phase
+    /// `nil` when no capacity or compression behavior was requested.
+    public let requestedConfiguration: KVCacheConfiguration?
+    public let requestSource: RequestSource?
+    /// Flattened leaf layers. ``KVCacheLayerStatus/path`` preserves composite topology.
+    public let layers: [KVCacheLayerStatus]
+    /// Authoritative model-wide position for realized session storage.
+    public let processedTokenCount: Int?
+    public let capacityDisposition: CapacityDisposition
+    public let capacityAppliedLayerCount: Int
+    public let capacityUnappliedLayerCount: Int
+
+    /// `true` when the topology contains both attention and recurrent state.
+    public var isHybrid: Bool {
+        layers.contains { $0.kind.isAttention }
+            && layers.contains { $0.kind.containsStateSpace }
+    }
+
+    /// Per-leaf attention token bounds (`nil` for unbounded or non-attention state).
+    public var attentionMaxSizes: [Int?] {
+        layers.map { $0.kind.attentionMaxSize }
+    }
+
+    public var requestedStrategy: KVCacheStrategyIdentifier? {
+        requestedConfiguration?.strategy.identifier
+    }
+
+    public var compressedLayerCount: Int {
+        layers.count {
+            $0.state == .active && $0.resolvedStrategy != .fullPrecision
+        }
+    }
+
+    public var pendingLayerCount: Int {
+        layers.count { $0.state == .pending }
+    }
+
+    public var skippedLayerCount: Int {
+        layers.count { $0.state == .skipped }
+    }
+
+    /// Inspect a raw cache array using a typed request.
+    public init(
+        cache: [KVCache],
+        configuration: KVCacheConfiguration? = nil,
+        phase: Phase = .realized,
+        processedTokenCount: Int? = nil
+    ) {
+        self.init(
+            cache: cache,
+            configuration: configuration,
+            requestSource: configuration == nil ? nil : .typed,
+            phase: phase,
+            processedTokenCount: processedTokenCount)
+    }
+
+    package init(
+        cache: [KVCache],
+        plan: KVCachePlan,
+        phase: Phase,
+        processedTokenCount: Int? = nil
+    ) {
+        self.init(
+            cache: cache,
+            configuration: plan.configuration,
+            requestSource: plan.requestSource,
+            phase: phase,
+            processedTokenCount: processedTokenCount)
+    }
+
+    private init(
+        cache: [KVCache],
+        configuration: KVCacheConfiguration?,
+        requestSource: RequestSource?,
+        phase: Phase,
+        processedTokenCount: Int?
+    ) {
+        let layers = kvCacheLayerStatuses(cache: cache, configuration: configuration)
+        let capacity = Self.capacityOutcome(
+            layers: layers,
+            capacity: configuration?.capacity,
+            requestSource: requestSource)
+
+        self.phase = phase
+        self.requestedConfiguration = configuration
+        self.requestSource = requestSource
+        self.layers = layers
+        self.processedTokenCount = processedTokenCount
+        self.capacityDisposition = capacity.disposition
+        self.capacityAppliedLayerCount = capacity.applied
+        self.capacityUnappliedLayerCount = capacity.unapplied
+    }
+
+    private static func capacityOutcome(
+        layers: [KVCacheLayerStatus],
+        capacity: KVCacheConfiguration.Capacity?,
+        requestSource: RequestSource?
+    ) -> (disposition: CapacityDisposition, applied: Int, unapplied: Int) {
+        guard let capacity else { return (.notRequested, 0, 0) }
+
+        var applied = 0
+        var unapplied = 0
+        for layer in layers where layer.kind.isAttention {
+            switch requestSource {
+            case .typed:
+                if layer.capacitySource == .modelDefined {
+                    continue
+                }
+                if case .rotatingAttention(let maxSize, let keep) = layer.kind,
+                    layer.capacitySource == .requested,
+                    maxSize == capacity.maxTokens,
+                    keep == capacity.preservedPrefixTokens
+                {
+                    applied += 1
+                } else {
+                    unapplied += 1
+                }
+            case .legacy, nil:
+                if let maxSize = layer.kind.attentionMaxSize, maxSize <= capacity.maxTokens {
+                    applied += 1
+                } else {
+                    unapplied += 1
+                }
+            }
+        }
+
+        if applied + unapplied == 0 { return (.unsupported, 0, 0) }
+        if unapplied == 0 { return (.fullyApplied, applied, 0) }
+        if applied == 0 { return (.ignored, 0, unapplied) }
+        return (.partiallyApplied, applied, unapplied)
+    }
+}
+
+// MARK: - Kind inference from concrete caches
+
+extension CacheLayerKind {
+    /// Best-effort classification of a concrete cache instance.
+    init(cache: KVCache) {
+        switch cache {
+        case let rotating as RotatingKVCache:
+            self = .rotatingAttention(maxSize: rotating.maxSize ?? 0, keep: rotating.keepCount)
+        case is MambaCache:
+            self = .stateSpace
+        case let list as CacheList:
+            self = .composite(list.children.map { CacheLayerKind(cache: $0) })
+        case let arrays as ArraysCache where !(arrays is MambaCache):
+            // Generic slot cache used by some SSM variants.
+            self = .stateSpace
+        default:
+            self = .attention(maxSize: cache.maxSize)
+        }
+    }
+}
+
+// MARK: - Construction helpers
+
+/// Build a standard full-attention cache kind that honors the requested capacity.
+///
+/// The capacity is the unified view of ``GenerateParameters/maxKVSize`` and the
+/// capacity carried by ``GenerateParameters/kvCache``.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request is invalid.
+public func attentionCacheKind(parameters: GenerateParameters?) throws -> CacheLayerKind {
+    guard let capacity = try parameters?.effectiveKVCacheCapacity() else {
+        return .attention(maxSize: nil)
+    }
+    return .rotatingAttention(
+        maxSize: capacity.maxTokens,
+        keep: capacity.preservedPrefixTokens)
+}
+
+/// Build a standard full-attention ``KVCache`` that honors the requested capacity.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request is invalid.
+public func makeAttentionKVCache(parameters: GenerateParameters?) throws -> KVCache {
+    if let capacity = try parameters?.effectiveKVCacheCapacity() {
+        return capacity.makeRotatingCache()
+    }
+    return KVCacheSimple()
+}
+
+/// Architecture-imposed sliding-window attention kind, capped by legacy `maxKVSize`.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request or window is invalid.
+public func slidingWindowCacheKind(
+    parameters: GenerateParameters?,
+    window: Int
+) throws -> CacheLayerKind {
+    .rotatingAttention(
+        maxSize: try effectiveSlidingWindow(parameters: parameters, window: window),
+        keep: 0)
+}
+
+/// Architecture-imposed sliding-window attention cache, capped by legacy `maxKVSize`.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request or window is invalid.
+public func makeSlidingWindowKVCache(parameters: GenerateParameters?, window: Int) throws
+    -> KVCache
+{
+    RotatingKVCache(maxSize: try effectiveSlidingWindow(parameters: parameters, window: window))
+}
+
+/// Full-attention kind if the layer is not sliding-window; otherwise the
+/// architecture sliding window capped by legacy `maxKVSize`.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request or window is invalid.
+public func hybridAttentionCacheKind(
+    parameters: GenerateParameters?,
+    slidingWindow: Int?,
+    usesSlidingWindow: Bool
+) throws -> CacheLayerKind {
+    if usesSlidingWindow, let slidingWindow {
+        return try slidingWindowCacheKind(parameters: parameters, window: slidingWindow)
+    }
+    return try attentionCacheKind(parameters: parameters)
+}
+
+/// Full-attention cache if the layer is not sliding-window; otherwise the
+/// architecture sliding window capped by legacy `maxKVSize`.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request or window is invalid.
+public func makeHybridAttentionKVCache(
+    parameters: GenerateParameters?,
+    slidingWindow: Int?,
+    usesSlidingWindow: Bool
+) throws -> KVCache {
+    if usesSlidingWindow, let slidingWindow {
+        return try makeSlidingWindowKVCache(parameters: parameters, window: slidingWindow)
+    }
+    return try makeAttentionKVCache(parameters: parameters)
+}
+
+/// The smaller of the architecture window and legacy `maxKVSize`.
+///
+/// Typed cache capacity deliberately does not participate: model-native sliding
+/// windows retain their architecture-defined window under `KVCacheConfiguration`.
+private func effectiveSlidingWindow(parameters: GenerateParameters?, window: Int) throws -> Int {
+    guard window > 0 else {
+        throw KVCacheConfigurationError.invalidSlidingWindow(window)
+    }
+    // Validate the whole request, including conflicts and compression fields,
+    // before a cache constructor can observe unchecked legacy values.
+    _ = try parameters?.kvCachePlan()
+    if let maxKVSize = parameters?.maxKVSize {
+        return min(window, maxKVSize)
+    }
+    return window
+}

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -315,6 +315,26 @@ public final class ChatSession {
     /// Speculative decoding configuration, nil if disabled.
     public let speculativeDecoding: SpeculativeDecodingConfig?
 
+    /// Unified KV / recurrent-cache status for this session.
+    ///
+    /// If the session owns a realized cache, this reports its actual request,
+    /// topology, strategy state, and progress. Otherwise it reports the cache
+    /// planned by the current ``generateParameters``.
+    public func cacheStatus() async throws -> KVCacheStatus {
+        let parameters = generateParameters
+        if let realized = await cache.read({ cache -> KVCacheStatus? in
+            guard case .kvcache(let stored) = cache else { return nil }
+            return KVCacheStatus(
+                cache: stored.main.cache,
+                plan: stored.main.plan,
+                phase: .realized,
+                processedTokenCount: stored.main.processedTokenCount)
+        }) {
+            return realized
+        }
+        return try await model.cacheStatus(parameters: parameters)
+    }
+
     /// Initialize the `ChatSession`.
     ///
     /// - Parameters:
@@ -899,22 +919,54 @@ public final class ChatSession {
                     switch cache {
                     case .empty:
                         kvCache = KVCacheStorage(
-                            model.newCache(parameters: generateParameters), plan: kvCachePlan)
+                            try model.newCache(parameters: generateParameters), plan: kvCachePlan)
                         conversation = Conversation(messages: [], cachedTokens: [])
                         cache = .kvcache(
                             .init(main: kvCache, conversation: conversation))
 
                     case .kvcache(let stored):
-                        try stored.requirePlan(kvCachePlan)
-                        kvCache = stored.main
-                        draftKVCache = stored.draft
-                        lmState = stored.state
-                        conversation = stored.conversation
+                        let realizedStatus = KVCacheStatus(
+                            cache: stored.main.cache,
+                            plan: stored.main.plan,
+                            phase: .realized,
+                            processedTokenCount: stored.main.processedTokenCount)
+                        let desiredStatus = try model.cacheStatus(
+                            parameters: generateParameters)
+
+                        // The plan captures the typed/legacy strategy and capacity; the
+                        // realized layer kinds additionally catch layout changes the plan
+                        // alone cannot see.
+                        if var restored = stored.conversation,
+                            stored.main.plan != kvCachePlan
+                                || realizedStatus.layers.map(\.kind)
+                                    != desiredStatus.layers.map(\.kind)
+                        {
+                            // Cache-affecting generation parameters changed. Because a
+                            // structured transcript is retained, rebuild the cache from it
+                            // rather than silently continuing with the old cache policy.
+                            restored.cachedTokens.removeAll()
+                            restored.uncommittedTokens.removeAll()
+                            kvCache = KVCacheStorage(
+                                try model.newCache(parameters: generateParameters),
+                                plan: kvCachePlan)
+                            draftKVCache = nil
+                            lmState = nil
+                            conversation = restored
+                        } else {
+                            // Either the realized policy is unchanged, or this is a
+                            // restored raw cache with no transcript to rebuild from.
+                            // In the latter case, requirePlan rejects a changed policy.
+                            try stored.requirePlan(kvCachePlan)
+                            kvCache = stored.main
+                            draftKVCache = stored.draft
+                            lmState = stored.state
+                            conversation = stored.conversation
+                        }
 
                     case .history(let history):
                         // the KVCache is represented by a chat history
                         kvCache = KVCacheStorage(
-                            model.newCache(parameters: generateParameters), plan: kvCachePlan)
+                            try model.newCache(parameters: generateParameters), plan: kvCachePlan)
                         conversation = Conversation(messages: history, cachedTokens: [])
                         cache = .kvcache(
                             .init(main: kvCache, conversation: conversation))
@@ -1078,7 +1130,7 @@ public final class ChatSession {
 
                             case .rebuild:
                                 kvCache = KVCacheStorage(
-                                    model.newCache(parameters: generateParameters),
+                                    try model.newCache(parameters: generateParameters),
                                     plan: kvCachePlan)
                                 draftKVCache = nil
                                 lmState = nil
@@ -1203,7 +1255,7 @@ public final class ChatSession {
                                         // speculation was admitted without a matching
                                         // draft cache. Rebuild both from the full input.
                                         kvCache = KVCacheStorage(
-                                            model.newCache(parameters: generateParameters),
+                                            try model.newCache(parameters: generateParameters),
                                             plan: kvCachePlan)
                                         draftKVCache = nil
                                         lmState = nil
@@ -1214,7 +1266,7 @@ public final class ChatSession {
                                     // exactly like the main model's KV cache.
                                     if draftKVCache == nil {
                                         draftKVCache = KVCacheStorage(
-                                            draftModel.newCache(
+                                            try draftModel.newCache(
                                                 parameters: generateParameters),
                                             plan: kvCachePlan)
                                         cache = .kvcache(
@@ -1389,10 +1441,11 @@ public final class ChatSession {
         await cache.read { _ in }
     }
 
-    /// Return the effective per-layer state of the configured KV-cache strategy.
+    /// Return the legacy runtime-only view of the configured KV-cache strategy.
     ///
     /// The report is `nil` until a typed or legacy cache configuration exists,
     /// or when the session currently stores history rather than a realized cache.
+    @available(*, deprecated, message: "Use cacheStatus() for unified cache diagnostics.")
     public func kvCacheRuntimeReport() async throws -> KVCacheRuntimeReport? {
         let kvCachePlan = try generateParameters.kvCachePlan()
         return try await cache.read { cache in
@@ -1475,7 +1528,7 @@ public enum ChatSessionError: LocalizedError {
         case .emptyPreparedInput:
             "The chat template produced no uncached tokens for generation."
         case .kvCacheConfigurationChanged:
-            "KV-cache configuration changed after the session cache was realized. Call clear() before continuing with the new configuration."
+            "KV-cache configuration changed after the session cache was realized. Clear the session or respond() to rebuild the cache from its retained transcript."
         }
     }
 }

--- a/Libraries/MLXLMCommon/Documentation.docc/kv-cache-quantization.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/kv-cache-quantization.md
@@ -61,15 +61,21 @@ Applications that need a hard total-context cap and compression should omit
 cache capacity, use `.requireAtLeastOneLayer`, and enforce the total token budget
 before inference. A bounded compressed ring cache is not currently implemented.
 
-``ChatSession/kvCacheRuntimeReport()`` reports the requested configuration and
-each realized layer's state, resolved strategy, and skip reason. Its aggregate
-counts let an application display compressed, pending, and skipped layer counts
-without assuming that a request took effect. Session reports also include the
-container-owned `processedTokenCount`; reports built directly from a raw cache
-array leave it `nil` because the array does not own the model-wide timeline.
+``ChatSession/cacheStatus()`` is the unified diagnostic surface for legacy and
+typed configuration. It reports the normalized request, request source,
+planned or realized phase, flattened cache topology, per-layer capacity source,
+strategy state, skip reason, and the container-owned `processedTokenCount`.
+Aggregate compressed, pending, skipped, and capacity-application counts are
+available on the same value.
+``LanguageModel/cacheStatus(parameters:)`` and
+``ModelContainer/cacheStatus(parameters:)`` provide the same shape for planned
+caches. The lower-level ``kvCacheRuntimeReport(cache:configuration:)`` remains
+available when directly applying a typed configuration to a raw cache array.
 
-A realized `ChatSession` cache is bound to its configuration. Call
-``ChatSession/clear()`` before changing its capacity or strategy.
+A realized `ChatSession` cache is bound to its configuration. When parameters
+change, a session with a structured transcript rebuilds automatically on the
+next response. A restored raw cache has no transcript to replay and rejects an
+incompatible request; clear it or create a new session.
 
 ## Cache ownership and progress
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -67,8 +67,19 @@ public struct GenerateParameters: Sendable {
     /// Maximum tokens to generate
     public var maxTokens: Int?
 
-    /// Maximum size of the key-value cache. Old entries (except the first 4 tokens) will be overwritten.
-    /// When set, uses ``RotatingKVCache`` instead of ``KVCacheSimple``
+    /// Maximum size of the key-value cache. Old entries are overwritten while retaining
+    /// up to the first 4 tokens when the requested size permits.
+    /// The value must be greater than zero; generation and cache construction throw
+    /// ``KVCacheConfigurationError/invalidCapacity(_:)`` for an invalid value.
+    ///
+    /// When set, full-attention layers that would otherwise use ``KVCacheSimple`` use
+    /// ``RotatingKVCache`` instead. Architecture sliding-window layers use the smaller
+    /// of their model-defined window and this limit. State-space / Mamba / GDN layers
+    /// are not token-windowed and therefore do not consume this budget.
+    ///
+    /// Inspect the effective policy with ``LanguageModel/cacheStatus(parameters:)``
+    /// (also on ``ModelContainer`` / ``ChatSession``). This is a cache policy, not a
+    /// generation stop reason — output token limits still surface as ``GenerateStopReason/length``.
     public var maxKVSize: Int?
 
     /// Typed key-value cache configuration.
@@ -703,7 +714,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         try self.init(
             input: .init(text: .init(tokens: prompt)), model: model,
             cacheStorage: KVCacheStorage(
-                cache ?? model.newCache(parameters: parameters), plan: plan),
+                cache ?? (try model.newCache(parameters: parameters)), plan: plan),
             parameters: parameters, components: components)
     }
 
@@ -731,7 +742,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         try self.init(
             input: input, model: model,
             cacheStorage: KVCacheStorage(
-                cache ?? model.newCache(parameters: parameters), plan: plan),
+                cache ?? (try model.newCache(parameters: parameters)), plan: plan),
             state: state, parameters: parameters, components: components)
     }
 
@@ -782,7 +793,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.state = state
         self.y = input.text
         self.cacheStorage = KVCacheStorage(
-            cache ?? model.newCache(parameters: nil), plan: .disabled)
+            try cache ?? model.newCache(parameters: nil), plan: .disabled)
 
         self.processor = processor
         self.sampler = sampler
@@ -1020,9 +1031,9 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         try self.init(
             input: input, mainModel: mainModel, draftModel: draftModel,
             mainCacheStorage: KVCacheStorage(
-                mainCache ?? mainModel.newCache(parameters: parameters), plan: plan),
+                mainCache ?? (try mainModel.newCache(parameters: parameters)), plan: plan),
             draftCacheStorage: KVCacheStorage(
-                draftCache ?? draftModel.newCache(parameters: parameters), plan: plan),
+                draftCache ?? (try draftModel.newCache(parameters: parameters)), plan: plan),
             mainState: mainState,
             parameters: parameters, numDraftTokens: numDraftTokens,
             components: components)

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -559,6 +559,9 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
 
     public override var maxSize: Int? { maxCacheSize }
 
+    /// Number of leading tokens that are never rotated out of the window.
+    var keepCount: Int { keep }
+
     public init(maxSize: Int, keep: Int = 0, step: Int = 256) {
         self.maxCacheSize = maxSize
         self.keep = keep
@@ -1516,7 +1519,7 @@ public class CacheList: BaseKVCache {
         super.init()
     }
 
-    /// Internal initializer for reconstruction from deserialized children
+    /// Internal initializer for reconstruction from deserialized children.
     internal init(caches: [KVCache]) {
         self.caches = caches
         super.init()
@@ -1614,7 +1617,7 @@ public class CacheList: BaseKVCache {
         return result
     }
 
-    /// Internal accessor for child caches (used by serialization)
+    /// Internal accessor for child caches (used by serialization and policy reporting).
     internal var children: [KVCache] { caches }
 
     // MARK: - Serialization
@@ -2207,38 +2210,40 @@ private func unflattenMetadata(_ flatMetadata: [String: String]) -> [Any] {
 ///
 /// This function will defer the cache construction to the model if it has a
 /// `newCache` method, otherwise it will make a default KV cache.
+///
+/// - Throws: ``KVCacheConfigurationError`` when the request or a model-defined
+///   cache size is invalid.
 public func makePromptCache(
     model: any LanguageModel,
     parameters: GenerateParameters? = nil
-) -> [KVCache] {
+) throws -> [KVCache] {
     // The model already conforms to LanguageModel which has newCache
     // If it also conforms to KVCacheDimensionProvider, the extension will provide the implementation
-    return model.newCache(parameters: parameters)
+    return try model.newCache(parameters: parameters)
 }
 
 /// Legacy function for backwards compatibility
 public func makePromptCache(
     model: any LanguageModel,
     maxKVSize: Int? = nil
-) -> [KVCache] {
+) throws -> [KVCache] {
     let parameters = maxKVSize.map { GenerateParameters(maxKVSize: $0) }
-    return makePromptCache(model: model, parameters: parameters)
+    return try makePromptCache(model: model, parameters: parameters)
 }
 
 /// Fallback function to create cache when layer count is known
 ///
 /// This function creates a default cache structure when the number of layers is known.
 /// Use this when `makePromptCache` cannot determine the layer count automatically.
+///
+/// - Throws: ``KVCacheConfigurationError`` when `maxKVSize` is invalid.
 public func makePromptCacheWithLayerCount(
     numLayers: Int,
     maxKVSize: Int? = nil
-) -> [KVCache] {
-    if let maxKVSize = maxKVSize {
-        return (0 ..< numLayers).map { _ in
-            RotatingKVCache(maxSize: maxKVSize, keep: 4)
-        }
-    } else {
-        return (0 ..< numLayers).map { _ in KVCacheSimple() }
+) throws -> [KVCache] {
+    let parameters = maxKVSize.map { GenerateParameters(maxKVSize: $0) }
+    return try (0 ..< numLayers).map { _ in
+        try makeAttentionKVCache(parameters: parameters)
     }
 }
 

--- a/Libraries/MLXLMCommon/KVCacheConfiguration.swift
+++ b/Libraries/MLXLMCommon/KVCacheConfiguration.swift
@@ -256,6 +256,7 @@ public struct TurboQuantKVCacheConfiguration: Sendable, Hashable {
 public enum KVCacheConfigurationError: Error, Sendable, Equatable, LocalizedError {
     case conflictingLegacyConfiguration
     case invalidCapacity(Int)
+    case invalidSlidingWindow(Int)
     case invalidPreservedPrefix(Int, capacity: Int)
     case invalidAffineBits(Int)
     case invalidGroupSize(Int)
@@ -271,6 +272,8 @@ public enum KVCacheConfigurationError: Error, Sendable, Equatable, LocalizedErro
             "Set either GenerateParameters.kvCache or the legacy KV-cache fields, not both."
         case .invalidCapacity(let value):
             "KV-cache capacity must be positive; received \(value)."
+        case .invalidSlidingWindow(let value):
+            "Model sliding-window size must be positive; received \(value)."
         case .invalidPreservedPrefix(let value, let capacity):
             "Preserved prefix \(value) must be non-negative and smaller than capacity \(capacity)."
         case .invalidAffineBits(let value):
@@ -291,30 +294,71 @@ public enum KVCacheConfigurationError: Error, Sendable, Equatable, LocalizedErro
     }
 }
 
-/// Effective per-layer state for a configured KV cache.
-public struct KVCacheRuntimeReport: Sendable, Hashable {
-    public struct Layer: Sendable, Hashable {
-        public enum State: Sendable, Hashable {
-            case active
-            case pending
-            case skipped
-            case notApplicable
-        }
-
-        public enum Reason: Sendable, Hashable {
-            case awaitingCompressionStart
-            case boundaryProtection
-            case slidingWindow
-            case unsupportedShape
-            case differentStrategy
-            case nonAttentionState
-        }
-
-        public let path: [Int]
-        public let state: State
-        public let resolvedStrategy: KVCacheStrategyIdentifier?
-        public let reason: Reason?
+/// Effective state of one leaf in a model's cache topology.
+///
+/// This is shared by the high-level ``KVCacheStatus`` API and the lower-level
+/// ``KVCacheRuntimeReport`` compatibility view.
+public struct KVCacheLayerStatus: Sendable, Hashable {
+    public enum State: Sendable, Hashable {
+        case active
+        case pending
+        case skipped
+        case notApplicable
     }
+
+    public enum Reason: Sendable, Hashable {
+        case awaitingCompressionStart
+        case boundaryProtection
+        case slidingWindow
+        case unsupportedShape
+        case differentStrategy
+        case nonAttentionState
+    }
+
+    /// Where an attention layer's resident-token bound originated.
+    public enum CapacitySource: Sendable, Hashable {
+        /// The attention cache grows without an explicit resident-token bound.
+        case unbounded
+        /// The model architecture defines the bound, such as sliding-window attention.
+        case modelDefined
+        /// The caller requested the bound through generation parameters.
+        case requested
+        /// A model-specific cache implementation defines the bound.
+        case implementationDefined
+    }
+
+    /// Stable path through top-level and composite cache entries.
+    public let path: [Int]
+    public let kind: CacheLayerKind
+    /// `nil` for recurrent or other non-attention state.
+    public let capacitySource: CapacitySource?
+    public let state: State
+    public let resolvedStrategy: KVCacheStrategyIdentifier?
+    public let reason: Reason?
+
+    package init(
+        path: [Int],
+        kind: CacheLayerKind,
+        capacitySource: CapacitySource?,
+        state: State,
+        resolvedStrategy: KVCacheStrategyIdentifier?,
+        reason: Reason?
+    ) {
+        self.path = path
+        self.kind = kind
+        self.capacitySource = capacitySource
+        self.state = state
+        self.resolvedStrategy = resolvedStrategy
+        self.reason = reason
+    }
+}
+
+/// Effective per-layer state for a configured KV cache.
+///
+/// Prefer ``KVCacheStatus`` for application diagnostics. This report remains
+/// useful when directly applying a configuration to a raw cache array.
+public struct KVCacheRuntimeReport: Sendable, Hashable {
+    public typealias Layer = KVCacheLayerStatus
 
     public let requestedConfiguration: KVCacheConfiguration
     public let layers: [Layer]

--- a/Libraries/MLXLMCommon/KVCachePlan.swift
+++ b/Libraries/MLXLMCommon/KVCachePlan.swift
@@ -8,9 +8,14 @@ package struct KVCachePlan: Sendable, Equatable {
     package static let disabled = KVCachePlan(configuration: nil)
 
     package let configuration: KVCacheConfiguration?
+    package let requestSource: KVCacheStatus.RequestSource?
 
-    package init(configuration: KVCacheConfiguration?) {
+    package init(
+        configuration: KVCacheConfiguration?,
+        requestSource: KVCacheStatus.RequestSource? = nil
+    ) {
         self.configuration = configuration
+        self.requestSource = configuration == nil ? nil : requestSource ?? .typed
     }
 
     package func validated(_ cache: [KVCache]) throws -> [KVCache] {
@@ -391,18 +396,28 @@ extension KVCacheConfiguration.Capacity {
 }
 
 extension GenerateParameters {
-    package var effectiveKVCacheCapacity: KVCacheConfiguration.Capacity? {
-        if let capacity = kvCache?.capacity {
-            return capacity
-        }
-        guard let maxKVSize else { return nil }
-        return .init(
-            uncheckedMaxTokens: maxKVSize,
-            preservedPrefixTokens: min(4, max(0, maxKVSize - 1)))
+    /// Resolve and validate the complete request before exposing its capacity.
+    ///
+    /// Cache factories use this instead of constructing an unchecked legacy
+    /// capacity so direct `newCache(parameters:)` calls fail with the same typed
+    /// errors as generation entry points.
+    package func effectiveKVCacheCapacity() throws -> KVCacheConfiguration.Capacity? {
+        try resolvedKVCacheConfiguration()?.capacity
     }
 
     package func kvCachePlan() throws -> KVCachePlan {
-        KVCachePlan(configuration: try resolvedKVCacheConfiguration())
+        let configuration = try resolvedKVCacheConfiguration()
+        let requestSource: KVCacheStatus.RequestSource? =
+            if configuration == nil {
+                nil
+            } else if kvCache == nil {
+                .legacy
+            } else {
+                .typed
+            }
+        return KVCachePlan(
+            configuration: configuration,
+            requestSource: requestSource)
     }
 
     package func resolvedKVCacheConfiguration() throws -> KVCacheConfiguration? {

--- a/Libraries/MLXLMCommon/KVCacheRuntime.swift
+++ b/Libraries/MLXLMCommon/KVCacheRuntime.swift
@@ -148,15 +148,24 @@ public func kvCacheRuntimeReport(
     cache: [KVCache],
     configuration: KVCacheConfiguration
 ) -> KVCacheRuntimeReport {
-    let leaves = KVCacheTree.leaves(in: cache)
-    let protectedPaths = protectedPaths(for: leaves, configuration: configuration)
     return KVCacheRuntimeReport(
         requestedConfiguration: configuration,
-        layers: leaves.map {
-            $0.runtimeLayer(
-                configuration: configuration,
-                protectedPaths: protectedPaths)
-        })
+        layers: kvCacheLayerStatuses(cache: cache, configuration: configuration))
+}
+
+/// Build the shared per-layer view used by planned, realized, and compatibility reports.
+package func kvCacheLayerStatuses(
+    cache: [KVCache],
+    configuration: KVCacheConfiguration?
+) -> [KVCacheLayerStatus] {
+    let configuration = configuration ?? KVCacheConfiguration()
+    let leaves = KVCacheTree.leaves(in: cache)
+    let protectedPaths = protectedPaths(for: leaves, configuration: configuration)
+    return leaves.map {
+        $0.runtimeLayer(
+            configuration: configuration,
+            protectedPaths: protectedPaths)
+    }
 }
 
 private func protectedPaths(
@@ -174,17 +183,42 @@ extension KVCacheLeaf {
     fileprivate func runtimeLayer(
         configuration: KVCacheConfiguration,
         protectedPaths: Set<[Int]>
-    ) -> KVCacheRuntimeReport.Layer {
+    ) -> KVCacheLayerStatus {
         let requested = configuration.strategy.identifier
-        switch kind {
+        let layerKind = CacheLayerKind(cache: cache)
+        let capacitySource: KVCacheLayerStatus.CapacitySource? =
+            switch self.kind {
+            case .recurrent:
+                nil
+            case .rotating(let rotating):
+                rotating.capacityOrigin == .requested ? .requested : .modelDefined
+            default:
+                cache.maxSize == nil ? .unbounded : .implementationDefined
+            }
+
+        func status(
+            state: KVCacheLayerStatus.State,
+            resolvedStrategy: KVCacheStrategyIdentifier?,
+            reason: KVCacheLayerStatus.Reason?
+        ) -> KVCacheLayerStatus {
+            .init(
+                path: path,
+                kind: layerKind,
+                capacitySource: capacitySource,
+                state: state,
+                resolvedStrategy: resolvedStrategy,
+                reason: reason)
+        }
+
+        switch self.kind {
         case .recurrent:
-            return .init(
-                path: path, state: .notApplicable, resolvedStrategy: nil,
+            return status(
+                state: .notApplicable,
+                resolvedStrategy: nil,
                 reason: .nonAttentionState)
         case .turboQuant(let turbo):
             let matches = requested == .turboQuant
-            return .init(
-                path: path,
+            return status(
                 state: matches ? (turbo.isCompressed ? .active : .pending) : .skipped,
                 resolvedStrategy: .turboQuant,
                 reason: matches
@@ -194,38 +228,38 @@ extension KVCacheLeaf {
             let isBoundaryProtection =
                 requested == .turboQuant && protectedPaths.contains(path)
             let matches = requested == .affine || isBoundaryProtection
-            return .init(
-                path: path,
+            return status(
                 state: matches ? .active : .skipped,
                 resolvedStrategy: .affine,
                 reason: isBoundaryProtection
                     ? .boundaryProtection : (matches ? nil : .differentStrategy))
         case .rotating:
-            return .init(
-                path: path,
+            return status(
                 state: requested == .fullPrecision ? .active : .skipped,
                 resolvedStrategy: .fullPrecision,
                 reason: requested == .fullPrecision ? nil : .slidingWindow)
         case .simple where requested == .fullPrecision:
-            return .init(
-                path: path, state: .active, resolvedStrategy: .fullPrecision, reason: nil)
+            return status(
+                state: .active,
+                resolvedStrategy: .fullPrecision,
+                reason: nil)
         case .simple:
             guard supports(configuration, protectedPaths: protectedPaths) == true else {
-                return .init(
-                    path: path,
+                return status(
                     state: .skipped,
                     resolvedStrategy: .fullPrecision,
                     reason: .unsupportedShape)
             }
             let compressionPending = cache.offset <= configuration.strategy.compressionStart
-            return .init(
-                path: path,
+            return status(
                 state: compressionPending ? .pending : .skipped,
                 resolvedStrategy: .fullPrecision,
                 reason: compressionPending ? .awaitingCompressionStart : .unsupportedShape)
         case .unsupported:
-            return .init(
-                path: path, state: .skipped, resolvedStrategy: nil, reason: .unsupportedShape)
+            return status(
+                state: .skipped,
+                resolvedStrategy: nil,
+                reason: .unsupportedShape)
         }
     }
 }

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -304,9 +304,29 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
     /// Models may implement this simplified interface if they do not produce any ``LMOutput/State``
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray
 
-    /// create a new array of ``KVCache``: automatic implementation if self
-    /// implements ``KVCacheDimensionProvider``
-    func newCache(parameters: GenerateParameters?) -> [KVCache]
+    /// Create a new array of ``KVCache`` appropriate for this model.
+    ///
+    /// Implementations must honor ``GenerateParameters/maxKVSize`` for any
+    /// attention layer that can be token-windowed. Hybrid attention / state-space
+    /// models apply the limit to attention caches only (see
+    /// ``makeAttentionKVCache(parameters:)``).
+    ///
+    /// - Throws: ``KVCacheConfigurationError`` when the request or a model-defined
+    ///   cache size is invalid.
+    ///
+    /// Automatic implementation if self implements ``KVCacheDimensionProvider``.
+    func newCache(parameters: GenerateParameters?) throws -> [KVCache]
+
+    /// Authoritative planned status of the cache ``newCache(parameters:)`` produces.
+    ///
+    /// Use this from ``ModelContainer`` / ``ChatSession`` (or directly on the model)
+    /// to inspect topology, requested capacity, and strategy compatibility without
+    /// allocating or casting probe caches in application code.
+    ///
+    /// The default implementation derives the description from ``newCache(parameters:)``.
+    /// Models may override with a zero-allocation declarative path, but must stay
+    /// consistent with ``newCache(parameters:)``.
+    func cacheStatus(parameters: GenerateParameters?) throws -> KVCacheStatus
 }
 
 extension LanguageModel {
@@ -331,6 +351,19 @@ extension LanguageModel {
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         fatalError("callAsFunction(inputs:cache:) not implemented for \(Self.self)")
     }
+
+    /// Default: classify the caches that ``newCache(parameters:)`` constructs.
+    ///
+    /// Empty caches allocate negligible state (no tensors until the first update),
+    /// so this is always consistent with the runtime path. Prefer a declarative
+    /// override only when construction itself is expensive.
+    public func cacheStatus(parameters: GenerateParameters?) throws -> KVCacheStatus {
+        let plan = try parameters?.kvCachePlan() ?? .disabled
+        return KVCacheStatus(
+            cache: try newCache(parameters: parameters),
+            plan: plan,
+            phase: .planned)
+    }
 }
 
 /// Optional protocol that can be implemented by ``LanguageModel`` and will
@@ -340,18 +373,17 @@ public protocol KVCacheDimensionProvider {
 }
 
 extension LanguageModel where Self: KVCacheDimensionProvider {
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
         // Create one cache per layer (kvHeads.count = number of layers)
         // The number of heads per layer (kvHeads[i]) is not used for cache creation
         let numLayers = kvHeads.count
-
-        // Follow Python logic: use RotatingKVCache if a capacity is provided.
-        if let capacity = parameters?.effectiveKVCacheCapacity {
-            return (0 ..< numLayers).map { _ in
-                capacity.makeRotatingCache()
-            }
-        } else {
-            return (0 ..< numLayers).map { _ in KVCacheSimple() }
+        return try (0 ..< numLayers).map { _ in
+            try makeAttentionKVCache(parameters: parameters)
         }
     }
+
+    // Note: do not specialize ``cacheStatus(parameters:)`` here. Hybrid models
+    // commonly conform to ``KVCacheDimensionProvider`` while overriding ``newCache``;
+    // a kvHeads-based default would mis-report those layouts. The base
+    // ``LanguageModel`` implementation classifies the caches ``newCache`` builds.
 }

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -117,7 +117,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         let kvCachePlan = try parameters.kvCachePlan()
         let mainCache = try kvCachePlan.validated(
-            mainCache ?? mainModel.newCache(parameters: parameters))
+            mainCache ?? (try mainModel.newCache(parameters: parameters)))
         self.y = input.text
         self.mainModel = mainModel
         self.drafter = drafter

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -128,6 +128,18 @@ public final class ModelContainer: Sendable {
 
     // MARK: - Thread-safe convenience methods
 
+    /// Authoritative planned cache status for the given generation parameters.
+    ///
+    /// Reports topology, capacity provenance, and strategy compatibility without
+    /// requiring application code to allocate or cast concrete ``KVCache`` types.
+    public func cacheStatus(parameters: GenerateParameters? = nil) async throws
+        -> KVCacheStatus
+    {
+        try await perform { context in
+            try context.model.cacheStatus(parameters: parameters)
+        }
+    }
+
     /// The resolved local model directory for the loaded container.
     public var modelDirectory: URL {
         get async throws {

--- a/Libraries/MLXLMCommon/WiredMemoryUtils.swift
+++ b/Libraries/MLXLMCommon/WiredMemoryUtils.swift
@@ -94,7 +94,7 @@ public enum WiredMemoryUtils {
         parameters: GenerateParameters
     ) throws -> [KVCache] {
         let kvCachePlan = try parameters.kvCachePlan()
-        var cache = try kvCachePlan.validated(model.newCache(parameters: parameters))
+        var cache = try kvCachePlan.validated(try model.newCache(parameters: parameters))
 
         switch try model.prepare(
             input, cache: cache, state: nil, prefill: parameters.prefill)

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -372,20 +372,22 @@ private class LanguageModel: Module, KVCacheDimensionProvider {
         self.kvHeads = Array(repeating: config.kvHeads, count: config.hiddenLayers)
     }
 
-    /// Creates appropriate cache types for each layer
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        var caches: [any KVCache] = []
+    /// Creates appropriate cache types for each layer.
+    /// Global layers honor caller-requested capacity. Local layers retain the
+    /// architecture sliding window for typed requests and are capped by legacy
+    /// ``GenerateParameters/maxKVSize``.
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
         let slidingWindow = config.slidingWindow > 0 ? config.slidingWindow : 4096
         let slidingWindowPattern = config.slidingWindowPattern
-        for i in 0 ..< config.hiddenLayers {
+        return try (0 ..< config.hiddenLayers).map { i in
             let isGlobalLayer = (i % slidingWindowPattern == slidingWindowPattern - 1)
             if isGlobalLayer {
-                caches.append(StandardKVCache())
+                return try makeAttentionKVCache(parameters: parameters)
             } else {
-                caches.append(RotatingKVCache(maxSize: slidingWindow, keep: 0))
+                return try makeSlidingWindowKVCache(
+                    parameters: parameters, window: slidingWindow)
             }
         }
-        return caches
     }
 
     func callAsFunction(
@@ -890,8 +892,8 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
 
     /// Create cache with proper types for each layer
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        return languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        return try languageModel.newCache(parameters: parameters)
     }
 
     public init(_ config: Gemma3Configuration) {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1391,15 +1391,14 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
         super.init()
     }
 
-    func newCache(parameters: GenerateParameters?) -> [any KVCache] {
+    func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
         let slidingWindow = config.slidingWindow > 0 ? config.slidingWindow : 4096
-        return config.layerTypes.prefix(config.hiddenLayers - config.numKVSharedLayers).map {
+        return try config.layerTypes.prefix(config.hiddenLayers - config.numKVSharedLayers).map {
             layerType in
-            if layerType == "full_attention" {
-                StandardKVCache()
-            } else {
-                RotatingKVCache(maxSize: slidingWindow, keep: 0)
-            }
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: slidingWindow,
+                usesSlidingWindow: layerType != "full_attention")
         }
     }
 
@@ -1983,8 +1982,8 @@ public final class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         super.init()
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 
     private func getInputEmbeddings(
@@ -2434,8 +2433,8 @@ public final class Gemma4Unified: Module, VLMModel, KVCacheDimensionProvider {
         super.init()
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 
     private func getImageFeatures(

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -1102,11 +1102,11 @@ public class LFM2VL: Module, VLMModel, KVCacheDimensionProvider {
         return sanitizedWeights
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
         let textConfig = config.textConfiguration
-        return (0 ..< textConfig.hiddenLayers).map { layerIdx in
+        return try (0 ..< textConfig.hiddenLayers).map { layerIdx in
             if textConfig.fullAttnIdxs.contains(layerIdx) {
-                KVCacheSimple()
+                try makeAttentionKVCache(parameters: parameters)
             } else {
                 MambaCache()
             }

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -571,19 +571,16 @@ private enum Language {
             return out
         }
 
-        func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
             let layerTypes =
                 config.layerTypes
                 ?? Array(repeating: "full_attention", count: config.numHiddenLayers)
 
-            return layerTypes.map { layerType in
-                if layerType == "sliding_attention", let slidingWindow = config.slidingWindow {
-                    return RotatingKVCache(maxSize: slidingWindow)
-                } else if let capacity = parameters?.effectiveKVCacheCapacity {
-                    return capacity.makeRotatingCache()
-                } else {
-                    return KVCacheSimple()
-                }
+            return try layerTypes.map { layerType in
+                try makeHybridAttentionKVCache(
+                    parameters: parameters,
+                    slidingWindow: config.slidingWindow,
+                    usesSlidingWindow: layerType == "sliding_attention")
             }
         }
     }
@@ -822,8 +819,8 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         return newWeights
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 }
 

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -712,9 +712,9 @@ private enum PixtralLanguage {
             return out
         }
 
-        func newCache(parameters: GenerateParameters?) -> [KVCache] {
-            (0 ..< config.numHiddenLayers).map { _ in
-                if let capacity = parameters?.effectiveKVCacheCapacity {
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try (0 ..< config.numHiddenLayers).map { _ in
+                if let capacity = try parameters?.effectiveKVCacheCapacity() {
                     return capacity.makeRotatingCache()
                 } else {
                     return KVCacheSimple()
@@ -947,8 +947,8 @@ public class PixtralVLM: Module, VLMModel, KVCacheDimensionProvider {
         return newWeights
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -907,8 +907,8 @@ public class Qwen35: Module, VLMModel {
         languageModel.model.layers
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        languageModel.makeCache(capacity: parameters?.effectiveKVCacheCapacity)
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        languageModel.makeCache(capacity: try parameters?.effectiveKVCacheCapacity())
     }
 
     private func mergeInputIdsWithImageFeatures(

--- a/Tests/MLXLMTests/CacheConfigurationTests.swift
+++ b/Tests/MLXLMTests/CacheConfigurationTests.swift
@@ -1,0 +1,481 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXNN
+import Testing
+
+@testable import MLXLMCommon
+
+// MARK: - Helpers
+
+/// Minimal model that uses the default ``KVCacheDimensionProvider`` cache path.
+private final class DummyModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let kvHeads: [Int]
+
+    init(layers: Int = 4) {
+        self.kvHeads = Array(repeating: 1, count: layers)
+        super.init()
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        inputs
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+}
+
+// MARK: - Unified status
+
+private func legacyStatus(cache: [KVCache], maxKVSize: Int) throws -> KVCacheStatus {
+    let plan = try GenerateParameters(maxKVSize: maxKVSize).kvCachePlan()
+    return KVCacheStatus(cache: cache, plan: plan, phase: .planned)
+}
+
+@Test func cacheStatusCapacityNotRequested() {
+    let status = KVCacheStatus(cache: [KVCacheSimple(), KVCacheSimple()])
+    #expect(status.capacityDisposition == .notRequested)
+    #expect(status.requestSource == nil)
+}
+
+@Test func cacheStatusCapacityFullyApplied() throws {
+    let status = try legacyStatus(
+        cache: [
+            RotatingKVCache(maxSize: 4096, keep: 4),
+            RotatingKVCache(maxSize: 4096, keep: 4),
+        ],
+        maxKVSize: 4096)
+    #expect(status.capacityDisposition == .fullyApplied)
+    #expect(status.capacityAppliedLayerCount == 2)
+    #expect(status.requestSource == .legacy)
+}
+
+@Test func cacheStatusHybridCapacityFullyApplied() throws {
+    let status = try legacyStatus(
+        cache: [
+            MambaCache(),
+            RotatingKVCache(maxSize: 4096, keep: 4),
+            MambaCache(),
+            RotatingKVCache(maxSize: 4096, keep: 4),
+        ],
+        maxKVSize: 4096)
+    #expect(status.capacityDisposition == .fullyApplied)
+    #expect(status.isHybrid)
+}
+
+@Test func cacheStatusCapacityPartiallyApplied() throws {
+    let status = try legacyStatus(
+        cache: [
+            RotatingKVCache(maxSize: 512),
+            KVCacheSimple(),
+            RotatingKVCache(maxSize: 512),
+        ],
+        maxKVSize: 4096)
+    #expect(status.capacityDisposition == .partiallyApplied)
+    #expect(status.capacityAppliedLayerCount == 2)
+    #expect(status.capacityUnappliedLayerCount == 1)
+}
+
+@Test func cacheStatusTreatsOversizedWindowAsUnapplied() throws {
+    let status = try legacyStatus(
+        cache: [
+            RotatingKVCache(maxSize: 8192),
+            RotatingKVCache(maxSize: 4096, keep: 4),
+        ],
+        maxKVSize: 4096)
+    #expect(status.capacityDisposition == .partiallyApplied)
+    #expect(status.capacityAppliedLayerCount == 1)
+    #expect(status.capacityUnappliedLayerCount == 1)
+}
+
+@Test func cacheStatusCapacityUnsupportedForPureSSM() throws {
+    let status = try legacyStatus(
+        cache: [MambaCache(), MambaCache()], maxKVSize: 4096)
+    #expect(status.capacityDisposition == .unsupported)
+}
+
+@Test func cacheStatusCapacityIgnored() throws {
+    let status = try legacyStatus(
+        cache: [KVCacheSimple(), KVCacheSimple()], maxKVSize: 4096)
+    #expect(status.capacityDisposition == .ignored)
+    #expect(status.capacityUnappliedLayerCount == 2)
+}
+
+@Test func cacheLayerStatusClassifiesConcreteCaches() {
+    let caches: [KVCache] = [
+        KVCacheSimple(),
+        RotatingKVCache(maxSize: 128, keep: 4),
+        MambaCache(),
+        CacheList(MambaCache(), RotatingKVCache(maxSize: 64, keep: 4)),
+    ]
+
+    let status = KVCacheStatus(cache: caches)
+    #expect(status.layers.count == 5)
+    #expect(status.layers[1].kind == .rotatingAttention(maxSize: 128, keep: 4))
+    #expect(status.layers[1].capacitySource == .modelDefined)
+    #expect(status.layers[2].kind == .stateSpace)
+    #expect(status.layers[3].path == [3, 0])
+    #expect(status.layers[4].path == [3, 1])
+}
+
+// MARK: - Default LanguageModel path
+
+@Test func defaultLanguageModelHonorsMaxKVSize() throws {
+    let model = DummyModel(layers: 3)
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 256
+
+    let caches = try model.newCache(parameters: parameters)
+    #expect(caches.count == 3)
+    #expect(caches.allSatisfy { $0 is RotatingKVCache })
+    #expect(caches.allSatisfy { $0.maxSize == 256 })
+
+    let status = try model.cacheStatus(parameters: parameters)
+    #expect(status.capacityDisposition == .fullyApplied)
+    #expect(status.requestSource == .legacy)
+    #expect(status.requestedConfiguration?.capacity?.maxTokens == 256)
+    #expect(status.attentionMaxSizes == [256, 256, 256])
+}
+
+@Test func defaultLanguageModelUnboundedWithoutMaxKVSize() throws {
+    let model = DummyModel(layers: 2)
+    let caches = try model.newCache(parameters: nil)
+    #expect(caches.allSatisfy { $0 is KVCacheSimple })
+    #expect(caches.allSatisfy { $0.maxSize == nil })
+
+    let status = try model.cacheStatus(parameters: nil)
+    #expect(status.capacityDisposition == .notRequested)
+    #expect(status.phase == .planned)
+}
+
+// MARK: - Construction helpers
+
+@Test func makeAttentionKVCacheHonorsMaxKVSize() throws {
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 64
+    let limited = try makeAttentionKVCache(parameters: parameters)
+    #expect(limited is RotatingKVCache)
+    #expect(limited.maxSize == 64)
+    if let rotating = limited as? RotatingKVCache {
+        #expect(rotating.keepCount == 4)
+    }
+
+    let unbounded = try makeAttentionKVCache(parameters: nil)
+    #expect(unbounded is KVCacheSimple)
+}
+
+@Test func makeAttentionKVCacheClampsKeepForTinyLimit() throws {
+    let parameters = GenerateParameters(maxKVSize: 1)
+    let cache = try #require(
+        makeAttentionKVCache(parameters: parameters) as? RotatingKVCache)
+    #expect(cache.maxSize == 1)
+    #expect(cache.keepCount == 0)
+}
+
+@Test func cacheConstructionRejectsInvalidLegacyCapacity() {
+    let parameters = GenerateParameters(maxKVSize: 0)
+    #expect(throws: KVCacheConfigurationError.invalidCapacity(0)) {
+        try makeAttentionKVCache(parameters: parameters)
+    }
+    let model = DummyModel()
+    #expect(throws: KVCacheConfigurationError.invalidCapacity(0)) {
+        try model.newCache(parameters: parameters)
+    }
+}
+
+@Test func slidingWindowConstructionRejectsInvalidModelConfiguration() {
+    #expect(throws: KVCacheConfigurationError.invalidSlidingWindow(0)) {
+        try makeSlidingWindowKVCache(parameters: nil, window: 0)
+    }
+    #expect(throws: KVCacheConfigurationError.invalidSlidingWindow(-1)) {
+        try slidingWindowCacheKind(parameters: nil, window: -1)
+    }
+}
+
+@Test func makeHybridAttentionKVCachePrefersSlidingWindow() throws {
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 4096
+
+    let sliding = try makeHybridAttentionKVCache(
+        parameters: parameters,
+        slidingWindow: 512,
+        usesSlidingWindow: true
+    )
+    #expect(sliding is RotatingKVCache)
+    #expect(sliding.maxSize == 512)
+
+    let cappedSliding = try makeHybridAttentionKVCache(
+        parameters: parameters,
+        slidingWindow: 8192,
+        usesSlidingWindow: true
+    )
+    #expect(cappedSliding is RotatingKVCache)
+    #expect(cappedSliding.maxSize == 4096)
+
+    let full = try makeHybridAttentionKVCache(
+        parameters: parameters,
+        slidingWindow: 512,
+        usesSlidingWindow: false
+    )
+    #expect(full is RotatingKVCache)
+    #expect(full.maxSize == 4096)
+}
+
+@Test func typedCapacityPreservesModelNativeSlidingWindow() throws {
+    let capacity = try KVCacheConfiguration.Capacity(
+        maxTokens: 64, preservedPrefixTokens: 3)
+    let parameters = GenerateParameters(
+        kvCache: KVCacheConfiguration(capacity: capacity))
+
+    let sliding = try #require(
+        makeHybridAttentionKVCache(
+            parameters: parameters,
+            slidingWindow: 512,
+            usesSlidingWindow: true
+        ) as? RotatingKVCache)
+    #expect(sliding.maxSize == 512)
+    #expect(sliding.keepCount == 0)
+    #expect(sliding.capacityOrigin == .modelNative)
+
+    let full = try #require(
+        makeHybridAttentionKVCache(
+            parameters: parameters,
+            slidingWindow: 512,
+            usesSlidingWindow: false
+        ) as? RotatingKVCache)
+    #expect(full.maxSize == 64)
+    #expect(full.keepCount == 3)
+    #expect(full.capacityOrigin == .requested)
+
+    let status = KVCacheStatus(
+        cache: [sliding, full],
+        configuration: parameters.kvCache)
+    #expect(status.requestSource == .typed)
+    #expect(status.requestedConfiguration == parameters.kvCache)
+    #expect(status.capacityDisposition == .fullyApplied)
+    #expect(status.capacityAppliedLayerCount == 1)
+    #expect(status.attentionMaxSizes == [512, 64])
+    #expect(status.layers.map(\.capacitySource) == [.modelDefined, .requested])
+}
+
+@Test func typedCapacityRequiresAnExactCallerConfiguredCache() throws {
+    let capacity = try KVCacheConfiguration.Capacity(
+        maxTokens: 64, preservedPrefixTokens: 3)
+    let requested = RotatingKVCache(maxSize: 32, keep: 3)
+    requested.capacityOrigin = .requested
+
+    let status = KVCacheStatus(
+        cache: [requested],
+        configuration: KVCacheConfiguration(capacity: capacity))
+
+    #expect(status.capacityDisposition == .ignored)
+    #expect(status.capacityAppliedLayerCount == 0)
+    #expect(status.capacityUnappliedLayerCount == 1)
+}
+
+@Test func typedCapacityIsUnsupportedForOnlyModelDefinedWindows() throws {
+    let capacity = try KVCacheConfiguration.Capacity(maxTokens: 64)
+    let status = KVCacheStatus(
+        cache: [RotatingKVCache(maxSize: 512)],
+        configuration: KVCacheConfiguration(capacity: capacity))
+
+    #expect(status.capacityDisposition == .unsupported)
+    #expect(status.capacityAppliedLayerCount == 0)
+    #expect(status.capacityUnappliedLayerCount == 0)
+}
+
+@Test func promptCacheWithLayerCountClampsTinyLegacyLimit() throws {
+    let caches = try makePromptCacheWithLayerCount(numLayers: 2, maxKVSize: 1)
+    #expect(caches.count == 2)
+    let keys = MLXArray.zeros([1, 1, 1, 8])
+    let values = MLXArray.zeros([1, 1, 1, 8])
+    for cache in caches {
+        let rotating = try #require(cache as? RotatingKVCache)
+        #expect(rotating.maxSize == 1)
+        #expect(rotating.keepCount == 0)
+        #expect(rotating.capacityOrigin == .requested)
+        _ = rotating.update(keys: keys, values: values)
+        _ = rotating.update(keys: keys, values: values)
+        #expect(rotating.offset == 2)
+    }
+}
+
+// MARK: - Model-specific overrides
+
+@Test func qwen35TextModelHonorsMaxKVSizeOnAttentionLayers() throws {
+    // Tiny hybrid: full attention every 4th layer (interval 4).
+    let json = """
+        {
+          "model_type": "qwen3_5",
+          "hidden_size": 64,
+          "num_hidden_layers": 4,
+          "intermediate_size": 128,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 2,
+          "head_dim": 16,
+          "linear_num_value_heads": 4,
+          "linear_num_key_heads": 2,
+          "linear_key_head_dim": 16,
+          "linear_value_head_dim": 16,
+          "linear_conv_kernel_dim": 4,
+          "rms_norm_eps": 1e-6,
+          "vocab_size": 128,
+          "full_attention_interval": 4,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+    let textConfig = try JSONDecoder().decode(Qwen35TextConfiguration.self, from: json)
+    let model = Qwen35TextModel(textConfig)
+
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 128
+
+    let caches = try model.newCache(parameters: parameters)
+    #expect(caches.count == 4)
+
+    // With interval 4: layers 0,1,2 linear; layer 3 full attention.
+    var attentionCount = 0
+    var stateSpaceCount = 0
+    for cache in caches {
+        if cache is MambaCache {
+            stateSpaceCount += 1
+            #expect(cache.maxSize == nil)
+        } else {
+            attentionCount += 1
+            #expect(cache is RotatingKVCache)
+            #expect(cache.maxSize == 128)
+        }
+    }
+    #expect(attentionCount >= 1)
+    #expect(stateSpaceCount >= 1)
+
+    let status = try model.cacheStatus(parameters: parameters)
+    #expect(status.capacityDisposition == .fullyApplied)
+    #expect(status.isHybrid)
+
+    // Without a limit, attention layers stay unbounded.
+    let unbounded = try model.newCache(parameters: nil)
+    for cache in unbounded where !(cache is MambaCache) {
+        #expect(cache is KVCacheSimple)
+        #expect(cache.maxSize == nil)
+    }
+}
+
+@Test func falconH1CacheConfigurationReportsHybridFullyApplied() throws {
+    let json = """
+        {
+            "model_type": "falcon_h1",
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "vocab_size": 100,
+            "mamba_d_ssm": 16,
+            "mamba_d_state": 8,
+            "mamba_d_head": 8,
+            "mamba_n_heads": 2,
+            "mamba_n_groups": 1,
+            "mamba_d_conv": 4,
+            "mamba_chunk_size": 64,
+            "attention_in_multiplier": 2.0,
+            "key_multiplier": 0.5,
+            "num_logits_to_keep": 1
+        }
+        """.data(using: .utf8)!
+    let config = try JSONDecoder.json5().decode(FalconH1Configuration.self, from: json)
+    let model = FalconH1Model(config)
+
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 8
+
+    let caches = try model.newCache(parameters: parameters)
+    for entry in caches {
+        let list = try #require(entry as? CacheList)
+        #expect(list.children[0] is MambaCache)
+        #expect(list.children[1] is RotatingKVCache)
+        #expect(list.children[1].maxSize == 8)
+    }
+
+    let status = try model.cacheStatus(parameters: parameters)
+    #expect(status.capacityDisposition == .fullyApplied)
+    #expect(status.isHybrid)
+}
+
+@Test func pureMambaReportsUnsupportedMaxKVSize() throws {
+    let json = """
+        {
+          "model_type": "mamba2",
+          "vocab_size": 64,
+          "hidden_size": 32,
+          "num_hidden_layers": 2,
+          "state_size": 8,
+          "ssm_state_size": 8,
+          "conv_kernel": 4,
+          "n_groups": 1,
+          "head_dim": 8,
+          "num_heads": 4,
+          "use_bias": false,
+          "use_conv_bias": true,
+          "tie_word_embeddings": true
+        }
+        """.data(using: .utf8)!
+    let config = try JSONDecoder().decode(Mamba2Configuration.self, from: json)
+    let model = Mamba2Model(config)
+
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 1024
+
+    let caches = model.newCache(parameters: parameters)
+    #expect(caches.allSatisfy { $0 is MambaCache })
+
+    let status = try model.cacheStatus(parameters: parameters)
+    #expect(status.capacityDisposition == .unsupported)
+}
+
+@Test func gemma3TextAllAttentionLayersHonorMaxKVSize() throws {
+    // 6 layers, pattern 3 → global at indices 2 and 5.
+    let config = Gemma3TextConfiguration(
+        modelType: "gemma3_text",
+        hiddenSize: 64,
+        hiddenLayers: 6,
+        intermediateSize: 128,
+        attentionHeads: 4,
+        headDim: 16,
+        rmsNormEps: 1e-6,
+        vocabularySize: 128,
+        kvHeads: 1,
+        ropeTheta: 1_000_000,
+        ropeLocalBaseFreq: 10_000,
+        ropeTraditional: false,
+        queryPreAttnScalar: 256,
+        slidingWindow: 32,
+        slidingWindowPattern: 3,
+        maxPositionEmbeddings: 128
+    )
+    let model = Gemma3TextModel(config)
+
+    var parameters = GenerateParameters()
+    parameters.maxKVSize = 16
+
+    let caches = try model.newCache(parameters: parameters)
+    #expect(caches.count == 6)
+
+    for (i, cache) in caches.enumerated() {
+        let isGlobal = (i % 3 == 2)
+        #expect(cache is RotatingKVCache)
+        if isGlobal {
+            #expect(cache.maxSize == 16)
+        } else {
+            #expect(cache.maxSize == 16)
+        }
+    }
+
+    let status = try model.cacheStatus(parameters: parameters)
+    #expect(status.capacityDisposition == .fullyApplied)
+}

--- a/Tests/MLXLMTests/CachedForwardSmokeTests.swift
+++ b/Tests/MLXLMTests/CachedForwardSmokeTests.swift
@@ -22,8 +22,8 @@ final class CachedForwardSmokeTests: XCTestCase {
         expectedLayers: Int,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) {
-        let cache = model.newCache(parameters: nil)
+    ) throws {
+        let cache = try model.newCache(parameters: nil)
         XCTAssertEqual(
             cache.count, expectedLayers,
             "newCache must return one cache per layer", file: file, line: line)
@@ -85,7 +85,7 @@ final class CachedForwardSmokeTests: XCTestCase {
     func testOlmo3SlidingLayersGetRotatingCache() throws {
         let config = try olmo3Config()
         let model: any LanguageModel = Olmo3Model(config)
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
 
         for (i, layerType) in config.layerTypes.enumerated() {
             if layerType == "full_attention" {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -162,8 +162,8 @@ public class ChatSessionTests: XCTestCase {
             base(input, cache: cache, state: state)
         }
 
-        func newCache(parameters: GenerateParameters?) -> [KVCache] {
-            base.newCache(parameters: parameters)
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try base.newCache(parameters: parameters)
         }
     }
 
@@ -268,8 +268,8 @@ public class ChatSessionTests: XCTestCase {
             LMOutput(logits: inner(batched(input.tokens), cache: cache), state: state)
         }
 
-        func newCache(parameters: GenerateParameters?) -> [KVCache] {
-            inner.newCache(parameters: parameters)
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try inner.newCache(parameters: parameters)
         }
     }
 
@@ -1223,7 +1223,7 @@ public class ChatSessionTests: XCTestCase {
     func testSpeculativeDecodingRunsWithCarriedModelState() async throws {
         let context = model()
         let parameters = GenerateParameters(maxTokens: 4, temperature: 0.0)
-        let cache = context.model.newCache(parameters: parameters)
+        let cache = try context.model.newCache(parameters: parameters)
         let stateKey = LMOutput.Key<MLXArray>("test.carriedState")
         var state = LMOutput.State()
         state[stateKey] = MLXArray([Int32(1)])
@@ -1309,7 +1309,7 @@ public class ChatSessionTests: XCTestCase {
     func testSpeculativeDecodingFallsBackForPrebuiltCacheWithoutDraftCache() async throws {
         let context = model()
         let parameters = GenerateParameters(maxTokens: 4, temperature: 0.0)
-        let cache = context.model.newCache(parameters: parameters)
+        let cache = try context.model.newCache(parameters: parameters)
         let input = try await context.processor.prepare(
             input: UserInput(chat: [.user("cached prefix")]))
         _ = try TokenIterator(
@@ -1571,7 +1571,7 @@ public class ChatSessionTests: XCTestCase {
 
         // Warm a cache directly, the way a caller building a prefix cache in
         // process would, and pair it with its state without going through disk.
-        let cache = context.model.newCache(parameters: parameters)
+        let cache = try context.model.newCache(parameters: parameters)
         let input = try await context.processor.prepare(
             input: UserInput(chat: [.user("cached prefix")]))
         let iterator = try TokenIterator(
@@ -1623,7 +1623,7 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
-    func testChangingKVCacheConfigurationRequiresClearingRealizedCache() async throws {
+    func testCacheStatusPreservesTheRealizedRequestWhenParametersChange() async throws {
         let initialConfiguration = KVCacheConfiguration(
             strategy: .turboQuant(.qualityFirst))
         let session = ChatSession(
@@ -1633,15 +1633,10 @@ public class ChatSessionTests: XCTestCase {
 
         session.generateParameters.kvCache = KVCacheConfiguration(strategy: .fullPrecision)
 
-        do {
-            _ = try await session.kvCacheRuntimeReport()
-            XCTFail("Expected a realized cache to reject configuration changes")
-        } catch ChatSessionError.kvCacheConfigurationChanged(
-            let previous, let requested)
-        {
-            XCTAssertEqual(previous, initialConfiguration)
-            XCTAssertEqual(requested, KVCacheConfiguration(strategy: .fullPrecision))
-        }
+        let status = try await session.cacheStatus()
+        XCTAssertEqual(status.phase, .realized)
+        XCTAssertEqual(status.requestSource, .typed)
+        XCTAssertEqual(status.requestedConfiguration, initialConfiguration)
     }
 
     func testSessionRetainsCacheReplacementTriggeredDuringDecode() async throws {
@@ -1669,9 +1664,16 @@ public class ChatSessionTests: XCTestCase {
             return quantized.offset
         }
         let firstOffset = try XCTUnwrap(observedFirstOffset)
-        let optionalFirstReport = try await session.kvCacheRuntimeReport()
-        let firstReport = try XCTUnwrap(optionalFirstReport)
-        XCTAssertEqual(firstReport.processedTokenCount, firstOffset)
+        let firstStatus = try await session.cacheStatus()
+        XCTAssertEqual(firstStatus.processedTokenCount, firstOffset)
+        XCTAssertEqual(firstStatus.phase, .realized)
+        XCTAssertEqual(firstStatus.requestSource, .typed)
+        XCTAssertEqual(firstStatus.requestedStrategy, .affine)
+        XCTAssertGreaterThan(firstStatus.compressedLayerCount, 0)
+        XCTAssertTrue(
+            firstStatus.layers.contains {
+                $0.state == .active && $0.resolvedStrategy == .affine
+            })
 
         _ = try await session.respond(to: "hello again")
         try await session.withCache { cache in
@@ -1680,6 +1682,116 @@ public class ChatSessionTests: XCTestCase {
                 cache.first { $0 is QuantizedKVCache } as? QuantizedKVCache)
             XCTAssertGreaterThan(quantized.offset, firstOffset)
         }
+    }
+
+    func testModelContainerReportsCappedSlidingAndFullAttentionCaches() async throws {
+        let container = ModelContainer(context: model())
+        let parameters = GenerateParameters(maxTokens: 1, maxKVSize: 64)
+
+        let status = try await container.cacheStatus(parameters: parameters)
+
+        XCTAssertEqual(status.requestSource, .legacy)
+        XCTAssertEqual(status.requestedConfiguration?.capacity?.maxTokens, 64)
+        XCTAssertEqual(status.capacityDisposition, .fullyApplied)
+        XCTAssertEqual(status.layers.count, 8)
+        XCTAssertTrue(status.attentionMaxSizes.allSatisfy { $0 == 64 })
+    }
+
+    func testModelContainerPreservesNativeSlidingWindowForTypedCapacity() async throws {
+        let container = ModelContainer(context: model())
+        let capacity = try KVCacheConfiguration.Capacity(
+            maxTokens: 64, preservedPrefixTokens: 3)
+        let parameters = GenerateParameters(
+            maxTokens: 1,
+            kvCache: KVCacheConfiguration(capacity: capacity))
+
+        let status = try await container.cacheStatus(parameters: parameters)
+
+        XCTAssertEqual(status.requestSource, .typed)
+        XCTAssertEqual(status.requestedConfiguration?.capacity, capacity)
+        XCTAssertEqual(status.capacityDisposition, .fullyApplied)
+        XCTAssertEqual(status.capacityAppliedLayerCount, 1)
+        XCTAssertEqual(status.layers.count, 8)
+        XCTAssertEqual(
+            status.attentionMaxSizes.compactMap { $0 },
+            [512, 512, 512, 512, 512, 64, 512, 512])
+    }
+
+    func testSessionReportsRealizedRawCacheInsteadOfPlannedLayout() async throws {
+        let rawCache: [KVCache] = Array(repeating: 0, count: 8).map { _ in KVCacheSimple() }
+        let session = ChatSession(
+            model(),
+            cache: rawCache,
+            generateParameters: GenerateParameters(maxTokens: 1, maxKVSize: 64))
+
+        let status = try await session.cacheStatus()
+
+        XCTAssertEqual(status.phase, .realized)
+        XCTAssertEqual(status.requestSource, .legacy)
+        XCTAssertEqual(status.requestedConfiguration?.capacity?.maxTokens, 64)
+        XCTAssertEqual(status.capacityDisposition, .ignored)
+        XCTAssertTrue(status.attentionMaxSizes.allSatisfy { $0 == nil })
+    }
+
+    func testSessionRebuildsStructuredCacheWhenMaxKVSizeChanges() async throws {
+        let session = ChatSession(
+            model(), generateParameters: GenerateParameters(maxTokens: 1))
+
+        _ = try await session.respond(to: "first")
+        let initial = try await session.cacheStatus()
+        XCTAssertEqual(initial.capacityDisposition, .notRequested)
+        XCTAssertTrue(initial.attentionMaxSizes.contains(512))
+        XCTAssertTrue(initial.attentionMaxSizes.contains(nil))
+
+        session.generateParameters = GenerateParameters(maxTokens: 1, maxKVSize: 64)
+        let stale = try await session.cacheStatus()
+        XCTAssertEqual(stale.phase, .realized)
+        XCTAssertNil(stale.requestedConfiguration)
+
+        _ = try await session.respond(to: "second")
+        let limited = try await session.cacheStatus()
+        XCTAssertEqual(limited.capacityDisposition, .fullyApplied)
+        XCTAssertEqual(limited.requestSource, .legacy)
+        XCTAssertTrue(limited.attentionMaxSizes.allSatisfy { $0 == 64 })
+        await session.withCache { cache in
+            XCTAssertEqual(cache?.count, 8)
+            XCTAssertTrue(cache?.allSatisfy { $0.maxSize == 64 } == true)
+        }
+
+        session.generateParameters = GenerateParameters(maxTokens: 1)
+        _ = try await session.respond(to: "third")
+        let restored = try await session.cacheStatus()
+        XCTAssertEqual(restored.capacityDisposition, .notRequested)
+        XCTAssertTrue(restored.attentionMaxSizes.contains(512))
+        XCTAssertTrue(restored.attentionMaxSizes.contains(nil))
+    }
+
+    func testSessionRebuildsWhenTypedRequestRestoresNativeWindows() async throws {
+        let session = ChatSession(
+            model(),
+            generateParameters: GenerateParameters(maxTokens: 1, maxKVSize: 64))
+
+        _ = try await session.respond(to: "legacy")
+        let legacy = try await session.cacheStatus()
+        XCTAssertEqual(legacy.capacityDisposition, .fullyApplied)
+        XCTAssertEqual(legacy.requestSource, .legacy)
+        XCTAssertTrue(legacy.attentionMaxSizes.allSatisfy { $0 == 64 })
+
+        let capacity = try KVCacheConfiguration.Capacity(maxTokens: 64)
+        session.generateParameters = GenerateParameters(
+            maxTokens: 1,
+            kvCache: KVCacheConfiguration(
+                capacity: capacity,
+                compatibility: .allowPartial))
+
+        _ = try await session.respond(to: "typed")
+        let typed = try await session.cacheStatus()
+        XCTAssertEqual(typed.requestSource, .typed)
+        XCTAssertEqual(typed.capacityDisposition, .fullyApplied)
+        XCTAssertEqual(typed.capacityAppliedLayerCount, 1)
+        XCTAssertEqual(
+            typed.attentionMaxSizes.compactMap { $0 },
+            [512, 512, 512, 512, 512, 64, 512, 512])
     }
 
     /// something that looks like a view model

--- a/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
+++ b/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
@@ -226,7 +226,7 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
             tokenizer: tokenizer,
             messageGenerator: RecordingMessageGenerator(log: log))
         let parameters = GenerateParameters(maxTokens: 40)
-        let rawCache = context.model.newCache(parameters: parameters)
+        let rawCache = try context.model.newCache(parameters: parameters)
         let session = ChatSession(
             context,
             cache: rawCache,

--- a/Tests/MLXLMTests/ContinuationAssertions.swift
+++ b/Tests/MLXLMTests/ContinuationAssertions.swift
@@ -92,10 +92,10 @@ struct ContinuationAssertions {
         let t1 = textTokens(40)
         let t2 = textTokens(8, seed: 3)
 
-        let cacheF = model.newCache(parameters: nil)
+        let cacheF = try model.newCache(parameters: nil)
         let (logitsF, _) = try prefill(model, concatenated([t1, t2], axis: 1), cache: cacheF)
 
-        let cacheD = model.newCache(parameters: nil)
+        let cacheD = try model.newCache(parameters: nil)
         let (_, s0) = try prefill(model, t1, cache: cacheD)
         var state = s0
         var logitsD = MLXArray(0)
@@ -107,7 +107,7 @@ struct ContinuationAssertions {
         }
         let noiseFloor = maxAbsDiff(logitsD, logitsF)
 
-        let cacheW = model.newCache(parameters: nil)
+        let cacheW = try model.newCache(parameters: nil)
         let (_, s1) = try prefill(model, t1, cache: cacheW)
         let (logitsW, _) = try prefill(model, t2, cache: cacheW, state: s1)
 
@@ -127,11 +127,11 @@ struct ContinuationAssertions {
         let t1 = concatenated([textTokens(10), imageRun(), textTokens(8, seed: 5)], axis: 1)
         let t2 = textTokens(8, seed: 9)
 
-        let cacheF = model.newCache(parameters: nil)
+        let cacheF = try model.newCache(parameters: nil)
         let (logitsF, _) = try prefill(
             model, concatenated([t1, t2], axis: 1), image: image, cache: cacheF)
 
-        let cacheW = model.newCache(parameters: nil)
+        let cacheW = try model.newCache(parameters: nil)
         let (_, s1) = try prefill(model, t1, image: image, cache: cacheW)
         let (logitsW, _) = try prefill(model, t2, cache: cacheW, state: s1)
 
@@ -154,11 +154,11 @@ struct ContinuationAssertions {
             [textTokens(4, seed: 2), imageRun(), textTokens(6, seed: 4)], axis: 1)
         let t3 = textTokens(8, seed: 6)
 
-        let cacheF = model.newCache(parameters: nil)
+        let cacheF = try model.newCache(parameters: nil)
         let (logitsF, _) = try prefill(
             model, concatenated([t1, t2, t3], axis: 1), image: image, cache: cacheF)
 
-        let cacheW = model.newCache(parameters: nil)
+        let cacheW = try model.newCache(parameters: nil)
         let (_, s1) = try prefill(model, t1, cache: cacheW)
         let (_, s2) = try prefill(model, t2, image: image, cache: cacheW, state: s1)
         let (logitsW, _) = try prefill(model, t3, cache: cacheW, state: s2)
@@ -176,10 +176,10 @@ struct ContinuationAssertions {
         MLXRandom.seed(11)
         let prompt = textTokens(40)
 
-        let cacheS = model.newCache(parameters: nil)
+        let cacheS = try model.newCache(parameters: nil)
         let (logitsS, _) = try prefill(model, prompt, cache: cacheS)
 
-        let cacheC = model.newCache(parameters: nil)
+        let cacheC = try model.newCache(parameters: nil)
         let (logitsC, _) = try prefill(model, prompt, cache: cacheC, stepSize: 8)
 
         XCTAssertLessThanOrEqual(
@@ -202,11 +202,11 @@ struct ContinuationAssertions {
         let image = image()
         let prompt = concatenated([textTokens(10), imageRun(), textTokens(12, seed: 7)], axis: 1)
 
-        let cacheS = model.newCache(parameters: nil)
+        let cacheS = try model.newCache(parameters: nil)
         let (logitsS, _) = try prefill(model, prompt, image: image, cache: cacheS)
 
         for stepSize in [3, 5, 8] {
-            let cacheC = model.newCache(parameters: nil)
+            let cacheC = try model.newCache(parameters: nil)
             let (logitsC, _) = try prefill(
                 model, prompt, image: image, cache: cacheC, stepSize: stepSize)
 

--- a/Tests/MLXLMTests/DeepseekV2Tests.swift
+++ b/Tests/MLXLMTests/DeepseekV2Tests.swift
@@ -64,7 +64,7 @@ final class DeepseekV2Tests: XCTestCase {
     /// every subsequent token attended over duplicated keys.
     func testForwardPassUpdatesCacheExactlyOnce() throws {
         let model = DeepseekV2Model(try makeConfig())
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let tokenCount = 5
         let inputs = MLXArray(Array(Int32(1) ... Int32(tokenCount))).reshaped(1, tokenCount)
 

--- a/Tests/MLXLMTests/DeepseekV3Tests.swift
+++ b/Tests/MLXLMTests/DeepseekV3Tests.swift
@@ -52,7 +52,7 @@ final class DeepseekV3Tests: XCTestCase {
     /// every subsequent token attended over duplicated keys.
     func testForwardPassUpdatesCacheExactlyOnce() throws {
         let model = DeepseekV3Model(try makeConfig())
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let tokenCount = 5
         let inputs = MLXArray(Array(Int32(1) ... Int32(tokenCount))).reshaped(1, tokenCount)
 

--- a/Tests/MLXLMTests/FalconH1Tests.swift
+++ b/Tests/MLXLMTests/FalconH1Tests.swift
@@ -109,7 +109,7 @@ final class FalconH1Tests: XCTestCase {
         let model = FalconH1Model(config)
         let params = GenerateParameters(maxKVSize: 8)
 
-        let cache = model.newCache(parameters: params)
+        let cache = try model.newCache(parameters: params)
         XCTAssertEqual(cache.count, 2)
 
         for entry in cache {
@@ -124,7 +124,7 @@ final class FalconH1Tests: XCTestCase {
         let model = FalconH1Model(config)
         let params = GenerateParameters(kvBits: 4, kvGroupSize: 32, quantizedKVStart: 0)
 
-        let cache = model.newCache(parameters: params)
+        let cache = try model.newCache(parameters: params)
         XCTAssertEqual(cache.count, 2)
 
         for entry in cache {

--- a/Tests/MLXLMTests/Gemma4AssistantDraftModelTests.swift
+++ b/Tests/MLXLMTests/Gemma4AssistantDraftModelTests.swift
@@ -350,7 +350,7 @@ func testDraftBlockAcceptsGemma4UnifiedTarget() throws {
     let target = Gemma4Unified(targetConfig)
 
     // Prime drafter state through the MTP entry point (what the iterator does).
-    let cache = target.newCache(parameters: nil)
+    let cache = try target.newCache(parameters: nil)
     var emitState = LMOutput.State()
     emitState[mtpEmitFlagKey] = true
     let tokens = MLXArray((0 ..< 8).map { Int32($0 % 32) }).reshaped([1, 8])

--- a/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChunkedPrefillTests.swift
@@ -72,7 +72,7 @@ struct Gemma4ChunkedPrefillTests {
     private static func prefillLogits(
         model: Gemma4, tokens: [Int], windowSize: Int
     ) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
         let result = try model.prepare(
             input, cache: cache, state: nil, prefill: .init(stepSize: windowSize))
@@ -139,7 +139,7 @@ struct Gemma4ChunkedPrefillTests {
 
         let input = LMInput(tokens: MLXArray(tokens).expandedDimensions(axis: 0))
         _ = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil, prefill: prefill)
+            input, cache: try model.newCache(parameters: nil), state: nil, prefill: prefill)
 
         #expect(log.events.last == [tokens.count, tokens.count])
         #expect(log.events.map { $0[0] } == log.events.map { $0[0] }.sorted())
@@ -151,7 +151,7 @@ struct Gemma4ChunkedPrefillTests {
         let model = try Self.makeTinyModel()
         let tokens = Self.makePrompt(count: 21)
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray(tokens))  // 1-D, no batch axis
         let result = try model.prepare(input, cache: cache, state: nil, prefill: .init(stepSize: 6))
         guard case .logits(let output) = result else {

--- a/Tests/MLXLMTests/Gemma4EmitDrafterStateTests.swift
+++ b/Tests/MLXLMTests/Gemma4EmitDrafterStateTests.swift
@@ -34,11 +34,11 @@ func testGemma4TextEmitFalseReturnsNoStateBySynthetic() {
 }
 
 @Test
-func testGemma4TextEmitTrueWithBothLayerTypesPopulatesStateBySynthetic() {
+func testGemma4TextEmitTrueWithBothLayerTypesPopulatesStateBySynthetic() throws {
     let model = makeSyntheticGemma4TextLanguageModel(layerTypes: [
         "full_attention", "sliding_attention",
     ])
-    let cache = model.newCache(parameters: nil)
+    let cache = try model.newCache(parameters: nil)
     let inputs = MLXArray((0 ..< 8).map { Int32($0) }).reshaped([1, 8])
 
     let out = model(inputs, cache: cache, emitDrafterState: true)
@@ -64,9 +64,9 @@ func testGemma4TextEmitTrueWithBothLayerTypesPopulatesStateBySynthetic() {
 }
 
 @Test
-func testGemma4TextEmitTrueWithMissingLayerTypeReturnsNilSharedKV() {
+func testGemma4TextEmitTrueWithMissingLayerTypeReturnsNilSharedKV() throws {
     let model = makeSyntheticGemma4TextLanguageModel(layerTypes: ["full_attention"])
-    let cache = model.newCache(parameters: nil)
+    let cache = try model.newCache(parameters: nil)
     let inputs = MLXArray((0 ..< 4).map { Int32($0) }).reshaped([1, 4])
 
     let out = model(inputs, cache: cache, emitDrafterState: true)

--- a/Tests/MLXLMTests/Gemma4TextTests.swift
+++ b/Tests/MLXLMTests/Gemma4TextTests.swift
@@ -10,7 +10,7 @@ struct Gemma4TextTests {
         let model = Gemma4TextModel(try Self.configuration(attentionKEqV: false))
         eval(model)
 
-        var cache: [KVCache] = model.newCache(parameters: nil)
+        var cache: [KVCache] = try model.newCache(parameters: nil)
         let promptLogits = model(MLXArray([1, 2, 3]).reshaped([1, 3]), cache: cache)
         eval(promptLogits)
         #expect(promptLogits.shape == [1, 3, 32])
@@ -30,7 +30,7 @@ struct Gemma4TextTests {
         let model = Gemma4TextModel(try Self.configuration(attentionKEqV: true))
         eval(model)
 
-        var cache: [KVCache] = model.newCache(parameters: nil)
+        var cache: [KVCache] = try model.newCache(parameters: nil)
         let promptLogits = model(MLXArray([1, 2, 3]).reshaped([1, 3]), cache: cache)
         eval(promptLogits)
         #expect(promptLogits.shape == [1, 3, 32])

--- a/Tests/MLXLMTests/Gemma4UnifiedTests.swift
+++ b/Tests/MLXLMTests/Gemma4UnifiedTests.swift
@@ -109,7 +109,7 @@ struct Gemma4UnifiedTests {
     @Test("Gemma4 Unified text-only prepare chunks prefill")
     func textOnlyPrepareChunksPrefill() throws {
         let model = Gemma4Unified(try tinyTextConfig())
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let input = LMInput(tokens: MLXArray([0, 2, 3, 4, 5, 1]).expandedDimensions(axis: 0))
 
         let result = try model.prepare(
@@ -137,7 +137,7 @@ struct Gemma4UnifiedTests {
         let input = LMInput(tokens: MLXArray([0, 2, 3, 4, 5, 1]).expandedDimensions(axis: 0))
 
         func prefill(windowSize: Int) throws -> (logits: MLXArray, cacheOffsets: [Int]) {
-            let cache = model.newCache(parameters: nil)
+            let cache = try model.newCache(parameters: nil)
             let result = try model.prepare(
                 input, cache: cache, state: nil, prefill: .init(stepSize: windowSize))
             guard case .logits(let output) = result else {
@@ -292,7 +292,7 @@ struct Gemma4UnifiedTests {
         )
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil, prefill: .init())
+            input, cache: try model.newCache(parameters: nil), state: nil, prefill: .init())
 
         guard case .logits(let output) = result else {
             Issue.record("Expected Gemma4Unified.prepare to return logits")

--- a/Tests/MLXLMTests/Gemma4VideoInputTests.swift
+++ b/Tests/MLXLMTests/Gemma4VideoInputTests.swift
@@ -54,7 +54,7 @@ struct Gemma4VideoInputTests {
                 ? LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
                 : LMInput(text: text, image: LMInput.ProcessedImage(pixels: pixels))
             let result = try model.prepare(
-                input, cache: model.newCache(parameters: nil), state: nil,
+                input, cache: try model.newCache(parameters: nil), state: nil,
                 prefill: .init(stepSize: 1024))
             guard case .logits(let out) = result else {
                 Issue.record("Expected .logits from Gemma4.prepare (multimodal branch)")
@@ -94,7 +94,7 @@ struct Gemma4VideoInputTests {
         let input = LMInput(text: text, video: LMInput.ProcessedVideo(pixels: pixels))
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil,
+            input, cache: try model.newCache(parameters: nil), state: nil,
             prefill: .init(stepSize: 1024))
         guard case .logits(let out) = result else {
             Issue.record("Expected .logits from Gemma4.prepare")

--- a/Tests/MLXLMTests/GlmOcrContinuationTests.swift
+++ b/Tests/MLXLMTests/GlmOcrContinuationTests.swift
@@ -116,7 +116,7 @@ final class GlmOcrContinuationTests: XCTestCase {
         MLXRandom.seed(23)
         let model = try makeTinyModel()
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let (_, warmState) = try lastLogits(
             try model.prepare(
                 LMInput(text: .init(tokens: textTokens(6))), cache: cache, state: nil,
@@ -147,7 +147,7 @@ final class GlmOcrContinuationTests: XCTestCase {
         MLXRandom.seed(19)
         let model = try makeTinyModel()
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         XCTAssertNoThrow(
             try model.prepare(
                 LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
@@ -175,7 +175,7 @@ final class GlmOcrContinuationTests: XCTestCase {
         MLXRandom.seed(23)
         let model = try makeTinyModel()
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let (_, state) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: textTokens(10))), cache: cache, state: nil,
@@ -200,7 +200,7 @@ final class GlmOcrContinuationTests: XCTestCase {
         let next = textTokens(1, seed: 8)
 
         // Reference: one cold prefill of everything, then one decode step.
-        let cacheF = model.newCache(parameters: nil)
+        let cacheF = try model.newCache(parameters: nil)
         let (_, stateF) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1)), image: image),
@@ -208,7 +208,7 @@ final class GlmOcrContinuationTests: XCTestCase {
         let decodeF = model(LMInput.Text(tokens: next), cache: cacheF, state: stateF)
 
         // Warm: prefill t1, continue with t2, then decode the same token.
-        let cacheW = model.newCache(parameters: nil)
+        let cacheW = try model.newCache(parameters: nil)
         let (_, s1) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
@@ -234,7 +234,7 @@ final class GlmOcrContinuationTests: XCTestCase {
         let t1 = concatenated([textTokens(6), imageRun(), textTokens(6, seed: 2)], axis: 1)
         let t2 = textTokens(8, seed: 4)
 
-        let warmCache = model.newCache(parameters: nil)
+        let warmCache = try model.newCache(parameters: nil)
         let (_, savedState) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,

--- a/Tests/MLXLMTests/KVCacheConfigurationTests.swift
+++ b/Tests/MLXLMTests/KVCacheConfigurationTests.swift
@@ -85,8 +85,23 @@ struct KVCacheConfigurationTests {
         let parameters = GenerateParameters(kvCache: .init(capacity: capacity))
         let resolved = try parameters.resolvedKVCacheConfiguration()
 
-        #expect(parameters.effectiveKVCacheCapacity == capacity)
+        #expect(try parameters.effectiveKVCacheCapacity() == capacity)
         #expect(resolved?.capacity == capacity)
+    }
+
+    @Test func cachePlanPreservesRequestSourceWhenConfigurationsMatch() throws {
+        let legacy = try GenerateParameters(maxKVSize: 64).kvCachePlan()
+        let capacity = try KVCacheConfiguration.Capacity(maxTokens: 64)
+        let typed = try GenerateParameters(
+            kvCache: KVCacheConfiguration(
+                capacity: capacity,
+                compatibility: .allowPartial)
+        ).kvCachePlan()
+
+        #expect(legacy.configuration == typed.configuration)
+        #expect(legacy.requestSource == .legacy)
+        #expect(typed.requestSource == .typed)
+        #expect(legacy != typed)
     }
 
     @Test func typedConfigurationRejectsAllRotatingCacheByDefault() {
@@ -138,9 +153,15 @@ struct KVCacheConfigurationTests {
         #expect(report.processedTokenCount == nil)
         #expect(report.layers.count == 3)
         #expect(report.layers[0].path == [0, 0])
+        #expect(report.layers[0].kind == .stateSpace)
+        #expect(report.layers[0].capacitySource == nil)
         #expect(report.layers[0].state == .notApplicable)
         #expect(report.layers[1].path == [0, 1])
+        #expect(report.layers[1].kind == .attention(maxSize: nil))
+        #expect(report.layers[1].capacitySource == .unbounded)
         #expect(report.layers[1].resolvedStrategy == .affine)
+        #expect(report.layers[2].kind == .rotatingAttention(maxSize: 128, keep: 0))
+        #expect(report.layers[2].capacitySource == .modelDefined)
         #expect(report.layers[2].reason == .slidingWindow)
     }
 
@@ -332,7 +353,7 @@ struct KVCacheConfigurationTests {
 
     @Test func modelCacheOwnsHybridProgressAcrossPrefillAndDecode() throws {
         let model = HybridProgressModel()
-        let storage = KVCacheStorage(model.newCache(parameters: nil), plan: .disabled)
+        let storage = KVCacheStorage(try model.newCache(parameters: nil), plan: .disabled)
         var iterator = try TokenIterator(
             input: LMInput(tokens: MLXArray([1, 2, 3])),
             model: model,

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 import MLX
-import MLXLMCommon
 import XCTest
 
 @testable import MLXLLM
+@testable import MLXLMCommon
 
 final class NanbeigeTests: XCTestCase {
 
@@ -101,7 +101,37 @@ final class NanbeigeTests: XCTestCase {
 
     func testNewCacheAllocatesOneCachePerLoopLayerPair() throws {
         let model = NanbeigeModel(try makeConfig())
-        XCTAssertEqual(model.newCache(parameters: nil).count, 6)
+        XCTAssertEqual(try model.newCache(parameters: nil).count, 6)
+    }
+
+    func testNewCacheHonorsTypedCapacity() throws {
+        let model = NanbeigeModel(try makeConfig())
+        let capacity = try KVCacheConfiguration.Capacity(
+            maxTokens: 32, preservedPrefixTokens: 3)
+        let parameters = GenerateParameters(
+            kvCache: KVCacheConfiguration(capacity: capacity))
+
+        let caches = try model.newCache(parameters: parameters)
+        XCTAssertEqual(caches.count, 6)
+        for cache in caches {
+            let rotating = try XCTUnwrap(cache as? RotatingKVCache)
+            XCTAssertEqual(rotating.maxSize, 32)
+            XCTAssertEqual(rotating.keepCount, 3)
+            XCTAssertEqual(rotating.capacityOrigin, .requested)
+        }
+    }
+
+    func testNewCacheClampsTinyLegacyLimit() throws {
+        let model = NanbeigeModel(try makeConfig())
+        let caches = try model.newCache(parameters: GenerateParameters(maxKVSize: 1))
+
+        XCTAssertEqual(caches.count, 6)
+        for cache in caches {
+            let rotating = try XCTUnwrap(cache as? RotatingKVCache)
+            XCTAssertEqual(rotating.maxSize, 1)
+            XCTAssertEqual(rotating.keepCount, 0)
+            XCTAssertEqual(rotating.capacityOrigin, .requested)
+        }
     }
 
     /// The released Nanbeige4.2-3B shape: 22 hidden layers, 2 loops → 44
@@ -124,7 +154,7 @@ final class NanbeigeTests: XCTestCase {
             }
             """
         let config = try JSONDecoder().decode(NanbeigeConfiguration.self, from: Data(json.utf8))
-        XCTAssertEqual(NanbeigeModel(config).newCache(parameters: nil).count, 44)
+        XCTAssertEqual(try NanbeigeModel(config).newCache(parameters: nil).count, 44)
     }
 
     // MARK: - Sanitize
@@ -171,10 +201,10 @@ final class NanbeigeTests: XCTestCase {
         let t2 = textTokens(8, seed: 3)
         let full = concatenated([t1, t2], axis: 0)
 
-        let cacheF = model.newCache(parameters: nil)
+        let cacheF = try model.newCache(parameters: nil)
         let logitsF = try prefillLogits(model, full, cache: cacheF)
 
-        let cacheW = model.newCache(parameters: nil)
+        let cacheW = try model.newCache(parameters: nil)
         _ = try prefillLogits(model, t1, cache: cacheW)
         let logitsW = try prefillLogits(model, t2, cache: cacheW)
 

--- a/Tests/MLXLMTests/NemotronHTests.swift
+++ b/Tests/MLXLMTests/NemotronHTests.swift
@@ -346,7 +346,7 @@ public class NemotronHTests: XCTestCase {
         let config = makeTestConfig(pattern: "M*M-")
         let model = NemotronHModel(config)
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
 
         // Only Mamba (M) and Attention (*) layers have caches
         // Pattern M*M- has M, *, M = 3 cacheable layers
@@ -357,7 +357,7 @@ public class NemotronHTests: XCTestCase {
         let config = makeTestConfig(pattern: "MMM")
         let model = NemotronHModel(config)
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
 
         // 3 Mamba layers = 3 caches
         XCTAssertEqual(cache.count, 3)
@@ -367,7 +367,7 @@ public class NemotronHTests: XCTestCase {
         let config = makeTestConfig(pattern: "***")
         let model = NemotronHModel(config)
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
 
         // 3 Attention layers = 3 caches
         XCTAssertEqual(cache.count, 3)
@@ -378,7 +378,7 @@ public class NemotronHTests: XCTestCase {
         let config = makeTestConfig(pattern: "M-E*-E")
         let model = NemotronHModel(config)
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
 
         // Only M and * have caches: M, * = 2 caches
         XCTAssertEqual(cache.count, 2)
@@ -392,7 +392,7 @@ public class NemotronHTests: XCTestCase {
 
         // First pass - process prompt
         let prompt = MLXArray([1, 2, 3, 4, 5])[.newAxis, .ellipsis]
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let promptOutput = model.callAsFunction(prompt, cache: cache)
 
         XCTAssertEqual(promptOutput.shape, [1, 5, 100])
@@ -597,7 +597,7 @@ public class NemotronHTests: XCTestCase {
         let config = makeTestConfig(pattern: "M*M*")
         let model = NemotronHModel(config)
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
 
         // Initial prompt
         let prompt = MLXArray([1, 2, 3, 4, 5])[.newAxis, .ellipsis]

--- a/Tests/MLXLMTests/PrefillParametersTests.swift
+++ b/Tests/MLXLMTests/PrefillParametersTests.swift
@@ -136,7 +136,7 @@ struct PrefillParametersTests {
             log.events.append([processed, total])
         }
         let prompt = MLXArray((0 ..< promptTokens).map { Int32($0 % 100) })
-        let cache = model.newCache(parameters: parameters)
+        let cache = try model.newCache(parameters: parameters)
         _ = try TokenIterator(
             input: LMInput(tokens: prompt), model: model, cache: cache, parameters: parameters)
         return (log.events, cache.map { $0.offset })

--- a/Tests/MLXLMTests/Qwen35CompiledDecodeLifecycleTests.swift
+++ b/Tests/MLXLMTests/Qwen35CompiledDecodeLifecycleTests.swift
@@ -55,7 +55,7 @@ final class Qwen35CompiledDecodeLifecycleTests: XCTestCase {
         file: StaticString = #filePath, line: UInt = #line
     ) throws {
         var model: Qwen35TextModel? = Qwen35TextModel(try tinyMoEConfiguration(headDim: headDim))
-        var cache: [KVCache]? = mapCache(model!.newCache(parameters: nil))
+        var cache: [KVCache]? = mapCache(try model!.newCache(parameters: nil))
 
         for token in [Int32(1), Int32(2)] {
             let logits = model!(MLXArray([token]).reshaped(1, 1), cache: cache)

--- a/Tests/MLXLMTests/Qwen35ContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen35ContinuationTests.swift
@@ -102,13 +102,13 @@ final class Qwen35ContinuationTests: XCTestCase {
         let t1 = textTokens(40)
         let t2 = textTokens(8, seed: 3)
 
-        let fullCache = model.newCache(parameters: nil)
+        let fullCache = try model.newCache(parameters: nil)
         let (fullLogits, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1))),
                 cache: fullCache, state: nil, prefill: .init()))
 
-        let warmCache = model.newCache(parameters: nil)
+        let warmCache = try model.newCache(parameters: nil)
         let (_, state) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1)), cache: warmCache, state: nil, prefill: .init()))
@@ -130,7 +130,7 @@ final class Qwen35ContinuationTests: XCTestCase {
         MLXRandom.seed(19)
         let model = try makeTinyModel()
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         XCTAssertNoThrow(
             try model.prepare(
                 LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
@@ -182,13 +182,13 @@ final class Qwen35ContinuationTests: XCTestCase {
             [textTokens(3, seed: 8), visionStart, imageRun, textTokens(5, seed: 10)], axis: 1)
         let full = concatenated([turn1, turn2, turn3, turn4], axis: 1)
 
-        let coldCache = model.newCache(parameters: nil)
+        let coldCache = try model.newCache(parameters: nil)
         let (coldLogits, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: full), image: bothImages), cache: coldCache,
                 state: nil, prefill: .init()))
 
-        let warmCache = model.newCache(parameters: nil)
+        let warmCache = try model.newCache(parameters: nil)
         let (_, turn1State) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: turn1)), cache: warmCache, state: nil,

--- a/Tests/MLXLMTests/Qwen3VLContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLContinuationTests.swift
@@ -116,13 +116,13 @@ final class Qwen3VLContinuationTests: XCTestCase {
             [textTokens(10), visionStart(), imageRun(), textTokens(8, seed: 5)], axis: 1)
         let t2 = textTokens(8, seed: 9)
 
-        let fullCache = model.newCache(parameters: nil)
+        let fullCache = try model.newCache(parameters: nil)
         let (fullLogits, _) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1)), image: image),
                 cache: fullCache, state: nil, prefill: .init()))
 
-        let warmCache = model.newCache(parameters: nil)
+        let warmCache = try model.newCache(parameters: nil)
         let (_, state) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
@@ -169,7 +169,7 @@ final class Qwen3VLContinuationTests: XCTestCase {
             prefill.progress = { log.events.append([$0, $1]) }
             _ = try model.prepare(
                 LMInput(text: .init(tokens: prompt)),
-                cache: model.newCache(parameters: nil), state: nil, prefill: prefill)
+                cache: try model.newCache(parameters: nil), state: nil, prefill: prefill)
             return log.events
         }
 
@@ -218,11 +218,11 @@ final class Qwen3VLContinuationTests: XCTestCase {
         ).expandedDimensions(axis: 0)
         let input = LMInput(text: .init(tokens: tokens, mask: mask), image: image)
 
-        let singleCache = model.newCache(parameters: nil)
+        let singleCache = try model.newCache(parameters: nil)
         let (singleLogits, _) = try lastLogits(
             model.prepare(input, cache: singleCache, state: nil, prefill: .init()))
 
-        let windowedCache = model.newCache(parameters: nil)
+        let windowedCache = try model.newCache(parameters: nil)
         let (windowedLogits, _) = try lastLogits(
             model.prepare(input, cache: windowedCache, state: nil, prefill: .init(stepSize: 8)))
 
@@ -240,7 +240,7 @@ final class Qwen3VLContinuationTests: XCTestCase {
         MLXRandom.seed(19)
         let model = try makeTinyModel()
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         XCTAssertNoThrow(
             try model.prepare(
                 LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
@@ -268,7 +268,7 @@ final class Qwen3VLContinuationTests: XCTestCase {
         MLXRandom.seed(23)
         let model = try makeTinyModel()
 
-        let cache = model.newCache(parameters: nil)
+        let cache = try model.newCache(parameters: nil)
         let (_, state) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: textTokens(10))), cache: cache, state: nil,
@@ -293,7 +293,7 @@ final class Qwen3VLContinuationTests: XCTestCase {
             [textTokens(6), visionStart(), imageRun(), textTokens(6, seed: 2)], axis: 1)
         let t2 = textTokens(8, seed: 4)
 
-        let warmCache = model.newCache(parameters: nil)
+        let warmCache = try model.newCache(parameters: nil)
         let (_, savedState) = try lastLogits(
             model.prepare(
                 LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,

--- a/Tests/MLXLMTests/TurboQuantTests.swift
+++ b/Tests/MLXLMTests/TurboQuantTests.swift
@@ -1584,8 +1584,8 @@ final class TurboQuantIntegrationTests: XCTestCase {
         quantize(model: model, groupSize: 64, bits: 4)
         eval(model)
 
-        func decode(scheme: String?) -> [Int] {
-            var cache = model.newCache(parameters: nil)
+        func decode(scheme: String?) throws -> [Int] {
+            var cache = try model.newCache(parameters: nil)
             let prompt = MLXArray([1, 7, 3, 12, 5, 9, 2, 8])[.newAxis, .ellipsis]
             var logits = model(prompt, cache: cache)
             var tokens: [Int] = []
@@ -1609,8 +1609,8 @@ final class TurboQuantIntegrationTests: XCTestCase {
             return tokens
         }
 
-        let turbo = decode(scheme: "turbo0v4")
-        let reference = decode(scheme: nil)
+        let turbo = try decode(scheme: "turbo0v4")
+        let reference = try decode(scheme: nil)
         XCTAssertEqual(turbo.count, 8)
         // The first decode token is computed from the still-raw cache, so it
         // must match the FP16 run exactly; later tokens may diverge within
@@ -1639,7 +1639,7 @@ final class TurboQuantIntegrationTests: XCTestCase {
         let model = Gemma3TextModel(config)
         eval(model)
 
-        var cache = model.newCache(parameters: nil)
+        var cache = try model.newCache(parameters: nil)
         // isGlobalLayer = (i % slidingWindowPattern == slidingWindowPattern - 1),
         // so with pattern 2: layers 0, 2 are sliding-window; 1, 3 are global.
         XCTAssertTrue(cache[0] is RotatingKVCache, "layer 0 should be sliding-window")

--- a/skills/mlx-swift-lm/references/kv-cache.md
+++ b/skills/mlx-swift-lm/references/kv-cache.md
@@ -115,7 +115,39 @@ let simpleAgain = quantizedCache.toUnquantized()
 ```swift
 // Models create appropriate cache for their architecture
 let cache = model.newCache(parameters: generateParameters)
+
+// Inspect planned topology, capacity, and strategy state
+let status = try model.cacheStatus(parameters: generateParameters)
+// Or via ModelContainer / ChatSession:
+// let status = try await container.cacheStatus(parameters: params)
+// let status = try await session.cacheStatus()
+
+switch status.capacityDisposition {
+case .notRequested: break
+case .fullyApplied: break          // every attention layer is at or below the request
+case .partiallyApplied: break      // only some attention layers satisfy the request
+case .unsupported: break           // pure SSM — no attention KV to limit
+case .ignored: break               // attention exists but stayed unbounded
+}
+
+for layer in status.layers {
+    print(layer.path, layer.kind, layer.capacitySource as Any,
+          layer.state, layer.resolvedStrategy as Any)
+}
 ```
+
+Hybrid attention / state-space models (Qwen3.5, Jamba, LFM2, Falcon-H1, …)
+apply `maxKVSize` only to attention layers. Architecture sliding-window layers
+use `min(slidingWindow, maxKVSize)`. State-space caches are never token-windowed.
+
+Typed `KVCacheConfiguration.Capacity` follows its separate contract: it bounds
+caller-configurable full-attention caches while leaving model-native sliding
+windows unchanged. `KVCacheStatus` normalizes both entry points into one
+requested configuration while preserving `.legacy` / `.typed` request source,
+per-layer capacity provenance, and planned / realized phase.
+
+Prefer `makeAttentionKVCache(parameters:)` / `makeHybridAttentionKVCache(...)`
+inside model `newCache` overrides so the limit cannot be silently dropped.
 
 ### Via Utility Functions
 


### PR DESCRIPTION
## Proposed changes

`GenerateParameters.maxKVSize` can currently be silently ignored by models that provide custom `newCache(parameters:)` implementations. This is particularly problematic for hybrid architectures, where attention and state-space layers use different cache types.

A caller may request a bounded KV cache while the model continues allocating an unbounded attention cache, with no public API for detecting that the requested policy was not applied. This makes memory usage unpredictable during long conversations and forces downstream applications to inspect private cache implementation details.

This PR makes the requested and effective KV-cache policies explicit and reliable.

### What

- Enforces `maxKVSize` across the audited model-specific cache implementations.
- Applies the smaller of the architecture's sliding-window size and the requested `maxKVSize`.
- Handles full-attention, sliding-window, hybrid attention/state-space, and pure state-space models.
- Adds a typed `EffectiveCacheConfiguration` API that describes:
  - the requested maximum KV-cache size;
  - the effective policy for every model layer;
  - bounded and unbounded attention caches;
  - rotating/sliding-window caches;
  - state-space caches;
  - composite caches used by hybrid models;
  - whether the request was fully applied, partially applied, unsupported, or ignored.
- Exposes the effective policy through `LanguageModel`, `ModelContainer`, and `ChatSession`.
- Makes `ChatSession` report the realized cache configuration rather than allocating and inspecting probe caches.
- Rebuilds a structured conversation cache when `maxKVSize` changes, ensuring the new policy is actually applied without losing the conversation transcript.
- Preserves externally restored raw caches when their original prefix cannot be reconstructed, while still reporting their actual effective policy.
- Safely handles very small limits such as `maxKVSize = 1`.
- Adds documentation describing cache-policy implementation and inspection.

### Why

`maxKVSize` is a memory-management contract. Silently ignoring it can cause unexpectedly high memory pressure, especially during long-running conversations and on memory-constrained Apple Silicon devices.

The new API also lets applications distinguish between:

- a limit that was fully enforced;
- a limit applied only to the attention layers of a hybrid model;
- an architecture where token-window limits do not apply;
- and an implementation that failed to apply the requested policy.

This distinction is important because state-space caches do not grow per token in the same way as attention KV caches and should not be reported as bounded attention caches.


With this change, an App using the library can:

- rely on `maxKVSize` being enforced for supported attention layers;
- display accurate user-facing diagnostics about the active cache policy;
- distinguish fully bounded models from partially bounded hybrid models;
- avoid allocating probe caches or casting to internal cache implementations;
- safely change the cache limit between conversation turns;
- make better model-selection and memory-management decisions before long generations;
- avoid presenting a configured memory limit as active when the model cannot apply it.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)