### PR TITLE
`ChatSession`: reuse the KV cache for append-only media turns

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -1133,10 +1133,21 @@ public final class ChatSession {
                             // and downgrade to a rebuild before prefilling.
                             var mediaSuffixInput: LMInput?
                             if case .appendMediaSuffix(let suffixStart, _) = decision {
-                                mediaSuffixInput = (model as? PreparedInputSplitting)?
+                                let splitInput = (model as? PreparedInputSplitting)?
                                     .splitPreparedInput(
                                         preparedInput, droppingFirst: suffixStart)
-                                if mediaSuffixInput == nil {
+                                // Returning *a* value is not enough: the ledger below
+                                // advances to `representedTokens` on the strength of the
+                                // requested boundary, so a suffix carrying any other
+                                // tokens would be prefilled verbatim and leave the record
+                                // describing a cache that was never built. Accept only the
+                                // exact tokens the boundary names.
+                                if let splitInput,
+                                    splitInput.text.tokens.asArray(Int.self)
+                                        == Array(promptTokenIds[suffixStart...])
+                                {
+                                    mediaSuffixInput = splitInput
+                                } else {
                                     decision = .rebuild
                                 }
                             }

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -1091,7 +1091,8 @@ public final class ChatSession {
                                 previousGenerationUncommittedTokens:
                                     currentConversation.uncommittedTokens,
                                 structuredToolCallCount: structuredToolCallCount,
-                                usesSpeculativeDecoding: speculativeDecoding != nil)
+                                usesSpeculativeDecoding: speculativeDecoding != nil,
+                                canSplitPreparedMedia: model is PreparedInputSplitting)
                             let cacheState = PromptCacheState(
                                 cachedTokens: cachedTokenIds,
                                 processedTokenCount: kvCache.processedTokenCount,
@@ -1125,6 +1126,21 @@ public final class ChatSession {
                                 }
                             }
 
+                            // Splitting a prepared input is the other decision that
+                            // can fail while being applied: only the model can carve
+                            // a media-carrying suffix, and it declines any boundary
+                            // it cannot prove equivalent to a cold prefill. Verify
+                            // and downgrade to a rebuild before prefilling.
+                            var mediaSuffixInput: LMInput?
+                            if case .appendMediaSuffix(let suffixStart, _) = decision {
+                                mediaSuffixInput = (model as? PreparedInputSplitting)?
+                                    .splitPreparedInput(
+                                        preparedInput, droppingFirst: suffixStart)
+                                if mediaSuffixInput == nil {
+                                    decision = .rebuild
+                                }
+                            }
+
                             switch decision {
                             case .prefillAll:
                                 break
@@ -1141,6 +1157,13 @@ public final class ChatSession {
                                 // cache and use it alone for this continuation.
                                 draftKVCache = nil
                                 requiresMainOnlyContinuation = true
+
+                            case .appendMediaSuffix:
+                                // A declined split was downgraded to `.rebuild`
+                                // above, so this is always populated here.
+                                if let mediaSuffixInput {
+                                    input = mediaSuffixInput
+                                }
 
                             case .trimToCommonPrefix(let commonPrefixLength, _):
                                 input = LMInput(
@@ -1165,7 +1188,8 @@ public final class ChatSession {
                             // keep generated tokens the cold render cannot reproduce.
                             switch decision {
                             case .appendSuffix(_, let representedTokens),
-                                .appendSuffixToMain(_, let representedTokens):
+                                .appendSuffixToMain(_, let representedTokens),
+                                .appendMediaSuffix(_, let representedTokens):
                                 currentConversation.cachedTokens = representedTokens
                             case .prefillAll, .trimToCommonPrefix, .rebuild:
                                 currentConversation.cachedTokens = promptTokenIds

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -1094,7 +1094,8 @@ public final class ChatSession {
                                 previousGenerationUncommittedTokens:
                                     currentConversation.uncommittedTokens,
                                 structuredToolCallCount: structuredToolCallCount,
-                                usesSpeculativeDecoding: speculativeDecoding != nil)
+                                usesSpeculativeDecoding: speculativeDecoding != nil,
+                                canSplitPreparedMedia: model is PreparedInputSplitting)
                             let cacheState = PromptCacheState(
                                 cachedTokens: cachedTokenIds,
                                 processedTokenCount: kvCache.processedTokenCount,
@@ -1128,6 +1129,28 @@ public final class ChatSession {
                                 }
                             }
 
+                            // Splitting a prepared input is the other decision that
+                            // can fail while being applied: only the model can carve
+                            // a media-carrying suffix, and it declines any boundary
+                            // it cannot prove equivalent to a cold prefill. Verify
+                            // and downgrade to a rebuild before prefilling.
+                            var mediaSuffixInput: LMInput?
+                            if case .appendMediaSuffix(let suffixStart, _) = decision {
+                                let splitInput = (model as? PreparedInputSplitting)?
+                                    .splitPreparedInput(
+                                        preparedInput, droppingFirst: suffixStart)
+                                // Only the exact tokens the boundary names may be prefilled;
+                                // the ledger below advances on the strength of that boundary.
+                                if let splitInput,
+                                    splitInput.text.tokens.asArray(Int.self)
+                                        == Array(promptTokenIds[suffixStart...])
+                                {
+                                    mediaSuffixInput = splitInput
+                                } else {
+                                    decision = .rebuild
+                                }
+                            }
+
                             switch decision {
                             case .prefillAll:
                                 break
@@ -1146,6 +1169,14 @@ public final class ChatSession {
                                 // cache and use it alone for this continuation.
                                 draftKVCache = nil
                                 requiresMainOnlyContinuation = true
+
+                            case .appendMediaSuffix(let suffixStart, _):
+                                // A declined split was downgraded to `.rebuild`
+                                // above, so this is always populated here.
+                                if let mediaSuffixInput {
+                                    input = mediaSuffixInput
+                                }
+                                cachedPromptTokenCount = suffixStart
 
                             case .trimToCommonPrefix(let commonPrefixLength, _):
                                 input = LMInput(
@@ -1171,7 +1202,8 @@ public final class ChatSession {
                             // keep generated tokens the cold render cannot reproduce.
                             switch decision {
                             case .appendSuffix(_, let representedTokens),
-                                .appendSuffixToMain(_, let representedTokens):
+                                .appendSuffixToMain(_, let representedTokens),
+                                .appendMediaSuffix(_, let representedTokens):
                                 currentConversation.cachedTokens = representedTokens
                             case .prefillAll, .trimToCommonPrefix, .rebuild:
                                 currentConversation.cachedTokens = promptTokenIds

--- a/Libraries/MLXLMCommon/PreparedInputSplitting.swift
+++ b/Libraries/MLXLMCommon/PreparedInputSplitting.swift
@@ -35,7 +35,7 @@ import Foundation
 /// the features computed for the items that remain, and the continuation no longer
 /// matches a cold prefill even when the token positions line up exactly.
 ///
-/// This is a real distinction and not a hypothetical one: ``Qwen25VL`` builds a
+/// This is a real distinction and not a hypothetical one: `Qwen25VL` builds a
 /// per-frame vision attention mask and so conforms, while `Qwen2VL` runs its vision
 /// attention unmasked over the whole concatenated buffer and so does not.
 public protocol PreparedInputSplitting {

--- a/Libraries/MLXLMCommon/PreparedInputSplitting.swift
+++ b/Libraries/MLXLMCommon/PreparedInputSplitting.swift
@@ -1,0 +1,59 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// A model that can split an already-prepared ``LMInput`` at a token boundary.
+///
+/// ``ChatSession`` reuses a warm KV cache when a new turn only *appends* to the
+/// transcript it already holds: it prefills the uncached suffix instead of the
+/// whole prompt. For a text turn the suffix is just an array slice, so
+/// ``ChatSession`` builds it directly.
+///
+/// A turn that carries media cannot be sliced that way. The prepared input holds
+/// one media payload for the *entire* transcript — for Qwen VL that is the
+/// concatenated patches and per-image grids of every image in the conversation —
+/// so keeping the payload while dropping the cached tokens would hand the model
+/// more images than the suffix has placeholders for. The result is a silent
+/// mis-merge of vision features and, because the position math walks the grids in
+/// token order, incorrect M-RoPE positions.
+///
+/// A model that knows its own media layout can do the split correctly: drop the
+/// media that belongs to the cached prefix, keep the media whose placeholders lie
+/// in the suffix. Conforming to this protocol opts a model into warm-cache reuse
+/// for append-only media turns. Models that do not conform keep the previous
+/// behavior — the cache is rebuilt.
+///
+/// Implementations must be conservative. Returning `nil` is always safe: it means
+/// "I cannot prove this split is equivalent to a full prefill", and ``ChatSession``
+/// falls back to rebuilding the cache.
+///
+/// ## Conformance requirement
+///
+/// A model may conform only if its media encoder computes each item's features
+/// **independently of the other items in the payload**. If the encoder lets media
+/// attend across item boundaries, then removing the cached prefix's items changes
+/// the features computed for the items that remain, and the continuation no longer
+/// matches a cold prefill even when the token positions line up exactly.
+///
+/// This is a real distinction and not a hypothetical one: ``Qwen25VL`` builds a
+/// per-frame vision attention mask and so conforms, while `Qwen2VL` runs its vision
+/// attention unmasked over the whole concatenated buffer and so does not.
+public protocol PreparedInputSplitting {
+
+    /// Return the suffix of `input` that begins at `prefixTokenCount`, carrying only
+    /// the media whose placeholder tokens lie inside that suffix.
+    ///
+    /// Returning `nil` means the input cannot be split safely at this boundary and
+    /// the caller must fall back to a full prefill. Implementations should return
+    /// `nil` rather than guess — in particular when the boundary falls inside a
+    /// media block, when a payload cannot be attributed to individual media items,
+    /// or when the input carries state the implementation does not know how to slice.
+    ///
+    /// - Parameters:
+    ///   - input: the prepared input for the full prompt
+    ///   - prefixTokenCount: number of leading tokens already represented in the cache
+    /// - Returns: an `LMInput` whose tokens are `input`'s tokens after the first
+    ///   `prefixTokenCount`, with a media payload consistent with those tokens, or
+    ///   `nil` if no such input can be produced.
+    func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int) -> LMInput?
+}

--- a/Libraries/MLXLMCommon/PreparedInputSplitting.swift
+++ b/Libraries/MLXLMCommon/PreparedInputSplitting.swift
@@ -1,0 +1,30 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// A model that can split its own prepared input at a token boundary, keeping
+/// only the media whose placeholders fall in the suffix.
+///
+/// Conform only if the media encoder computes each item's features independently
+/// of the others; otherwise dropping cached items changes the features of the
+/// items that remain. `Qwen25VL` masks each frame to itself and conforms;
+/// `Qwen2VL` attends across the whole buffer and does not.
+public protocol PreparedInputSplitting {
+
+    /// Return the suffix of `input` that begins at `prefixTokenCount`, carrying only
+    /// the media whose placeholder tokens lie inside that suffix.
+    ///
+    /// Returning `nil` means the input cannot be split safely at this boundary and
+    /// the caller must fall back to a full prefill. Implementations should return
+    /// `nil` rather than guess -- in particular when the boundary falls inside a
+    /// media block, when a payload cannot be attributed to individual media items,
+    /// or when the input carries state the implementation does not know how to slice.
+    ///
+    /// - Parameters:
+    ///   - input: the prepared input for the full prompt
+    ///   - prefixTokenCount: number of leading tokens already represented in the cache
+    /// - Returns: an `LMInput` whose tokens are `input`'s tokens after the first
+    ///   `prefixTokenCount`, with a media payload consistent with those tokens, or
+    ///   `nil` if no such input can be produced.
+    func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int) -> LMInput?
+}

--- a/Libraries/MLXLMCommon/PromptCacheReusePolicy.swift
+++ b/Libraries/MLXLMCommon/PromptCacheReusePolicy.swift
@@ -26,6 +26,17 @@ enum PromptCacheReuseDecision: Equatable {
     /// turn may rebuild a draft cache from a reproducible prompt.
     case appendSuffixToMain(suffixStart: Int, representedTokens: [Int])
 
+    /// The cache already represents a usable prefix, but this turn introduces
+    /// new media, so a plain token slice would drop the payload that belongs
+    /// to the suffix. Ask the model to split its own prepared input at
+    /// `suffixStart`; afterwards the cache represents `representedTokens`.
+    ///
+    /// Only the model knows which part of a prepared input belongs to the
+    /// suffix, so this decision — like ``trimToCommonPrefix`` — can fail while
+    /// being applied. A model that declines the split must be downgraded to
+    /// ``rebuild`` before prefilling.
+    case appendMediaSuffix(suffixStart: Int, representedTokens: [Int])
+
     /// Rewind every cache by `trimCount` (down to `commonPrefixLength`), then
     /// feed `promptTokens[commonPrefixLength...]`.
     case trimToCommonPrefix(commonPrefixLength: Int, trimCount: Int)
@@ -37,7 +48,7 @@ enum PromptCacheReuseDecision: Equatable {
     /// `true` when a non-empty cached prefix is carried into this turn.
     var reusesCachedPrefix: Bool {
         switch self {
-        case .appendSuffix, .appendSuffixToMain, .trimToCommonPrefix:
+        case .appendSuffix, .appendSuffixToMain, .appendMediaSuffix, .trimToCommonPrefix:
             return true
         case .prefillAll, .rebuild:
             return false
@@ -88,6 +99,15 @@ struct PromptCacheTurn: Sendable {
     /// rules use this to avoid resuming from a private main-cache path with a
     /// missing or divergent draft cache.
     var usesSpeculativeDecoding: Bool = false
+
+    /// The model can split a prepared input into a media-carrying suffix, so an
+    /// append-only media turn has a way to reuse the cached prefix. The session
+    /// reports the capability here rather than the policy inspecting the model,
+    /// which keeps the decision table free of MLX and session types.
+    ///
+    /// Capability is not a guarantee: the split may still be declined for a
+    /// specific input, which the caller handles when applying the decision.
+    var canSplitPreparedMedia: Bool = false
 }
 
 /// What the caches currently hold.
@@ -135,6 +155,7 @@ struct PromptCacheReusePolicy: Sendable {
     /// Rules that apply to every model, in priority order.
     static let standardRules: [any PromptCacheReuseRule] = [
         ExtendCachedPrefixRule(),
+        AppendOnlyMediaRule(),
         RewindToCommonPrefixRule(),
     ]
 
@@ -176,6 +197,40 @@ struct ExtendCachedPrefixRule: PromptCacheReuseRule {
         }
 
         return .appendSuffix(
+            suffixStart: cache.cachedTokens.count, representedTokens: turn.promptTokens)
+    }
+}
+
+/// Appends the trailing tokens when a turn adds media to an otherwise unchanged
+/// transcript.
+///
+/// An append-only media turn extends the cached prefix exactly as a text turn
+/// does, so ``ExtendCachedPrefixRule`` would accept it but for its
+/// `carriesNewMedia` guard: a plain token slice drops the media payload that
+/// belongs to the suffix. The split itself is the model's job, so this rule only
+/// fires when the session reports the model can perform it.
+///
+/// Unlike ``ExtendCachedPrefixRule`` this rule does **not** require the absence
+/// of an attention mask. A VL processor pairs media with an all-ones mask as a
+/// matter of course, so refusing masks here would disable the path for exactly
+/// the inputs it exists to serve. Distinguishing that benign mask from a real
+/// padding mask needs the model's own layout knowledge, so the check belongs to
+/// the splitter, which refuses anything that is not all-ones.
+struct AppendOnlyMediaRule: PromptCacheReuseRule {
+    func reuse(turn: PromptCacheTurn, cache: PromptCacheState) -> PromptCacheReuseDecision? {
+        guard turn.carriesNewMedia,
+            turn.canSplitPreparedMedia,
+            !turn.usesSpeculativeDecoding,
+            !cache.cachedTokens.isEmpty,
+            cache.mainCacheIsAligned,
+            cache.draftCacheIsAligned,
+            turn.promptTokens.count > cache.cachedTokens.count,
+            turn.promptTokens.starts(with: cache.cachedTokens)
+        else {
+            return nil
+        }
+
+        return .appendMediaSuffix(
             suffixStart: cache.cachedTokens.count, representedTokens: turn.promptTokens)
     }
 }

--- a/Libraries/MLXLMCommon/PromptCacheReusePolicy.swift
+++ b/Libraries/MLXLMCommon/PromptCacheReusePolicy.swift
@@ -26,6 +26,17 @@ enum PromptCacheReuseDecision: Equatable {
     /// turn may rebuild a draft cache from a reproducible prompt.
     case appendSuffixToMain(suffixStart: Int, representedTokens: [Int])
 
+    /// The cache already represents a usable prefix, but this turn introduces
+    /// new media, so a plain token slice would drop the payload that belongs
+    /// to the suffix. Ask the model to split its own prepared input at
+    /// `suffixStart`; afterwards the cache represents `representedTokens`.
+    ///
+    /// Only the model knows which part of a prepared input belongs to the
+    /// suffix, so this decision -- like ``trimToCommonPrefix`` -- can fail while
+    /// being applied. A model that declines the split must be downgraded to
+    /// ``rebuild`` before prefilling.
+    case appendMediaSuffix(suffixStart: Int, representedTokens: [Int])
+
     /// Rewind every cache by `trimCount` (down to `commonPrefixLength`), then
     /// feed `promptTokens[commonPrefixLength...]`.
     case trimToCommonPrefix(commonPrefixLength: Int, trimCount: Int)
@@ -37,7 +48,7 @@ enum PromptCacheReuseDecision: Equatable {
     /// `true` when a non-empty cached prefix is carried into this turn.
     var reusesCachedPrefix: Bool {
         switch self {
-        case .appendSuffix, .appendSuffixToMain, .trimToCommonPrefix:
+        case .appendSuffix, .appendSuffixToMain, .appendMediaSuffix, .trimToCommonPrefix:
             return true
         case .prefillAll, .rebuild:
             return false
@@ -88,6 +99,15 @@ struct PromptCacheTurn: Sendable {
     /// rules use this to avoid resuming from a private main-cache path with a
     /// missing or divergent draft cache.
     var usesSpeculativeDecoding: Bool = false
+
+    /// The model can split a prepared input into a media-carrying suffix, so an
+    /// append-only media turn has a way to reuse the cached prefix. The session
+    /// reports the capability here rather than the policy inspecting the model,
+    /// which keeps the decision table free of MLX and session types.
+    ///
+    /// Capability is not a guarantee: the split may still be declined for a
+    /// specific input, which the caller handles when applying the decision.
+    var canSplitPreparedMedia: Bool = false
 }
 
 /// What the caches currently hold.
@@ -135,6 +155,7 @@ struct PromptCacheReusePolicy: Sendable {
     /// Rules that apply to every model, in priority order.
     static let standardRules: [any PromptCacheReuseRule] = [
         ExtendCachedPrefixRule(),
+        AppendOnlyMediaRule(),
         RewindToCommonPrefixRule(),
     ]
 
@@ -176,6 +197,40 @@ struct ExtendCachedPrefixRule: PromptCacheReuseRule {
         }
 
         return .appendSuffix(
+            suffixStart: cache.cachedTokens.count, representedTokens: turn.promptTokens)
+    }
+}
+
+/// Appends the trailing tokens when a turn adds media to an otherwise unchanged
+/// transcript.
+///
+/// An append-only media turn extends the cached prefix exactly as a text turn
+/// does, so ``ExtendCachedPrefixRule`` would accept it but for its
+/// `carriesNewMedia` guard: a plain token slice drops the media payload that
+/// belongs to the suffix. The split itself is the model's job, so this rule only
+/// fires when the session reports the model can perform it.
+///
+/// Unlike ``ExtendCachedPrefixRule`` this rule does **not** require the absence
+/// of an attention mask. A VL processor pairs media with an all-ones mask as a
+/// matter of course, so refusing masks here would disable the path for exactly
+/// the inputs it exists to serve. Distinguishing that benign mask from a real
+/// padding mask needs the model's own layout knowledge, so the check belongs to
+/// the splitter, which refuses anything that is not all-ones.
+struct AppendOnlyMediaRule: PromptCacheReuseRule {
+    func reuse(turn: PromptCacheTurn, cache: PromptCacheState) -> PromptCacheReuseDecision? {
+        guard turn.carriesNewMedia,
+            turn.canSplitPreparedMedia,
+            !turn.usesSpeculativeDecoding,
+            !cache.cachedTokens.isEmpty,
+            cache.mainCacheIsAligned,
+            cache.draftCacheIsAligned,
+            turn.promptTokens.count > cache.cachedTokens.count,
+            turn.promptTokens.starts(with: cache.cachedTokens)
+        else {
+            return nil
+        }
+
+        return .appendMediaSuffix(
             suffixStart: cache.cachedTokens.count, representedTokens: turn.promptTokens)
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -1278,6 +1278,27 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
     }
 }
 
+extension Qwen25VL: PreparedInputSplitting {
+
+    /// Opt into ``ChatSession`` warm-cache reuse for append-only media turns.
+    ///
+    /// The continuation path (``prepareContinuation(_:cache:state:windowSize:)``)
+    /// already prefills a media-bearing remainder at a `positionOffset` carried in
+    /// ``LMOutput/State``; what it needs is a remainder whose media payload matches
+    /// its tokens. ``QwenVL/splitPreparedInput(_:droppingFirst:imageTokenId:videoTokenId:mergeSize:)``
+    /// produces exactly that, or `nil` when it cannot prove the split is sound.
+    public func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
+        -> LMInput?
+    {
+        QwenVL.splitPreparedInput(
+            input,
+            droppingFirst: prefixTokenCount,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            mergeSize: config.visionConfiguration.spatialMergeSize)
+    }
+}
+
 // MARK: - Configuration
 
 /// Configuration for ``Qwen25VL``

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -1280,12 +1280,12 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
 
 extension Qwen25VL: PreparedInputSplitting {
 
-    /// Opt into ``ChatSession`` warm-cache reuse for append-only media turns.
+    /// Opt into `ChatSession` warm-cache reuse for append-only media turns.
     ///
-    /// The continuation path (``prepareContinuation(_:cache:state:windowSize:)``)
+    /// The continuation path (`prepareContinuation(_:cache:state:windowSize:)`)
     /// already prefills a media-bearing remainder at a `positionOffset` carried in
-    /// ``LMOutput/State``; what it needs is a remainder whose media payload matches
-    /// its tokens. ``QwenVL/splitPreparedInput(_:droppingFirst:imageTokenId:videoTokenId:mergeSize:)``
+    /// `LMOutput.State`; what it needs is a remainder whose media payload matches
+    /// its tokens. `QwenVL.splitPreparedInput(_:droppingFirst:imageTokenId:videoTokenId:mergeSize:)`
     /// produces exactly that, or `nil` when it cannot prove the split is sound.
     public func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
         -> LMInput?

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -1278,6 +1278,23 @@ public class Qwen25VL: Module, VLMModel, KVCacheDimensionProvider {
     }
 }
 
+extension Qwen25VL: PreparedInputSplitting {
+
+    /// Opt into `ChatSession` warm-cache reuse for append-only media turns by
+    /// delegating to `QwenVL.splitPreparedInput` with this model's image and video
+    /// token ids and spatial merge size.
+    public func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
+        -> LMInput?
+    {
+        QwenVL.splitPreparedInput(
+            input,
+            droppingFirst: prefixTokenCount,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            videoTokenId: config.baseConfiguration.videoTokenId,
+            mergeSize: config.visionConfiguration.spatialMergeSize)
+    }
+}
+
 // MARK: - Configuration
 
 /// Configuration for ``Qwen25VL``

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -1110,6 +1110,16 @@ public class Qwen2VL: Module, VLMModel, KVCacheDimensionProvider {
 
 }
 
+// Qwen2-VL deliberately does NOT conform to `PreparedInputSplitting`.
+//
+// Its vision `Attention` runs `scaledDotProductAttention(..., mask: .none)` over a
+// batch derived as `B = frames[0].t` / `L = sequenceLength / B`. For images `t == 1`,
+// so every patch of every image in the payload attends to every other — the images
+// are not isolated from one another. Dropping the cached prefix's rows would then
+// change the features computed for the image that is kept, and the continuation
+// would not match a cold prefill. `Qwen25VL` builds a real per-frame mask
+// (`attentionMask(sequenceLength:cuSeqlens:)`), which is why it can conform.
+
 // MARK: - Configuration
 
 /// Configuration for ``Qwen2VL``

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -412,7 +412,15 @@ public struct QwenVL {
         var rowCounts: [Int] = []
         padCounts.reserveCapacity(frames.count)
         rowCounts.reserveCapacity(frames.count)
+        // Still images only. A `t > 1` grid is a temporal stack, and the reason
+        // ``splitPreparedInput`` refuses video applies to any temporal grid whatever
+        // payload carries it: the vision full-attention mask mis-accumulates
+        // `cuSeqlens` across temporal slices, so those rows are not isolated from the
+        // rest of the buffer and dropping earlier rows changes the features of the
+        // rows that are kept. The video guard catches the usual case; this catches a
+        // temporal grid handed in as an image.
         for frame in frames {
+            guard frame.t == 1 else { return nil }
             guard frame.product > 0, frame.product % mergeLength == 0 else { return nil }
             padCounts.append(frame.product / mergeLength)
             rowCounts.append(frame.product)

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -294,4 +294,152 @@ public struct QwenVL {
         return (flattenedPatches, .init(gridT, gridH, gridW))
     }
 
+    // MARK: - Prepared input splitting
+
+    /// Split a Qwen VL prepared input at `prefixTokenCount`, keeping only the media
+    /// whose placeholder tokens fall in the suffix.
+    ///
+    /// Shared by ``Qwen25VL`` and ``Qwen2VL``, whose prepared-input layout is the
+    /// same: `pixels` is the images' patch rows concatenated along axis 0 in prompt
+    /// order, and `frames` carries one `THW` per image, so image *i* owns
+    /// `frames[i].product` rows and `frames[i].product / (mergeSize * mergeSize)`
+    /// placeholder tokens (see ``patchify(images:mergeSize:patchSize:temporalPatchSize:)``
+    /// and ``replacePaddingTokens(in:frames:paddingToken:mergeSize:tokenizer:)``).
+    ///
+    /// Returns `nil` — meaning "fall back to a full prefill" — unless every
+    /// assumption above is checked against the input actually handed in.
+    static func splitPreparedInput(
+        _ input: LMInput,
+        droppingFirst prefixTokenCount: Int,
+        imageTokenId: Int,
+        videoTokenId: Int,
+        mergeSize: Int
+    ) -> LMInput? {
+        // Audio is not part of the Qwen VL prepared-input contract.
+        guard input.audio == nil else { return nil }
+
+        // Images only. Video is refused for two reasons, both checked against the
+        // encoders rather than assumed:
+        //
+        //  * ``Qwen25VL``'s vision full-attention mask mis-accumulates `cuSeqlens`
+        //    for frames with `t > 1` — `cuSeqlens.last!` is read inside a `map`
+        //    that has not appended yet, so a 3-frame block yields `[16, 16, 16]`
+        //    rather than `[16, 32, 48]`. A video's rows are therefore not isolated
+        //    from the rest of the buffer, and dropping earlier rows changes the
+        //    features of the rows that are kept.
+        //  * Both models pass `videoGridTHW: nil` to `getRopeIndex`, which makes
+        //    video positions degenerate.
+        //
+        // Neither is this change's to fix, but either one makes a video split
+        // unsound, so it is not offered.
+        guard input.video == nil else { return nil }
+
+        // Only the processor's own `[1, seq]` layout. A rank-1 suffix would route
+        // back to the cold path in `prepare(_:cache:state:windowSize:)`, which
+        // computes positions from zero — silently wrong against a warm cache.
+        let tokens = input.text.tokens
+        guard tokens.ndim == 2, tokens.dim(0) == 1 else { return nil }
+
+        let ids = tokens.asArray(Int.self)
+        guard prefixTokenCount > 0, prefixTokenCount < ids.count else { return nil }
+
+        // The processor pairs media with an all-ones mask. Anything else is a real
+        // padding mask this routine will not reinterpret.
+        if let mask = input.text.mask {
+            guard mask.size == ids.count else { return nil }
+            guard mask.asType(.int32).asArray(Int32.self).allSatisfy({ $0 == 1 }) else {
+                return nil
+            }
+        }
+
+        var splitImage: LMInput.ProcessedImage?
+        if let image = input.image {
+            guard
+                let split = splitVisionPayload(
+                    pixels: image.pixels, positionIds: image.positionIds, frames: image.frames,
+                    ids: ids, prefixTokenCount: prefixTokenCount, padTokenId: imageTokenId,
+                    mergeSize: mergeSize)
+            else { return nil }
+            splitImage = LMInput.ProcessedImage(pixels: split.pixels, frames: split.frames)
+        }
+
+        // A video placeholder inside an image-only payload would mean the prompt
+        // carries media this routine is not accounting for.
+        guard !ids.contains(videoTokenId) else { return nil }
+
+        let suffixIds = Array(ids[prefixTokenCount...])
+        let suffixTokens = MLXArray(suffixIds).expandedDimensions(axis: 0)
+        let suffixMask = input.text.mask.map { mask in
+            ones([1, suffixIds.count]).asType(mask.dtype)
+        }
+
+        return LMInput(
+            text: .init(tokens: suffixTokens, mask: suffixMask),
+            image: splitImage)
+    }
+
+    /// Drop the leading media items that the cached prefix already covers.
+    ///
+    /// Returns `nil` when the payload cannot be attributed item-by-item, or when the
+    /// cut falls *inside* a media block — in that case the suffix would carry a
+    /// partial set of placeholders and neither the feature merge nor the position
+    /// walk would line up.
+    private static func splitVisionPayload(
+        pixels: MLXArray,
+        positionIds: MLXArray?,
+        frames: [THW]?,
+        ids: [Int],
+        prefixTokenCount: Int,
+        padTokenId: Int,
+        mergeSize: Int
+    ) -> (pixels: MLXArray, frames: [THW])? {
+        // Precomputed position ids describe the full prompt; slicing them is not
+        // attempted here.
+        guard positionIds == nil else { return nil }
+        guard let frames, !frames.isEmpty else { return nil }
+
+        let mergeLength = mergeSize * mergeSize
+        guard mergeLength > 0 else { return nil }
+
+        var prefixPadCount = 0
+        var totalPadCount = 0
+        for (index, id) in ids.enumerated() where id == padTokenId {
+            totalPadCount += 1
+            if index < prefixTokenCount { prefixPadCount += 1 }
+        }
+
+        var padCounts: [Int] = []
+        var rowCounts: [Int] = []
+        padCounts.reserveCapacity(frames.count)
+        rowCounts.reserveCapacity(frames.count)
+        for frame in frames {
+            guard frame.product > 0, frame.product % mergeLength == 0 else { return nil }
+            padCounts.append(frame.product / mergeLength)
+            rowCounts.append(frame.product)
+        }
+
+        // The payload must describe exactly the placeholders in the prompt, and the
+        // rows must account for the whole pixel buffer. If either is off, the layout
+        // is not the one documented above and nothing here may be assumed.
+        guard padCounts.reduce(0, +) == totalPadCount else { return nil }
+        guard pixels.ndim == 2, pixels.dim(0) == rowCounts.reduce(0, +) else { return nil }
+
+        var consumedPads = 0
+        var consumedRows = 0
+        var droppedItems = 0
+        while droppedItems < frames.count, consumedPads < prefixPadCount {
+            consumedPads += padCounts[droppedItems]
+            consumedRows += rowCounts[droppedItems]
+            droppedItems += 1
+        }
+        // Overshoot means the boundary landed inside a media block.
+        guard consumedPads == prefixPadCount else { return nil }
+
+        let remainingFrames = Array(frames[droppedItems...])
+        guard !remainingFrames.isEmpty else { return nil }
+
+        let remainingPixels = pixels[consumedRows ..< pixels.dim(0), 0...]
+        return (remainingPixels, remainingFrames)
+    }
+
 }

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -294,4 +294,143 @@ public struct QwenVL {
         return (flattenedPatches, .init(gridT, gridH, gridW))
     }
 
+    // MARK: - Prepared input splitting
+
+    /// Split a Qwen VL prepared input at `prefixTokenCount`, keeping only the media
+    /// whose placeholder tokens fall in the suffix.
+    ///
+    /// Shared by ``Qwen25VL`` and ``Qwen2VL``, whose prepared-input layout is the
+    /// same: `pixels` is the images' patch rows concatenated along axis 0 in prompt
+    /// order, and `frames` carries one `THW` per image, so image *i* owns
+    /// `frames[i].product` rows and `frames[i].product / (mergeSize * mergeSize)`
+    /// placeholder tokens (see ``patchify(images:mergeSize:patchSize:temporalPatchSize:)``
+    /// and ``replacePaddingTokens(in:frames:paddingToken:mergeSize:tokenizer:)``).
+    ///
+    /// Returns `nil` -- meaning "fall back to a full prefill" -- unless every
+    /// assumption above is checked against the input actually handed in.
+    static func splitPreparedInput(
+        _ input: LMInput,
+        droppingFirst prefixTokenCount: Int,
+        imageTokenId: Int,
+        videoTokenId: Int,
+        mergeSize: Int
+    ) -> LMInput? {
+        // Audio is not part of the Qwen VL prepared-input contract.
+        guard input.audio == nil else { return nil }
+
+        // Images only. Both models pass `videoGridTHW: nil` to `getRopeIndex`,
+        // so video positions are degenerate and a split cannot be verified.
+        guard input.video == nil else { return nil }
+
+        // Only the processor's own `[1, seq]` layout. A rank-1 suffix would route
+        // back to the cold path in `prepare(_:cache:state:prefill:)`, which
+        // computes positions from zero -- silently wrong against a warm cache.
+        let tokens = input.text.tokens
+        guard tokens.ndim == 2, tokens.dim(0) == 1 else { return nil }
+
+        let ids = tokens.asArray(Int.self)
+        guard prefixTokenCount > 0, prefixTokenCount < ids.count else { return nil }
+
+        // The processor pairs media with an all-ones mask. Anything else is a real
+        // padding mask this routine will not reinterpret.
+        if let mask = input.text.mask {
+            guard mask.size == ids.count else { return nil }
+            guard mask.asType(.int32).asArray(Int32.self).allSatisfy({ $0 == 1 }) else {
+                return nil
+            }
+        }
+
+        var splitImage: LMInput.ProcessedImage?
+        if let image = input.image {
+            guard
+                let split = splitVisionPayload(
+                    pixels: image.pixels, positionIds: image.positionIds, frames: image.frames,
+                    ids: ids, prefixTokenCount: prefixTokenCount, padTokenId: imageTokenId,
+                    mergeSize: mergeSize)
+            else { return nil }
+            splitImage = LMInput.ProcessedImage(pixels: split.pixels, frames: split.frames)
+        }
+
+        // A video placeholder inside an image-only payload would mean the prompt
+        // carries media this routine is not accounting for.
+        guard !ids.contains(videoTokenId) else { return nil }
+
+        let suffixIds = Array(ids[prefixTokenCount...])
+        let suffixTokens = MLXArray(suffixIds).expandedDimensions(axis: 0)
+        let suffixMask = input.text.mask.map { mask in
+            ones([1, suffixIds.count]).asType(mask.dtype)
+        }
+
+        return LMInput(
+            text: .init(tokens: suffixTokens, mask: suffixMask),
+            image: splitImage)
+    }
+
+    /// Drop the leading media items that the cached prefix already covers.
+    ///
+    /// Returns `nil` when the payload cannot be attributed item-by-item, or when the
+    /// cut falls *inside* a media block -- in that case the suffix would carry a
+    /// partial set of placeholders and neither the feature merge nor the position
+    /// walk would line up.
+    private static func splitVisionPayload(
+        pixels: MLXArray,
+        positionIds: MLXArray?,
+        frames: [THW]?,
+        ids: [Int],
+        prefixTokenCount: Int,
+        padTokenId: Int,
+        mergeSize: Int
+    ) -> (pixels: MLXArray, frames: [THW])? {
+        // Precomputed position ids describe the full prompt; slicing them is not
+        // attempted here.
+        guard positionIds == nil else { return nil }
+        guard let frames, !frames.isEmpty else { return nil }
+
+        let mergeLength = mergeSize * mergeSize
+        guard mergeLength > 0 else { return nil }
+
+        var prefixPadCount = 0
+        var totalPadCount = 0
+        for (index, id) in ids.enumerated() where id == padTokenId {
+            totalPadCount += 1
+            if index < prefixTokenCount { prefixPadCount += 1 }
+        }
+
+        var padCounts: [Int] = []
+        var rowCounts: [Int] = []
+        padCounts.reserveCapacity(frames.count)
+        rowCounts.reserveCapacity(frames.count)
+        // Still images only. A `t > 1` grid is a temporal stack, and `getRopeIndex`
+        // is handed `videoGridTHW: nil` for it too, so its positions are degenerate.
+        for frame in frames {
+            guard frame.t == 1 else { return nil }
+            guard frame.product > 0, frame.product % mergeLength == 0 else { return nil }
+            padCounts.append(frame.product / mergeLength)
+            rowCounts.append(frame.product)
+        }
+
+        // The payload must describe exactly the placeholders in the prompt, and the
+        // rows must account for the whole pixel buffer. If either is off, the layout
+        // is not the one documented above.
+        guard padCounts.reduce(0, +) == totalPadCount else { return nil }
+        guard pixels.ndim == 2, pixels.dim(0) == rowCounts.reduce(0, +) else { return nil }
+
+        var consumedPads = 0
+        var consumedRows = 0
+        var droppedItems = 0
+        while droppedItems < frames.count, consumedPads < prefixPadCount {
+            consumedPads += padCounts[droppedItems]
+            consumedRows += rowCounts[droppedItems]
+            droppedItems += 1
+        }
+        // Overshoot means the boundary landed inside a media block.
+        guard consumedPads == prefixPadCount else { return nil }
+
+        let remainingFrames = Array(frames[droppedItems...])
+        guard !remainingFrames.isEmpty else { return nil }
+
+        let remainingPixels = pixels[consumedRows ..< pixels.dim(0), 0...]
+        return (remainingPixels, remainingFrames)
+    }
+
 }

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -167,6 +167,54 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
+    /// A model that opts into append-only media cache reuse.
+    ///
+    /// The synthetic text model underneath cannot consume a media payload, so the
+    /// split keeps the token suffix and the payload is stripped in `prepare` — the
+    /// same shape as `MaskTolerantLanguageModel`. What these tests measure is
+    /// `ChatSession`'s decision, which is made before the model is called.
+    private final class SplittingLanguageModel: Module, LanguageModel, PreparedInputSplitting {
+        let base: any LanguageModel
+        let declinesToSplit: Bool
+
+        init(_ base: any LanguageModel, declinesToSplit: Bool = false) {
+            self.base = base
+            self.declinesToSplit = declinesToSplit
+            super.init()
+        }
+
+        func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
+            -> LMInput?
+        {
+            guard !declinesToSplit else { return nil }
+            let ids = input.text.tokens.asArray(Int.self)
+            guard prefixTokenCount > 0, prefixTokenCount < ids.count else { return nil }
+            return LMInput(
+                text: .init(tokens: MLXArray(Array(ids[prefixTokenCount...]))),
+                image: input.image)
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+        ) throws -> PrepareResult {
+            try base.prepare(
+                LMInput(tokens: input.text.tokens),
+                cache: cache,
+                state: state,
+                prefill: prefill)
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            base(input, cache: cache, state: state)
+        }
+
+        func newCache(parameters: GenerateParameters?) -> [KVCache] {
+            base.newCache(parameters: parameters)
+        }
+    }
+
     private struct EmptyChatTemplateTokenizer: Tokenizer {
         var bosToken: String? = nil
         var eosToken: String? = nil
@@ -346,6 +394,20 @@ public class ChatSessionTests: XCTestCase {
             processor: processor,
             configuration: processor.configuration,
             tokenizer: processor.tokenizer)
+    }
+
+    private func model(
+        processor: MediaAwareInputProcessor, splitting: Bool, declinesToSplit: Bool = false
+    ) -> ModelContext {
+        var context = Self.makeModel(
+            processor: processor,
+            configuration: processor.configuration,
+            tokenizer: processor.tokenizer)
+        if splitting {
+            context.model = SplittingLanguageModel(
+                context.model, declinesToSplit: declinesToSplit)
+        }
+        return context
     }
 
     private func model(processor: MaskedInputProcessor) -> ModelContext {
@@ -1090,6 +1152,116 @@ public class ChatSessionTests: XCTestCase {
             components: GenerationComponents())
         let result = try await session.respond(to: "hello")
         XCTAssertGreaterThan(result.count, targetLength, result)
+    }
+
+    /// The append-only counterpart of
+    /// `testHistoricalMediaReusesSuffixButNewMediaRebuildsCache`: same transcript,
+    /// same turns, but a model that can split its own prepared input. The new-image
+    /// turn now prefills only the uncached suffix instead of the whole prompt.
+    func testAppendOnlyMediaReusesCacheWhenModelSplitsPreparedInput() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor, splitting: true),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        for try await _ in session.streamDetails(to: "describe it") {}
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+
+        XCTAssertEqual(
+            newMediaInfo?.promptTokenCount,
+            thirdRenderedLength - secondRenderedLength - 3,
+            "an append-only media turn should prefill only the uncached suffix")
+    }
+
+    /// A model that declines the split keeps the pre-existing behavior, which is
+    /// also what every non-conforming model gets.
+    func testAppendOnlyMediaRebuildsWhenModelDeclinesToSplit() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor, splitting: true, declinesToSplit: true),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        for try await _ in session.streamDetails(to: "describe it") {}
+        _ = await lengthIterator.next()
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+
+        XCTAssertEqual(newMediaInfo?.promptTokenCount, thirdRenderedLength)
+    }
+
+    /// Splitting is offered only where the transcript is *extended*. When the
+    /// template rewrites an already-cached tail the turn needs a rewind, and media
+    /// still forces a rebuild there — the guard PR #472 added is untouched.
+    func testLongestCommonPrefixTrimmingStillFallsBackForMediaWhenModelCanSplit()
+        async throws
+    {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: continuation,
+            rewritesCachedTailOnContinuation: true)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor, splitting: true),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "describe it") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+        let fullSecondPromptLengthValue = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(fullSecondPromptLengthValue)
+        XCTAssertEqual(completionInfo?.promptTokenCount, fullSecondPromptLength)
     }
 
     func testChatSessionAsyncInterrupt() async throws {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -210,8 +210,55 @@ public class ChatSessionTests: XCTestCase {
             base(input, cache: cache, state: state)
         }
 
-        func newCache(parameters: GenerateParameters?) -> [KVCache] {
-            base.newCache(parameters: parameters)
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try base.newCache(parameters: parameters)
+        }
+    }
+
+    /// A conformer that honors the protocol's shape but not its contract: it returns
+    /// a suffix starting `extraDrop` tokens past the boundary it was handed. It never
+    /// returns `nil`, so a nil-only check would let it through.
+    private final class MisSplittingLanguageModel: Module, LanguageModel,
+        PreparedInputSplitting
+    {
+        let base: any LanguageModel
+        let extraDrop: Int
+
+        init(_ base: any LanguageModel, extraDrop: Int) {
+            self.base = base
+            self.extraDrop = extraDrop
+            super.init()
+        }
+
+        func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
+            -> LMInput?
+        {
+            let ids = input.text.tokens.asArray(Int.self)
+            let wrongStart = prefixTokenCount + extraDrop
+            guard wrongStart > 0, wrongStart < ids.count else { return nil }
+            return LMInput(
+                text: .init(tokens: MLXArray(Array(ids[wrongStart...]))),
+                image: input.image)
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+        ) throws -> PrepareResult {
+            try base.prepare(
+                LMInput(tokens: input.text.tokens),
+                cache: cache,
+                state: state,
+                prefill: prefill)
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            base(input, cache: cache, state: state)
+        }
+
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try base.newCache(parameters: parameters)
         }
     }
 
@@ -825,6 +872,52 @@ public class ChatSessionTests: XCTestCase {
         let thirdRenderedLengthValue = await lengthIterator.next()
         let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
         XCTAssertEqual(newMediaInfo?.promptTokenCount, thirdRenderedLength)
+    }
+
+    /// Returning *a* suffix is not enough. A conformer that returns the wrong tokens
+    /// must be treated exactly like one that declines: the ledger advances to
+    /// `representedTokens` on the strength of the requested boundary, so accepting
+    /// any other suffix would leave the record describing a cache never built.
+    func testAppendOnlyMediaRebuildsWhenModelSplitsAtTheWrongBoundary() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+
+        var context = Self.makeModel(
+            processor: processor,
+            configuration: processor.configuration,
+            tokenizer: processor.tokenizer)
+        context.model = MisSplittingLanguageModel(context.model, extraDrop: 2)
+
+        let session = ChatSession(
+            context, generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        for try await _ in session.streamDetails(to: "describe it") {}
+        _ = await lengthIterator.next()
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+
+        XCTAssertEqual(
+            newMediaInfo?.promptTokenCount, thirdRenderedLength,
+            "a wrong-boundary split must downgrade to a full rebuild")
     }
 
     func testLongestCommonPrefixTrimmingFallsBackForHistoricalMedia() async throws {

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -167,6 +167,101 @@ public class ChatSessionTests: XCTestCase {
         }
     }
 
+    /// A model that opts into append-only media cache reuse.
+    ///
+    /// The synthetic text model underneath cannot consume a media payload, so the
+    /// split keeps the token suffix and the payload is stripped in `prepare` -- the
+    /// same shape as `MaskTolerantLanguageModel`. What these tests measure is
+    /// `ChatSession`'s decision, which is made before the model is called.
+    private final class SplittingLanguageModel: Module, LanguageModel, PreparedInputSplitting {
+        let base: any LanguageModel
+        let declinesToSplit: Bool
+
+        init(_ base: any LanguageModel, declinesToSplit: Bool = false) {
+            self.base = base
+            self.declinesToSplit = declinesToSplit
+            super.init()
+        }
+
+        func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
+            -> LMInput?
+        {
+            guard !declinesToSplit else { return nil }
+            let ids = input.text.tokens.asArray(Int.self)
+            guard prefixTokenCount > 0, prefixTokenCount < ids.count else { return nil }
+            return LMInput(
+                text: .init(tokens: MLXArray(Array(ids[prefixTokenCount...]))),
+                image: input.image)
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+        ) throws -> PrepareResult {
+            try base.prepare(
+                LMInput(tokens: input.text.tokens),
+                cache: cache,
+                state: state,
+                prefill: prefill)
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            base(input, cache: cache, state: state)
+        }
+
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try base.newCache(parameters: parameters)
+        }
+    }
+
+    /// A conformer that honors the protocol's shape but not its contract: it returns
+    /// a suffix starting `extraDrop` tokens past the boundary it was handed. It never
+    /// returns `nil`, so a nil-only check would let it through.
+    private final class MisSplittingLanguageModel: Module, LanguageModel,
+        PreparedInputSplitting
+    {
+        let base: any LanguageModel
+        let extraDrop: Int
+
+        init(_ base: any LanguageModel, extraDrop: Int) {
+            self.base = base
+            self.extraDrop = extraDrop
+            super.init()
+        }
+
+        func splitPreparedInput(_ input: LMInput, droppingFirst prefixTokenCount: Int)
+            -> LMInput?
+        {
+            let ids = input.text.tokens.asArray(Int.self)
+            let wrongStart = prefixTokenCount + extraDrop
+            guard wrongStart > 0, wrongStart < ids.count else { return nil }
+            return LMInput(
+                text: .init(tokens: MLXArray(Array(ids[wrongStart...]))),
+                image: input.image)
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+        ) throws -> PrepareResult {
+            try base.prepare(
+                LMInput(tokens: input.text.tokens),
+                cache: cache,
+                state: state,
+                prefill: prefill)
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            base(input, cache: cache, state: state)
+        }
+
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try base.newCache(parameters: parameters)
+        }
+    }
+
     private struct EmptyChatTemplateTokenizer: Tokenizer {
         var bosToken: String? = nil
         var eosToken: String? = nil
@@ -346,6 +441,20 @@ public class ChatSessionTests: XCTestCase {
             processor: processor,
             configuration: processor.configuration,
             tokenizer: processor.tokenizer)
+    }
+
+    private func model(
+        processor: MediaAwareInputProcessor, splitting: Bool, declinesToSplit: Bool = false
+    ) -> ModelContext {
+        var context = Self.makeModel(
+            processor: processor,
+            configuration: processor.configuration,
+            tokenizer: processor.tokenizer)
+        if splitting {
+            context.model = SplittingLanguageModel(
+                context.model, declinesToSplit: declinesToSplit)
+        }
+        return context
     }
 
     private func model(processor: MaskedInputProcessor) -> ModelContext {
@@ -795,6 +904,52 @@ public class ChatSessionTests: XCTestCase {
         XCTAssertEqual(newMediaInfo?.promptTokenCount, thirdRenderedLength)
     }
 
+    /// Returning *a* suffix is not enough. A conformer that returns the wrong tokens
+    /// must be treated exactly like one that declines: the ledger advances to
+    /// `representedTokens` on the strength of the requested boundary, so accepting
+    /// any other suffix would leave the record describing a cache never built.
+    func testAppendOnlyMediaRebuildsWhenModelSplitsAtTheWrongBoundary() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+
+        var context = Self.makeModel(
+            processor: processor,
+            configuration: processor.configuration,
+            tokenizer: processor.tokenizer)
+        context.model = MisSplittingLanguageModel(context.model, extraDrop: 2)
+
+        let session = ChatSession(
+            context, generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        for try await _ in session.streamDetails(to: "describe it") {}
+        _ = await lengthIterator.next()
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+
+        XCTAssertEqual(
+            newMediaInfo?.promptTokenCount, thirdRenderedLength,
+            "a wrong-boundary split must downgrade to a full rebuild")
+    }
+
     func testLongestCommonPrefixTrimmingFallsBackForHistoricalMedia() async throws {
         let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
         var lengthIterator = renderedLengths.makeAsyncIterator()
@@ -1120,6 +1275,124 @@ public class ChatSessionTests: XCTestCase {
             components: GenerationComponents())
         let result = try await session.respond(to: "hello")
         XCTAssertGreaterThan(result.count, targetLength, result)
+    }
+
+    /// The append-only counterpart of
+    /// `testHistoricalMediaReusesSuffixButNewMediaRebuildsCache`: same transcript,
+    /// same turns, but a model that can split its own prepared input. The new-image
+    /// turn now prefills only the uncached suffix instead of the whole prompt.
+    func testAppendOnlyMediaReusesCacheWhenModelSplitsPreparedInput() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor, splitting: true),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        for try await _ in session.streamDetails(to: "describe it") {}
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+
+        XCTAssertEqual(
+            newMediaInfo?.promptTokenCount,
+            thirdRenderedLength - secondRenderedLength - 3,
+            "an append-only media turn should prefill only the uncached suffix")
+        // The split boundary is what the turn did not prefill, so it is also what
+        // the completion info must attribute to the cache: the previous prompt
+        // plus the tokens it generated.
+        XCTAssertEqual(
+            newMediaInfo?.cachedPromptTokenCount,
+            secondRenderedLength + 3,
+            "the reused prefix should be attributed to the cache, not dropped")
+        XCTAssertEqual(newMediaInfo?.totalPromptTokenCount, thirdRenderedLength)
+    }
+
+    /// A model that declines the split keeps the pre-existing behavior, which is
+    /// also what every non-conforming model gets.
+    func testAppendOnlyMediaRebuildsWhenModelDeclinesToSplit() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor, splitting: true, declinesToSplit: true),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        for try await _ in session.streamDetails(to: "describe it") {}
+        _ = await lengthIterator.next()
+
+        var newMediaInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(
+            to: "now inspect this",
+            role: .user,
+            images: [.array(MLXArray([Float(1)]))],
+            videos: [])
+        {
+            if let info = item.info {
+                newMediaInfo = info
+            }
+        }
+        let thirdRenderedLengthValue = await lengthIterator.next()
+        let thirdRenderedLength = try XCTUnwrap(thirdRenderedLengthValue)
+
+        XCTAssertEqual(newMediaInfo?.promptTokenCount, thirdRenderedLength)
+    }
+
+    /// Splitting is offered only where the transcript is *extended*. When the
+    /// template rewrites an already-cached tail the turn needs a rewind, and media
+    /// still forces a rebuild there -- the guard PR #472 added is untouched.
+    func testLongestCommonPrefixTrimmingStillFallsBackForMediaWhenModelCanSplit()
+        async throws
+    {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: continuation,
+            rewritesCachedTailOnContinuation: true)
+        let processor = MediaAwareInputProcessor(tokenizer: tokenizer)
+        let session = ChatSession(
+            model(processor: processor, splitting: true),
+            generateParameters: GenerateParameters(maxTokens: 3))
+
+        _ = try await session.respond(
+            to: "inspect this",
+            image: .array(MLXArray([Float(0)])))
+        _ = await lengthIterator.next()
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "describe it") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+        let fullSecondPromptLengthValue = await lengthIterator.next()
+        let fullSecondPromptLength = try XCTUnwrap(fullSecondPromptLengthValue)
+        XCTAssertEqual(completionInfo?.promptTokenCount, fullSecondPromptLength)
     }
 
     func testChatSessionAsyncInterrupt() async throws {

--- a/Tests/MLXLMTests/ContinuationAssertions.swift
+++ b/Tests/MLXLMTests/ContinuationAssertions.swift
@@ -145,6 +145,68 @@ struct ContinuationAssertions {
         }
     }
 
+    /// An append-only media turn: turn 2 adds its own image to an unchanged turn 1.
+    /// `split` carves the suffix out of the full prepared input, and prefilling that
+    /// suffix on turn 1's cache must land where a cold prefill of the whole prompt
+    /// does -- but only if the vision encoder computes each image independently.
+    ///
+    /// `expectsIsolation` says which model this is. `Qwen25VL` masks each frame to
+    /// itself, so the split is exact; `Qwen2VL` attends across the concatenated
+    /// buffer, so dropping the cached image changes the kept image's features and
+    /// the logits must differ. Asserting the divergence is what makes the
+    /// conformance a measured claim rather than a stated one.
+    func assertAppendOnlyMediaSplit<M: LanguageModel>(
+        _ model: M, split: (LMInput, Int) -> LMInput?, expectsIsolation: Bool,
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws {
+        try withRandomState(MLXRandom.RandomState(seed: 17)) {
+            let imageA = image()
+            let imageB = image()
+            let t1 = concatenated([textTokens(10), imageRun(), textTokens(8, seed: 5)], axis: 1)
+            let t2 = concatenated(
+                [textTokens(6, seed: 2), imageRun(), textTokens(4, seed: 9)], axis: 1)
+
+            // The prepared input a VL processor hands over for the whole transcript:
+            // both images' patch rows concatenated, one grid each.
+            let bothImages = LMInput.ProcessedImage(
+                pixels: concatenated([imageA.pixels, imageB.pixels], axis: 0),
+                frames: (imageA.frames ?? []) + (imageB.frames ?? []))
+            let fullInput = LMInput(
+                text: .init(tokens: concatenated([t1, t2], axis: 1)), image: bothImages)
+
+            let cacheF = try model.newCache(parameters: nil)
+            let (logitsF, _) = try lastLogits(
+                model.prepare(
+                    fullInput, cache: cacheF, state: nil, prefill: PrefillParameters()))
+
+            let cacheW = try model.newCache(parameters: nil)
+            let (_, s1) = try prefill(model, t1, image: imageA, cache: cacheW)
+
+            let suffix = try XCTUnwrap(
+                split(fullInput, t1.dim(1)), "the split was declined", file: file, line: line)
+            XCTAssertEqual(suffix.text.tokens.dim(-1), t2.dim(1), file: file, line: line)
+            XCTAssertEqual(
+                suffix.image?.frames?.count, 1, "the suffix must carry only the new image",
+                file: file, line: line)
+
+            let (logitsW, _) = try lastLogits(
+                model.prepare(
+                    suffix, cache: cacheW, state: s1, prefill: PrefillParameters()))
+
+            let diff = maxAbsDiff(logitsW, logitsF)
+            if expectsIsolation {
+                XCTAssertLessThanOrEqual(
+                    diff, 1e-3,
+                    "split-suffix prefill diverged from full prefill", file: file, line: line)
+            } else {
+                XCTAssertGreaterThan(
+                    diff, 1e-3,
+                    "cross-image vision attention should have changed the logits",
+                    file: file, line: line)
+            }
+        }
+    }
+
     /// Three turns, with the image in the middle one. The continuation must place that image at
     /// the anchor *and* hand back a resume state that positions the following turn — the two
     /// halves of the anchor invariant, which a single-turn test cannot separate.

--- a/Tests/MLXLMTests/PromptCacheReusePolicyTests.swift
+++ b/Tests/MLXLMTests/PromptCacheReusePolicyTests.swift
@@ -19,7 +19,9 @@ struct PromptCacheReusePolicyTests {
         preparedMedia: Bool = false,
         attentionMask: Bool = false,
         modelState: Bool = false,
-        toolResultContinuation: Bool = false
+        toolResultContinuation: Bool = false,
+        speculativeDecoding: Bool = false,
+        canSplitMedia: Bool = false
     ) -> PromptCacheTurn {
         PromptCacheTurn(
             promptTokens: prompt,
@@ -27,7 +29,9 @@ struct PromptCacheReusePolicyTests {
             carriesPreparedMedia: preparedMedia,
             carriesAttentionMask: attentionMask,
             carriesModelState: modelState,
-            isToolResultContinuation: toolResultContinuation)
+            isToolResultContinuation: toolResultContinuation,
+            usesSpeculativeDecoding: speculativeDecoding,
+            canSplitPreparedMedia: canSplitMedia)
     }
 
     /// A cache whose model-wide timeline agrees with `cached`, unless
@@ -102,6 +106,64 @@ struct PromptCacheReusePolicyTests {
             turn: turn(prompt: [1, 2, 3, 4], newMedia: true), cache: alignedCache([1, 2, 3]))
 
         #expect(decision == .rebuild)
+    }
+
+    // MARK: - Append-only media turns
+
+    @Test func `an append-only media turn appends its suffix when the model can split`() {
+        let decision = PromptCacheReusePolicy().decide(
+            turn: turn(prompt: [1, 2, 3, 4], newMedia: true, canSplitMedia: true),
+            cache: alignedCache([1, 2, 3]))
+
+        #expect(
+            decision == .appendMediaSuffix(suffixStart: 3, representedTokens: [1, 2, 3, 4]))
+        #expect(decision.reusesCachedPrefix)
+    }
+
+    /// A VL processor pairs media with an all-ones mask as a matter of course, so
+    /// the media path must not inherit ``ExtendCachedPrefixRule``'s mask guard —
+    /// doing so would disable it for exactly the inputs it serves. Telling a
+    /// benign mask from a real padding mask needs the model's layout knowledge,
+    /// so that check belongs to the splitter.
+    @Test func `a benign attention mask does not block the media split`() {
+        let decision = PromptCacheReusePolicy().decide(
+            turn: turn(
+                prompt: [1, 2, 3, 4], newMedia: true, attentionMask: true, canSplitMedia: true),
+            cache: alignedCache([1, 2, 3]))
+
+        #expect(
+            decision == .appendMediaSuffix(suffixStart: 3, representedTokens: [1, 2, 3, 4]))
+    }
+
+    @Test func `a model that cannot split keeps the rebuild on a media turn`() {
+        #expect(
+            PromptCacheReusePolicy().decide(
+                turn: turn(prompt: [1, 2, 3, 4], newMedia: true, canSplitMedia: false),
+                cache: alignedCache([1, 2, 3])) == .rebuild)
+    }
+
+    @Test func `speculative decoding blocks the media split`() {
+        #expect(
+            PromptCacheReusePolicy().decide(
+                turn: turn(
+                    prompt: [1, 2, 3, 4], newMedia: true, speculativeDecoding: true,
+                    canSplitMedia: true),
+                cache: alignedCache([1, 2, 3])) == .rebuild)
+    }
+
+    @Test func `a media turn that diverges from the cache does not split`() {
+        let decision = PromptCacheReusePolicy().decide(
+            turn: turn(prompt: [1, 2, 9, 9], newMedia: true, canSplitMedia: true),
+            cache: alignedCache([1, 2, 3]))
+
+        #expect(decision == .rebuild)
+    }
+
+    @Test func `a misaligned draft cache blocks the media split`() {
+        #expect(
+            PromptCacheReusePolicy().decide(
+                turn: turn(prompt: [1, 2, 3, 4], newMedia: true, canSplitMedia: true),
+                cache: alignedCache([1, 2, 3], draftAligned: false)) == .rebuild)
     }
 
     @Test func `an explicit attention mask blocks suffix reuse`() {

--- a/Tests/MLXLMTests/PromptCacheReusePolicyTests.swift
+++ b/Tests/MLXLMTests/PromptCacheReusePolicyTests.swift
@@ -19,7 +19,9 @@ struct PromptCacheReusePolicyTests {
         preparedMedia: Bool = false,
         attentionMask: Bool = false,
         modelState: Bool = false,
-        toolResultContinuation: Bool = false
+        toolResultContinuation: Bool = false,
+        speculativeDecoding: Bool = false,
+        canSplitMedia: Bool = false
     ) -> PromptCacheTurn {
         PromptCacheTurn(
             promptTokens: prompt,
@@ -27,7 +29,9 @@ struct PromptCacheReusePolicyTests {
             carriesPreparedMedia: preparedMedia,
             carriesAttentionMask: attentionMask,
             carriesModelState: modelState,
-            isToolResultContinuation: toolResultContinuation)
+            isToolResultContinuation: toolResultContinuation,
+            usesSpeculativeDecoding: speculativeDecoding,
+            canSplitPreparedMedia: canSplitMedia)
     }
 
     /// A cache whose model-wide timeline agrees with `cached`, unless
@@ -102,6 +106,64 @@ struct PromptCacheReusePolicyTests {
             turn: turn(prompt: [1, 2, 3, 4], newMedia: true), cache: alignedCache([1, 2, 3]))
 
         #expect(decision == .rebuild)
+    }
+
+    // MARK: - Append-only media turns
+
+    @Test func `an append-only media turn appends its suffix when the model can split`() {
+        let decision = PromptCacheReusePolicy().decide(
+            turn: turn(prompt: [1, 2, 3, 4], newMedia: true, canSplitMedia: true),
+            cache: alignedCache([1, 2, 3]))
+
+        #expect(
+            decision == .appendMediaSuffix(suffixStart: 3, representedTokens: [1, 2, 3, 4]))
+        #expect(decision.reusesCachedPrefix)
+    }
+
+    /// A VL processor pairs media with an all-ones mask as a matter of course, so
+    /// the media path must not inherit ``ExtendCachedPrefixRule``'s mask guard --
+    /// doing so would disable it for exactly the inputs it serves. Telling a
+    /// benign mask from a real padding mask needs the model's layout knowledge,
+    /// so that check belongs to the splitter.
+    @Test func `a benign attention mask does not block the media split`() {
+        let decision = PromptCacheReusePolicy().decide(
+            turn: turn(
+                prompt: [1, 2, 3, 4], newMedia: true, attentionMask: true, canSplitMedia: true),
+            cache: alignedCache([1, 2, 3]))
+
+        #expect(
+            decision == .appendMediaSuffix(suffixStart: 3, representedTokens: [1, 2, 3, 4]))
+    }
+
+    @Test func `a model that cannot split keeps the rebuild on a media turn`() {
+        #expect(
+            PromptCacheReusePolicy().decide(
+                turn: turn(prompt: [1, 2, 3, 4], newMedia: true, canSplitMedia: false),
+                cache: alignedCache([1, 2, 3])) == .rebuild)
+    }
+
+    @Test func `speculative decoding blocks the media split`() {
+        #expect(
+            PromptCacheReusePolicy().decide(
+                turn: turn(
+                    prompt: [1, 2, 3, 4], newMedia: true, speculativeDecoding: true,
+                    canSplitMedia: true),
+                cache: alignedCache([1, 2, 3])) == .rebuild)
+    }
+
+    @Test func `a media turn that diverges from the cache does not split`() {
+        let decision = PromptCacheReusePolicy().decide(
+            turn: turn(prompt: [1, 2, 9, 9], newMedia: true, canSplitMedia: true),
+            cache: alignedCache([1, 2, 3]))
+
+        #expect(decision == .rebuild)
+    }
+
+    @Test func `a misaligned draft cache blocks the media split`() {
+        #expect(
+            PromptCacheReusePolicy().decide(
+                turn: turn(prompt: [1, 2, 3, 4], newMedia: true, canSplitMedia: true),
+                cache: alignedCache([1, 2, 3], draftAligned: false)) == .rebuild)
     }
 
     @Test func `an explicit attention mask blocks suffix reuse`() {

--- a/Tests/MLXLMTests/Qwen25VLContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen25VLContinuationTests.swift
@@ -11,8 +11,9 @@
 import Foundation
 import MLX
 import MLXLMCommon
-import MLXVLM
 import XCTest
+
+@testable import MLXVLM
 
 final class Qwen25VLContinuationTests: XCTestCase {
 
@@ -135,6 +136,16 @@ final class Qwen25VLContinuationTests: XCTestCase {
         try continuation.assertWindowedImagePrefill(makeTinyQwen25VL())
     }
 
+    /// Through the `PreparedInputSplitting` conformance, so the config-derived token
+    /// ids and merge size are exercised alongside the split itself.
+    func testQwen25VLAppendOnlyMediaSplitMatchesFullPrefill() throws {
+        let model = try makeTinyQwen25VL()
+        try continuation.assertAppendOnlyMediaSplit(
+            model,
+            split: { (model as PreparedInputSplitting).splitPreparedInput($0, droppingFirst: $1) },
+            expectsIsolation: true)
+    }
+
     // MARK: - Qwen2-VL
 
     func testQwen2VLWarmTextContinuationMatchesFullPrefill() throws {
@@ -155,5 +166,23 @@ final class Qwen25VLContinuationTests: XCTestCase {
 
     func testQwen2VLWindowedImagePrefillMatchesSingleShot() throws {
         try continuation.assertWindowedImagePrefill(makeTinyQwen2VL())
+    }
+
+    /// The counterexample the conformance rests on. `Qwen2VL` does not conform, so
+    /// the split runs through `QwenVL` directly with this model's ids; the logits
+    /// must diverge because its vision attention is unmasked across images.
+    func testQwen2VLAppendOnlyMediaSplitDiverges() throws {
+        let model = try makeTinyQwen2VL()
+        try continuation.assertAppendOnlyMediaSplit(
+            model,
+            split: {
+                QwenVL.splitPreparedInput(
+                    $0,
+                    droppingFirst: $1,
+                    imageTokenId: model.config.baseConfiguration.imageTokenId,
+                    videoTokenId: model.config.baseConfiguration.videoTokenId,
+                    mergeSize: model.config.visionConfiguration.spatialMergeSize)
+            },
+            expectsIsolation: false)
     }
 }

--- a/Tests/MLXLMTests/QwenVLPreparedInputSplitTests.swift
+++ b/Tests/MLXLMTests/QwenVLPreparedInputSplitTests.swift
@@ -215,6 +215,33 @@ final class QwenVLPreparedInputSplitTests: XCTestCase {
 
     // MARK: - Refusals
 
+    /// A temporal grid (`t > 1`) carried in the *image* payload is refused for the
+    /// same reason video is: the vision full-attention mask mis-accumulates
+    /// `cuSeqlens` across temporal slices, so those rows are not independently
+    /// reusable. Refused whether the temporal frame is dropped with the prefix or
+    /// retained in the suffix.
+    func testSplitRefusesTemporalImageFrame() throws {
+        let dropped = THW(2, 4, 4)
+        let plain = THW(1, 2, 4)
+
+        let prefixIds = turnTokens(frame: dropped, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: plain, leadingText: 2, trailingText: 3)
+        XCTAssertNil(
+            split(
+                input(ids: prefixIds + suffixIds, frames: [dropped, plain]),
+                droppingFirst: prefixIds.count),
+            "a temporal frame in the cached prefix must refuse")
+
+        let retainedPrefixIds = turnTokens(frame: plain, leadingText: 3, trailingText: 4)
+        let retainedSuffixIds = turnTokens(frame: dropped, leadingText: 2, trailingText: 3)
+        XCTAssertNil(
+            split(
+                input(
+                    ids: retainedPrefixIds + retainedSuffixIds, frames: [plain, dropped]),
+                droppingFirst: retainedPrefixIds.count),
+            "a temporal frame retained in the suffix must refuse")
+    }
+
     /// A boundary inside a vision block would hand the suffix a partial run of
     /// placeholders. The split must decline rather than guess.
     func testSplitRefusesBoundaryInsideAnImageBlock() throws {

--- a/Tests/MLXLMTests/QwenVLPreparedInputSplitTests.swift
+++ b/Tests/MLXLMTests/QwenVLPreparedInputSplitTests.swift
@@ -1,0 +1,378 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Covers ``QwenVL/splitPreparedInput(_:droppingFirst:imageTokenId:videoTokenId:mergeSize:)``
+/// and, more importantly, the property that makes it safe to use: prefilling only
+/// the split-off suffix at the carried `positionOffset` produces the *same* M-RoPE
+/// positions a cold full prefill would have produced for those tokens.
+///
+/// These tests are deliberately weight-free. They drive the position math directly,
+/// so the equality below is exact rather than inferred from generated text.
+final class QwenVLPreparedInputSplitTests: XCTestCase {
+
+    // Qwen2.5-VL's actual special-token ids; any distinct values would do.
+    private let imageTokenId = 151_655
+    private let videoTokenId = 151_656
+    private let visionStartTokenId = 151_652
+    private let visionEndTokenId = 151_653
+    private let mergeSize = 2
+
+    /// Tokens for one "turn": leading text, a vision block sized for `frame`,
+    /// then trailing text (which also stands in for the turn's generated tokens).
+    private func turnTokens(frame: THW, leadingText: Int, trailingText: Int) -> [Int] {
+        let padCount = frame.product / (mergeSize * mergeSize)
+        return Array(repeating: 1, count: leadingText)
+            + [visionStartTokenId]
+            + Array(repeating: imageTokenId, count: padCount)
+            + [visionEndTokenId]
+            + Array(repeating: 2, count: trailingText)
+    }
+
+    private func pixels(rows: Int) -> MLXArray {
+        MLXArray((0 ..< (rows * 8)).map { Float($0) }).reshaped(rows, 8)
+    }
+
+    private func input(ids: [Int], frames: [THW], mask: MLXArray? = nil) -> LMInput {
+        let rows = frames.reduce(0) { $0 + $1.product }
+        return LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0), mask: mask),
+            image: LMInput.ProcessedImage(pixels: pixels(rows: rows), frames: frames))
+    }
+
+    private func split(_ input: LMInput, droppingFirst prefixTokenCount: Int) -> LMInput? {
+        QwenVL.splitPreparedInput(
+            input,
+            droppingFirst: prefixTokenCount,
+            imageTokenId: imageTokenId,
+            videoTokenId: videoTokenId,
+            mergeSize: mergeSize)
+    }
+
+    private func ropeIndex(ids: [Int], frames: [THW], positionOffset: Int = 0) -> (
+        positions: MLXArray, delta: Int
+    ) {
+        let (positions, deltas) = Qwen25VL.getRopeIndex(
+            inputIds: MLXArray(ids).expandedDimensions(axis: 0),
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: mergeSize,
+            imageTokenId: imageTokenId,
+            videoTokenId: videoTokenId,
+            visionStartTokenId: visionStartTokenId,
+            positionOffset: positionOffset)
+        return (positions, deltas.asType(.int32).item(Int.self))
+    }
+
+    // MARK: - The correctness property
+
+    /// The whole justification for reusing the cache on an append-only media turn:
+    /// positions computed for the suffix alone, offset by the carried rope delta,
+    /// are identical to the tail of the positions a cold full prefill computes.
+    ///
+    /// This is checked with an image in the *prefix* and another in the *suffix*,
+    /// which is the Qwen-VL "new screenshot every turn" shape.
+    func testSuffixPositionsMatchColdPrefillPositions() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let fullIds = prefixIds + suffixIds
+
+        let cold = ropeIndex(ids: fullIds, frames: [frame1, frame2])
+
+        // Turn 1 prefilled the prefix cold; `prepare` stores its rope delta as-is.
+        let prefix = ropeIndex(ids: prefixIds, frames: [frame1])
+        // Turn 2 resumes with the cache holding exactly the prefix.
+        let positionOffset = prefixIds.count + prefix.delta
+        let warm = ropeIndex(
+            ids: suffixIds, frames: [frame2], positionOffset: positionOffset)
+
+        let coldTail = cold.positions[0..., 0..., prefixIds.count ..< fullIds.count]
+        XCTAssertEqual(warm.positions.shape, coldTail.shape)
+        XCTAssertEqual(
+            warm.positions.asArray(Int32.self), coldTail.asArray(Int32.self),
+            "warm suffix positions must equal the cold prefill's positions for the same tokens")
+    }
+
+    /// Same property with two images already cached, so the offset has to survive
+    /// more than one vision block.
+    func testSuffixPositionsMatchColdPrefillWithMultipleCachedImages() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 6, 6)
+        let frame3 = THW(1, 2, 4)
+        let turn1 = turnTokens(frame: frame1, leadingText: 3, trailingText: 2)
+        let turn2 = turnTokens(frame: frame2, leadingText: 1, trailingText: 5)
+        let turn3 = turnTokens(frame: frame3, leadingText: 2, trailingText: 1)
+        let prefixIds = turn1 + turn2
+        let fullIds = prefixIds + turn3
+
+        let cold = ropeIndex(ids: fullIds, frames: [frame1, frame2, frame3])
+        let prefix = ropeIndex(ids: prefixIds, frames: [frame1, frame2])
+        let warm = ropeIndex(
+            ids: turn3, frames: [frame3],
+            positionOffset: prefixIds.count + prefix.delta)
+
+        let coldTail = cold.positions[0..., 0..., prefixIds.count ..< fullIds.count]
+        XCTAssertEqual(
+            warm.positions.asArray(Int32.self), coldTail.asArray(Int32.self))
+    }
+
+    /// The delta the continuation stores back must anchor the *next* turn too,
+    /// mirroring `prepareContinuation`'s `ropeDeltas - cacheOffset` bookkeeping.
+    func testCarriedDeltaAnchorsASecondContinuation() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let frame3 = THW(1, 4, 4)
+        let turn1 = turnTokens(frame: frame1, leadingText: 3, trailingText: 2)
+        let turn2 = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let turn3 = turnTokens(frame: frame3, leadingText: 1, trailingText: 2)
+        let fullIds = turn1 + turn2 + turn3
+
+        let cold = ropeIndex(ids: fullIds, frames: [frame1, frame2, frame3])
+
+        // turn 1 cold
+        let s1 = ropeIndex(ids: turn1, frames: [frame1])
+        var cacheOffset = turn1.count
+        var carriedDelta = s1.delta
+
+        // turn 2 as a continuation
+        let s2 = ropeIndex(
+            ids: turn2, frames: [frame2], positionOffset: cacheOffset + carriedDelta)
+        carriedDelta = s2.delta - cacheOffset
+        cacheOffset += turn2.count
+
+        // turn 3 as a continuation off turn 2's carried state
+        let s3 = ropeIndex(
+            ids: turn3, frames: [frame3], positionOffset: cacheOffset + carriedDelta)
+
+        let coldTail = cold.positions[
+            0..., 0..., (turn1.count + turn2.count) ..< fullIds.count]
+        XCTAssertEqual(s3.positions.asArray(Int32.self), coldTail.asArray(Int32.self))
+    }
+
+    // MARK: - Splitting
+
+    func testSplitKeepsOnlyTheSuffixImage() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+
+        let result = try XCTUnwrap(split(full, droppingFirst: prefixIds.count))
+
+        XCTAssertEqual(result.text.tokens.shape, [1, suffixIds.count])
+        XCTAssertEqual(result.text.tokens.asArray(Int.self), suffixIds)
+
+        let image = try XCTUnwrap(result.image)
+        XCTAssertEqual(image.frames?.count, 1)
+        XCTAssertEqual(image.frames?.first?.values.0, frame2.t)
+        XCTAssertEqual(image.frames?.first?.values.1, frame2.h)
+        XCTAssertEqual(image.frames?.first?.values.2, frame2.w)
+        XCTAssertEqual(image.pixels.shape, [frame2.product, 8])
+
+        // the retained rows must be the *tail* of the original buffer
+        let expected = pixels(rows: frame1.product + frame2.product)[
+            frame1.product ..< (frame1.product + frame2.product), 0...]
+        XCTAssertEqual(image.pixels.asArray(Float.self), expected.asArray(Float.self))
+    }
+
+    /// The payload the split hands back must satisfy the arity the feature merge
+    /// silently assumes: one feature row group per placeholder run.
+    func testSplitSuffixPlaceholderCountMatchesRetainedFrames() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+
+        let result = try XCTUnwrap(split(full, droppingFirst: prefixIds.count))
+        let padCount = result.text.tokens.asArray(Int.self).filter { $0 == imageTokenId }.count
+        let framePads = (result.image?.frames ?? []).reduce(0) {
+            $0 + $1.product / (mergeSize * mergeSize)
+        }
+        XCTAssertEqual(padCount, framePads)
+    }
+
+    func testSplitAcceptsAllOnesMaskAndResizesIt() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let ids = prefixIds + suffixIds
+        let mask = MLXArray.ones([1, ids.count]).asType(.int8)
+        let full = input(ids: ids, frames: [frame1, frame2], mask: mask)
+
+        let result = try XCTUnwrap(split(full, droppingFirst: prefixIds.count))
+        XCTAssertEqual(result.text.mask?.shape, [1, suffixIds.count])
+    }
+
+    // MARK: - Refusals
+
+    /// A boundary inside a vision block would hand the suffix a partial run of
+    /// placeholders. The split must decline rather than guess.
+    func testSplitRefusesBoundaryInsideAnImageBlock() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+
+        // land two tokens into the suffix's placeholder run
+        let insideBlock = prefixIds.count + 2 + 1 + 2
+        XCTAssertNil(split(full, droppingFirst: insideBlock))
+    }
+
+    func testSplitRefusesWhenFramesDoNotAccountForPlaceholders() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let ids =
+            turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+            + turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        // frames claim more placeholders than the prompt has
+        let wrong = LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product + frame2.product + THW(1, 2, 2).product),
+                frames: [frame1, frame2, THW(1, 2, 2)]))
+        XCTAssertNil(split(wrong, droppingFirst: 12))
+    }
+
+    func testSplitRefusesWhenPixelRowsDoNotMatchFrames() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let wrong = LMInput(
+            text: .init(tokens: MLXArray(prefixIds + suffixIds).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product), frames: [frame1, frame2]))
+        XCTAssertNil(split(wrong, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesMixedImageAndVideo() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let mixed = LMInput(
+            text: .init(tokens: MLXArray(prefixIds + suffixIds).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product), frames: [frame1]),
+            video: LMInput.ProcessedVideo(
+                pixels: pixels(rows: frame2.product), frames: [frame2]))
+        XCTAssertNil(split(mixed, droppingFirst: prefixIds.count))
+    }
+
+    /// Video is refused outright: `Qwen25VL`'s vision full-attention mask
+    /// mis-accumulates `cuSeqlens` for `t > 1`, so a video's rows are not isolated
+    /// from the rest of the buffer and dropping earlier rows is not neutral.
+    func testSplitRefusesVideoOnly() throws {
+        let frame1 = THW(2, 4, 6)
+        let frame2 = THW(3, 2, 4)
+        let padCount1 = frame1.product / (mergeSize * mergeSize)
+        let padCount2 = frame2.product / (mergeSize * mergeSize)
+        let prefixIds =
+            [visionStartTokenId] + Array(repeating: videoTokenId, count: padCount1)
+            + [visionEndTokenId, 1, 1]
+        let suffixIds =
+            [visionStartTokenId] + Array(repeating: videoTokenId, count: padCount2)
+            + [visionEndTokenId, 2]
+        let videoOnly = LMInput(
+            text: .init(
+                tokens: MLXArray(prefixIds + suffixIds).expandedDimensions(axis: 0)),
+            video: LMInput.ProcessedVideo(
+                pixels: pixels(rows: frame1.product + frame2.product),
+                frames: [frame1, frame2]))
+        XCTAssertNil(split(videoOnly, droppingFirst: prefixIds.count))
+    }
+
+    /// A video placeholder in a prompt whose payload is images-only means media this
+    /// routine is not accounting for.
+    func testSplitRefusesStrayVideoPlaceholder() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds =
+            turnTokens(frame: frame2, leadingText: 2, trailingText: 3) + [videoTokenId]
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+        XCTAssertNil(split(full, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesNonUniformMask() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let ids = prefixIds + suffixIds
+        var maskValues = Array(repeating: Int32(1), count: ids.count)
+        maskValues[0] = 0
+        let mask = MLXArray(maskValues).reshaped(1, ids.count).asType(.int8)
+        let full = input(ids: ids, frames: [frame1, frame2], mask: mask)
+        XCTAssertNil(split(full, droppingFirst: prefixIds.count))
+    }
+
+    /// A rank-1 suffix would route back to the cold path in
+    /// `prepare(_:cache:state:windowSize:)`, which computes positions from zero.
+    func testSplitRefusesRankOneTokens() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let flat = LMInput(
+            text: .init(tokens: MLXArray(prefixIds + suffixIds)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product + frame2.product),
+                frames: [frame1, frame2]))
+        XCTAssertNil(split(flat, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesPrecomputedPositionIds() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let ids = prefixIds + suffixIds
+        let withPositions = LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product + frame2.product),
+                positionIds: MLXArray(Array(0 ..< ids.count)),
+                frames: [frame1, frame2]))
+        XCTAssertNil(split(withPositions, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesMissingFrames() throws {
+        let frame1 = THW(1, 4, 6)
+        let ids = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let noFrames = LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(pixels: pixels(rows: frame1.product)))
+        XCTAssertNil(split(noFrames, droppingFirst: 3))
+    }
+
+    func testSplitRefusesOutOfRangeBoundaries() throws {
+        let frame1 = THW(1, 4, 6)
+        let ids = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let full = input(ids: ids, frames: [frame1])
+        XCTAssertNil(split(full, droppingFirst: 0))
+        XCTAssertNil(split(full, droppingFirst: ids.count))
+        XCTAssertNil(split(full, droppingFirst: ids.count + 5))
+    }
+
+    /// Nothing remains for the suffix — the caller has no reason to reuse and the
+    /// split must not hand back an image-free payload that looks reusable.
+    func testSplitRefusesWhenAllMediaBelongsToThePrefix() throws {
+        let frame1 = THW(1, 4, 6)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = Array(repeating: 3, count: 5)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1])
+        XCTAssertNil(split(full, droppingFirst: prefixIds.count))
+    }
+}

--- a/Tests/MLXLMTests/QwenVLPreparedInputSplitTests.swift
+++ b/Tests/MLXLMTests/QwenVLPreparedInputSplitTests.swift
@@ -1,0 +1,404 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Covers ``QwenVL/splitPreparedInput(_:droppingFirst:imageTokenId:videoTokenId:mergeSize:)``
+/// and, more importantly, the property that makes it safe to use: prefilling only
+/// the split-off suffix at the carried `positionOffset` produces the *same* M-RoPE
+/// positions a cold full prefill would have produced for those tokens.
+///
+/// These tests are deliberately weight-free. They drive the position math directly,
+/// so the equality below is exact rather than inferred from generated text.
+final class QwenVLPreparedInputSplitTests: XCTestCase {
+
+    // Qwen2.5-VL's actual special-token ids; any distinct values would do.
+    private let imageTokenId = 151_655
+    private let videoTokenId = 151_656
+    private let visionStartTokenId = 151_652
+    private let visionEndTokenId = 151_653
+    private let mergeSize = 2
+
+    /// Tokens for one "turn": leading text, a vision block sized for `frame`,
+    /// then trailing text (which also stands in for the turn's generated tokens).
+    private func turnTokens(frame: THW, leadingText: Int, trailingText: Int) -> [Int] {
+        let padCount = frame.product / (mergeSize * mergeSize)
+        return Array(repeating: 1, count: leadingText)
+            + [visionStartTokenId]
+            + Array(repeating: imageTokenId, count: padCount)
+            + [visionEndTokenId]
+            + Array(repeating: 2, count: trailingText)
+    }
+
+    private func pixels(rows: Int) -> MLXArray {
+        MLXArray((0 ..< (rows * 8)).map { Float($0) }).reshaped(rows, 8)
+    }
+
+    private func input(ids: [Int], frames: [THW], mask: MLXArray? = nil) -> LMInput {
+        let rows = frames.reduce(0) { $0 + $1.product }
+        return LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0), mask: mask),
+            image: LMInput.ProcessedImage(pixels: pixels(rows: rows), frames: frames))
+    }
+
+    private func split(_ input: LMInput, droppingFirst prefixTokenCount: Int) -> LMInput? {
+        QwenVL.splitPreparedInput(
+            input,
+            droppingFirst: prefixTokenCount,
+            imageTokenId: imageTokenId,
+            videoTokenId: videoTokenId,
+            mergeSize: mergeSize)
+    }
+
+    private func ropeIndex(ids: [Int], frames: [THW], positionOffset: Int = 0) -> (
+        positions: MLXArray, delta: Int
+    ) {
+        let (positions, deltas) = Qwen25VL.getRopeIndex(
+            inputIds: MLXArray(ids).expandedDimensions(axis: 0),
+            imageGridTHW: frames,
+            videoGridTHW: nil,
+            spatialMergeSize: mergeSize,
+            imageTokenId: imageTokenId,
+            videoTokenId: videoTokenId,
+            visionStartTokenId: visionStartTokenId,
+            positionOffset: positionOffset)
+        return (positions, deltas.asType(.int32).item(Int.self))
+    }
+
+    // MARK: - The correctness property
+
+    /// The whole justification for reusing the cache on an append-only media turn:
+    /// positions computed for the suffix alone, offset by the carried rope delta,
+    /// are identical to the tail of the positions a cold full prefill computes.
+    ///
+    /// This is checked with an image in the *prefix* and another in the *suffix*,
+    /// which is the Qwen-VL "new screenshot every turn" shape.
+    func testSuffixPositionsMatchColdPrefillPositions() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let fullIds = prefixIds + suffixIds
+
+        let cold = ropeIndex(ids: fullIds, frames: [frame1, frame2])
+
+        // Turn 1 prefilled the prefix cold; `prepare` stores its rope delta as-is.
+        let prefix = ropeIndex(ids: prefixIds, frames: [frame1])
+        // Turn 2 resumes with the cache holding exactly the prefix.
+        let positionOffset = prefixIds.count + prefix.delta
+        let warm = ropeIndex(
+            ids: suffixIds, frames: [frame2], positionOffset: positionOffset)
+
+        let coldTail = cold.positions[0..., 0..., prefixIds.count ..< fullIds.count]
+        XCTAssertEqual(warm.positions.shape, coldTail.shape)
+        XCTAssertEqual(
+            warm.positions.asArray(Int32.self), coldTail.asArray(Int32.self),
+            "warm suffix positions must equal the cold prefill's positions for the same tokens")
+    }
+
+    /// Same property with two images already cached, so the offset has to survive
+    /// more than one vision block.
+    func testSuffixPositionsMatchColdPrefillWithMultipleCachedImages() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 6, 6)
+        let frame3 = THW(1, 2, 4)
+        let turn1 = turnTokens(frame: frame1, leadingText: 3, trailingText: 2)
+        let turn2 = turnTokens(frame: frame2, leadingText: 1, trailingText: 5)
+        let turn3 = turnTokens(frame: frame3, leadingText: 2, trailingText: 1)
+        let prefixIds = turn1 + turn2
+        let fullIds = prefixIds + turn3
+
+        let cold = ropeIndex(ids: fullIds, frames: [frame1, frame2, frame3])
+        let prefix = ropeIndex(ids: prefixIds, frames: [frame1, frame2])
+        let warm = ropeIndex(
+            ids: turn3, frames: [frame3],
+            positionOffset: prefixIds.count + prefix.delta)
+
+        let coldTail = cold.positions[0..., 0..., prefixIds.count ..< fullIds.count]
+        XCTAssertEqual(
+            warm.positions.asArray(Int32.self), coldTail.asArray(Int32.self))
+    }
+
+    /// The delta the continuation stores back must anchor the *next* turn too,
+    /// mirroring `prepareContinuation`'s `ropeDeltas - cacheOffset` bookkeeping.
+    func testCarriedDeltaAnchorsASecondContinuation() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let frame3 = THW(1, 4, 4)
+        let turn1 = turnTokens(frame: frame1, leadingText: 3, trailingText: 2)
+        let turn2 = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let turn3 = turnTokens(frame: frame3, leadingText: 1, trailingText: 2)
+        let fullIds = turn1 + turn2 + turn3
+
+        let cold = ropeIndex(ids: fullIds, frames: [frame1, frame2, frame3])
+
+        // turn 1 cold
+        let s1 = ropeIndex(ids: turn1, frames: [frame1])
+        var cacheOffset = turn1.count
+        var carriedDelta = s1.delta
+
+        // turn 2 as a continuation
+        let s2 = ropeIndex(
+            ids: turn2, frames: [frame2], positionOffset: cacheOffset + carriedDelta)
+        carriedDelta = s2.delta - cacheOffset
+        cacheOffset += turn2.count
+
+        // turn 3 as a continuation off turn 2's carried state
+        let s3 = ropeIndex(
+            ids: turn3, frames: [frame3], positionOffset: cacheOffset + carriedDelta)
+
+        let coldTail = cold.positions[
+            0..., 0..., (turn1.count + turn2.count) ..< fullIds.count]
+        XCTAssertEqual(s3.positions.asArray(Int32.self), coldTail.asArray(Int32.self))
+    }
+
+    // MARK: - Splitting
+
+    func testSplitKeepsOnlyTheSuffixImage() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+
+        let result = try XCTUnwrap(split(full, droppingFirst: prefixIds.count))
+
+        XCTAssertEqual(result.text.tokens.shape, [1, suffixIds.count])
+        XCTAssertEqual(result.text.tokens.asArray(Int.self), suffixIds)
+
+        let image = try XCTUnwrap(result.image)
+        XCTAssertEqual(image.frames?.count, 1)
+        XCTAssertEqual(image.frames?.first?.values.0, frame2.t)
+        XCTAssertEqual(image.frames?.first?.values.1, frame2.h)
+        XCTAssertEqual(image.frames?.first?.values.2, frame2.w)
+        XCTAssertEqual(image.pixels.shape, [frame2.product, 8])
+
+        // the retained rows must be the *tail* of the original buffer
+        let expected = pixels(rows: frame1.product + frame2.product)[
+            frame1.product ..< (frame1.product + frame2.product), 0...]
+        XCTAssertEqual(image.pixels.asArray(Float.self), expected.asArray(Float.self))
+    }
+
+    /// The payload the split hands back must satisfy the arity the feature merge
+    /// silently assumes: one feature row group per placeholder run.
+    func testSplitSuffixPlaceholderCountMatchesRetainedFrames() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+
+        let result = try XCTUnwrap(split(full, droppingFirst: prefixIds.count))
+        let padCount = result.text.tokens.asArray(Int.self).filter { $0 == imageTokenId }.count
+        let framePads = (result.image?.frames ?? []).reduce(0) {
+            $0 + $1.product / (mergeSize * mergeSize)
+        }
+        XCTAssertEqual(padCount, framePads)
+    }
+
+    func testSplitAcceptsAllOnesMaskAndResizesIt() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let ids = prefixIds + suffixIds
+        let mask = MLXArray.ones([1, ids.count]).asType(.int8)
+        let full = input(ids: ids, frames: [frame1, frame2], mask: mask)
+
+        let result = try XCTUnwrap(split(full, droppingFirst: prefixIds.count))
+        XCTAssertEqual(result.text.mask?.shape, [1, suffixIds.count])
+    }
+
+    // MARK: - Refusals
+
+    /// A temporal grid (`t > 1`) carried in the *image* payload is refused for the
+    /// same reason video is: `getRopeIndex` is handed `videoGridTHW: nil`, so its
+    /// positions are degenerate. Refused whether the temporal frame is dropped with
+    /// the prefix or retained in the suffix.
+    func testSplitRefusesTemporalImageFrame() throws {
+        let dropped = THW(2, 4, 4)
+        let plain = THW(1, 2, 4)
+
+        let prefixIds = turnTokens(frame: dropped, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: plain, leadingText: 2, trailingText: 3)
+        XCTAssertNil(
+            split(
+                input(ids: prefixIds + suffixIds, frames: [dropped, plain]),
+                droppingFirst: prefixIds.count),
+            "a temporal frame in the cached prefix must refuse")
+
+        let retainedPrefixIds = turnTokens(frame: plain, leadingText: 3, trailingText: 4)
+        let retainedSuffixIds = turnTokens(frame: dropped, leadingText: 2, trailingText: 3)
+        XCTAssertNil(
+            split(
+                input(
+                    ids: retainedPrefixIds + retainedSuffixIds, frames: [plain, dropped]),
+                droppingFirst: retainedPrefixIds.count),
+            "a temporal frame retained in the suffix must refuse")
+    }
+
+    /// A boundary inside a vision block would hand the suffix a partial run of
+    /// placeholders. The split must decline rather than guess.
+    func testSplitRefusesBoundaryInsideAnImageBlock() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+
+        // land two tokens into the suffix's placeholder run
+        let insideBlock = prefixIds.count + 2 + 1 + 2
+        XCTAssertNil(split(full, droppingFirst: insideBlock))
+    }
+
+    func testSplitRefusesWhenFramesDoNotAccountForPlaceholders() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let ids =
+            turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+            + turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        // frames claim more placeholders than the prompt has
+        let wrong = LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product + frame2.product + THW(1, 2, 2).product),
+                frames: [frame1, frame2, THW(1, 2, 2)]))
+        XCTAssertNil(split(wrong, droppingFirst: 12))
+    }
+
+    func testSplitRefusesWhenPixelRowsDoNotMatchFrames() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let wrong = LMInput(
+            text: .init(tokens: MLXArray(prefixIds + suffixIds).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product), frames: [frame1, frame2]))
+        XCTAssertNil(split(wrong, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesMixedImageAndVideo() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let mixed = LMInput(
+            text: .init(tokens: MLXArray(prefixIds + suffixIds).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product), frames: [frame1]),
+            video: LMInput.ProcessedVideo(
+                pixels: pixels(rows: frame2.product), frames: [frame2]))
+        XCTAssertNil(split(mixed, droppingFirst: prefixIds.count))
+    }
+
+    /// Video is refused outright: both models pass `videoGridTHW: nil` to
+    /// `getRopeIndex`, so video positions are degenerate and a split cannot be
+    /// verified.
+    func testSplitRefusesVideoOnly() throws {
+        let frame1 = THW(2, 4, 6)
+        let frame2 = THW(3, 2, 4)
+        let padCount1 = frame1.product / (mergeSize * mergeSize)
+        let padCount2 = frame2.product / (mergeSize * mergeSize)
+        let prefixIds =
+            [visionStartTokenId] + Array(repeating: videoTokenId, count: padCount1)
+            + [visionEndTokenId, 1, 1]
+        let suffixIds =
+            [visionStartTokenId] + Array(repeating: videoTokenId, count: padCount2)
+            + [visionEndTokenId, 2]
+        let videoOnly = LMInput(
+            text: .init(
+                tokens: MLXArray(prefixIds + suffixIds).expandedDimensions(axis: 0)),
+            video: LMInput.ProcessedVideo(
+                pixels: pixels(rows: frame1.product + frame2.product),
+                frames: [frame1, frame2]))
+        XCTAssertNil(split(videoOnly, droppingFirst: prefixIds.count))
+    }
+
+    /// A video placeholder in a prompt whose payload is images-only means media this
+    /// routine is not accounting for.
+    func testSplitRefusesStrayVideoPlaceholder() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds =
+            turnTokens(frame: frame2, leadingText: 2, trailingText: 3) + [videoTokenId]
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1, frame2])
+        XCTAssertNil(split(full, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesNonUniformMask() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let ids = prefixIds + suffixIds
+        var maskValues = Array(repeating: Int32(1), count: ids.count)
+        maskValues[0] = 0
+        let mask = MLXArray(maskValues).reshaped(1, ids.count).asType(.int8)
+        let full = input(ids: ids, frames: [frame1, frame2], mask: mask)
+        XCTAssertNil(split(full, droppingFirst: prefixIds.count))
+    }
+
+    /// A rank-1 suffix would route back to the cold path in
+    /// `prepare(_:cache:state:prefill:)`, which computes positions from zero.
+    func testSplitRefusesRankOneTokens() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let flat = LMInput(
+            text: .init(tokens: MLXArray(prefixIds + suffixIds)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product + frame2.product),
+                frames: [frame1, frame2]))
+        XCTAssertNil(split(flat, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesPrecomputedPositionIds() throws {
+        let frame1 = THW(1, 4, 6)
+        let frame2 = THW(1, 2, 4)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = turnTokens(frame: frame2, leadingText: 2, trailingText: 3)
+        let ids = prefixIds + suffixIds
+        let withPositions = LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(
+                pixels: pixels(rows: frame1.product + frame2.product),
+                positionIds: MLXArray(Array(0 ..< ids.count)),
+                frames: [frame1, frame2]))
+        XCTAssertNil(split(withPositions, droppingFirst: prefixIds.count))
+    }
+
+    func testSplitRefusesMissingFrames() throws {
+        let frame1 = THW(1, 4, 6)
+        let ids = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let noFrames = LMInput(
+            text: .init(tokens: MLXArray(ids).expandedDimensions(axis: 0)),
+            image: LMInput.ProcessedImage(pixels: pixels(rows: frame1.product)))
+        XCTAssertNil(split(noFrames, droppingFirst: 3))
+    }
+
+    func testSplitRefusesOutOfRangeBoundaries() throws {
+        let frame1 = THW(1, 4, 6)
+        let ids = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let full = input(ids: ids, frames: [frame1])
+        XCTAssertNil(split(full, droppingFirst: 0))
+        XCTAssertNil(split(full, droppingFirst: ids.count))
+        XCTAssertNil(split(full, droppingFirst: ids.count + 5))
+    }
+
+    /// Nothing remains for the suffix -- the caller has no reason to reuse and the
+    /// split must not hand back an image-free payload that looks reusable.
+    func testSplitRefusesWhenAllMediaBelongsToThePrefix() throws {
+        let frame1 = THW(1, 4, 6)
+        let prefixIds = turnTokens(frame: frame1, leadingText: 3, trailingText: 4)
+        let suffixIds = Array(repeating: 3, count: 5)
+        let full = input(ids: prefixIds + suffixIds, frames: [frame1])
+        XCTAssertNil(split(full, droppingFirst: prefixIds.count))
+    }
+}


### PR DESCRIPTION
## Proposed changes

A turn that adds a new image to an unchanged transcript extends the cached prefix exactly as a text turn does, but #472 excludes every media turn from reuse, so it re-prefills the whole transcript and re-runs the vision tower over every cached image. (The figure in the comments below shows it.)

- `PreparedInputSplitting`: an opt-in protocol for models that can split their prepared input at a token boundary, keeping only the suffix's media.
- `AppendOnlyMediaRule` in `PromptCacheReusePolicy`: fires when the turn carries new media, extends the cached prefix, and no speculative decoding is configured. `ChatSession` asks the model to split, verifies the returned tokens against the boundary, and downgrades to `.rebuild` otherwise. The trim path is untouched, so the #472 guard still holds.
- `Qwen25VL` conforms: its vision mask isolates each frame, so dropping a cached image leaves the remaining features unchanged -- `testQwen25VLAppendOnlyMediaSplitMatchesFullPrefill` checks warm split against cold prefill on a tiny random-weight model. `Qwen2VL` attends across images and does not conform; `testQwen2VLAppendOnlyMediaSplitDiverges` shows why.
- Refused, and rebuild as before: video, temporal grids, audio, precomputed position ids, non-uniform masks, a boundary inside a media block. No other model changes.

Overlaps #581 in the reuse switch; happy to rebase across it if that lands first. No speedup is claimed; cost is stated in prompt tokens and encoder passes only.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it accurately describes the code changes.
- AI usage disclosure: Yes, I used Claude Code for parts of this. I reviewed and understand all of it.
