### PR TITLE
Speculate past the sliding window in MTP

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1970,10 +1970,11 @@ public func generateTokens(
 ///   - mtpDrafter: the ``MTPDrafterModel``. The target is threaded through
 ///     ``MTPDrafterModel/draftBlock(target:lastToken:lastHidden:sharedKV:queryOffset:blockSize:sampler:)``
 ///     per round; drafter instances hold no target-derived state and are safe
-///     to share across iterators. Speculation requires a rewindable KV cache,
-///     so on a sliding-window model it is available only while total context
-///     (prompt plus generation) stays inside the window. Past that the
-///     iterator logs once, reports
+///     to share across iterators. Speculative rounds are staged and committed
+///     rather than written and rewound, so a sliding-window model speculates
+///     for the whole stream rather than only while total context stays inside
+///     the window. If the target ever stops emitting drafter state — a KV
+///     cache that quantizes mid-stream, say — the iterator logs once, reports
 ///     ``GenerateCompletionInfo/passthroughReason``, and finishes the stream
 ///     with ordinary single-token generation.
 ///   - blockSize: total tokens per round (`blockSize - 1` drafted plus the
@@ -2024,9 +2025,11 @@ public func generate(
 /// but for MTP drafters. Yields raw token IDs instead of decoded text or
 /// tool calls.
 ///
-/// Speculation requires a rewindable KV cache, so on a sliding-window model it
-/// is available only while total context (prompt plus generation) stays inside
-/// the window. Past that the iterator logs once, reports
+/// Speculative rounds are staged and committed rather than written and rewound,
+/// so a sliding-window model speculates for the whole stream rather than only
+/// while total context stays inside the window. If the target ever stops
+/// emitting drafter state — a KV cache that quantizes mid-stream, say — the
+/// iterator logs once, reports
 /// ``GenerateCompletionInfo/passthroughReason`` on the emitted `.info` event,
 /// and finishes the stream with ordinary single-token generation.
 public func generateTokens(

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -602,6 +602,49 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         }
     }
 
+    /// The trailing `tail` cache entries in chronological order, without mutating the cache.
+    ///
+    /// `update(keys:values:)` is the only other way to read a rotating cache's contents, and it
+    /// necessarily writes. This is the read-only counterpart: `keys`, `values`, `idx` and
+    /// `offset` are all left exactly as they were, so a caller can present the ring's history
+    /// alongside K/V it has not committed yet.
+    ///
+    /// The result is built by the same two steps the multi-token write path uses --
+    /// ``temporalOrder(_:)`` to linearize, then the front-trim that preserves the pinned `keep`
+    /// prefix -- so a view of length `n` holds exactly the entries a write that front-trimmed to
+    /// `n` rows would have presented. When the ring is already chronological (`idx` at the end of
+    /// the buffer, which is where every multi-token write leaves it) both steps degrade to
+    /// slices and nothing is copied.
+    ///
+    /// - Parameter tail: Maximum number of entries to return. Clamped to what the cache holds;
+    ///   a negative value returns an empty view.
+    /// - Returns: `(keys, values)` shaped `[B, kvHeads, min(tail, count), headDim]`, or `nil`
+    ///   before the first write.
+    public func logicalView(tail: Int) -> (MLXArray, MLXArray)? {
+        guard let keys = self.keys, let values = self.values else { return nil }
+
+        let orderedKeys = temporalOrder(keys)
+        let orderedValues = temporalOrder(values)
+
+        let available = orderedKeys.dim(2)
+        let bound = Swift.min(Swift.max(tail, 0), available)
+        let trimSize = available - bound
+        guard trimSize > 0 else { return (orderedKeys, orderedValues) }
+
+        // `keep == 0` is the sliding-window case (Gemma 3/3n/4, GPT-OSS, Exaone4): no pinned
+        // prefix to splice around, so the trailing window is one slice per array.
+        if keep == 0 {
+            return (
+                orderedKeys[.ellipsis, trimSize..., 0...],
+                orderedValues[.ellipsis, trimSize..., 0...]
+            )
+        }
+        return (
+            trim(trimSize: trimSize, orderedKeys),
+            trim(trimSize: trimSize, orderedValues)
+        )
+    }
+
     private func updateConcat(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
         if self.keys == nil {
             self.keys = keys

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -616,18 +616,27 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     /// the buffer, which is where every multi-token write leaves it) both steps degrade to
     /// slices and nothing is copied.
     ///
-    /// - Parameter tail: Maximum number of entries to return. Clamped to what the cache holds;
-    ///   a negative value returns an empty view.
-    /// - Returns: `(keys, values)` shaped `[B, kvHeads, min(tail, count), headDim]`, or `nil`
-    ///   before the first write.
-    public func logicalView(tail: Int) -> (MLXArray, MLXArray)? {
+    /// The pinned `keep` prefix is a floor, not just a splice point: a `tail` below it still
+    /// comes back, because those entries are not evictable and a view that dropped them would be
+    /// a context this ring can never present. With `keep == 0` -- every sliding-window model --
+    /// the floor is zero and the length is exactly `min(tail, count)`.
+    ///
+    /// - Parameter tail: Requested number of trailing entries. Clamped to what the cache holds;
+    ///   a negative value is read as zero.
+    /// - Returns: `(keys, values)` shaped `[B, kvHeads, n, headDim]` where
+    ///   `n == max(min(tail, count), min(keep, count))`, or `nil` before the first write.
+    package func logicalView(tail: Int) -> (MLXArray, MLXArray)? {
         guard let keys = self.keys, let values = self.values else { return nil }
 
         let orderedKeys = temporalOrder(keys)
         let orderedValues = temporalOrder(values)
 
         let available = orderedKeys.dim(2)
-        let bound = Swift.min(Swift.max(tail, 0), available)
+        // Raising the bound to the pinned prefix is what keeps the front-trim's second slice in
+        // range; stated here rather than left to slice clamping, since the length it produces is
+        // the documented contract.
+        let requested = Swift.min(Swift.max(tail, 0), available)
+        let bound = Swift.max(requested, Swift.min(keep, available))
         let trimSize = available - bound
         guard trimSize > 0 else { return (orderedKeys, orderedValues) }
 

--- a/Libraries/MLXLMCommon/KVCachePlan.swift
+++ b/Libraries/MLXLMCommon/KVCachePlan.swift
@@ -22,6 +22,7 @@ package struct KVCachePlan: Sendable, Equatable {
 
     package func validated(_ storage: KVCacheStorage) throws -> KVCacheStorage {
         precondition(storage.plan == self, "KVCacheStorage used with a different plan")
+        precondition(!storage.roundIsOpen, "validated(_:) ran inside a staged round")
         storage.cache = try validated(storage.cache)
         return storage
     }
@@ -37,6 +38,7 @@ package struct KVCachePlan: Sendable, Equatable {
     /// unsupported state, later decode steps only compare the completed plan.
     package func apply(to storage: KVCacheStorage) {
         precondition(storage.plan == self, "KVCacheStorage used with a different plan")
+        precondition(!storage.roundIsOpen, "apply(to:) ran inside a staged round")
         guard !storage.isApplicationTerminal else { return }
         guard let configuration else {
             storage.isApplicationTerminal = true
@@ -63,6 +65,7 @@ package struct KVCachePlan: Sendable, Equatable {
         to storage: KVCacheStorage
     ) throws -> KVCacheApplicationResult? {
         precondition(storage.plan == self, "KVCacheStorage used with a different plan")
+        precondition(!storage.roundIsOpen, "applyAndValidate(to:) ran inside a staged round")
         guard !storage.isApplicationTerminal else { return nil }
         guard let configuration else {
             storage.isApplicationTerminal = true
@@ -103,10 +106,23 @@ package struct KVCachePlan: Sendable, Equatable {
 /// permit unsynchronized mutation of both the cache and its progress state.
 package final class KVCacheStorage {
     package var cache: [KVCache] {
-        didSet { isApplicationTerminal = false }
+        didSet {
+            precondition(
+                !roundIsOpen,
+                "the realized cache was replaced while a staged round was open")
+            isApplicationTerminal = false
+        }
     }
     package let plan: KVCachePlan
     package fileprivate(set) var isApplicationTerminal = false
+
+    /// Whether a staged round is presently writing provisionally against these entries.
+    ///
+    /// A round hands the model substitute caches and defers part of its writes, so the entries
+    /// and the timeline are deliberately out of step until it commits. Operations that assume
+    /// they are in step -- replacing entries, trimming, snapshotting -- are refused while one is
+    /// open rather than silently reading a half-written position.
+    package internal(set) var roundIsOpen = false
     /// Authoritative logical position represented by this model cache.
     ///
     /// Individual cache entries retain their native offsets and metadata, but
@@ -142,6 +158,7 @@ package final class KVCacheStorage {
     @discardableResult
     package func trim(_ count: Int) -> Int {
         precondition(count >= 0, "Trim count cannot be negative")
+        precondition(!roundIsOpen, "cannot trim while a staged round is open")
         let trimmed = trimPromptCache(cache, numTokens: count)
         precondition(
             trimmed <= processedTokenCount,
@@ -152,6 +169,7 @@ package final class KVCacheStorage {
 
     /// Create an independent snapshot while preserving plan and progress.
     package func copy() -> KVCacheStorage {
+        precondition(!roundIsOpen, "cannot snapshot while a staged round is open")
         let copy = KVCacheStorage(
             cache.map { $0.copy() },
             plan: plan,

--- a/Libraries/MLXLMCommon/KVCachePlan.swift
+++ b/Libraries/MLXLMCommon/KVCachePlan.swift
@@ -116,13 +116,15 @@ package final class KVCacheStorage {
     package let plan: KVCachePlan
     package fileprivate(set) var isApplicationTerminal = false
 
+    private var openRound: KVCacheRound?
+
     /// Whether a staged round is presently writing provisionally against these entries.
     ///
     /// A round hands the model substitute caches and defers part of its writes, so the entries
     /// and the timeline are deliberately out of step until it commits. Operations that assume
     /// they are in step -- replacing entries, trimming, snapshotting -- are refused while one is
     /// open rather than silently reading a half-written position.
-    package internal(set) var roundIsOpen = false
+    package var roundIsOpen: Bool { openRound != nil }
     /// Authoritative logical position represented by this model cache.
     ///
     /// Individual cache entries retain their native offsets and metadata, but
@@ -165,6 +167,84 @@ package final class KVCacheStorage {
             "Cache trimmed beyond its processed-token timeline")
         processedTokenCount -= trimmed
         return trimmed
+    }
+
+    /// Open a staged round over these entries, or `nil` when one of them cannot take part.
+    ///
+    /// Every leaf is classified before anything is constructed, so a refusal leaves the entries
+    /// exactly as they were and the caller can fall back to unstaged decoding. Nested
+    /// ``CacheList`` topologies are refused too: they expand to more leaves than array slots, and
+    /// the caches handed back have to line up with the live array positionally.
+    ///
+    /// - Parameter maximumPositions: the widest write the round will make. Append-only leaves are
+    ///   admitted only if they can still be rewound after absorbing it.
+    package func beginRound(maximumPositions: Int) -> KVCacheRound? {
+        precondition(!roundIsOpen, "a staged round is already open on this storage")
+
+        let leaves = KVCacheTree.leaves(in: cache)
+        guard leaves.count == cache.count, leaves.allSatisfy({ $0.path.count == 1 }) else {
+            return nil
+        }
+
+        var strategies = [any KVCacheRoundStrategy]()
+        strategies.reserveCapacity(leaves.count)
+        for leaf in leaves {
+            guard
+                let strategy = KVCacheRoundStrategyFactory.make(
+                    for: leaf, maximumPositions: maximumPositions)
+            else { return nil }
+            strategies.append(strategy)
+        }
+
+        let round = KVCacheRound(strategies: strategies, maximumPositions: maximumPositions)
+        openRound = round
+        return round
+    }
+
+    /// Keep the first `retaining` positions the round wrote and drop the rest, advancing the
+    /// timeline by exactly that much.
+    ///
+    /// Leaf commit and timeline advance are one operation on purpose. A commit that moved leaf
+    /// K/V without moving the timeline -- or the reverse -- would recreate, one level up, the
+    /// split brain this storage exists to prevent.
+    @discardableResult
+    package func commit(_ round: KVCacheRound, retaining: Int) -> KVCacheRoundCommit {
+        precondition(openRound === round, "committing a round that is not open on this storage")
+        let written = round.writtenPositions
+        precondition(
+            retaining >= 0 && retaining <= written,
+            "cannot retain \(retaining) of \(written) written positions")
+
+        for strategy in round.strategies {
+            strategy.commit(retaining: retaining)
+        }
+        processedTokenCount += retaining
+        openRound = nil
+
+        assert(
+            nativeAttentionOffsetsAreAligned,
+            "committing a staged round left the leaves and the timeline out of step")
+
+        return KVCacheRoundCommit(
+            committedPositions: retaining,
+            discardedPositions: written - retaining,
+            emittedLengths: round.strategies.map(\.emittedLength))
+    }
+
+    /// Drop everything the round wrote.
+    @discardableResult
+    package func rollback(_ round: KVCacheRound) -> KVCacheRoundCommit {
+        commit(round, retaining: 0)
+    }
+
+    /// How much of the emitted sequence the given leaf can still describe, outside a round.
+    ///
+    /// The whole stream for a global layer; the trailing window for a sliding one. This is the
+    /// same quantity ``KVCacheRoundCommit/emittedLengths`` reports, for callers that need it
+    /// without a round in hand -- prefill, for instance.
+    package func emittedLength(forLeaf index: Int) -> Int {
+        guard cache.indices.contains(index) else { return processedTokenCount }
+        return Swift.min(processedTokenCount, cache[index].maxSize ?? .max)
     }
 
     /// Create an independent snapshot while preserving plan and progress.

--- a/Libraries/MLXLMCommon/KVCachePlan.swift
+++ b/Libraries/MLXLMCommon/KVCachePlan.swift
@@ -110,6 +110,9 @@ package final class KVCacheStorage {
             precondition(
                 !roundIsOpen,
                 "the realized cache was replaced while a staged round was open")
+            // A rewind record names slots, and a replacement changes what those slots hold --
+            // so it invalidates the record rather than being restored into blindly.
+            lastRound = nil
             isApplicationTerminal = false
         }
     }
@@ -118,11 +121,19 @@ package final class KVCacheStorage {
 
     private var openRound: KVCacheRound?
 
+    /// How to take one leaf's share of a commit back, addressed by slot rather than by object.
+    ///
+    /// `point == nil` means a plain `trim(_:)` undoes it exactly, which is true for every leaf
+    /// that had not wrapped when the commit ran.
+    private struct LeafRewind {
+        let slot: Int
+        let point: (any KVCacheLeafRestorePoint)?
+    }
+
     /// What it would take to undo the most recent commit, kept only until the next write.
     private struct CompletedRound {
         let committedPositions: Int
-        let restorePoints: [any KVCacheLeafRestorePoint]
-        let trimmableLeaves: [KVCache]
+        let leaves: [LeafRewind]
     }
     private var lastRound: CompletedRound?
 
@@ -201,7 +212,7 @@ package final class KVCacheStorage {
         for leaf in leaves {
             guard
                 let strategy = KVCacheRoundStrategyFactory.make(
-                    for: leaf, maximumPositions: maximumPositions)
+                    for: leaf, slot: leaf.path[0], maximumPositions: maximumPositions)
             else { return nil }
             strategies.append(strategy)
         }
@@ -227,26 +238,25 @@ package final class KVCacheStorage {
             "cannot retain \(retaining) of \(written) written positions")
 
         // Built before the commit, because that is the last moment the pre-commit contents of a
-        // wrapped ring still exist.
-        var restorePoints = [any KVCacheLeafRestorePoint]()
-        var trimmableLeaves = [KVCache]()
+        // wrapped ring still exist. Records name slots: the object a rotating strategy presents
+        // is a round-scoped wrapper that outlives nothing, and its `trim(_:)` is a no-op.
+        var rewinds = [LeafRewind]()
+        rewinds.reserveCapacity(round.strategies.count)
         for strategy in round.strategies {
-            if let point = strategy.makeRestorePoint(retaining: retaining) {
-                restorePoints.append(point)
-            } else {
-                trimmableLeaves.append(strategy.presented)
-            }
+            rewinds.append(
+                LeafRewind(
+                    slot: strategy.slot,
+                    point: strategy.makeRestorePoint(retaining: retaining)))
             strategy.commit(retaining: retaining)
         }
         processedTokenCount += retaining
         openRound = nil
+        // Nothing to keep when every leaf can be undone by a trim: that is the path `trim(_:)`
+        // already takes, and recording a round would only widen what a rewind means.
         lastRound =
-            restorePoints.isEmpty
-            ? nil
-            : CompletedRound(
-                committedPositions: retaining,
-                restorePoints: restorePoints,
-                trimmableLeaves: trimmableLeaves)
+            rewinds.contains { $0.point != nil }
+            ? CompletedRound(committedPositions: retaining, leaves: rewinds)
+            : nil
 
         assert(
             nativeAttentionOffsetsAreAligned,
@@ -272,7 +282,8 @@ package final class KVCacheStorage {
     /// so the commit left behind what it takes to put that leaf back and replay the part that was
     /// emitted. Either way this is exact, and it is the only rewind left on the staged path.
     ///
-    /// Only the most recent commit can be taken back: any write after it invalidates the record.
+    /// Only the most recent commit can be taken back: any write after it invalidates the record,
+    /// and so does replacing an entry, since the record names slots rather than objects.
     @discardableResult
     package func rewindLastRound(_ count: Int) -> Int {
         precondition(count >= 0, "Rewind count cannot be negative")
@@ -283,11 +294,31 @@ package final class KVCacheStorage {
         let rewound = Swift.min(count, last.committedPositions)
         guard rewound > 0 else { return 0 }
 
-        for point in last.restorePoints {
-            point.restore(retaining: last.committedPositions - rewound)
+        // Resolve and check every slot before touching one. A rewind that undid some leaves and
+        // not others would leave the entries further out of step than doing nothing does, so a
+        // record that cannot be applied in full falls back to the plain trim instead.
+        let leaves = last.leaves.map { record -> (record: LeafRewind, leaf: KVCache)? in
+            guard cache.indices.contains(record.slot) else { return nil }
+            let leaf = cache[record.slot]
+            if let point = record.point {
+                return point.canRestore(into: leaf) ? (record, leaf) : nil
+            }
+            return leaf.isTrimmable ? (record, leaf) : nil
         }
-        for leaf in last.trimmableLeaves {
-            leaf.trim(rewound)
+        guard leaves.allSatisfy({ $0 != nil }) else { return trim(count) }
+
+        for (record, leaf) in leaves.compactMap({ $0 }) {
+            if let point = record.point {
+                point.restore(into: leaf, retaining: last.committedPositions - rewound)
+            } else {
+                let trimmed = leaf.trim(rewound)
+                precondition(
+                    trimmed == rewound,
+                    """
+                    entry \(record.slot) took back \(trimmed) of \(rewound) positions; a commit \
+                    admits a leaf only if a trim can undo it exactly
+                    """)
+            }
         }
         processedTokenCount -= rewound
         lastRound = nil

--- a/Libraries/MLXLMCommon/KVCachePlan.swift
+++ b/Libraries/MLXLMCommon/KVCachePlan.swift
@@ -118,6 +118,14 @@ package final class KVCacheStorage {
 
     private var openRound: KVCacheRound?
 
+    /// What it would take to undo the most recent commit, kept only until the next write.
+    private struct CompletedRound {
+        let committedPositions: Int
+        let restorePoints: [any KVCacheLeafRestorePoint]
+        let trimmableLeaves: [KVCache]
+    }
+    private var lastRound: CompletedRound?
+
     /// Whether a staged round is presently writing provisionally against these entries.
     ///
     /// A round hands the model substitute caches and defers part of its writes, so the entries
@@ -154,6 +162,7 @@ package final class KVCacheStorage {
         let (updated, overflow) = processedTokenCount.addingReportingOverflow(count)
         precondition(!overflow, "Processed token count overflow")
         processedTokenCount = updated
+        lastRound = nil
     }
 
     /// Trim cache state and the shared logical timeline atomically.
@@ -166,6 +175,7 @@ package final class KVCacheStorage {
             trimmed <= processedTokenCount,
             "Cache trimmed beyond its processed-token timeline")
         processedTokenCount -= trimmed
+        lastRound = nil
         return trimmed
     }
 
@@ -196,6 +206,7 @@ package final class KVCacheStorage {
             strategies.append(strategy)
         }
 
+        lastRound = nil
         let round = KVCacheRound(strategies: strategies, maximumPositions: maximumPositions)
         openRound = round
         return round
@@ -215,11 +226,27 @@ package final class KVCacheStorage {
             retaining >= 0 && retaining <= written,
             "cannot retain \(retaining) of \(written) written positions")
 
+        // Built before the commit, because that is the last moment the pre-commit contents of a
+        // wrapped ring still exist.
+        var restorePoints = [any KVCacheLeafRestorePoint]()
+        var trimmableLeaves = [KVCache]()
         for strategy in round.strategies {
+            if let point = strategy.makeRestorePoint(retaining: retaining) {
+                restorePoints.append(point)
+            } else {
+                trimmableLeaves.append(strategy.presented)
+            }
             strategy.commit(retaining: retaining)
         }
         processedTokenCount += retaining
         openRound = nil
+        lastRound =
+            restorePoints.isEmpty
+            ? nil
+            : CompletedRound(
+                committedPositions: retaining,
+                restorePoints: restorePoints,
+                trimmableLeaves: trimmableLeaves)
 
         assert(
             nativeAttentionOffsetsAreAligned,
@@ -235,6 +262,40 @@ package final class KVCacheStorage {
     @discardableResult
     package func rollback(_ round: KVCacheRound) -> KVCacheRoundCommit {
         commit(round, retaining: 0)
+    }
+
+    /// Take back `count` positions the last commit kept.
+    ///
+    /// A generation can stop with positions committed but never emitted, and those have to leave
+    /// the cache before anything reconciles a token ledger against it. `trim(_:)` handles that
+    /// whenever every leaf can undo an append by bookkeeping; past a sliding window one cannot,
+    /// so the commit left behind what it takes to put that leaf back and replay the part that was
+    /// emitted. Either way this is exact, and it is the only rewind left on the staged path.
+    ///
+    /// Only the most recent commit can be taken back: any write after it invalidates the record.
+    @discardableResult
+    package func rewindLastRound(_ count: Int) -> Int {
+        precondition(count >= 0, "Rewind count cannot be negative")
+        precondition(!roundIsOpen, "cannot rewind while a staged round is open")
+        guard count > 0 else { return 0 }
+
+        guard let last = lastRound else { return trim(count) }
+        let rewound = Swift.min(count, last.committedPositions)
+        guard rewound > 0 else { return 0 }
+
+        for point in last.restorePoints {
+            point.restore(retaining: last.committedPositions - rewound)
+        }
+        for leaf in last.trimmableLeaves {
+            leaf.trim(rewound)
+        }
+        processedTokenCount -= rewound
+        lastRound = nil
+
+        assert(
+            nativeAttentionOffsetsAreAligned,
+            "rewinding a committed round left the leaves and the timeline out of step")
+        return rewound
     }
 
     /// How much of the emitted sequence the given leaf can still describe, outside a round.

--- a/Libraries/MLXLMCommon/KVCacheRound.swift
+++ b/Libraries/MLXLMCommon/KVCacheRound.swift
@@ -15,6 +15,13 @@ import MLX
 /// leaf before constructing anything, and a single leaf that cannot commit exactly abandons the
 /// round with nothing touched.
 package protocol KVCacheRoundStrategy: AnyObject {
+    /// Which entry of the storage's array this leaf occupies.
+    ///
+    /// The slot is the leaf's stable identity, and the only one worth recording: ``presented`` is
+    /// round-scoped for a staged leaf, and dynamic compression can replace the live object at any
+    /// point outside a round. Anything that has to find this leaf again looks it up here.
+    var slot: Int { get }
+
     /// The cache to hand the model in this leaf's slot for the duration of the round.
     var presented: KVCache { get }
 
@@ -49,9 +56,19 @@ extension KVCacheRoundStrategy {
 /// through a round's accepted prefix, a consumer that walked away. Those have to come back out of
 /// the cache, and for a wrapped ring `trim(_:)` cannot do it: the append already evicted the
 /// entries the rewind would need to restore.
+///
+/// Deliberately holds no reference to the cache it was made from. The leaf is resolved from the
+/// storage at rewind time and passed in, so a record can never write into an object the storage
+/// has stopped owning.
 package protocol KVCacheLeafRestorePoint {
-    /// Restore the pre-commit contents, then re-apply the first `retaining` committed positions.
-    func restore(retaining: Int)
+    /// Whether `leaf` is something this record can be applied to.
+    func canRestore(into leaf: KVCache) -> Bool
+
+    /// Restore `leaf`'s pre-commit contents, then re-apply the first `retaining` committed
+    /// positions. Returns `false` if `leaf` is not a cache this record was made from, in which
+    /// case nothing is written.
+    @discardableResult
+    func restore(into leaf: KVCache, retaining: Int) -> Bool
 }
 
 extension KVCacheRoundStrategy {
@@ -68,10 +85,12 @@ extension KVCacheRoundStrategy {
 /// layer's presentation is its whole history, so staging one would cost a concatenation across
 /// the full context on every round.
 final class AppendOnlyRoundStrategy: KVCacheRoundStrategy {
+    let slot: Int
     let live: KVCache
     private let startOffset: Int
 
-    init(live: KVCache) {
+    init(slot: Int, live: KVCache) {
+        self.slot = slot
         self.live = live
         self.startOffset = live.offset
     }
@@ -92,10 +111,12 @@ final class AppendOnlyRoundStrategy: KVCacheRoundStrategy {
 
 /// A rotating leaf: staged beside the ring, which stays physically untouched until commit.
 final class RotatingRoundStrategy: KVCacheRoundStrategy {
+    let slot: Int
     let live: RotatingKVCache
     let staged: RotatingStagedKVCache
 
-    init(live: RotatingKVCache) {
+    init(slot: Int, live: RotatingKVCache) {
+        self.slot = slot
         self.live = live
         self.staged = RotatingStagedKVCache(live: live)
     }
@@ -117,7 +138,6 @@ final class RotatingRoundStrategy: KVCacheRoundStrategy {
         let snapshot = live.state
         guard snapshot.count == 2 else { return nil }
         return RotatingRestorePoint(
-            live: live,
             // Detached the same way `RotatingKVCache.copy()` detaches: a full-range slice shares
             // the node but is a new object, and an in-place write rebinds the *receiver*. Holding
             // `live.state` directly would hold the very objects the commit is about to rebind.
@@ -133,20 +153,24 @@ final class RotatingRoundStrategy: KVCacheRoundStrategy {
 /// while the snapshot is alive the next ring write cannot donate its buffer. It is dropped as
 /// soon as another round opens.
 struct RotatingRestorePoint: KVCacheLeafRestorePoint {
-    let live: RotatingKVCache
     let state: [MLXArray]
     let metaState: [String]
     let replay: (MLXArray, MLXArray)?
 
-    func restore(retaining: Int) {
+    func canRestore(into leaf: KVCache) -> Bool { leaf is RotatingKVCache }
+
+    @discardableResult
+    func restore(into leaf: KVCache, retaining: Int) -> Bool {
+        guard let live = leaf as? RotatingKVCache else { return false }
         // Order matters and mirrors `copy()`: the state setter deliberately leaves `offset`
         // alone, because `idx` and `offset` both arrive with the metadata.
         live.state = state
         live.metaState = metaState
-        guard retaining > 0, let replay else { return }
+        guard retaining > 0, let replay else { return true }
         _ = live.update(
             keys: replay.0[.ellipsis, ..<retaining, 0...],
             values: replay.1[.ellipsis, ..<retaining, 0...])
+        return true
     }
 }
 
@@ -157,8 +181,10 @@ struct RotatingRestorePoint: KVCacheLeafRestorePoint {
 /// ceiling worth naming — a conformer from outside this package cannot opt into staging. It gets
 /// write-through if it can prove it stays trimmable, and refusal otherwise.
 enum KVCacheRoundStrategyFactory {
+    /// - Parameter slot: the leaf's index in the storage's array, which the strategy carries so a
+    ///   later rewind can resolve the live entry rather than trust a captured object.
     static func make(
-        for leaf: KVCacheLeaf, maximumPositions: Int
+        for leaf: KVCacheLeaf, slot: Int, maximumPositions: Int
     ) -> (any KVCacheRoundStrategy)? {
         // Recurrent state has no rewindable position and no staged form, and deliberately does
         // not participate in the shared timeline at all.
@@ -166,7 +192,7 @@ enum KVCacheRoundStrategyFactory {
 
         switch leaf.kind {
         case .rotating(let rotating):
-            return RotatingRoundStrategy(live: rotating)
+            return RotatingRoundStrategy(slot: slot, live: rotating)
         case .recurrent:
             return nil
         case .simple, .affine, .turboQuant, .unsupported:
@@ -174,7 +200,7 @@ enum KVCacheRoundStrategyFactory {
             // positions -- asked with the round's real width, because the entry that matters is
             // one that is trimmable now and would stop being trimmable during the round.
             guard leaf.cache.isTrimmable(after: maximumPositions) else { return nil }
-            return AppendOnlyRoundStrategy(live: leaf.cache)
+            return AppendOnlyRoundStrategy(slot: slot, live: leaf.cache)
         }
     }
 }

--- a/Libraries/MLXLMCommon/KVCacheRound.swift
+++ b/Libraries/MLXLMCommon/KVCacheRound.swift
@@ -29,6 +29,29 @@ package protocol KVCacheRoundStrategy: AnyObject {
 
     /// Keep the first `retaining` written positions and drop the rest. Called at most once.
     func commit(retaining: Int)
+
+    /// Enough to put this leaf back should the committed positions turn out not to have been
+    /// emitted after all, or `nil` when a later `trim(_:)` would undo them exactly.
+    ///
+    /// Called immediately before ``commit(retaining:)``, because that is the last moment the
+    /// pre-commit contents still exist.
+    func makeRestorePoint(retaining: Int) -> (any KVCacheLeafRestorePoint)?
+}
+
+extension KVCacheRoundStrategy {
+    /// Most leaves need nothing: their `trim(_:)` is bookkeeping and undoes an append exactly.
+    func makeRestorePoint(retaining: Int) -> (any KVCacheLeafRestorePoint)? { nil }
+}
+
+/// Enough to put one leaf back the way it was before a commit, and replay part of it.
+///
+/// A generation can stop with positions committed but never emitted -- a stop token partway
+/// through a round's accepted prefix, a consumer that walked away. Those have to come back out of
+/// the cache, and for a wrapped ring `trim(_:)` cannot do it: the append already evicted the
+/// entries the rewind would need to restore.
+package protocol KVCacheLeafRestorePoint {
+    /// Restore the pre-commit contents, then re-apply the first `retaining` committed positions.
+    func restore(retaining: Int)
 }
 
 extension KVCacheRoundStrategy {
@@ -84,6 +107,46 @@ final class RotatingRoundStrategy: KVCacheRoundStrategy {
 
     func commit(retaining: Int) {
         staged.commit(retaining: retaining)
+    }
+
+    func makeRestorePoint(retaining: Int) -> (any KVCacheLeafRestorePoint)? {
+        // Below the window a trim is exact bookkeeping, so a snapshot would be dead weight on
+        // every round of every short generation. Ask about the post-commit position, since that
+        // is the state a later rewind would be undoing.
+        guard !live.isTrimmable(after: retaining) else { return nil }
+        let snapshot = live.state
+        guard snapshot.count == 2 else { return nil }
+        return RotatingRestorePoint(
+            live: live,
+            // Detached the same way `RotatingKVCache.copy()` detaches: a full-range slice shares
+            // the node but is a new object, and an in-place write rebinds the *receiver*. Holding
+            // `live.state` directly would hold the very objects the commit is about to rebind.
+            state: snapshot.map { $0[.ellipsis] },
+            metaState: live.metaState,
+            replay: staged.stagedArrays)
+    }
+}
+
+/// Restores a rotating leaf by putting its ring back and replaying the accepted rows.
+///
+/// Capture is cheap -- a full-range slice reuses the underlying node -- so the price is deferred:
+/// while the snapshot is alive the next ring write cannot donate its buffer. It is dropped as
+/// soon as another round opens.
+struct RotatingRestorePoint: KVCacheLeafRestorePoint {
+    let live: RotatingKVCache
+    let state: [MLXArray]
+    let metaState: [String]
+    let replay: (MLXArray, MLXArray)?
+
+    func restore(retaining: Int) {
+        // Order matters and mirrors `copy()`: the state setter deliberately leaves `offset`
+        // alone, because `idx` and `offset` both arrive with the metadata.
+        live.state = state
+        live.metaState = metaState
+        guard retaining > 0, let replay else { return }
+        _ = live.update(
+            keys: replay.0[.ellipsis, ..<retaining, 0...],
+            values: replay.1[.ellipsis, ..<retaining, 0...])
     }
 }
 

--- a/Libraries/MLXLMCommon/KVCacheRound.swift
+++ b/Libraries/MLXLMCommon/KVCacheRound.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// How one cache leaf takes part in a staged round.
+///
+/// Speculative decoding writes several candidate positions and keeps only a prefix. Undoing the
+/// rest by writing everything and then trimming works for an append-only cache, whose `trim(_:)`
+/// is pure bookkeeping, but not for a ``RotatingKVCache``: once its ring has wrapped, the write a
+/// rewind would undo has already evicted the entries that rewind would have to restore. So the
+/// leaf chooses: provisional tail and a cursor commit, or staged K/V and a chronological view.
+///
+/// Selection is fail-closed. ``KVCacheStorage/beginRound(maximumPositions:)`` classifies every
+/// leaf before constructing anything, and a single leaf that cannot commit exactly abandons the
+/// round with nothing touched.
+package protocol KVCacheRoundStrategy: AnyObject {
+    /// The cache to hand the model in this leaf's slot for the duration of the round.
+    var presented: KVCache { get }
+
+    /// Positions written through ``presented`` so far this round.
+    var writtenPositions: Int { get }
+
+    /// The live entry's own position. Reads as the pre-round value until the round commits.
+    var liveOffset: Int { get }
+
+    /// The window the live entry attends over, or `nil` when it is unbounded.
+    var attentionBound: Int? { get }
+
+    /// Keep the first `retaining` written positions and drop the rest. Called at most once.
+    func commit(retaining: Int)
+}
+
+extension KVCacheRoundStrategy {
+    /// How much of the emitted sequence this leaf can still describe after a commit: everything
+    /// for a global layer, the trailing window for a sliding one.
+    var emittedLength: Int {
+        Swift.min(liveOffset, attentionBound ?? .max)
+    }
+}
+
+/// An append-only leaf: written through, then clamped back over the rejected rows.
+///
+/// This is what the rewind already did, and it is deliberately cheaper than staging — a global
+/// layer's presentation is its whole history, so staging one would cost a concatenation across
+/// the full context on every round.
+final class AppendOnlyRoundStrategy: KVCacheRoundStrategy {
+    let live: KVCache
+    private let startOffset: Int
+
+    init(live: KVCache) {
+        self.live = live
+        self.startOffset = live.offset
+    }
+
+    var presented: KVCache { live }
+    var writtenPositions: Int { live.offset - startOffset }
+    var liveOffset: Int { live.offset }
+    var attentionBound: Int? { live.maxSize }
+
+    func commit(retaining: Int) {
+        let written = writtenPositions
+        let keep = Swift.min(Swift.max(retaining, 0), written)
+        if written > keep {
+            live.trim(written - keep)
+        }
+    }
+}
+
+/// A rotating leaf: staged beside the ring, which stays physically untouched until commit.
+final class RotatingRoundStrategy: KVCacheRoundStrategy {
+    let live: RotatingKVCache
+    let staged: RotatingStagedKVCache
+
+    init(live: RotatingKVCache) {
+        self.live = live
+        self.staged = RotatingStagedKVCache(live: live)
+    }
+
+    var presented: KVCache { staged }
+    var writtenPositions: Int { staged.stagedCount }
+    var liveOffset: Int { live.offset }
+    var attentionBound: Int? { live.maxSize }
+
+    func commit(retaining: Int) {
+        staged.commit(retaining: retaining)
+    }
+}
+
+/// Chooses a strategy per leaf, or refuses.
+///
+/// Deliberately not a requirement on ``KVCache`` itself: that protocol is public, so a `package`
+/// requirement could not be added to it, and a public one would be new API. The consequence is a
+/// ceiling worth naming — a conformer from outside this package cannot opt into staging. It gets
+/// write-through if it can prove it stays trimmable, and refusal otherwise.
+enum KVCacheRoundStrategyFactory {
+    static func make(
+        for leaf: KVCacheLeaf, maximumPositions: Int
+    ) -> (any KVCacheRoundStrategy)? {
+        // Recurrent state has no rewindable position and no staged form, and deliberately does
+        // not participate in the shared timeline at all.
+        guard leaf.isAttentionCache else { return nil }
+
+        switch leaf.kind {
+        case .rotating(let rotating):
+            return RotatingRoundStrategy(live: rotating)
+        case .recurrent:
+            return nil
+        case .simple, .affine, .turboQuant, .unsupported:
+            // Write-through plus a clamp is sound exactly when a later trim undoes the appended
+            // positions -- asked with the round's real width, because the entry that matters is
+            // one that is trimmable now and would stop being trimmable during the round.
+            guard leaf.cache.isTrimmable(after: maximumPositions) else { return nil }
+            return AppendOnlyRoundStrategy(live: leaf.cache)
+        }
+    }
+}
+
+/// An open staged round: the caches to run the model against, and the per-leaf strategies that
+/// will commit them.
+///
+/// Deliberately has no `commit` of its own. Committing means advancing the model-wide
+/// processed-token timeline by exactly the retained count, and that timeline lives on
+/// ``KVCacheStorage`` — so commit does too, and the two cannot be separated or reordered.
+package final class KVCacheRound {
+    let strategies: [any KVCacheRoundStrategy]
+
+    /// Positionally matches the storage's live array.
+    package let caches: [KVCache]
+
+    /// The width the round was opened for. Leaves were admitted on the promise of absorbing it.
+    package let maximumPositions: Int
+
+    init(strategies: [any KVCacheRoundStrategy], maximumPositions: Int) {
+        self.strategies = strategies
+        self.caches = strategies.map(\.presented)
+        self.maximumPositions = maximumPositions
+    }
+
+    /// Positions this round wrote, which every leaf must agree on.
+    var writtenPositions: Int {
+        guard let first = strategies.first else { return 0 }
+        let written = first.writtenPositions
+        assert(
+            strategies.allSatisfy { $0.writtenPositions == written },
+            "leaves disagree on how much this round wrote: "
+                + "\(strategies.map(\.writtenPositions))")
+        return written
+    }
+}
+
+/// What a commit retained, and what the leaves can still describe afterwards.
+package struct KVCacheRoundCommit {
+    /// Positions kept. The timeline advanced by exactly this much.
+    package let committedPositions: Int
+
+    /// Positions written and then dropped — the rejected tail.
+    package let discardedPositions: Int
+
+    /// Per leaf, how much of the emitted sequence it still describes: the whole stream for a
+    /// global layer, the trailing window for a sliding one.
+    package let emittedLengths: [Int]
+}

--- a/Libraries/MLXLMCommon/MTPDrafterModel.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModel.swift
@@ -138,9 +138,11 @@ public let mtpEmitFlagKey = LMOutput.Key<Bool>("mtp.emitDrafterState")
 /// consumer knows the entry behind each tuple: a sliding layer's snapshot is bounded by its ring
 /// and a global layer's is not, and at the crossing the two are indistinguishable by length.
 ///
-/// `package` rather than `public`: unlike the keys above, both the writer and the reader live
-/// inside this package, so this adds no API.
-package let mtpSharedKVSourceIndicesKey =
+/// Public alongside its siblings, because it is part of the same contract rather than an
+/// implementation detail of one writer: a target that sets ``mtpSharedKVStatesKey`` is expected to
+/// set this too, and a snapshot that arrives without it is refused rather than reconciled against
+/// a guessed bound. A target outside this package cannot satisfy that contract without it.
+public let mtpSharedKVSourceIndicesKey =
     LMOutput.Key<[String: Int]>("mtp.sharedKVSourceIndices")
 
 // MARK: - Iterator stats surface

--- a/Libraries/MLXLMCommon/MTPDrafterModel.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModel.swift
@@ -131,6 +131,18 @@ public let mtpSharedKVStatesKey =
 /// reads as `false` (no emit), so non-MTP callers are unaffected.
 public let mtpEmitFlagKey = LMOutput.Key<Bool>("mtp.emitDrafterState")
 
+/// Which cache entry each ``mtpSharedKVStatesKey`` tuple was read from, keyed the same way.
+///
+/// A speculative round keeps only part of what its verify pass wrote, so the emitted snapshot has
+/// to be reconciled against the cache afterwards. That reconciliation is exact only if the
+/// consumer knows the entry behind each tuple: a sliding layer's snapshot is bounded by its ring
+/// and a global layer's is not, and at the crossing the two are indistinguishable by length.
+///
+/// `package` rather than `public`: unlike the keys above, both the writer and the reader live
+/// inside this package, so this adds no API.
+package let mtpSharedKVSourceIndicesKey =
+    LMOutput.Key<[String: Int]>("mtp.sharedKVSourceIndices")
+
 // MARK: - Iterator stats surface
 
 /// Introspection surface for token iterators that perform MTP speculative

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -207,10 +207,15 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             mainState = result.state
             // Prefill emits too, and a multi-token prefill presents a sliding layer more than its
             // window just as a verify pass does. Nothing was rejected here, so only the head
-            // clamp applies.
-            reconcileSharedKVState(
+            // clamp applies -- but a snapshot that cannot be placed against the entries at all is
+            // refused here for the same reason it is mid-stream, and before anything reads it.
+            if !reconcileSharedKVState(
                 &mainState, discarding: 0,
                 lengths: mainCacheStorage.emittedLength(forLeaf:))
+            {
+                switchToPassthrough(reason: Self.missingSharedKVSourcesReason)
+                mainState = nil
+            }
             // Yield the bonus to the iterator's consumer. Without this,
             // the iterator silently starts 1 position ahead of an
             // equivalent autoregressive run, violating speculative
@@ -233,22 +238,33 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             processor?.didSample(token: token)
             y = .init(tokens: token)
             mainState = prefillResult.state
-            reconcileSharedKVState(
+            let placeable = reconcileSharedKVState(
                 &mainState, discarding: 0,
                 lengths: mainCacheStorage.emittedLength(forLeaf:))
+            if !placeable {
+                switchToPassthrough(reason: Self.missingSharedKVSourcesReason)
+                mainState = nil
+            }
 
             // If prefill didn't emit drafter state, do one more forward call
             // with the just-sampled bonus token to prime the state. The cost
-            // is one extra token's forward pass; acceptable.
-            if mainState?[mtpLastHiddenStatesKey] == nil
-                || mainState?[mtpSharedKVStatesKey] == nil
+            // is one extra token's forward pass; acceptable. Skipped once the
+            // snapshot has been refused: it exists only to obtain drafter
+            // state, and this stream has stopped having a use for any.
+            if placeable,
+                mainState?[mtpLastHiddenStatesKey] == nil
+                    || mainState?[mtpSharedKVStatesKey] == nil
             {
                 let primed = mainModel(y[text: .newAxis], cache: mainCache, state: prefillState)
                 mainCacheStorage.commitProcessedTokens(y.cacheSequenceLength)
                 mainState = primed.state
-                reconcileSharedKVState(
+                if !reconcileSharedKVState(
                     &mainState, discarding: 0,
                     lengths: mainCacheStorage.emittedLength(forLeaf:))
+                {
+                    switchToPassthrough(reason: Self.missingSharedKVSourcesReason)
+                    mainState = nil
+                }
                 // Resample bonus from this forward's logits so the chain stays
                 // coherent at this position (the cache offset moves by 1, so
                 // we must re-pick the bonus from the new step's logits).
@@ -557,6 +573,8 @@ extension MTPSpeculativeTokenIterator: GenerationFinalizingTokenIterator {
         // even past a sliding window, where a plain trim is not: the commit kept what it takes to
         // put a wrapped ring back and replay the part that was emitted.
         let rewound = mainCacheStorage.rewindLastRound(lookahead)
+        // The only site that ignores the result, and the only one that can: the stream is over,
+        // so nothing reads the snapshot after this. Everywhere else a refusal stops speculation.
         reconcileSharedKVState(
             &mainState, discarding: rewound,
             lengths: mainCacheStorage.emittedLength(forLeaf:))

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -118,11 +118,6 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         let kvCachePlan = try parameters.kvCachePlan()
         let mainCache = try kvCachePlan.validated(
             mainCache ?? mainModel.newCache(parameters: parameters))
-        guard canTrimPromptCache(mainCache) else {
-            throw KVCacheError(
-                message: "MTP speculative decoding requires a trimmable main KV cache.")
-        }
-
         self.y = input.text
         self.mainModel = mainModel
         self.drafter = drafter
@@ -133,22 +128,49 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         self.processor = components.logitProcessor(parameters: parameters)
 
         self.maxTokens = parameters.maxTokens
-        self.blockSize = blockSize
+        // A round presents `blockSize` positions at once, and a sliding layer can only show a
+        // query the `maxSize` entries before it. Past that the extra drafts still decode
+        // correctly -- masks are position-relative and the staged view is clamped -- but the
+        // deepest ones attend over less context than the verifier gave them, so acceptance
+        // stops meaning what the stats say it means. Clamp rather than trap: the block size is
+        // a tuning knob, not a correctness input.
+        let effectiveBlockSize = Swift.min(blockSize, Self.maximumBlockSize(for: mainCache))
+        self.blockSize = effectiveBlockSize
+
+        // Probe by opening a round at the width rounds will actually use and discarding it,
+        // rather than duplicating the leaf classification as a predicate that could drift from
+        // it. Rounds open their own: dynamic compression can replace entries between them.
+        guard let probe = self.mainCacheStorage.beginRound(maximumPositions: effectiveBlockSize)
+        else {
+            throw KVCacheError(
+                message: "MTP speculative decoding requires a stageable main KV cache.")
+        }
+        self.mainCacheStorage.rollback(probe)
 
         let prefillStart = Date.timeIntervalSinceReferenceDate
         try prepare(input: input, prefill: parameters.prefill)
         self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
+    }
 
-        // The guard above ran against a fresh, zero-offset cache, where a
-        // rotating cache is trimmable vacuously. Re-check now that the prompt
-        // is in: one whose length leaves no room for a speculative round can
-        // never be rewound, so speculation is unavailable for this stream.
-        // `blockSize` bounds the first round's width.
-        standDownIfNoTrimHeadroom(
-            positions: blockSize,
-            reason:
-                "prompt fills the sliding window — MTP rewind unavailable; generating without speculation"
-        )
+    static let missingSharedKVSourcesReason =
+        "main model did not report which cache entries its shared K/V came from; continuing "
+        + "without speculation"
+
+    /// The tightest sliding window among the cache's layers, or `nil` when no layer slides.
+    static func narrowestSlidingWindow(in cache: [KVCache]) -> Int? {
+        KVCacheTree.leaves(in: cache)
+            .compactMap { leaf -> Int? in
+                guard case .rotating(let rotating) = leaf.kind else { return nil }
+                return rotating.maxSize
+            }
+            .min()
+    }
+
+    /// The widest round the narrowest sliding layer can present coherently: one bonus plus a
+    /// window's worth of drafts. Unbounded when no layer slides.
+    static func maximumBlockSize(for cache: [KVCache]) -> Int {
+        guard let narrowest = narrowestSlidingWindow(in: cache) else { return .max }
+        return Swift.max(2, narrowest + 1)
     }
 
     /// Prefill the main model with the prompt. The drafter has no cache to
@@ -183,6 +205,12 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             processor?.didSample(token: token)
             y = .init(tokens: token)
             mainState = result.state
+            // Prefill emits too, and a multi-token prefill presents a sliding layer more than its
+            // window just as a verify pass does. Nothing was rejected here, so only the head
+            // clamp applies.
+            reconcileSharedKVState(
+                &mainState, discarding: 0,
+                lengths: mainCacheStorage.emittedLength(forLeaf:))
             // Yield the bonus to the iterator's consumer. Without this,
             // the iterator silently starts 1 position ahead of an
             // equivalent autoregressive run, violating speculative
@@ -205,6 +233,9 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             processor?.didSample(token: token)
             y = .init(tokens: token)
             mainState = prefillResult.state
+            reconcileSharedKVState(
+                &mainState, discarding: 0,
+                lengths: mainCacheStorage.emittedLength(forLeaf:))
 
             // If prefill didn't emit drafter state, do one more forward call
             // with the just-sampled bonus token to prime the state. The cost
@@ -215,6 +246,9 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
                 let primed = mainModel(y[text: .newAxis], cache: mainCache, state: prefillState)
                 mainCacheStorage.commitProcessedTokens(y.cacheSequenceLength)
                 mainState = primed.state
+                reconcileSharedKVState(
+                    &mainState, discarding: 0,
+                    lengths: mainCacheStorage.emittedLength(forLeaf:))
                 // Resample bonus from this forward's logits so the chain stays
                 // coherent at this position (the cache offset moves by 1, so
                 // we must re-pick the bonus from the new step's logits).
@@ -275,15 +309,14 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        // This round's verify pass commits `numDraft + 1` positions. If that
-        // would carry the sliding cache past its window, the rewind below
-        // would no-op and strand this round's rejected drafts in the cache —
-        // stand down now, while the cache is still rewindable.
-        if standDownIfNoTrimHeadroom(
-            positions: numDraft + 1,
-            reason:
-                "sliding cache wrapped mid-stream — MTP rewind unavailable; continuing without speculation"
-        ) {
+        // Run the verify pass against staged caches so the live ones only ever
+        // see the tokens that are accepted. Cache types are re-classified every
+        // round because dynamic quantization can replace entries between them.
+        guard let round = mainCacheStorage.beginRound(maximumPositions: numDraft + 1) else {
+            switchToPassthrough(
+                reason: "main KV cache cannot stage a speculative round; continuing without "
+                    + "speculation")
+            mainState = nil
             return
         }
 
@@ -300,16 +333,22 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
 
         let cacheOffset = mainCacheStorage.processedTokenCount
 
-        // Invariant: the span the drafter attends over describes exactly the
-        // true sequence — the rewind site trims the emitted snapshot in
-        // lockstep with the cache. `dim()` is shape metadata (no eval, no GPU
-        // sync). The check stands down if the cache ever leaves the trimmable
-        // regime (post-wrap sliding window), where the rewind machinery
-        // itself no-ops.
+        // Invariant: the snapshot the drafter attends over describes the emitted sequence and
+        // nothing else. A global layer's entry spans the whole stream; a sliding layer's spans
+        // its window. Both are exact, because the commit that decided what the cache kept also
+        // reconciled the snapshot. `dim()` is shape metadata (no eval, no GPU sync).
         assert(
-            sharedKV.allSatisfy { $0.value.0.dim(-2) == cacheOffset }
-                || !canTrimPromptCache(mainCache),
-            "stale sharedKV: spans \(sharedKV.mapValues { $0.0.dim(-2) }) != main cache offset \(cacheOffset)"
+            {
+                guard let sources = state[mtpSharedKVSourceIndicesKey] else { return false }
+                return sharedKV.allSatisfy { key, entry in
+                    guard let leaf = sources[key] else { return false }
+                    return entry.0.dim(-2) == mainCacheStorage.emittedLength(forLeaf: leaf)
+                }
+            }(),
+            """
+            stale sharedKV: spans \(sharedKV.mapValues { $0.0.dim(-2) }) do not match the \
+            emitted lengths implied by a timeline of \(cacheOffset)
+            """
         )
 
         let bonusToken = y.tokens
@@ -333,8 +372,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         let verifyInput = LMInput.Text(tokens: verifyTokens)
         let verifyStart = verifyInput.tokens.dim(0) - (numDraft + 1)
         let mainResult = mainModel(
-            verifyInput[text: .newAxis], cache: mainCache, state: verifyState)
-        mainCacheStorage.commitProcessedTokens(verifyInput.cacheSequenceLength)
+            verifyInput[text: .newAxis], cache: round.caches, state: verifyState)
         let mainLogits = mainResult.logits
         mainState = mainResult.state
 
@@ -393,17 +431,27 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
             draftModelCalls: 1
         )
 
-        // Rewind the main cache and the emitted sharedKV snapshot by the
-        // rejected count, in lockstep. The drafter has no cache of its own,
-        // but the verify pass's state emission spans the full verify chunk —
-        // stale tail rows must not survive into the next round's draftBlock.
-        // Trimming the snapshot by the amount the cache actually trimmed
-        // keeps the two consistent even if the cache ever reports itself
-        // untrimmable (post-wrap sliding window), where trimPromptCache
-        // no-ops and returns 0.
+        // Commit the bonus plus the accepted drafts and drop the rest. Staged
+        // layers never held the rejected rows at all; written-through layers
+        // clamp back over them. Either way every entry advances by exactly
+        // this count, which is what the model-wide processed-token timeline
+        // records.
         let rejected = numDraft - accepted
-        let trimmed = mainCacheStorage.trim(rejected)
-        trimSharedKVState(&mainState, numTokens: trimmed)
+        let commit = mainCacheStorage.commit(round, retaining: accepted + 1)
+
+        // The emitted snapshot is reconciled by the same commit that decided what the cache
+        // keeps. Otherwise the cache can be right while the next `draftBlock` still attends over
+        // a rejected tail.
+        guard
+            reconcileSharedKVState(
+                &mainState, discarding: rejected,
+                lengths: { commit.emittedLengths[$0] })
+        else {
+            switchToPassthrough(reason: Self.missingSharedKVSourcesReason)
+            mainState = nil
+            y = .init(tokens: finalToken)
+            return
+        }
 
         // Dynamic cache quantization may convert `.regular` K/V to `.quantized`,
         // at which point the target's emit-hook returns sharedKV: nil and the
@@ -425,36 +473,6 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         }
         passthroughReason = reason
         passthrough = true
-    }
-
-    /// Stand down to passthrough if the main cache cannot absorb `positions`
-    /// more tokens and still be rewound.
-    ///
-    /// MTP's accept/reject step depends on `trimPromptCache`, so each cache
-    /// predicts whether it will remain trimmable after the verify positions
-    /// are appended. The append happens *inside* the verify pass, so a check
-    /// that merely asks "is it trimmable now?" fires a round too late: that
-    /// round's rewind silently returns 0 (the guard in `trimPromptCache` is
-    /// all-or-nothing over the array, so even the trimmable full-attention
-    /// entries are skipped) and its rejected drafts stay welded into every
-    /// layer's cache. Standing down while headroom remains keeps every rewind
-    /// valid, so a passthrough-crossing stream stays bit-exact to a plain
-    /// autoregressive run.
-    @discardableResult
-    private mutating func standDownIfNoTrimHeadroom(
-        positions: Int, reason: String
-    ) -> Bool {
-        guard !passthrough else { return false }
-        let hasHeadroom = mainCache.allSatisfy {
-            $0.isTrimmable(after: positions)
-        }
-        guard !hasHeadroom else { return false }
-        switchToPassthrough(reason: reason)
-        // Release the emitted snapshot: passthrough passes `state: nil` and
-        // never reads it again, and its sliding entries can span up to
-        // `maxCacheSize + S - 1` per layer.
-        mainState = nil
-        return true
     }
 
     /// One single-token forward step against the main model, used in
@@ -533,11 +551,15 @@ extension MTPSpeculativeTokenIterator: GenerationFinalizingTokenIterator {
         let lookahead = committedPendingTokenCount - consumed
         guard lookahead > 0 else { return }
 
-        // Trim through the storage so the model-wide processed-token timeline
-        // rewinds with the cache; `ChatSession` reconciles its ledger against
-        // that timeline, not against per-entry offsets.
-        let trimmed = mainCacheStorage.trim(lookahead)
-        trimSharedKVState(&mainState, numTokens: trimmed)
+        // A round commits its accepted prefix before the consumer has drained it, so a stop token
+        // partway through -- or a consumer that walks away -- leaves positions in the cache that
+        // were never emitted. Taking them back through the round that committed them is exact
+        // even past a sliding window, where a plain trim is not: the commit kept what it takes to
+        // put a wrapped ring back and replay the part that was emitted.
+        let rewound = mainCacheStorage.rewindLastRound(lookahead)
+        reconcileSharedKVState(
+            &mainState, discarding: rewound,
+            lengths: mainCacheStorage.emittedLength(forLeaf:))
     }
 }
 
@@ -567,32 +589,47 @@ extension MTPSpeculativeTokenIterator {
     }
 }
 
-/// Rewinds the emitted MTP shared-K/V snapshot by `numTokens` trailing
-/// sequence positions, mirroring `trimPromptCache` on the main cache.
+/// Bring the emitted MTP shared-K/V snapshot into line with what the cache actually kept.
 ///
-/// The verify pass emits K/V spanning the full `[bonus, d_1 ... d_numDraft]`
-/// chunk — materialized before acceptance is known. After a partial
-/// acceptance, the rejected tail rows describe tokens that are not part of
-/// the sequence; without this trim, the next round's `draftBlock` would
-/// cross-attend over them. (PR #308 review: discussion_r3391133046,
-/// discussion_r3391147261.)
+/// The verify pass emits K/V spanning its whole chunk, materialized before acceptance is known,
+/// and a sliding layer is presented more than its window on purpose so every query in the chunk
+/// still sees a full one. The drafter has no cache of its own and attends over this snapshot
+/// bidirectionally, so both excesses have to go: the rejected tail, then the head beyond what the
+/// layer can still describe.
 ///
-/// No-op when `numTokens <= 0`, when `state` is nil, or when the key is
-/// absent (e.g. the quantization-onset round, whose fresh verify state
-/// carries no sharedKV). Cost is metadata-only: the slices are lazy views
-/// consumed by the next `draftBlock` like the rest of the round's inputs;
-/// no `eval`. Iterator-internal — `trimPromptCache` is public because
-/// caches are a public surface, but this snapshot is the iterator's own
-/// cross-round state.
-func trimSharedKVState(_ state: inout LMOutput.State?, numTokens: Int) {
-    guard numTokens > 0,
-        let sharedKV = state?[mtpSharedKVStatesKey]
-    else { return }
-    state?[mtpSharedKVStatesKey] = sharedKV.mapValues { kv in
-        let newLen = kv.0.dim(-2) - numTokens
-        return (
-            kv.0[.ellipsis, ..<newLen, 0...],
-            kv.1[.ellipsis, ..<newLen, 0...]
+/// Order matters. Dropping the tail first and clamping the head second leaves a sliding entry
+/// with a full window; clamping first would leave it `discarding` rows short, every round.
+///
+/// - Parameters:
+///   - discarding: trailing positions the commit did not keep.
+///   - lengths: for the cache entry behind a given key, how much of the emitted sequence it still
+///     describes — the whole stream for a global layer, the trailing window for a sliding one.
+///
+/// No-op when `state` is nil or carries no snapshot (the quantization-onset round emits none).
+/// Returns `false` when the snapshot cannot be placed against cache entries at all, which is a
+/// signal to stop speculating rather than reconcile against a guess. Cost is metadata-only: every
+/// slice is a lazy view consumed by the next `draftBlock` like the rest of the round's inputs.
+@discardableResult
+func reconcileSharedKVState(
+    _ state: inout LMOutput.State?, discarding: Int, lengths: (Int) -> Int
+) -> Bool {
+    guard let sharedKV = state?[mtpSharedKVStatesKey] else { return true }
+    guard let sources = state?[mtpSharedKVSourceIndicesKey],
+        sharedKV.keys.allSatisfy({ sources[$0] != nil })
+    else { return false }
+
+    state?[mtpSharedKVStatesKey] = sharedKV.reduce(into: [:]) { result, entry in
+        let (key, kv) = entry
+        var length = kv.0.dim(-2)
+        if discarding > 0 {
+            length = Swift.max(0, length - discarding)
+        }
+        let bound = lengths(sources[key]!)
+        let start = Swift.max(0, length - bound)
+        result[key] = (
+            kv.0[.ellipsis, start ..< length, 0...],
+            kv.1[.ellipsis, start ..< length, 0...]
         )
     }
+    return true
 }

--- a/Libraries/MLXLMCommon/RotatingStagedKVCache.swift
+++ b/Libraries/MLXLMCommon/RotatingStagedKVCache.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// A ``RotatingKVCache`` presented with uncommitted rows appended.
+///
+/// `update(keys:values:)` stages its arguments instead of writing them and returns the trailing
+/// window of the live ring followed by everything staged so far -- the same arrays, in the same
+/// chronological order, that the live cache would have returned had it written them.
+final class RotatingStagedKVCache: KVCache {
+    let live: RotatingKVCache
+
+    private var stagedKeys: MLXArray?
+    private var stagedValues: MLXArray?
+
+    init(live: RotatingKVCache) {
+        self.live = live
+    }
+
+    /// Positions staged but not yet committed.
+    var stagedCount: Int { stagedKeys?.dim(2) ?? 0 }
+
+    /// The live ring's position plus whatever is staged.
+    ///
+    /// Masks are built before the layer writes, so at mask time this reads as the live offset --
+    /// which is exactly what makes delegating ``makeMask(n:windowSize:returnArray:)`` correct.
+    var offset: Int { live.offset + stagedCount }
+
+    var maxSize: Int? { live.maxSize }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        stagedKeys = stagedKeys.map { concatenated([$0, keys], axis: 2) } ?? keys
+        stagedValues = stagedValues.map { concatenated([$0, values], axis: 2) } ?? values
+        return presentation()
+    }
+
+    /// The live cache's own mask.
+    ///
+    /// For a multi-token write ``RotatingKVCache`` builds a causal-intersect-window mask over
+    /// `min(maxSize - 1, offset) + n` chronological key positions, and that is precisely the
+    /// length of the presentation below. Delegating means the model sees the mask it would have
+    /// seen without a staged round, rather than one this type had to reconstruct.
+    func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        live.makeMask(n: n, windowSize: windowSize, returnArray: returnArray)
+    }
+
+    /// Append the first `retaining` staged positions to the ring through the normal write path and
+    /// drop the rest. The ring is untouched until this point.
+    func commit(retaining: Int) {
+        defer {
+            stagedKeys = nil
+            stagedValues = nil
+        }
+        guard let stagedKeys, let stagedValues else { return }
+        let keep = Swift.min(Swift.max(retaining, 0), stagedKeys.dim(2))
+        guard keep > 0 else { return }
+        _ = live.update(
+            keys: stagedKeys[.ellipsis, ..<keep, 0...],
+            values: stagedValues[.ellipsis, ..<keep, 0...])
+    }
+
+    private func presentation() -> (MLXArray, MLXArray) {
+        guard let stagedKeys, let stagedValues else {
+            return live.logicalView(tail: live.offset) ?? emptyPresentation()
+        }
+        // `maxSize - 1` is the same bound the multi-token write path front-trims to, so the first
+        // staged query still reaches back a full window.
+        let bound = Swift.min(live.offset, (live.maxSize ?? Int.max) - 1)
+        guard bound > 0, let view = live.logicalView(tail: bound) else {
+            return (stagedKeys, stagedValues)
+        }
+        return (
+            concatenated([view.0, stagedKeys], axis: 2),
+            concatenated([view.1, stagedValues], axis: 2)
+        )
+    }
+
+    private func emptyPresentation() -> (MLXArray, MLXArray) {
+        let empty = MLXArray.zeros([1, 1, 0, 1])
+        return (empty, empty)
+    }
+
+    func innerState() -> [MLXArray] {
+        live.innerState() + [stagedKeys, stagedValues].compactMap { $0 }
+    }
+
+    // MARK: - Round-scoped: not serializable, not rewindable, not copyable
+
+    /// This never outlives its round, and prompt caches are saved between generations, so the live
+    /// ring is the whole answer here. Restoring into one is a programming error.
+    var state: [MLXArray] {
+        get { live.state }
+        set(newState) {
+            fatalError(
+                "RotatingStagedKVCache is round-scoped and cannot be restored from state "
+                    + "(\(newState.count) arrays)")
+        }
+    }
+
+    var metaState: [String] {
+        get { live.metaState }
+        set(newMetaState) {
+            fatalError(
+                "RotatingStagedKVCache is round-scoped and cannot be restored from metaState "
+                    + "(\(newMetaState.count) values)")
+        }
+    }
+
+    /// Staged rows are dropped wholesale by ``commit(retaining:)``, never trimmed. Reporting
+    /// `false` keeps a caller from mistaking this for something it can rewind.
+    var isTrimmable: Bool { false }
+
+    @discardableResult
+    func trim(_ n: Int) -> Int { 0 }
+
+    func copy() -> any KVCache {
+        fatalError("RotatingStagedKVCache is round-scoped and cannot be copied")
+    }
+
+    func prepare(lengths: [Int]?) { live.prepare(lengths: lengths) }
+
+    func prepare(lengths: MLXArray?) { live.prepare(lengths: lengths) }
+
+    func finalize() { live.finalize() }
+}

--- a/Libraries/MLXLMCommon/RotatingStagedKVCache.swift
+++ b/Libraries/MLXLMCommon/RotatingStagedKVCache.swift
@@ -22,6 +22,13 @@ final class RotatingStagedKVCache: KVCache {
     /// Positions staged but not yet committed.
     var stagedCount: Int { stagedKeys?.dim(2) ?? 0 }
 
+    /// The staged rows, for a caller that needs to replay them after a restore. Valid until
+    /// ``commit(retaining:)`` clears them.
+    var stagedArrays: (MLXArray, MLXArray)? {
+        guard let stagedKeys, let stagedValues else { return nil }
+        return (stagedKeys, stagedValues)
+    }
+
     /// The live ring's position plus whatever is staged.
     ///
     /// Masks are built before the layer writes, so at mask time this reads as the live offset --

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1184,7 +1184,10 @@ final class Gemma4TextBackbone: Module {
         perLayerInputs: MLXArray? = nil,
         tokenTypeIds: MLXArray? = nil,
         emitDrafterState: Bool = false
-    ) -> (hidden: MLXArray, sharedKV: [String: (MLXArray, MLXArray)]?) {
+    ) -> (
+        hidden: MLXArray, sharedKV: [String: (MLXArray, MLXArray)]?,
+        sharedKVSources: [String: Int]
+    ) {
         // Tolerate callers that hand us a 1D `(L,)` token array instead
         // of the canonical 2D `(B, L)` produced by `Gemma4Processor.prepare`.
         // The downstream `perLayerInputs` indexing path (`finalPerLayerInputs[
@@ -1319,7 +1322,7 @@ final class Gemma4TextBackbone: Module {
         let finalHidden = norm(h)
 
         guard emitDrafterState else {
-            return (finalHidden, nil)
+            return (finalHidden, nil, [:])
         }
 
         // Walk intermediates from the last layer backward; for each unique
@@ -1328,6 +1331,11 @@ final class Gemma4TextBackbone: Module {
         // signal to fall back to single-token generation (R8/R13 limitation,
         // documented).
         var sharedKV: [String: (MLXArray, MLXArray)] = [:]
+        // Which cache entry each emitted tuple came from. The consumer reconciles the emitted
+        // snapshot against the cache after a speculative commit, and it can only do that exactly
+        // if it knows the entry -- a sliding layer's snapshot is bounded by its ring, a global
+        // layer's is not, and the two are indistinguishable by length at the crossing.
+        var sharedKVSources: [String: Int] = [:]
         var seenTypes = Set<String>()
         let targetTypes: Set<String> = ["full_attention", "sliding_attention"]
         for idx in stride(from: layers.count - 1, through: 0, by: -1) {
@@ -1337,13 +1345,18 @@ final class Gemma4TextBackbone: Module {
             }
             if case .regular(let keys, let values) = intermediates[idx].kv {
                 sharedKV[layerType] = (keys, values)
+                // Recorded here rather than derived from `config.layerTypes`: the walk keeps
+                // descending past a quantized entry, so which layer supplies a type is a runtime
+                // fact.
+                sharedKVSources[layerType] = layerIdxToCacheIdx[idx]
                 seenTypes.insert(layerType)
             }
             if seenTypes == targetTypes { break }
         }
         // Treat partial coverage (e.g. only one layer_type populated, or
         // quantized cache for the other) as no-emit — iterator falls back.
-        return (finalHidden, seenTypes == targetTypes ? sharedKV : nil)
+        let complete = seenTypes == targetTypes
+        return (finalHidden, complete ? sharedKV : nil, complete ? sharedKVSources : [:])
     }
 }
 
@@ -1399,7 +1412,7 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         emitDrafterState: Bool = false
     ) -> LMOutput {
-        let (hidden, sharedKV) = model(
+        let (hidden, sharedKV, sharedKVSources) = model(
             inputs, inputsEmbeds: inputsEmbeds, mask: mask, cache: cache?.map { $0 as KVCache? },
             perLayerInputs: perLayerInputs,
             tokenTypeIds: tokenTypeIds,
@@ -1425,6 +1438,7 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
         var state = LMOutput.State()
         state[mtpLastHiddenStatesKey] = hidden
         state[mtpSharedKVStatesKey] = sharedKV
+        state[mtpSharedKVSourceIndicesKey] = sharedKVSources
         return LMOutput(logits: softcappedLogits, state: state)
     }
 

--- a/Tests/MLXLMTests/KVCacheRoundTests.swift
+++ b/Tests/MLXLMTests/KVCacheRoundTests.swift
@@ -1,0 +1,656 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+// MARK: - Fixtures
+
+/// K/V whose every element encodes its own sequence position: keys hold `+p`, values `-p`.
+/// Any reordering, duplication, or K/V mix-up changes the numbers.
+private func positionedKV(
+    _ positions: Range<Int>, headDim: Int = 2
+) -> (MLXArray, MLXArray) {
+    let count = positions.count
+    let keys = MLXArray(
+        positions.flatMap { Array(repeating: Float($0), count: headDim) },
+        [1, 1, count, headDim])
+    let values = MLXArray(
+        positions.flatMap { Array(repeating: Float(-$0), count: headDim) },
+        [1, 1, count, headDim])
+    return (keys, values)
+}
+
+/// Recover the sequence positions encoded by `positionedKV` from a `[B, H, S, D]` key array.
+private func encodedPositions(_ keys: MLXArray) -> [Int] {
+    keys[0, 0, 0..., 0].asArray(Float.self).map { Int($0) }
+}
+
+/// The round width these cases open with unless they are probing the width itself.
+private let defaultRoundWidth = 8
+
+/// A storage and its open round, paired so a case can commit without threading both. Rounds are
+/// opened on a storage because committing has to advance the processed-token timeline in the same
+/// operation; this is only sugar over that.
+private final class StagedRound {
+    let storage: KVCacheStorage
+    let round: KVCacheRound
+
+    var caches: [KVCache] { round.caches }
+
+    init?(_ storage: KVCacheStorage, width: Int = defaultRoundWidth) {
+        guard let round = storage.beginRound(maximumPositions: width) else { return nil }
+        self.storage = storage
+        self.round = round
+    }
+
+    convenience init?(_ caches: [KVCache], width: Int = defaultRoundWidth) {
+        self.init(KVCacheStorage(caches, plan: .disabled), width: width)
+    }
+
+    @discardableResult
+    func commit(accepted: Int) -> KVCacheRoundCommit {
+        storage.commit(round, retaining: accepted)
+    }
+
+    func rollback() { storage.rollback(round) }
+}
+
+/// Write `positions` to every cache in the round, as one verify forward would.
+@discardableResult
+private func stageRound(
+    _ staged: StagedRound, _ positions: Range<Int>
+) -> [(MLXArray, MLXArray)] {
+    let (keys, values) = positionedKV(positions)
+    return staged.caches.map { $0.update(keys: keys, values: values) }
+}
+
+/// A deep-enough snapshot of a rotating cache's physical state to detect any mutation.
+private struct RingSnapshot {
+    let arrays: [MLXArray]
+    let offset: Int
+    let metaState: [String]
+
+    init(_ cache: RotatingKVCache) {
+        // Materialize, so the snapshot cannot alias buffers the cache may later write in place.
+        arrays = cache.innerState().map { MLXArray($0.asArray(Float.self), $0.shape) }
+        offset = cache.offset
+        metaState = cache.metaState
+    }
+
+    func expectUnchanged(_ cache: RotatingKVCache, _ note: String) {
+        let now = cache.innerState()
+        #expect(now.count == arrays.count, "innerState array count changed — \(note)")
+        for (index, (before, after)) in zip(arrays, now).enumerated() {
+            #expect(before.shape == after.shape, "innerState[\(index)] reshaped — \(note)")
+            #expect(
+                allClose(before, after, rtol: 0, atol: 0).item(Bool.self),
+                "innerState[\(index)] mutated — \(note)")
+        }
+        #expect(cache.offset == offset, "offset moved — \(note)")
+        #expect(cache.metaState == metaState, "idx/offset bookkeeping moved — \(note)")
+    }
+}
+
+// MARK: - Invariant 1: the live ring is physically untouched until commit
+
+@Test func testOverlayLeavesTheLiveRingUntouchedBeforeCommit() throws {
+    let live = RotatingKVCache(maxSize: 8, keep: 0)
+    for p in 0 ..< 20 {
+        let (k, v) = positionedKV(p ..< (p + 1))
+        _ = live.update(keys: k, values: v)
+    }
+
+    let snapshot = RingSnapshot(live)
+    let overlay = try #require(StagedRound([live]))
+
+    stageRound(overlay, 20 ..< 24)
+    snapshot.expectUnchanged(live, "after staging a full round")
+
+    overlay.rollback()
+    snapshot.expectUnchanged(live, "after rolling the round back")
+}
+
+@Test func testOverlayWriteThroughLayerIsRestoredByRollback() throws {
+    let live = KVCacheSimple()
+    for p in 0 ..< 6 {
+        let (k, v) = positionedKV(p ..< (p + 1))
+        _ = live.update(keys: k, values: v)
+    }
+
+    let overlay = try #require(StagedRound([live]))
+    stageRound(overlay, 6 ..< 10)
+    #expect(live.offset == 10, "an append-only layer is written through, not staged")
+
+    overlay.rollback()
+    #expect(live.offset == 6, "rollback did not clamp the append-only layer back")
+}
+
+// MARK: - Invariant 2: the presentation is the live write path's, exactly
+
+/// The overlay's whole correctness argument: what the adapter returns is what the live cache
+/// would have returned had it written the same rows, so the model cannot tell the difference.
+@Test func testOverlayPresentationEqualsTheLiveWritePath() throws {
+    let window = 8
+
+    let staged = RotatingKVCache(maxSize: window, keep: 0)
+    let written = RotatingKVCache(maxSize: window, keep: 0)
+    for p in 0 ..< 20 {
+        let (k, v) = positionedKV(p ..< (p + 1))
+        _ = staged.update(keys: k, values: v)
+        _ = written.update(keys: k, values: v)
+    }
+
+    let overlay = try #require(StagedRound([staged]))
+    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+
+    // Masks are built before the layer writes, on both paths.
+    let overlayMask = adapter.makeMask(n: 4, windowSize: window, returnArray: false)
+    let liveMask = written.makeMask(n: 4, windowSize: window, returnArray: false)
+
+    let (newKeys, newValues) = positionedKV(20 ..< 24)
+    let presented = adapter.update(keys: newKeys, values: newValues)
+    let reference = written.update(keys: newKeys, values: newValues)
+
+    #expect(
+        encodedPositions(presented.0) == encodedPositions(reference.0),
+        "overlay presented a different sequence than the live write path")
+    // Shape first: `allClose` on mismatched shapes is a fatal error inside MLX, which would take
+    // the whole bundle down and hide every test after this one.
+    guard presented.0.shape == reference.0.shape, presented.1.shape == reference.1.shape else {
+        Issue.record(
+            "presentation shape \(presented.0.shape) != write-path shape \(reference.0.shape)")
+        return
+    }
+    #expect(allClose(presented.0, reference.0, rtol: 0, atol: 0).item(Bool.self))
+    #expect(allClose(presented.1, reference.1, rtol: 0, atol: 0).item(Bool.self))
+
+    guard case .array(let overlayMaskArray) = overlayMask,
+        case .array(let liveMaskArray) = liveMask
+    else {
+        Issue.record("expected array masks past the window, got \(overlayMask) / \(liveMask)")
+        return
+    }
+    #expect(overlayMaskArray.shape == liveMaskArray.shape)
+    #expect(
+        overlayMaskArray.dim(-1) == presented.0.dim(2),
+        """
+        mask key axis \(overlayMaskArray.dim(-1)) does not span the presentation \
+        (\(presented.0.dim(2)) keys) — attention would broadcast-fail
+        """)
+    if overlayMaskArray.shape == liveMaskArray.shape {
+        #expect(allClose(overlayMaskArray, liveMaskArray, rtol: 0, atol: 0).item(Bool.self))
+    }
+}
+
+/// Attention through the overlay, past a wrap, against a reference that never rotated.
+@Test func testOverlayAttentionPastWrapMatchesLogicalOrderReference() throws {
+    MLXRandom.seed(0)
+
+    let window = 8
+    let history = 20
+    let queries = 4
+    let heads = 2
+    let headDim = 4
+    let scale = 1.0 / Float(headDim).squareRoot()
+
+    let allKeys = MLXRandom.normal([1, heads, history + queries, headDim])
+    let allValues = MLXRandom.normal([1, heads, history + queries, headDim])
+    let q = MLXRandom.normal([1, heads, queries, headDim])
+
+    let live = RotatingKVCache(maxSize: window, keep: 0)
+    for p in 0 ..< history {
+        _ = live.update(
+            keys: allKeys[0..., 0..., p ..< (p + 1), 0...],
+            values: allValues[0..., 0..., p ..< (p + 1), 0...])
+    }
+
+    let overlay = try #require(StagedRound([live]))
+    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+
+    let mask = adapter.makeMask(n: queries, windowSize: window, returnArray: false)
+    let (keys, values) = adapter.update(
+        keys: allKeys[0..., 0..., history ..< (history + queries), 0...],
+        values: allValues[0..., 0..., history ..< (history + queries), 0...])
+    let out = MLXFast.scaledDotProductAttention(
+        queries: q, keys: keys, values: values, scale: scale, mask: mask)
+
+    let queryPositions = MLXArray(Int32(history) ..< Int32(history + queries))[0..., .newAxis]
+    let keyPositions = MLXArray(Int32(0) ..< Int32(history + queries))[.newAxis]
+    let referenceMask =
+        (queryPositions .>= keyPositions) & (queryPositions .< keyPositions + Int32(window))
+    let expected = MLXFast.scaledDotProductAttention(
+        queries: q, keys: allKeys, values: allValues, scale: scale, mask: .array(referenceMask))
+
+    #expect(out.shape == expected.shape)
+    #expect(
+        allClose(out, expected, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+        "overlay attention diverged from the logical-order reference")
+}
+
+// MARK: - Invariant 3: commit equivalence
+
+/// After a schedule of rounds, a cache driven through the overlay must hold exactly what a cache
+/// that only ever saw the accepted tokens holds. Sliding attention only reads the window, so
+/// equal windows and equal offsets is equality for every subsequent query.
+private func expectCommitEquivalence(
+    window: Int, keep: Int = 0, rounds: [(written: Int, accepted: Int)], prefill: Int,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+    let live = RotatingKVCache(maxSize: window, keep: keep)
+    let reference = RotatingKVCache(maxSize: window, keep: keep)
+
+    if prefill > 0 {
+        let (k, v) = positionedKV(0 ..< prefill)
+        _ = live.update(keys: k, values: v)
+        _ = reference.update(keys: k, values: v)
+    }
+
+    var next = prefill
+    for (index, round) in rounds.enumerated() {
+        let overlay = try #require(StagedRound([live]), sourceLocation: sourceLocation)
+        stageRound(overlay, next ..< (next + round.written))
+        overlay.commit(accepted: round.accepted)
+
+        if round.accepted > 0 {
+            let (k, v) = positionedKV(next ..< (next + round.accepted))
+            _ = reference.update(keys: k, values: v)
+        }
+        next += round.accepted
+
+        #expect(
+            live.offset == reference.offset,
+            "round \(index): offset \(live.offset) != \(reference.offset)",
+            sourceLocation: sourceLocation)
+
+        let liveWindow = try #require(
+            live.logicalView(tail: window), sourceLocation: sourceLocation)
+        let referenceWindow = try #require(
+            reference.logicalView(tail: window), sourceLocation: sourceLocation)
+        #expect(
+            encodedPositions(liveWindow.0) == encodedPositions(referenceWindow.0),
+            """
+            round \(index): window diverged — \
+            \(encodedPositions(liveWindow.0)) vs \(encodedPositions(referenceWindow.0))
+            """,
+            sourceLocation: sourceLocation)
+        #expect(
+            encodedPositions(liveWindow.1).map { -$0 } == encodedPositions(referenceWindow.0),
+            "round \(index): values diverged from keys",
+            sourceLocation: sourceLocation)
+    }
+}
+
+@Test func testOverlayCommitAcceptsNothing() throws {
+    try expectCommitEquivalence(
+        window: 8, rounds: Array(repeating: (written: 4, accepted: 0), count: 3), prefill: 6)
+}
+
+@Test func testOverlayCommitAcceptsEverything() throws {
+    try expectCommitEquivalence(
+        window: 8, rounds: Array(repeating: (written: 4, accepted: 4), count: 6), prefill: 6)
+}
+
+@Test func testOverlayCommitAcceptsPartialPrefixesAcrossTheWrap() throws {
+    // Prefill sits just under the window, so the first rounds cross it and the rest run far past.
+    try expectCommitEquivalence(
+        window: 8,
+        rounds: [
+            (4, 1), (4, 4), (4, 0), (4, 2), (4, 3), (4, 1), (4, 4), (4, 2), (4, 0), (4, 3),
+        ],
+        prefill: 7)
+}
+
+@Test func testOverlayCommitEquivalenceHoldsWithAPinnedPrefix() throws {
+    try expectCommitEquivalence(
+        window: 8, keep: 2,
+        rounds: [(4, 2), (4, 4), (4, 1), (4, 3), (4, 0), (4, 4)],
+        prefill: 6)
+}
+
+@Test func testOverlayCommitEquivalenceFromAnEmptyCache() throws {
+    try expectCommitEquivalence(
+        window: 8, rounds: [(4, 3), (4, 4), (4, 1), (4, 4), (4, 2)], prefill: 0)
+}
+
+// MARK: - Invariant 6: rounds at or beyond the window
+
+/// A round wider than the window is not reachable at a sane block size, but the API accepts an
+/// arbitrary one. It has to stay correct rather than silently corrupt the ring.
+@Test func testOverlayCommitEquivalenceWhenTheRoundExceedsTheWindow() throws {
+    try expectCommitEquivalence(
+        window: 4, rounds: [(6, 2), (6, 6), (6, 0), (6, 3)], prefill: 3)
+    try expectCommitEquivalence(
+        window: 4, rounds: [(8, 5), (8, 8), (8, 1)], prefill: 0)
+}
+
+// MARK: - Mixed topologies and the processed-token timeline
+
+/// `KVCacheStorage` audits that every attention entry's offset equals the model-wide
+/// processed-token count, so a commit has to advance sliding and global layers in lockstep.
+@Test func testOverlayCommitAdvancesEveryLayerByExactlyTheAcceptedCount() throws {
+    let rotating = RotatingKVCache(maxSize: 8, keep: 0)
+    let simple = KVCacheSimple()
+    let cache: [KVCache] = [simple, rotating, KVCacheSimple(), RotatingKVCache(maxSize: 8)]
+
+    let (k, v) = positionedKV(0 ..< 7)
+    cache.forEach { _ = $0.update(keys: k, values: v) }
+    #expect(Set(cache.map(\.offset)) == [7])
+
+    for (round, accepted) in [(0, 2), (1, 4), (2, 0), (3, 3)] {
+        let overlay = try #require(StagedRound(cache))
+        let before = try #require(cache.first?.offset)
+        stageRound(overlay, 100 ..< 104)
+        overlay.commit(accepted: accepted)
+
+        let offsets = Set(cache.map(\.offset))
+        #expect(
+            offsets == [before + accepted],
+            "round \(round): layers diverged — \(cache.map(\.offset))")
+    }
+}
+
+// MARK: - begin: what the overlay refuses
+
+@Test func testOverlayRefusesRecurrentState() {
+    #expect(StagedRound([MambaCache()]) == nil)
+    #expect(StagedRound([ArraysCache(size: 2)]) == nil)
+    #expect(
+        StagedRound([KVCacheSimple(), MambaCache()]) == nil,
+        "one recurrent entry has to disqualify the whole array")
+}
+
+@Test func testOverlayRefusesNestedCacheLists() {
+    let nested = CacheList(KVCacheSimple(), RotatingKVCache(maxSize: 8))
+    #expect(
+        StagedRound([nested]) == nil,
+        "nested topologies are not supported yet and must fall back, not misalign")
+}
+
+@Test func testOverlayAcceptsTheGemma4Topology() throws {
+    // Gemma 4's newCache: a standard cache for full-attention layers, a rotating one per sliding
+    // layer, in a 4:1 pattern.
+    let cache: [KVCache] = (0 ..< 10).map { index in
+        index % 5 == 4 ? KVCacheSimple() : RotatingKVCache(maxSize: 512, keep: 0)
+    }
+    let overlay = try #require(StagedRound(cache))
+    #expect(overlay.caches.count == cache.count)
+
+    for (index, (live, presented)) in zip(cache, overlay.caches).enumerated() {
+        if live is RotatingKVCache {
+            #expect(presented is RotatingStagedKVCache, "sliding layer \(index) was not staged")
+        } else {
+            #expect(
+                presented as AnyObject === live as AnyObject,
+                "global layer \(index) should be written through")
+        }
+    }
+}
+
+@Test func testOverlayAcceptsQuantizedLayersAsWriteThrough() throws {
+    let overlay = try #require(StagedRound([QuantizedKVCache()]))
+    #expect(overlay.caches.first is QuantizedKVCache, "quantized layers are written through")
+}
+
+/// A cache type the overlay has never heard of is judged on the contract it advertises, not on
+/// whether it appears in a list: write-through plus a clamp is sound exactly when `trim(_:)`
+/// undoes the appended positions, which is what `isTrimmable` promises.
+@Test func testOverlayJudgesUnknownCacheTypesByTrimmability() throws {
+    let trimmable = ProbeCache(isTrimmable: true)
+    let overlay = try #require(StagedRound([trimmable]))
+    #expect(overlay.caches.first as AnyObject === trimmable as AnyObject)
+
+    let (k, v) = positionedKV(0 ..< 4)
+    _ = overlay.caches[0].update(keys: k, values: v)
+    overlay.commit(accepted: 1)
+    #expect(trimmable.offset == 1, "commit did not clamp an unknown write-through layer")
+
+    #expect(
+        StagedRound([ProbeCache(isTrimmable: false)]) == nil,
+        "a cache that cannot be rewound cannot be written through")
+}
+
+/// A minimal `KVCache` conformer that is none of the types the overlay knows by name.
+private final class ProbeCache: KVCache {
+    var offset: Int = 0
+    let trimmable: Bool
+
+    init(isTrimmable: Bool) { self.trimmable = isTrimmable }
+
+    var maxSize: Int? { nil }
+    var isTrimmable: Bool { trimmable }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        offset += keys.dim(2)
+        return (keys, values)
+    }
+
+    @discardableResult
+    func trim(_ n: Int) -> Int {
+        guard trimmable else { return 0 }
+        let removed = Swift.min(n, offset)
+        offset -= removed
+        return removed
+    }
+
+    var state: [MLXArray] {
+        get { [] }
+        set {}
+    }
+    var metaState: [String] {
+        get { [] }
+        set {}
+    }
+    func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode { .none }
+    func copy() -> any KVCache { ProbeCache(isTrimmable: trimmable) }
+    func innerState() -> [MLXArray] { [] }
+}
+
+// MARK: - Adapter surface
+
+@Test func testOverlayAdapterReportsStagedPositionsInItsOffset() throws {
+    let live = RotatingKVCache(maxSize: 8, keep: 0)
+    let (k, v) = positionedKV(0 ..< 5)
+    _ = live.update(keys: k, values: v)
+
+    let overlay = try #require(StagedRound([live]))
+    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+
+    #expect(adapter.offset == 5, "before staging the adapter must read as the live cache")
+    #expect(adapter.maxSize == 8)
+
+    stageRound(overlay, 5 ..< 9)
+    #expect(adapter.stagedCount == 4)
+    #expect(adapter.offset == 9)
+    #expect(live.offset == 5, "staging must not move the live offset")
+
+    overlay.commit(accepted: 2)
+    #expect(adapter.stagedCount == 0, "commit must clear staging")
+    #expect(live.offset == 7)
+}
+
+@Test func testOverlayAdapterIsNotTrimmable() throws {
+    let live = RotatingKVCache(maxSize: 8, keep: 0)
+    let (k, v) = positionedKV(0 ..< 5)
+    _ = live.update(keys: k, values: v)
+
+    let overlay = try #require(StagedRound([live]))
+    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+
+    #expect(adapter.isTrimmable == false)
+    #expect(adapter.trim(3) == 0, "staged rows are dropped by commit, never trimmed")
+    #expect(live.offset == 5)
+}
+
+@Test func testOverlayAdapterInnerStateExposesStagedArraysForEval() throws {
+    let live = RotatingKVCache(maxSize: 8, keep: 0)
+    let (k, v) = positionedKV(0 ..< 5)
+    _ = live.update(keys: k, values: v)
+
+    let overlay = try #require(StagedRound([live]))
+    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+    let liveArrays = adapter.innerState().count
+
+    stageRound(overlay, 5 ..< 9)
+    #expect(
+        adapter.innerState().count == liveArrays + 2,
+        "staged K/V must be reachable from innerState or eval would miss them")
+}
+
+// MARK: - Oracle: a staged round vs an accepted-only replay
+//
+// The tests above check the overlay against hand-computed expectations. This one checks it
+// against the other implementation of the same idea: take a deep snapshot before the round, run
+// the round, then replay *only* the accepted tokens into the snapshot through the ordinary write
+// path. Snapshot-and-replay is correct by construction and slow; the overlay is fast and has to
+// agree with it exactly. `KVCacheStorage.copy()` is the snapshot.
+
+/// Everything that has to match between a storage driven through staged rounds and one that only
+/// ever saw the accepted tokens.
+private func expectStoragesEquivalent(
+    _ staged: KVCacheStorage, _ replayed: KVCacheStorage, _ note: String,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    #expect(
+        staged.processedTokenCount == replayed.processedTokenCount,
+        "\(note): timeline \(staged.processedTokenCount) != \(replayed.processedTokenCount)",
+        sourceLocation: sourceLocation)
+    #expect(
+        staged.nativeAttentionOffsetsAreAligned,
+        "\(note): staged leaves drifted from the timeline", sourceLocation: sourceLocation)
+    #expect(
+        replayed.nativeAttentionOffsetsAreAligned,
+        "\(note): replayed leaves drifted from the timeline", sourceLocation: sourceLocation)
+
+    #expect(staged.cache.count == replayed.cache.count, sourceLocation: sourceLocation)
+    for (index, (a, b)) in zip(staged.cache, replayed.cache).enumerated() {
+        #expect(
+            a.offset == b.offset, "\(note): leaf \(index) offset", sourceLocation: sourceLocation)
+
+        if let a = a as? RotatingKVCache, let b = b as? RotatingKVCache {
+            guard let aView = a.logicalView(tail: a.maxSize ?? 0),
+                let bView = b.logicalView(tail: b.maxSize ?? 0)
+            else {
+                #expect(
+                    a.logicalView(tail: 1) == nil && b.logicalView(tail: 1) == nil,
+                    "\(note): leaf \(index) — one ring is empty and the other is not",
+                    sourceLocation: sourceLocation)
+                continue
+            }
+            #expect(
+                encodedPositions(aView.0) == encodedPositions(bView.0),
+                """
+                \(note): leaf \(index) window \(encodedPositions(aView.0)) \
+                != \(encodedPositions(bView.0))
+                """,
+                sourceLocation: sourceLocation)
+            // Physical layout too: `idx` and the ring's rotation are invisible to the logical
+            // view, and a divergence there would surface later as a wrong single-token write.
+            #expect(
+                a.metaState == b.metaState,
+                "\(note): leaf \(index) ring layout \(a.metaState) != \(b.metaState)",
+                sourceLocation: sourceLocation)
+        } else {
+            let aState = a.state
+            let bState = b.state
+            #expect(
+                aState.count == bState.count, "\(note): leaf \(index) state arity",
+                sourceLocation: sourceLocation)
+            for (arrayIndex, (x, y)) in zip(aState, bState).enumerated() {
+                guard x.shape == y.shape else {
+                    Issue.record(
+                        "\(note): leaf \(index) state[\(arrayIndex)] \(x.shape) != \(y.shape)",
+                        sourceLocation: sourceLocation)
+                    continue
+                }
+                #expect(
+                    allClose(x, y, rtol: 0, atol: 0).item(Bool.self),
+                    "\(note): leaf \(index) state[\(arrayIndex)] values",
+                    sourceLocation: sourceLocation)
+            }
+        }
+    }
+}
+
+private func makeGemmaShapedStorage(window: Int, keep: Int) -> KVCacheStorage {
+    KVCacheStorage(
+        [KVCacheSimple(), RotatingKVCache(maxSize: window, keep: keep)], plan: .disabled)
+}
+
+private func expectRoundMatchesAcceptedOnlyReplay(
+    window: Int, keep: Int = 0, prefill: Int, rounds: [(written: Int, retaining: Int)],
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+    let live = makeGemmaShapedStorage(window: window, keep: keep)
+
+    if prefill > 0 {
+        let (k, v) = positionedKV(0 ..< prefill)
+        for leaf in live.cache { _ = leaf.update(keys: k, values: v) }
+        live.commitProcessedTokens(prefill)
+    }
+
+    var next = prefill
+    for (index, round) in rounds.enumerated() {
+        // The oracle has to be taken before the round: `copy()` refuses to run inside one.
+        let oracle = live.copy()
+
+        let overlay = try #require(
+            StagedRound(live), sourceLocation: sourceLocation)
+        let (writtenKeys, writtenValues) = positionedKV(next ..< (next + round.written))
+        for presented in overlay.caches {
+            _ = presented.update(keys: writtenKeys, values: writtenValues)
+        }
+        overlay.commit(accepted: round.retaining)
+
+        if round.retaining > 0 {
+            let (k, v) = positionedKV(next ..< (next + round.retaining))
+            for leaf in oracle.cache { _ = leaf.update(keys: k, values: v) }
+            oracle.commitProcessedTokens(round.retaining)
+        }
+        next += round.retaining
+
+        expectStoragesEquivalent(live, oracle, "round \(index)", sourceLocation: sourceLocation)
+    }
+}
+
+@Test func testStagedRoundMatchesAcceptedOnlyReplayFromEmpty() throws {
+    try expectRoundMatchesAcceptedOnlyReplay(
+        window: 8, prefill: 0, rounds: [(4, 3), (4, 4), (4, 1), (4, 4), (4, 2)])
+}
+
+@Test func testStagedRoundMatchesAcceptedOnlyReplayAcrossTheWrap() throws {
+    try expectRoundMatchesAcceptedOnlyReplay(
+        window: 8, prefill: 7,
+        rounds: [(4, 1), (4, 4), (4, 0), (4, 2), (4, 3), (4, 1), (4, 4), (4, 2), (4, 0), (4, 3)])
+}
+
+@Test func testStagedRoundMatchesAcceptedOnlyReplayWithAPinnedPrefix() throws {
+    try expectRoundMatchesAcceptedOnlyReplay(
+        window: 8, keep: 2, prefill: 6, rounds: [(4, 2), (4, 4), (4, 1), (4, 3), (4, 0), (4, 4)])
+}
+
+@Test func testStagedRoundMatchesAcceptedOnlyReplayWhenWiderThanTheWindow() throws {
+    try expectRoundMatchesAcceptedOnlyReplay(
+        window: 4, prefill: 3, rounds: [(6, 2), (6, 6), (6, 0), (6, 3)])
+}
+
+/// The timeline half of the oracle, without the replay: a round leaves the storage's
+/// processed-token count and its leaves in step. (The `roundIsOpen` refusals this checks
+/// against are inert until the transaction is hosted on the storage itself.)
+@Test func testStagedRoundLeavesTheTimelineAligned() throws {
+    let live = makeGemmaShapedStorage(window: 8, keep: 0)
+    let (k, v) = positionedKV(0 ..< 5)
+    for leaf in live.cache { _ = leaf.update(keys: k, values: v) }
+    live.commitProcessedTokens(5)
+
+    #expect(live.roundIsOpen == false)
+    let overlay = try #require(StagedRound(live))
+    stageRound(overlay, 5 ..< 9)
+    overlay.commit(accepted: 2)
+    #expect(live.processedTokenCount == 7)
+    #expect(live.nativeAttentionOffsetsAreAligned)
+}

--- a/Tests/MLXLMTests/KVCacheRoundTests.swift
+++ b/Tests/MLXLMTests/KVCacheRoundTests.swift
@@ -654,3 +654,97 @@ private func expectRoundMatchesAcceptedOnlyReplay(
     #expect(live.processedTokenCount == 7)
     #expect(live.nativeAttentionOffsetsAreAligned)
 }
+
+// MARK: - Taking back committed-but-unemitted positions
+//
+// A round commits its accepted prefix before the consumer has drained it, so a stop token partway
+// through leaves positions in the cache that were never emitted. Past a wrapped ring a plain trim
+// cannot take them back — the append already evicted what the rewind would restore — so the
+// commit keeps a restore point. Same oracle as above: the answer has to equal a cache that only
+// ever saw the positions that were actually emitted.
+
+private func expectRewindMatchesEmittedOnlyReplay(
+    window: Int, keep: Int = 0, prefill: Int, written: Int, retaining: Int, rewinding: Int,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+    let live = makeGemmaShapedStorage(window: window, keep: keep)
+    if prefill > 0 {
+        let (k, v) = positionedKV(0 ..< prefill)
+        for leaf in live.cache { _ = leaf.update(keys: k, values: v) }
+        live.commitProcessedTokens(prefill)
+    }
+
+    let oracle = live.copy()
+
+    let staged = try #require(
+        StagedRound(live, width: written), sourceLocation: sourceLocation)
+    stageRound(staged, prefill ..< (prefill + written))
+    staged.commit(accepted: retaining)
+
+    let rewound = live.rewindLastRound(rewinding)
+    #expect(
+        rewound == Swift.min(rewinding, retaining),
+        "rewind took back \(rewound), expected \(Swift.min(rewinding, retaining))",
+        sourceLocation: sourceLocation)
+
+    // The oracle only ever sees the positions that survived both steps.
+    let emitted = retaining - rewound
+    if emitted > 0 {
+        let (k, v) = positionedKV(prefill ..< (prefill + emitted))
+        for leaf in oracle.cache { _ = leaf.update(keys: k, values: v) }
+        oracle.commitProcessedTokens(emitted)
+    }
+
+    expectStoragesEquivalent(
+        live, oracle, "rewind \(rewinding) of \(retaining)", sourceLocation: sourceLocation)
+}
+
+@Test(arguments: [1, 2, 3, 4])
+func testRewindPastTheWrapMatchesEmittedOnlyReplay(rewinding: Int) throws {
+    // Prefill alone clears the window, so every ring here has already wrapped and a plain trim
+    // would silently no-op.
+    try expectRewindMatchesEmittedOnlyReplay(
+        window: 8, prefill: 20, written: 4, retaining: 4, rewinding: rewinding)
+}
+
+@Test(arguments: [1, 2, 3])
+func testRewindBelowTheWrapMatchesEmittedOnlyReplay(rewinding: Int) throws {
+    // Below the window the commit needs no restore point; the exact trim path handles it.
+    try expectRewindMatchesEmittedOnlyReplay(
+        window: 32, prefill: 4, written: 4, retaining: 4, rewinding: rewinding)
+}
+
+@Test func testRewindPastTheWrapWithAPinnedPrefix() throws {
+    try expectRewindMatchesEmittedOnlyReplay(
+        window: 8, keep: 2, prefill: 20, written: 4, retaining: 3, rewinding: 2)
+}
+
+@Test func testRewindingEverythingTheRoundCommittedPastTheWrap() throws {
+    try expectRewindMatchesEmittedOnlyReplay(
+        window: 8, prefill: 20, written: 4, retaining: 3, rewinding: 3)
+}
+
+/// The record is only good for the most recent commit: anything written after it invalidates the
+/// pre-commit contents the restore point refers to.
+@Test func testRewindIsRefusedAfterAnotherWrite() throws {
+    let live = makeGemmaShapedStorage(window: 8, keep: 0)
+    let (k, v) = positionedKV(0 ..< 20)
+    for leaf in live.cache { _ = leaf.update(keys: k, values: v) }
+    live.commitProcessedTokens(20)
+
+    let staged = try #require(StagedRound(live, width: 4))
+    stageRound(staged, 20 ..< 24)
+    staged.commit(accepted: 4)
+    #expect(live.processedTokenCount == 24)
+
+    // A single-token write outside a round: exactly what passthrough decoding does.
+    let (k2, v2) = positionedKV(24 ..< 25)
+    for leaf in live.cache { _ = leaf.update(keys: k2, values: v2) }
+    live.commitProcessedTokens(1)
+
+    // The rotating ring has wrapped, so the fallback trim reports that it took nothing back
+    // rather than corrupting the ring.
+    #expect(live.rewindLastRound(2) == 0)
+    #expect(live.processedTokenCount == 25)
+    #expect(live.nativeAttentionOffsetsAreAligned)
+}

--- a/Tests/MLXLMTests/KVCacheRoundTests.swift
+++ b/Tests/MLXLMTests/KVCacheRoundTests.swift
@@ -748,3 +748,63 @@ func testRewindBelowTheWrapMatchesEmittedOnlyReplay(rewinding: Int) throws {
     #expect(live.processedTokenCount == 25)
     #expect(live.nativeAttentionOffsetsAreAligned)
 }
+
+/// Two sliding layers at different widths: at a timeline between them one has wrapped and one has
+/// not, so the same commit produces a restore point for the first and a plain trim record for the
+/// second. The trim has to reach the *live* ring — the round presented a staged wrapper whose
+/// `trim(_:)` is deliberately a no-op, and rewinding through that moves the timeline while the
+/// leaf stays put.
+@Test func testRewindReachesTheLiveRingWhenOnlySomeLayersWrapped() throws {
+    let narrow = RotatingKVCache(maxSize: 4, keep: 0)
+    let wide = RotatingKVCache(maxSize: 16, keep: 0)
+    let live = KVCacheStorage([narrow, wide], plan: .disabled)
+
+    let (k, v) = positionedKV(0 ..< 6)
+    for leaf in live.cache { _ = leaf.update(keys: k, values: v) }
+    live.commitProcessedTokens(6)
+    #expect(narrow.isTrimmable == false, "the narrow ring must have wrapped")
+    #expect(wide.isTrimmable, "the wide ring must not have wrapped")
+
+    let oracle = live.copy()
+
+    let staged = try #require(StagedRound(live, width: 3))
+    stageRound(staged, 6 ..< 9)
+    staged.commit(accepted: 3)
+
+    #expect(live.rewindLastRound(2) == 2)
+
+    let (ok, ov) = positionedKV(6 ..< 7)
+    for leaf in oracle.cache { _ = leaf.update(keys: ok, values: ov) }
+    oracle.commitProcessedTokens(1)
+
+    expectStoragesEquivalent(live, oracle, "mixed-width rewind")
+}
+
+/// Dynamic compression can replace an entry between a commit and a rewind. The record refers to a
+/// cache slot, not to the object the commit happened to hold, so a replacement invalidates it and
+/// the rewind falls back to the plain trim rather than restoring into a leaf the storage no longer
+/// owns.
+@Test func testRewindIsRefusedAfterTheCacheIsReplaced() throws {
+    let original = RotatingKVCache(maxSize: 8, keep: 0)
+    let live = KVCacheStorage([original], plan: .disabled)
+    let (k, v) = positionedKV(0 ..< 20)
+    _ = original.update(keys: k, values: v)
+    live.commitProcessedTokens(20)
+
+    let staged = try #require(StagedRound(live, width: 4))
+    stageRound(staged, 20 ..< 24)
+    staged.commit(accepted: 4)
+    #expect(live.processedTokenCount == 24)
+
+    // Stand in for a compression pass: an equivalent leaf, a different object.
+    let replacement = try #require(original.copy() as? RotatingKVCache)
+    let replacementBefore = RingSnapshot(replacement)
+    live.replace(with: [replacement])
+
+    // The ring has wrapped, so the fallback trim takes nothing back rather than restoring a
+    // snapshot into a cache that is no longer the one at this slot.
+    #expect(live.rewindLastRound(2) == 0)
+    #expect(live.processedTokenCount == 24)
+    #expect(live.nativeAttentionOffsetsAreAligned)
+    replacementBefore.expectUnchanged(replacement, "after a rewind against a replaced entry")
+}

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -1008,3 +1008,197 @@ private final class BatchOffsetProbeCache: BaseKVCache {
     }
     #expect(offsets.asArray(Int32.self) == [10, 20])
 }
+
+// MARK: - RotatingKVCache.logicalView
+//
+// `logicalView(tail:)` is the read-only counterpart to `update(keys:values:)`: it exposes the
+// ring's contents in chronological order without writing. Speculative decoding needs it to
+// present committed history alongside K/V it has not committed yet.
+//
+// Nothing in this repo drove a `RotatingKVCache` ring past its wrap before these tests, so the
+// rotation in `updateInPlace`, the linearization in `temporalOrder`, and the windowed mask that
+// `makeMask` builds over the multi-token presentation were all uncovered. They are the
+// foundation the view rests on, so they are pinned here too.
+
+/// K/V whose every element encodes its own sequence position: keys hold `+p`, values `-p`.
+/// Any reordering, duplication, or K/V mix-up changes the numbers.
+private func positionedKV(
+    _ positions: Range<Int>, headDim: Int = 2
+) -> (MLXArray, MLXArray) {
+    let count = positions.count
+    let keys = MLXArray(
+        positions.flatMap { Array(repeating: Float($0), count: headDim) },
+        [1, 1, count, headDim])
+    let values = MLXArray(
+        positions.flatMap { Array(repeating: Float(-$0), count: headDim) },
+        [1, 1, count, headDim])
+    return (keys, values)
+}
+
+/// Recover the sequence positions encoded by `positionedKV` from a `[B, H, S, D]` key array.
+private func encodedPositions(_ keys: MLXArray) -> [Int] {
+    keys[0, 0, 0..., 0].asArray(Float.self).map { Int($0) }
+}
+
+/// Drive `cache` through `count` single-token writes, so the ring actually rotates.
+private func fillOneAtATime(_ cache: RotatingKVCache, positions: Range<Int>) {
+    for p in positions {
+        let (k, v) = positionedKV(p ..< (p + 1))
+        _ = cache.update(keys: k, values: v)
+    }
+}
+
+@Test func testRotatingLogicalViewIsNilBeforeFirstWrite() {
+    #expect(RotatingKVCache(maxSize: 8, keep: 0).logicalView(tail: 8) == nil)
+}
+
+@Test func testRotatingLogicalViewReturnsChronologicalTailPastWrap() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    // The ring has wrapped twice; physical order is rotated, chronological order is not.
+    #expect(cache.offset == 20)
+
+    let full = try #require(cache.logicalView(tail: 8))
+    #expect(
+        encodedPositions(full.0) == Array(12 ..< 20),
+        "logicalView did not linearize the rotated ring")
+    #expect(encodedPositions(full.1).map { -$0 } == Array(12 ..< 20), "values diverged from keys")
+
+    let short = try #require(cache.logicalView(tail: 3))
+    #expect(encodedPositions(short.0) == [17, 18, 19], "a short tail took the wrong end")
+}
+
+@Test func testRotatingLogicalViewClampsTailToWhatTheCacheHolds() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 5)
+
+    #expect(encodedPositions(try #require(cache.logicalView(tail: 99)).0) == Array(0 ..< 5))
+    #expect(encodedPositions(try #require(cache.logicalView(tail: 5)).0) == Array(0 ..< 5))
+    #expect(try #require(cache.logicalView(tail: 0)).0.dim(2) == 0)
+    #expect(try #require(cache.logicalView(tail: -1)).0.dim(2) == 0, "negative tail must clamp")
+}
+
+@Test func testRotatingLogicalViewLeavesTheRingUntouched() {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    let beforeState = cache.innerState().map { MLXArray($0.asArray(Float.self), $0.shape) }
+    let beforeOffset = cache.offset
+    let beforeMeta = cache.metaState
+
+    _ = cache.logicalView(tail: 7)
+    _ = cache.logicalView(tail: 3)
+
+    let afterState = cache.innerState()
+    #expect(afterState.count == beforeState.count)
+    for (index, (before, after)) in zip(beforeState, afterState).enumerated() {
+        #expect(before.shape == after.shape, "innerState[\(index)] was reshaped by a read")
+        #expect(
+            allClose(before, after, rtol: 0, atol: 0).item(Bool.self),
+            "innerState[\(index)] was mutated by a read")
+    }
+    #expect(cache.offset == beforeOffset, "logicalView moved the offset")
+    #expect(cache.metaState == beforeMeta, "logicalView disturbed idx/offset bookkeeping")
+}
+
+@Test func testRotatingLogicalViewPreservesPinnedPrefix() throws {
+    // `keep` pins the oldest entries; the write path front-trims *after* them, so a view must
+    // splice around the prefix rather than take a flat tail.
+    let cache = RotatingKVCache(maxSize: 8, keep: 2)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    let view = try #require(cache.logicalView(tail: 5))
+    let positions = encodedPositions(view.0)
+    #expect(positions.count == 5)
+    #expect(Array(positions.prefix(2)) == [0, 1], "pinned prefix was evicted by the view")
+    #expect(positions == [0, 1] + Array(positions.suffix(3)))
+    #expect(positions.suffix(3).sorted() == Array(positions.suffix(3)), "tail out of order")
+}
+
+/// The property the speculative overlay rests on: for a multi-token write, the presentation the
+/// cache *would* return equals `logicalView(tail: maxSize - 1)` followed by the new rows. An
+/// adapter can therefore stage beside the ring and hand the model an identical view.
+@Test func testRotatingLogicalViewPlusNewRowsEqualsTheWritePresentation() throws {
+    let window = 8
+    let staged = 4
+
+    let cache = RotatingKVCache(maxSize: window, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    // Read the view and the mask *before* the write, exactly as an adapter would.
+    let view = try #require(cache.logicalView(tail: window - 1))
+    let mask = cache.makeMask(n: staged, windowSize: window, returnArray: false)
+
+    let (newKeys, newValues) = positionedKV(20 ..< (20 + staged))
+    let presented = cache.update(keys: newKeys, values: newValues)
+
+    let composedKeys = concatenated([view.0, newKeys], axis: 2)
+    let composedValues = concatenated([view.1, newValues], axis: 2)
+
+    #expect(
+        encodedPositions(presented.0) == encodedPositions(composedKeys),
+        "staged presentation diverged from the live write path")
+    #expect(
+        allClose(presented.0, composedKeys, rtol: 0, atol: 0).item(Bool.self),
+        "keys diverged from the live write path")
+    #expect(
+        allClose(presented.1, composedValues, rtol: 0, atol: 0).item(Bool.self),
+        "values diverged from the live write path")
+
+    // The mask the cache built before the write has to span exactly that presentation, or an
+    // adapter could not delegate mask construction to the live cache.
+    guard case .array(let maskArray) = mask else {
+        Issue.record("expected an array mask once offset + n exceeds the window, got \(mask)")
+        return
+    }
+    #expect(
+        maskArray.dim(-1) == composedKeys.dim(2),
+        "mask key axis \(maskArray.dim(-1)) != presented length \(composedKeys.dim(2))")
+    #expect(maskArray.dim(-2) == staged)
+}
+
+/// Attention through the rotating cache's own presentation and mask, past a wrap, must equal a
+/// reference that never rotated: every position kept in a plain array under an explicit
+/// causal-intersect-window mask over absolute positions.
+@Test func testRotatingCacheAttentionPastWrapMatchesLogicalOrderReference() {
+    MLXRandom.seed(0)
+
+    let window = 8
+    let history = 20
+    let queries = 4
+    let heads = 2
+    let headDim = 4
+    let scale = 1.0 / Float(headDim).squareRoot()
+
+    let allKeys = MLXRandom.normal([1, heads, history + queries, headDim])
+    let allValues = MLXRandom.normal([1, heads, history + queries, headDim])
+    let q = MLXRandom.normal([1, heads, queries, headDim])
+
+    let cache = RotatingKVCache(maxSize: window, keep: 0)
+    for p in 0 ..< history {
+        _ = cache.update(
+            keys: allKeys[0..., 0..., p ..< (p + 1), 0...],
+            values: allValues[0..., 0..., p ..< (p + 1), 0...])
+    }
+
+    let mask = cache.makeMask(n: queries, windowSize: window, returnArray: false)
+    let (cachedKeys, cachedValues) = cache.update(
+        keys: allKeys[0..., 0..., history ..< (history + queries), 0...],
+        values: allValues[0..., 0..., history ..< (history + queries), 0...])
+    let out = MLXFast.scaledDotProductAttention(
+        queries: q, keys: cachedKeys, values: cachedValues, scale: scale, mask: mask)
+
+    // Reference: all history retained, masked by absolute position.
+    let queryPositions = MLXArray(Int32(history) ..< Int32(history + queries))[0..., .newAxis]
+    let keyPositions = MLXArray(Int32(0) ..< Int32(history + queries))[.newAxis]
+    let referenceMask =
+        (queryPositions .>= keyPositions) & (queryPositions .< keyPositions + Int32(window))
+    let reference = MLXFast.scaledDotProductAttention(
+        queries: q, keys: allKeys, values: allValues, scale: scale, mask: .array(referenceMask))
+
+    #expect(out.shape == reference.shape)
+    #expect(
+        allClose(out, reference, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+        "post-wrap attention diverged from the logical-order reference")
+}

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -1116,6 +1116,36 @@ private func fillOneAtATime(_ cache: RotatingKVCache, positions: Range<Int>) {
     #expect(positions.suffix(3).sorted() == Array(positions.suffix(3)), "tail out of order")
 }
 
+@Test func testRotatingLogicalViewFloorsAtThePinnedPrefix() throws {
+    // A pinned entry is never evictable, so `keep` is a floor on the view and not just a
+    // splice point: a `tail` below it still returns the prefix. The alternative -- honouring
+    // `tail` exactly -- would hand back a context the ring itself can never present.
+    let cache = RotatingKVCache(maxSize: 8, keep: 2)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    for tail in 0 ... 2 {
+        let view = try #require(cache.logicalView(tail: tail))
+        #expect(
+            encodedPositions(view.0) == [0, 1],
+            "tail \(tail) below `keep` dropped the pinned prefix")
+        #expect(encodedPositions(view.1).map { -$0 } == [0, 1], "values diverged from keys")
+    }
+
+    // One past the floor is the first tail that actually selects anything.
+    let positions = encodedPositions(try #require(cache.logicalView(tail: 3)).0)
+    #expect(positions.count == 3)
+    #expect(Array(positions.prefix(2)) == [0, 1], "the prefix moved once the tail cleared it")
+}
+
+@Test func testRotatingLogicalViewFloorIsBoundedByWhatTheCacheHolds() throws {
+    // Fewer entries written than `keep` pins: the floor is what exists, not what is reserved.
+    let cache = RotatingKVCache(maxSize: 8, keep: 4)
+    fillOneAtATime(cache, positions: 0 ..< 2)
+
+    #expect(encodedPositions(try #require(cache.logicalView(tail: 0)).0) == [0, 1])
+    #expect(encodedPositions(try #require(cache.logicalView(tail: 9)).0) == [0, 1])
+}
+
 /// The property the speculative overlay rests on: for a multi-token write, the presentation the
 /// cache *would* return equals `logicalView(tail: maxSize - 1)` followed by the new rows. An
 /// adapter can therefore stage beside the ring and hand the model an identical view.

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -677,23 +677,44 @@ func testTrimSharedKVStateNoOpOnNilStateAndAbsentKey() {
 private final class PositionScriptedMainModel: Module, LanguageModel, KVCacheDimensionProvider {
     static let vocabularySize = 32
 
+    /// Which of `prepare`'s two shapes this model returns, and whether it emits drafter state
+    /// while doing so. The iterator reconciles the emitted snapshot at a different site in each
+    /// case, and the re-prime forward exists only for the middle one.
+    enum PrefillStyle {
+        /// `prepare` hands back the prompt; the iterator runs the final position itself.
+        case tokens
+        /// `prepare` evaluates the prompt and returns logits, carrying no drafter state -- so the
+        /// iterator follows up with a re-prime forward to obtain some.
+        case logits
+        /// `prepare` evaluates the prompt and threads drafter state through, so no re-prime.
+        case logitsWithDrafterState
+    }
+
     var kvHeads: [Int] { Array(repeating: 1, count: wideSlidingWindow == nil ? 2 : 3) }
     let script: [Int32]
     let slidingWindow: Int
     let wideSlidingWindow: Int?
     let omitDrafterState: Bool
+    /// Emit `mtpSharedKVStatesKey` without the source map that says which entry each tuple came
+    /// from -- a snapshot the consumer cannot place against the cache.
+    let omitSharedKVSources: Bool
+    let prefillStyle: PrefillStyle
 
     private(set) var emittedSharedKVSpans: [[String: Int]] = []
     private(set) var verifyChunkLengths: [Int] = []
+    private(set) var forwardCallCount = 0
 
     init(
         script: [Int32], slidingWindow: Int, wideSlidingWindow: Int? = nil,
-        omitDrafterState: Bool = false
+        omitDrafterState: Bool = false, omitSharedKVSources: Bool = false,
+        prefillStyle: PrefillStyle = .tokens
     ) {
         self.script = script
         self.slidingWindow = slidingWindow
         self.wideSlidingWindow = wideSlidingWindow
         self.omitDrafterState = omitDrafterState
+        self.omitSharedKVSources = omitSharedKVSources
+        self.prefillStyle = prefillStyle
         super.init()
     }
 
@@ -711,7 +732,16 @@ private final class PositionScriptedMainModel: Module, LanguageModel, KVCacheDim
     func prepare(
         _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
     ) throws -> PrepareResult {
-        .tokens(input.text)
+        switch prefillStyle {
+        case .tokens:
+            return .tokens(input.text)
+        case .logits:
+            return .logits(callAsFunction(input.text, cache: cache, state: nil))
+        case .logitsWithDrafterState:
+            var emitting = LMOutput.State()
+            emitting[mtpEmitFlagKey] = true
+            return .logits(callAsFunction(input.text, cache: cache, state: emitting))
+        }
     }
 
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
@@ -721,6 +751,7 @@ private final class PositionScriptedMainModel: Module, LanguageModel, KVCacheDim
     func callAsFunction(
         _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
     ) -> LMOutput {
+        forwardCallCount += 1
         let positions = input.tokens.dim(-1)
         // Read the base position before the caches move; every entry is at the same offset.
         let base = cache?.first?.offset ?? 0
@@ -745,7 +776,9 @@ private final class PositionScriptedMainModel: Module, LanguageModel, KVCacheDim
 
         var out = LMOutput.State()
         out[mtpLastHiddenStatesKey] = MLXArray.zeros([1, positions, 4])
-        out[mtpSharedKVSourceIndicesKey] = ["full_attention": 0, "sliding_attention": 1]
+        if !omitSharedKVSources {
+            out[mtpSharedKVSourceIndicesKey] = ["full_attention": 0, "sliding_attention": 1]
+        }
         out[mtpSharedKVStatesKey] = sharedKV
         return LMOutput(logits: logits, state: out)
     }
@@ -810,6 +843,83 @@ private func runGreedy(
     var tokens = [Int]()
     while let token = iter.next() { tokens.append(token) }
     return tokens
+}
+
+// MARK: - A snapshot the consumer cannot place is refused at prefill too
+//
+// Prefill emits, and it emits at three sites depending on which shape the target's `prepare`
+// returns. All three reconcile the snapshot against the cache, and all three have to act on a
+// refusal: the round-level `assert` that would otherwise catch it is compiled out in release,
+// leaving the drafter attending an unreconciled sliding snapshot.
+
+/// Shared body: a target that emits a snapshot with no source map must stand the drafter down
+/// during `init`, and the stream must still come out token-identical to plain greedy decoding.
+private func expectSourcelessPrefillStandsDown(
+    _ style: PositionScriptedMainModel.PrefillStyle,
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+    let window = 8
+    let prompt = Array(1 ... Int32(window * 3))
+    func makeModel() -> PositionScriptedMainModel {
+        PositionScriptedMainModel(
+            script: mixedAcceptanceScript(drafted: 7), slidingWindow: window,
+            omitSharedKVSources: true, prefillStyle: style)
+    }
+
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let (tokens, iter) = try runMTP(
+        model: makeModel(), drafter: drafter, prompt: prompt, maxTokens: 24)
+
+    #expect(
+        iter.passthroughReason == MTPSpeculativeTokenIterator.missingSharedKVSourcesReason,
+        "a sourceless snapshot at prefill did not stand the drafter down",
+        sourceLocation: sourceLocation)
+    #expect(
+        drafter.draftBlockCallCount == 0, "the drafter ran against an unreconciled snapshot",
+        sourceLocation: sourceLocation)
+    #expect(
+        tokens.count == 24, "the stream did not complete in passthrough",
+        sourceLocation: sourceLocation)
+
+    let greedy = try runGreedy(model: makeModel(), prompt: prompt, maxTokens: 24)
+    #expect(
+        tokens == greedy, "standing down at prefill changed the emitted stream",
+        sourceLocation: sourceLocation)
+}
+
+@Test func testSourcelessPrefillStandsDownWhenPrepareReturnsTokens() throws {
+    try expectSourcelessPrefillStandsDown(.tokens)
+}
+
+@Test func testSourcelessPrefillStandsDownWhenPrepareReturnsLogits() throws {
+    try expectSourcelessPrefillStandsDown(.logits)
+}
+
+@Test func testSourcelessPrefillStandsDownWhenPrepareEmitsDrafterState() throws {
+    try expectSourcelessPrefillStandsDown(.logitsWithDrafterState)
+}
+
+/// The re-prime forward exists only to obtain drafter state. Once prefill's own state has been
+/// refused there is nothing to obtain, so it is skipped rather than run and thrown away.
+@Test func testSourcelessPrefillSkipsTheRePrimeForward() throws {
+    let window = 8
+    let prompt = Array(1 ... Int32(window * 3))
+
+    let refused = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window,
+        omitSharedKVSources: true, prefillStyle: .logitsWithDrafterState)
+    var refusedIterator = try MTPSpeculativeTokenIterator(
+        input: LMInput(tokens: MLXArray(prompt)),
+        mainModel: refused, drafter: MockDrafter(draftedTokenValue: 7),
+        mainCache: refused.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: 4, temperature: 0), blockSize: 4)
+    #expect(
+        refused.forwardCallCount == 1,
+        "prefill ran \(refused.forwardCallCount) forwards; the re-prime should have been skipped")
+    #expect(
+        refusedIterator.passthroughReason
+            == MTPSpeculativeTokenIterator.missingSharedKVSourcesReason)
+    #expect(refusedIterator.next() != nil)
 }
 
 /// The regression that started this: a prompt longer than the sliding window used to stand the

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -677,24 +677,35 @@ func testTrimSharedKVStateNoOpOnNilStateAndAbsentKey() {
 private final class PositionScriptedMainModel: Module, LanguageModel, KVCacheDimensionProvider {
     static let vocabularySize = 32
 
-    var kvHeads: [Int] { [1, 1] }
+    var kvHeads: [Int] { Array(repeating: 1, count: wideSlidingWindow == nil ? 2 : 3) }
     let script: [Int32]
     let slidingWindow: Int
+    let wideSlidingWindow: Int?
     let omitDrafterState: Bool
 
     private(set) var emittedSharedKVSpans: [[String: Int]] = []
     private(set) var verifyChunkLengths: [Int] = []
 
-    init(script: [Int32], slidingWindow: Int, omitDrafterState: Bool = false) {
+    init(
+        script: [Int32], slidingWindow: Int, wideSlidingWindow: Int? = nil,
+        omitDrafterState: Bool = false
+    ) {
         self.script = script
         self.slidingWindow = slidingWindow
+        self.wideSlidingWindow = wideSlidingWindow
         self.omitDrafterState = omitDrafterState
         super.init()
     }
 
-    /// Layer 0 is global, layer 1 slides -- Gemma 4's topology in miniature.
+    /// Layer 0 is global, layer 1 slides -- Gemma 4's topology in miniature. `wideSlidingWindow`
+    /// adds a third layer sliding at a different width, so a timeline between the two widths has
+    /// one ring wrapped and the other not.
     func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        [KVCacheSimple(), RotatingKVCache(maxSize: slidingWindow, keep: 0)]
+        var cache: [KVCache] = [KVCacheSimple(), RotatingKVCache(maxSize: slidingWindow, keep: 0)]
+        if let wideSlidingWindow {
+            cache.append(RotatingKVCache(maxSize: wideSlidingWindow, keep: 0))
+        }
+        return cache
     }
 
     func prepare(
@@ -1106,6 +1117,49 @@ func testStoppingEarlyLeavesTheTimelineAtWhatWasEmitted(stopAfter: Int) throws {
         timeline >= prompt.count + emitted - 1,
         "timeline \(timeline) dropped tokens the consumer did see")
     #expect(iter.mainCacheStorage.nativeAttentionOffsetsAreAligned)
+}
+
+/// The same stop, on a topology whose sliding layers have different widths. At a timeline between
+/// them the narrow ring has wrapped and the wide one has not, so one commit produces a restore
+/// point for the first and a plain trim record for the second — and the trim has to reach the live
+/// ring rather than the round's staged wrapper, whose `trim(_:)` is a deliberate no-op.
+@Test(arguments: [8, 11, 13])
+func testStoppingEarlyOnMixedWidthSlidingLayers(stopAfter: Int) throws {
+    let prompt: [Int32] = [1, 2, 3]
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: 8, wideSlidingWindow: 64)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: LMInput(tokens: MLXArray(prompt)),
+        mainModel: model, drafter: MockDrafter(draftedTokenValue: 7),
+        mainCache: model.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: 48, temperature: 0), blockSize: 4)
+
+    var emitted = 0
+    while emitted < stopAfter, iter.next() != nil { emitted += 1 }
+    iter.finalizeGeneration()
+
+    #expect(emitted == stopAfter)
+
+    // The premise, asserted rather than assumed: these stop points are past the narrow window and
+    // well inside the wide one, so the two layers really did take different commit records.
+    let leaves = iter.mainCacheStorage.cache
+    #expect(leaves.count == 3)
+    #expect(
+        (leaves[1] as? RotatingKVCache)?.isTrimmable == false,
+        "the narrow ring should have wrapped by \(stopAfter) tokens")
+    #expect(
+        (leaves[2] as? RotatingKVCache)?.isTrimmable == true,
+        "the wide ring should not have wrapped by \(stopAfter) tokens")
+
+    let timeline = iter.mainCacheStorage.processedTokenCount
+    #expect(
+        timeline <= prompt.count + emitted,
+        "timeline \(timeline) describes tokens beyond the \(emitted) the consumer saw")
+    #expect(timeline >= prompt.count + emitted - 1)
+    #expect(
+        iter.mainCacheStorage.nativeAttentionOffsetsAreAligned,
+        "the wide sliding layer stayed ahead of the timeline")
 }
 
 /// `discardGeneratedToken` is telemetry only: a stop token that is not delivered was still

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -112,6 +112,8 @@ private final class MockMainModel: Module, LanguageModel, KVCacheDimensionProvid
             emittedSharedKVSpans.append(kvSpan)
             var out = LMOutput.State()
             out[mtpLastHiddenStatesKey] = MLXArray.zeros([1, positions, 4])
+            // One cache entry stands in for both layer types here.
+            out[mtpSharedKVSourceIndicesKey] = ["full_attention": 0, "sliding_attention": 0]
             out[mtpSharedKVStatesKey] = [
                 "full_attention": (
                     MLXArray.zeros([1, 1, kvSpan, 4]),
@@ -552,7 +554,7 @@ func testMTPSharedKVSpanTrimmedAfterPartialAcceptance() throws {
     )
 }
 
-// MARK: - trimSharedKVState contract
+// MARK: - reconcileSharedKVState contract
 
 /// Builds a state carrying a sharedKV snapshot with distinguishable content
 /// (values encode their flat index) so prefix byte-identity is checkable
@@ -566,6 +568,7 @@ private func makeSharedKVState(span: Int) -> LMOutput.State {
     }
     var state = LMOutput.State()
     state[mtpLastHiddenStatesKey] = arange([1, 2, 4])
+    state[mtpSharedKVSourceIndicesKey] = ["full_attention": 0, "sliding_attention": 1]
     state[mtpSharedKVStatesKey] = [
         "full_attention": (arange([1, 1, span, 4]), arange([1, 1, span, 4])),
         "sliding_attention": (arange([1, 2, span, 2]), arange([1, 2, span, 2])),
@@ -573,10 +576,17 @@ private func makeSharedKVState(span: Int) -> LMOutput.State {
     return state
 }
 
+/// A snapshot with no source map is one the consumer cannot place against cache entries.
+private func makeSourcelessSharedKVState(span: Int) -> LMOutput.State {
+    var state = makeSharedKVState(span: span)
+    state[mtpSharedKVSourceIndicesKey] = nil
+    return state
+}
+
 @Test
 func testTrimSharedKVStateZeroTokensIsNoOp() throws {
     var state: LMOutput.State? = makeSharedKVState(span: 6)
-    trimSharedKVState(&state, numTokens: 0)
+    reconcileSharedKVState(&state, discarding: 0, lengths: { _ in Int.max })
 
     let kv = try #require(state?[mtpSharedKVStatesKey])
     let original = try #require(makeSharedKVState(span: 6)[mtpSharedKVStatesKey])
@@ -592,7 +602,7 @@ func testTrimSharedKVStateZeroTokensIsNoOp() throws {
 @Test
 func testTrimSharedKVStateTrimsTrailingRowsPreservingPrefix() throws {
     var state: LMOutput.State? = makeSharedKVState(span: 6)
-    trimSharedKVState(&state, numTokens: 2)
+    reconcileSharedKVState(&state, discarding: 2, lengths: { _ in Int.max })
 
     let kv = try #require(state?[mtpSharedKVStatesKey])
     let original = try #require(makeSharedKVState(span: 6)[mtpSharedKVStatesKey])
@@ -625,7 +635,7 @@ func testTrimSharedKVStateTrimsTrailingRowsPreservingPrefix() throws {
 func testTrimSharedKVStateNoOpOnNilStateAndAbsentKey() {
     // Nil state: must not crash, must stay nil.
     var nilState: LMOutput.State? = nil
-    trimSharedKVState(&nilState, numTokens: 3)
+    reconcileSharedKVState(&nilState, discarding: 3, lengths: { _ in Int.max })
     #expect(nilState == nil)
 
     // Present state without the sharedKV key (e.g. the quantization-onset
@@ -633,166 +643,495 @@ func testTrimSharedKVStateNoOpOnNilStateAndAbsentKey() {
     // keys alone.
     var keylessState: LMOutput.State? = LMOutput.State()
     keylessState?[mtpEmitFlagKey] = true
-    trimSharedKVState(&keylessState, numTokens: 3)
+    reconcileSharedKVState(&keylessState, discarding: 3, lengths: { _ in Int.max })
     #expect(keylessState?[mtpSharedKVStatesKey] == nil)
     #expect(keylessState?[mtpEmitFlagKey] == true)
 }
 
-// MARK: - Stand-down when the sliding cache runs out of trim headroom
+// MARK: - Speculating past the sliding window
 //
-// MTP's accept/reject step rewinds the main cache with `trimPromptCache`, and
-// `RotatingKVCache.isTrimmable(after:)` owns the strict sliding-window boundary.
-// Before the stand-down existed the iterator only checked trimmability at init,
-// against a fresh zero-offset cache where the check is vacuously true, so any
-// stream whose total context crossed the window kept drafting: the verify pass's
-// sliding K/V grew to `maxCacheSize + S - 1`, flowed into `sharedKV`, and the next
-// `draftBlock` tripped `precondition(slidingKvLen <= textCfg.slidingWindow)`.
+// MTP's accept/reject step used to rewind the main cache, and a `RotatingKVCache` cannot be
+// rewound once its ring has wrapped, so the iterator stood down to plain decoding as soon as the
+// stream's total context crossed the window (512 on Gemma 4 E2B/E4B). With a chat template and
+// any real system prompt that happened at prefill, so the drafter never fired at all.
 //
-// `CountingKVCache(wrapAt:)` mirrors that regime; the checks below pin both
-// entry points and the equivalence-to-greedy guarantee across the transition.
+// Rounds now run against `MTPCacheOverlay`: staged K/V beside the ring, only the accepted prefix
+// committed, nothing ever trimmed. These checks pin the behavior that replaced the stand-down --
+// speculation survives the crossing, and the stream stays token-identical to a plain
+// autoregressive run on both sides of it.
+//
+// Coverage boundary: these are bookkeeping tests. The mock's predictions are a function of
+// position, not of K/V content, so they pin offsets, spans, commit counts and token identity --
+// not whether the committed rows hold the right numbers. That is `MTPCacheOverlayTests`, which
+// drives real position-encoded K/V through the cache and compares attention against a
+// logical-order reference.
 
-/// A prompt that leaves no room for a speculative round stands down during
-/// `init` — the drafter is never called, and the stream still completes.
+/// A target whose prediction at every position is a pure function of that absolute position, so a
+/// speculative run and a greedy run must agree token for token no matter how the drafts land.
+/// (The older `MockMainModel` scripts by forward-call index, which only stays in step when every
+/// draft is accepted -- too weak to test an accept/reject path across a wrap.)
 ///
-/// The first-token assertion is the load-bearing one: `prepare` has already
-/// queued the prefill bonus in `pendingTokens` by the time the stand-down
-/// fires, and that token is already committed to the cache (`y` is the token
-/// after it). If `next()` short-circuits into `passthroughStep()` without
-/// draining the buffer, the bonus vanishes and the whole stream shifts a
-/// position relative to an equivalent autoregressive run.
-@Test
-func testMTPIteratorStandsDownWhenPromptFillsSlidingWindow() throws {
-    // Prompt of 8 against a window of 6: the cache is already past the window
-    // when prefill returns, so no rewind is possible for the rest of the run.
-    let mainLogitTokens: [Int32] = [
-        // Prefill follow-up call (length 8): only the final position is
-        // sampled; the rest are inert placeholders (< vocab=20).
-        0, 0, 0, 0, 0, 0, 0, 5,
-        // Passthrough single-token steps.
-        11, 12, 13,
-    ]
-    let main = MockMainModel(nextLogitTokens: mainLogitTokens)
-    let drafter = MockDrafter(draftedTokenValue: 7)
-    let input = LMInput(tokens: MLXArray([Int32(1), 2, 3, 4, 5, 6, 7, 8]))
-    let cache = CountingKVCache(wrapAt: 6)
+/// It writes real K/V through whatever caches it is handed and emits `sharedKV` from what those
+/// caches returned, clamped per layer type exactly as the Gemma 4 emit hook does. So the cache
+/// machinery under test is exercised rather than simulated.
+private final class PositionScriptedMainModel: Module, LanguageModel, KVCacheDimensionProvider {
+    static let vocabularySize = 32
 
-    var iter = try MTPSpeculativeTokenIterator(
-        input: input, mainModel: main, drafter: drafter, mainCache: [cache],
-        parameters: GenerateParameters(maxTokens: 4, temperature: 0), blockSize: 4
-    )
+    var kvHeads: [Int] { [1, 1] }
+    let script: [Int32]
+    let slidingWindow: Int
+    let omitDrafterState: Bool
 
-    let tokens = [iter.next(), iter.next(), iter.next(), iter.next(), iter.next()]
+    private(set) var emittedSharedKVSpans: [[String: Int]] = []
+    private(set) var verifyChunkLengths: [Int] = []
 
-    // The prefill bonus must be yielded first, then passthrough tokens.
-    #expect(tokens[0] == 5, "prefill bonus was dropped by the init-time stand-down")
-    #expect(tokens[1] == 11)
-    #expect(tokens[2] == 12)
-    #expect(tokens[3] == 13)
-    #expect(tokens[4] == nil)
-    #expect(iter.tokenCount == 4)
+    init(script: [Int32], slidingWindow: Int, omitDrafterState: Bool = false) {
+        self.script = script
+        self.slidingWindow = slidingWindow
+        self.omitDrafterState = omitDrafterState
+        super.init()
+    }
 
-    #expect(
-        iter.passthroughReason
-            == "prompt fills the sliding window — MTP rewind unavailable; generating without speculation"
-    )
-    // Never speculated: no draft was ever requested.
-    #expect(drafter.draftBlockCallCount == 0)
-    #expect(iter.proposedCount == 0)
-    #expect(iter.acceptedCount == 0)
+    /// Layer 0 is global, layer 1 slides -- Gemma 4's topology in miniature.
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        [KVCacheSimple(), RotatingKVCache(maxSize: slidingWindow, keep: 0)]
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        makeLogits(from: cache?.first?.offset ?? 0, positions: inputs.dim(-1))
+    }
+
+    func callAsFunction(
+        _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        let positions = input.tokens.dim(-1)
+        // Read the base position before the caches move; every entry is at the same offset.
+        let base = cache?.first?.offset ?? 0
+        let logits = makeLogits(from: base, positions: positions)
+
+        guard let cache else { return LMOutput(logits: logits) }
+        if positions > 1 { verifyChunkLengths.append(positions) }
+
+        let (keys, values) = Self.positionedKV(base ..< (base + positions))
+        let presented = cache.map { $0.update(keys: keys, values: values) }
+
+        guard !omitDrafterState, state?[mtpEmitFlagKey] ?? false else {
+            return LMOutput(logits: logits)
+        }
+
+        // Emitted verbatim: presenting a sliding layer more than its window is what the write
+        // path does, and clamping it back is the consumer's job now, not the target's.
+        var sharedKV = [String: (MLXArray, MLXArray)]()
+        sharedKV["full_attention"] = presented[0]
+        sharedKV["sliding_attention"] = presented[1]
+        emittedSharedKVSpans.append(sharedKV.mapValues { $0.0.dim(-2) })
+
+        var out = LMOutput.State()
+        out[mtpLastHiddenStatesKey] = MLXArray.zeros([1, positions, 4])
+        out[mtpSharedKVSourceIndicesKey] = ["full_attention": 0, "sliding_attention": 1]
+        out[mtpSharedKVStatesKey] = sharedKV
+        return LMOutput(logits: logits, state: out)
+    }
+
+    private func makeLogits(from base: Int, positions: Int) -> MLXArray {
+        let vocab = Self.vocabularySize
+        var data = [Float](repeating: 0, count: positions * vocab)
+        for i in 0 ..< positions {
+            data[i * vocab + Int(prediction(at: base + i))] = 100
+        }
+        return MLXArray(data, [1, positions, vocab])
+    }
+
+    /// The token this model predicts will follow absolute position `p`.
+    private func prediction(at p: Int) -> Int32 { script[p % script.count] }
+
+    private static func positionedKV(_ positions: Range<Int>) -> (MLXArray, MLXArray) {
+        let count = positions.count
+        let keys = MLXArray(
+            positions.flatMap { Array(repeating: Float($0), count: 4) }, [1, 1, count, 4])
+        return (keys, keys * -1)
+    }
+
 }
 
-/// A stream that speculates successfully and only later runs out of headroom
-/// stands down mid-stream, after real speculation has happened.
-@Test
-func testMTPIteratorStandsDownWhenSlidingCacheWrapsMidStream() throws {
-    // window=8, prompt=3, blockSize=4. Prefill leaves offset=3, so round 1 has
-    // headroom (3 + 4 < 8) and runs; its verify pass carries offset to 7, so
-    // round 2 (3 more positions) does not, and the iterator stands down before
-    // drafting rather than after the cache has already wrapped.
-    let mainLogitTokens: [Int32] = [
-        // Prefill follow-up (length 3): bonus 7.
-        0, 0, 7,
-        // Verify pass (length 4): all three drafts match, then correction 9.
-        7, 7, 7, 9,
-        // Passthrough single-token steps.
-        11, 12, 13,
-    ]
-    let main = MockMainModel(nextLogitTokens: mainLogitTokens)
-    let drafter = MockDrafter(draftedTokenValue: 7)
-    let input = LMInput(tokens: MLXArray([Int32(1), 2, 3]))
-    let cache = CountingKVCache(wrapAt: 8)
+/// A script that mixes the drafted token with others, so rounds land on a spread of acceptance
+/// counts rather than always-accept or always-reject.
+private func mixedAcceptanceScript(drafted: Int32, length: Int = 512) -> [Int32] {
+    (0 ..< length).map { position in
+        // Runs of the drafted value separated by other tokens: acceptance varies round to round
+        // as the phase drifts against the block size.
+        (position % 7) < 3 ? drafted : Int32((position % 11) + 12)
+    }
+}
 
+private func runMTP(
+    model: PositionScriptedMainModel, drafter: MockDrafter, prompt: [Int32], maxTokens: Int,
+    blockSize: Int = 4
+) throws -> (tokens: [Int], iterator: MTPSpeculativeTokenIterator) {
     var iter = try MTPSpeculativeTokenIterator(
-        input: input, mainModel: main, drafter: drafter, mainCache: [cache],
-        parameters: GenerateParameters(maxTokens: 8, temperature: 0), blockSize: 4
+        input: LMInput(tokens: MLXArray(prompt)),
+        mainModel: model,
+        drafter: drafter,
+        mainCache: model.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: maxTokens, temperature: 0),
+        blockSize: blockSize
     )
-
-    var tokens: [Int] = []
+    var tokens = [Int]()
     while let token = iter.next() { tokens.append(token) }
-
-    #expect(tokens == [7, 7, 7, 7, 9, 11, 12, 13])
-
-    // It really speculated before standing down.
-    #expect(drafter.draftBlockCallCount == 1)
-    #expect(iter.proposedCount == 3)
-    #expect(iter.acceptedCount == 3)
-
-    #expect(
-        iter.passthroughReason
-            == "sliding cache wrapped mid-stream — MTP rewind unavailable; continuing without speculation"
-    )
+    return (tokens, iter)
 }
 
-/// Bit-exact equivalence to greedy survives the stand-down: a stream that
-/// speculates, crosses the window, and finishes in passthrough emits exactly
-/// the tokens a plain `TokenIterator` emits from the same model.
-///
-/// Note on the harness: `MockMainModel` addresses its script by a running
-/// per-forward-call index, not by absolute sequence position, and a rejected
-/// draft rewinds the cache without rewinding that index. The two arms
-/// therefore only stay in step while every draft is accepted — which is the
-/// regime scripted here (`MockDrafter` emits one constant value, and the
-/// verify positions hold that same value). A rejection would desynchronize the
-/// script rather than reveal a real divergence.
+private func runGreedy(
+    model: PositionScriptedMainModel, prompt: [Int32], maxTokens: Int
+) throws -> [Int] {
+    var iter = try TokenIterator(
+        input: LMInput(tokens: MLXArray(prompt)),
+        model: model,
+        cache: model.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: maxTokens, temperature: 0)
+    )
+    var tokens = [Int]()
+    while let token = iter.next() { tokens.append(token) }
+    return tokens
+}
+
+/// The regression that started this: a prompt longer than the sliding window used to stand the
+/// drafter down at init, so it never fired for the whole stream.
 @Test
-func testMTPIteratorMatchesGreedyAcrossMidStreamStandDown() throws {
-    let mainLogitTokens: [Int32] = [
-        0, 0, 7,
-        7, 7, 7, 9,
-        11, 12, 13,
-        // Greedy consumes one script entry per emitted token, so it reads one
-        // position further than the speculative arm on the final step.
-        0,
-    ]
-    let promptTokens = MLXArray([Int32(1), 2, 3])
-    let parameters = GenerateParameters(maxTokens: 8, temperature: 0)
+func testMTPIteratorSpeculatesWhenThePromptExceedsTheSlidingWindow() throws {
+    let window = 8
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window)
 
-    var mtpTokens: [Int] = []
-    do {
-        let main = MockMainModel(nextLogitTokens: mainLogitTokens)
-        var iter = try MTPSpeculativeTokenIterator(
-            input: LMInput(tokens: promptTokens), mainModel: main,
-            drafter: MockDrafter(draftedTokenValue: 7),
-            mainCache: [CountingKVCache(wrapAt: 8)],
-            parameters: parameters, blockSize: 4
-        )
-        while let token = iter.next() { mtpTokens.append(token) }
-        #expect(iter.passthroughReason != nil, "the run must actually cross the window")
-        #expect(iter.acceptedCount > 0, "the run must actually speculate first")
-    }
+    let (tokens, iter) = try runMTP(
+        model: model, drafter: drafter, prompt: Array(1 ... Int32(window * 3)), maxTokens: 16)
 
-    var greedyTokens: [Int] = []
-    do {
-        let main = MockMainModel(nextLogitTokens: mainLogitTokens)
-        var iter = try TokenIterator(
-            input: LMInput(tokens: promptTokens), model: main,
-            cache: [CountingKVCache(wrapAt: 8)],
-            parameters: parameters
-        )
-        while let token = iter.next() { greedyTokens.append(token) }
-    }
+    #expect(tokens.count == 16)
+    #expect(iter.passthroughReason == nil, "the drafter stood down on a long prompt")
+    #expect(drafter.draftBlockCallCount > 0, "the drafter never fired")
+    #expect(iter.proposedCount > 0)
+}
 
+/// ...and a stream that crosses the window mid-generation used to stand down at the crossing.
+@Test
+func testMTPIteratorKeepsSpeculatingAcrossTheWindowCrossing() throws {
+    let window = 8
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window)
+
+    // Prompt sits under the window; generation runs several multiples past it.
+    let (tokens, iter) = try runMTP(
+        model: model, drafter: drafter, prompt: [1, 2, 3], maxTokens: window * 5)
+
+    #expect(tokens.count == window * 5)
+    #expect(iter.passthroughReason == nil, "the drafter stood down at the crossing")
+
+    // Rounds kept running after the crossing rather than stopping at it.
+    let roundsBeforeCrossing = (window - 3) / 4 + 1
+    #expect(
+        drafter.draftBlockCallCount > roundsBeforeCrossing,
+        "speculation stopped at the window: \(drafter.draftBlockCallCount) rounds")
+    #expect(iter.acceptedCount > 0, "no draft was ever accepted")
+}
+
+/// Invariant: speculation is an optimization, so the emitted stream has to be the one a plain
+/// autoregressive run produces -- before, across, and long after the window crossing.
+@Test(arguments: [
+    // (prompt length, generated tokens) with window 8: below, at, above, and far past.
+    (3, 40), (7, 40), (8, 40), (9, 40), (20, 64),
+])
+func testMTPIteratorMatchesGreedyAcrossTheWindow(promptLength: Int, maxTokens: Int) throws {
+    let window = 8
+    let script = mixedAcceptanceScript(drafted: 7)
+    let prompt = Array(1 ... Int32(promptLength))
+
+    let model = PositionScriptedMainModel(script: script, slidingWindow: window)
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let (mtpTokens, iter) = try runMTP(
+        model: model, drafter: drafter, prompt: prompt, maxTokens: maxTokens)
+
+    let greedyTokens = try runGreedy(
+        model: PositionScriptedMainModel(script: script, slidingWindow: window),
+        prompt: prompt, maxTokens: maxTokens)
+
+    #expect(iter.passthroughReason == nil, "the run fell back instead of speculating")
+    #expect(iter.acceptedCount > 0, "the run never accepted a draft, so it proves little")
+    #expect(
+        iter.proposedCount > iter.acceptedCount,
+        "the run never rejected a draft, so the commit path is untested here")
     #expect(
         mtpTokens == greedyTokens,
-        "MTP diverged from greedy across the stand-down: \(mtpTokens) vs \(greedyTokens)")
+        "prompt \(promptLength): MTP diverged from greedy\n  \(mtpTokens)\n  \(greedyTokens)")
+}
+
+/// The drafter attends over `sharedKV` bidirectionally and preconditions on the sliding entry
+/// fitting its window (`Gemma4Assistant.forwardHidden`). A round presents the target up to
+/// `window + blockSize - 1` sliding entries, so the hand-off has to be clamped -- this is the
+/// check that the clamp is actually reaching the drafter.
+@Test
+func testDrafterSeesExactlyTheWindowItCanAttendOver() throws {
+    let window = 8
+    let drafter = MockDrafter(draftedTokenValue: 7)
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window)
+
+    let (_, iter) = try runMTP(
+        model: model, drafter: drafter, prompt: [1, 2, 3], maxTokens: window * 6)
+    #expect(iter.passthroughReason == nil)
+    #expect(drafter.receivedSharedKVSpans.count > 1)
+
+    // Exact, not merely bounded: the commit that decided what the cache kept also clamped the
+    // snapshot, so the drafter sees the whole window rather than the window minus that round's
+    // rejects. `queryOffset` is the timeline the iterator handed the drafter.
+    for (round, spans) in drafter.receivedSharedKVSpans.enumerated() {
+        let sliding = try #require(spans["sliding_attention"])
+        let timeline = drafter.receivedQueryOffsets[round]
+        #expect(
+            sliding == Swift.min(timeline, window),
+            "round \(round): drafter got \(sliding) sliding entries at timeline \(timeline)")
+        #expect(try #require(spans["full_attention"]) == timeline, "round \(round): global span")
+    }
+}
+
+/// A cache the overlay cannot stage or rewind is refused at init rather than silently producing
+/// a wrong stream.
+@Test
+func testMTPIteratorRejectsACacheItCannotStage() {
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: 8)
+    #expect(throws: KVCacheError.self) {
+        _ = try MTPSpeculativeTokenIterator(
+            input: LMInput(tokens: MLXArray([Int32(1), 2, 3])),
+            mainModel: model,
+            drafter: MockDrafter(),
+            mainCache: [MambaCache()],
+            parameters: GenerateParameters(maxTokens: 4, temperature: 0),
+            blockSize: 4)
+    }
+}
+
+/// If an entry stops being stageable mid-stream the round falls back stickily, and the stream
+/// still completes.
+@Test
+func testMTPIteratorFallsBackWhenACacheStopsBeingStageable() throws {
+    let cache = CountingKVCache(wrapAt: 8)
+    let main = MockMainModel(nextLogitTokens: [0, 0, 7, 7, 7, 7, 9, 11, 12, 13, 14])
+    let drafter = MockDrafter(draftedTokenValue: 7)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: LMInput(tokens: MLXArray([Int32(1), 2, 3])),
+        mainModel: main, drafter: drafter, mainCache: [cache],
+        parameters: GenerateParameters(maxTokens: 8, temperature: 0), blockSize: 4)
+
+    var tokens = [Int]()
+    while let token = iter.next() { tokens.append(token) }
+
+    #expect(tokens.count == 8, "the stream did not complete")
+    #expect(
+        iter.passthroughReason
+            == "main KV cache cannot stage a speculative round; continuing without speculation")
+}
+
+/// The block size is clamped to what the narrowest sliding layer can present rather than
+/// trapping, because it is a tuning knob rather than a correctness input.
+@Test
+func testBlockSizeIsClampedToTheNarrowestSlidingWindow() throws {
+    let cache: [KVCache] = [KVCacheSimple(), RotatingKVCache(maxSize: 8, keep: 0)]
+    #expect(MTPSpeculativeTokenIterator.maximumBlockSize(for: cache) == 9)
+    #expect(
+        MTPSpeculativeTokenIterator.maximumBlockSize(for: [KVCacheSimple()]) == .max,
+        "nothing slides, so nothing bounds the round")
+    #expect(
+        MTPSpeculativeTokenIterator.maximumBlockSize(for: [RotatingKVCache(maxSize: 1)]) == 2,
+        "the clamp must never fall below the blockSize >= 2 precondition")
+
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: 8)
+    let (tokens, iter) = try runMTP(
+        model: model, drafter: MockDrafter(draftedTokenValue: 7), prompt: [1, 2, 3],
+        maxTokens: 24, blockSize: 64)
+    #expect(iter.blockSize == 9, "blockSize was not clamped to the window")
+    #expect(tokens.count == 24)
+}
+
+/// A round wider than the window still decodes correctly; the clamp exists for the stats, not
+/// for correctness, so bypassing it must not change the stream.
+@Test
+func testStreamMatchesGreedyWhenTheRoundIsWiderThanTheWindow() throws {
+    let window = 4
+    let script = mixedAcceptanceScript(drafted: 7)
+    let prompt: [Int32] = [1, 2, 3]
+
+    let model = PositionScriptedMainModel(script: script, slidingWindow: window)
+    let (mtpTokens, iter) = try runMTP(
+        model: model, drafter: MockDrafter(draftedTokenValue: 7), prompt: prompt,
+        maxTokens: 32, blockSize: 5)
+    #expect(iter.blockSize == 5, "this case is only interesting at blockSize == window + 1")
+
+    let greedyTokens = try runGreedy(
+        model: PositionScriptedMainModel(script: script, slidingWindow: window),
+        prompt: prompt, maxTokens: 32)
+    #expect(mtpTokens == greedyTokens)
+}
+
+/// The head clamp is the other half of reconciliation: a sliding layer is presented more than its
+/// window on purpose, and what the drafter may attend over is bounded by what the layer can still
+/// describe.
+@Test
+func testReconcileSharedKVStateClampsTheHeadToWhatTheLeafDescribes() throws {
+    var state: LMOutput.State? = makeSharedKVState(span: 10)
+    // Leaf 0 is global and unbounded; leaf 1 slides with a 4-entry window.
+    reconcileSharedKVState(&state, discarding: 0, lengths: { $0 == 0 ? Int.max : 4 })
+
+    let sharedKV = try #require(state?[mtpSharedKVStatesKey])
+    #expect(try #require(sharedKV["full_attention"]).0.dim(-2) == 10, "global entry was clamped")
+    #expect(try #require(sharedKV["sliding_attention"]).0.dim(-2) == 4)
+}
+
+/// Tail first, then head. Clamping first would leave a sliding entry short by the rejected count
+/// every round, which is a silent acceptance-rate loss rather than a failure.
+@Test
+func testReconcileSharedKVStateDropsTheTailBeforeClampingTheHead() throws {
+    var state: LMOutput.State? = makeSharedKVState(span: 10)
+    reconcileSharedKVState(&state, discarding: 3, lengths: { $0 == 0 ? Int.max : 4 })
+
+    let sharedKV = try #require(state?[mtpSharedKVStatesKey])
+    #expect(try #require(sharedKV["full_attention"]).0.dim(-2) == 7)
+    // 10 - 3 rejected = 7 true rows, of which the window keeps the last 4 — not 4 - 3 = 1.
+    #expect(try #require(sharedKV["sliding_attention"]).0.dim(-2) == 4)
+}
+
+/// Without a source map the snapshot cannot be placed against cache entries, so reconciliation
+/// refuses rather than guessing a bound. The iterator reads that as a reason to stop speculating.
+@Test
+func testReconcileSharedKVStateRefusesWithoutSourceIndices() throws {
+    var state: LMOutput.State? = makeSourcelessSharedKVState(span: 6)
+    #expect(reconcileSharedKVState(&state, discarding: 2, lengths: { _ in Int.max }) == false)
+
+    let sharedKV = try #require(state?[mtpSharedKVStatesKey])
+    #expect(
+        try #require(sharedKV["full_attention"]).0.dim(-2) == 6,
+        "a refused reconciliation must leave the snapshot untouched")
+}
+
+/// An absent snapshot is not a refusal — the quantization-onset round emits none.
+@Test
+func testReconcileSharedKVStateAcceptsAnAbsentSnapshot() throws {
+    var state: LMOutput.State? = LMOutput.State()
+    state?[mtpEmitFlagKey] = true
+    #expect(reconcileSharedKVState(&state, discarding: 3, lengths: { _ in Int.max }))
+    #expect(state?[mtpSharedKVStatesKey] == nil)
+    #expect(state?[mtpEmitFlagKey] == true)
+}
+
+// MARK: - The timeline tracks what was emitted
+//
+// `KVCacheStorage.processedTokenCount` is the authoritative position, and `ChatSession`
+// reconciles its token ledger against it rather than against per-entry offsets. So it has to
+// describe exactly the tokens the consumer saw — including when the consumer stops partway
+// through a round's accepted prefix, which is where the old rewind silently gave up past a
+// sliding window.
+//
+// The `- 1` is not slack: the last verifier sample is never cached in its own round. It is the
+// input to the next one.
+
+@Test
+func testEveryRoundLeavesTheLeavesInStepWithTheTimeline() throws {
+    let window = 8
+    let prompt: [Int32] = [1, 2, 3]
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: LMInput(tokens: MLXArray(prompt)),
+        mainModel: model, drafter: MockDrafter(draftedTokenValue: 7),
+        mainCache: model.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: window * 6, temperature: 0), blockSize: 4)
+
+    var emitted = 0
+    while iter.next() != nil {
+        emitted += 1
+        #expect(
+            iter.mainCacheStorage.nativeAttentionOffsetsAreAligned,
+            "leaves drifted from the timeline after token \(emitted)")
+    }
+    iter.finalizeGeneration()
+
+    #expect(iter.passthroughReason == nil)
+    #expect(emitted == window * 6)
+    #expect(iter.mainCacheStorage.processedTokenCount == prompt.count + emitted - 1)
+    #expect(iter.mainCacheStorage.nativeAttentionOffsetsAreAligned)
+}
+
+/// A consumer that stops partway through a round — a stop token, a stop string, cancellation —
+/// leaves committed positions undrained. They have to come back out, past the wrap too.
+@Test(arguments: [1, 2, 3, 5, 8, 13])
+func testStoppingEarlyLeavesTheTimelineAtWhatWasEmitted(stopAfter: Int) throws {
+    let window = 8
+    let prompt: [Int32] = [1, 2, 3]
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: LMInput(tokens: MLXArray(prompt)),
+        mainModel: model, drafter: MockDrafter(draftedTokenValue: 7),
+        mainCache: model.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: window * 6, temperature: 0), blockSize: 4)
+
+    var emitted = 0
+    while emitted < stopAfter, iter.next() != nil {
+        emitted += 1
+    }
+    iter.finalizeGeneration()
+
+    #expect(emitted == stopAfter)
+    // The `- 1` applies only when the last token emitted was a verifier sample, whose K/V is
+    // deliberately not cached in its own round. Stopping mid-buffer ends on an accepted draft
+    // instead, which *is* cached — so the timeline lands on one of two adjacent values. The half
+    // that matters is the upper bound: describing more than the consumer saw is the failure the
+    // old rewind produced silently past the window.
+    let timeline = iter.mainCacheStorage.processedTokenCount
+    #expect(
+        timeline <= prompt.count + emitted,
+        "timeline \(timeline) describes tokens beyond the \(emitted) the consumer saw")
+    #expect(
+        timeline >= prompt.count + emitted - 1,
+        "timeline \(timeline) dropped tokens the consumer did see")
+    #expect(iter.mainCacheStorage.nativeAttentionOffsetsAreAligned)
+}
+
+/// `discardGeneratedToken` is telemetry only: a stop token that is not delivered was still
+/// returned by `next()` and is genuinely in the cache, so it must not move the retain count.
+@Test
+func testDiscardingAGeneratedTokenDoesNotMoveTheTimeline() throws {
+    let window = 8
+    let prompt: [Int32] = [1, 2, 3]
+    let model = PositionScriptedMainModel(
+        script: mixedAcceptanceScript(drafted: 7), slidingWindow: window)
+
+    var iter = try MTPSpeculativeTokenIterator(
+        input: LMInput(tokens: MLXArray(prompt)),
+        mainModel: model, drafter: MockDrafter(draftedTokenValue: 7),
+        mainCache: model.newCache(parameters: nil),
+        parameters: GenerateParameters(maxTokens: window * 4, temperature: 0), blockSize: 4)
+
+    var emitted = 0
+    while emitted < 11, iter.next() != nil { emitted += 1 }
+    iter.discardGeneratedToken()
+    iter.finalizeGeneration()
+
+    // Same two-sided bound as above, and the point is that discarding did not shift it: the
+    // discarded token was returned by `next()` and is genuinely part of the model's context.
+    let timeline = iter.mainCacheStorage.processedTokenCount
+    #expect(timeline <= prompt.count + emitted)
+    #expect(timeline >= prompt.count + emitted - 1)
+    #expect(iter.mainCacheStorage.nativeAttentionOffsetsAreAligned)
 }


### PR DESCRIPTION
**Status:** Follow-up to [#506](https://github.com/ml-explore/mlx-swift-lm/pull/506), implementing the design agreed on [#474](https://github.com/ml-explore/mlx-swift-lm/issues/474#issuecomment-5209017252) and shaped by @aleroot's [review](https://github.com/ml-explore/mlx-swift-lm/issues/474#issuecomment-5212511569). Addresses the limitation #506 disclosed rather than the crash it fixed. Fixes #474. cc @davidkoski, @aleroot.

## Proposed changes

Removes the sliding-window bound on Gemma 4 MTP speculative decoding.

MTP's accept/reject step rewound the main KV cache with `trimPromptCache`, and a `RotatingKVCache` cannot be rewound once its ring has wrapped — the write a rewind would undo has already evicted the entries it would need to restore. #506 made that safe by standing the drafter down as soon as the stream's total context crossed the window. On E2B/E4B the window is 512, which a chat template and any real system prompt clear at prefill, so in practice the drafter stood down at `init` and never fired at all. That is what #474 reports.

The fix is the one described on-thread — append to an overlay, mix it with the live cache on use, commit whatever is accepted at the end — with @aleroot's placement: the transaction lives on `KVCacheStorage`, where the timeline lives, and each cache leaf chooses how it takes part. Rounds run against staged caches; commit appends only the bonus plus the accepted drafts through the normal write path and advances the timeline by exactly that much in the same operation; rejected drafts are dropped rather than written and undone. Nothing is trimmed on the MTP path any more, so the wrap stops mattering.

Speculation is an optimization, so the emitted stream is unchanged — what changes is only *where the speedup applies*, from "inside the window" to "everywhere".

## Design

`RotatingKVCache` gains one read-only `package` method. `logicalView(tail:)` returns the trailing `tail` entries in chronological order without touching `keys`, `values`, `idx` or `offset`. It is built from the same two steps the multi-token write path already uses — `temporalOrder(_:)` to linearize, then the front-trim that preserves the pinned `keep` prefix — so a view of length `n` holds exactly the entries a write that front-trimmed to `n` rows would have presented. When the ring is already chronological, which is where every multi-token write leaves it, both steps degrade to slices and nothing is copied.

The pinned prefix is a floor on the result, not just a splice point: a `tail` below `keep` still returns it, because those entries are not evictable and a view that dropped them would be a context the ring can never present. So the length is `max(min(tail, count), min(keep, count))` — plain `min(tail, count)` for the `keep == 0` case every sliding-window model uses, which is also the only case the staged round reaches.

**The transaction lives on `KVCacheStorage`.** That is where `processedTokenCount` lives, and `storage.trim` already pairs cache mutation with timeline rollback atomically; a commit that moved leaf K/V without advancing the timeline by exactly the retained count in the same operation would recreate that split brain one level up. `beginRound(maximumPositions:)` returns a handle carrying the caches to run the model against, and the handle deliberately has no `commit` of its own — commit is `storage.commit(round, retaining:)`, so the two cannot be separated or reordered. The transaction is entirely `package`; the only public API this PR adds is one `LMOutput.Key`, described below.

**Each leaf picks its own implementation** behind `KVCacheRoundStrategy`, with selection fail-closed. An append-only cache takes a provisional tail and a cursor commit — deliberately cheaper than staging, since a global layer's presentation is its whole history. A rotating cache stages K/V beside the ring. Anything else is refused *before* a single entry is touched, and the caller falls back to unstaged decoding. Append-only leaves are admitted on `isTrimmable(after: maximumPositions)` rather than `isTrimmable`: the entry that matters is one that is trimmable now and stops being trimmable *during* the round, which the narrower question cannot see. That restores the predictive check #506 introduced.

The part worth reviewing closely is that the rotating strategy does not reconstruct what the cache would have done. It presents `logicalView(tail: maxSize - 1)` followed by the staged rows, and it delegates `makeMask` to the live cache, whose offset has not moved. So the model sees the same arrays in the same order under the same mask it would have seen with no round at all, and correctness rests on the existing write path rather than on this type imitating it. The `maxSize - 1` bound is forced rather than chosen: it is both `updateConcat`'s front-trim target and `makeMask`'s `cappedOffset`, so any other value desynchronizes the mask from the presentation — with the bound set to `maxSize` the parity test fails and attention then broadcast-errors on the shape mismatch.

**The emitted shared-K/V state is reconciled by the same commit.** Otherwise the cache can be right while the next `draftBlock` still attends over a rejected tail. Doing it exactly needs to know which cache entry each emitted tuple came from — a sliding layer's snapshot is bounded by its ring and a global layer's is not, and at the crossing the two are indistinguishable by length. The target already has that mapping in scope where its capture loop runs, so it reports it alongside the tuples under a new `LMOutput.Key`; a snapshot that arrives without one is refused rather than reconciled against a guessed bound. Reconciliation drops the rejected tail first and clamps the head second, and runs after every emitting forward, prefill included — and a refusal stands the drafter down at whichever of those it happens at, prefill included.

That key is `public`, like the three MTP state keys beside it. It is part of the contract a target implements rather than an implementation detail of this one: emitting shared K/V without it now means having the snapshot refused, so a target outside this package could not take part at all if it were `package`.

The shape is Ollama's, which ships it as the default Gemma 4 MTP path in its MLX runner: [ollama/ollama#15980](https://github.com/ollama/ollama/pull/15980), `x/mlxrunner/cache/cache.go` — `Speculation`, `BeginSpeculation`, `speculativeKVCache`, `speculativeRotatingKVCache`, `RotatingKVCache.View`/`logicalTail` — MIT. Design port with credit, not a code translation: the implementation here is derived from this repository's own write path and mask construction. One point of agreement is worth stating because it was reached independently — their `View` is `logicalTail(maxSize - 1)`, and the same bound falls out here of `updateConcat`'s front-trim and `makeMask`'s `cappedOffset`, which is why it is forced rather than chosen.

### Answering the round-larger-than-the-window question

Not reachable at a sane block size — a round is `blockSize` positions against a 512- or 1024-entry window — but the API takes an arbitrary `blockSize`, so it is now clamped to `window + 1` rather than trapping. Wider rounds still decode correctly: masks are position-relative, the staged view is clamped, and commit rotates. What degrades is the meaning of the statistics, because the deepest drafts in such a round attend over less context than the verifier gave them. The clamp exists for that reason, and there is a test that a round at `window + 1` still matches greedy exactly.

## Behavior notes

**`passthroughReason` no longer reports either sliding-window string.** Both retire. Anything watching for them will now see `nil`, because the drafter no longer stands down for that reason — which is the point, but it is a silent change for a consumer keying off the string rather than off the behavior. The remaining triggers are a target that stops emitting drafter state (mid-stream KV quantization), a cache that cannot stage a round, and a target that emits shared K/V it does not say the source of.

**Speculation can now stand down before it starts, not only mid-stream.** That last trigger is reachable from `prepare`, so a target with an incomplete emit hook reports a `passthroughReason` from token zero rather than only after the first round. The stream is unaffected — `next()` already drained the prefill bonus ahead of the passthrough branch for exactly this case — but a consumer that reads `passthroughReason` as "speculation stopped partway" should read it as "speculation stopped, or never started".

**Speculation no longer commits anything the consumer did not see.** A round commits its accepted prefix before that prefix is drained, so a stop token partway through used to leave positions in the cache that were never emitted — and `finalizeGeneration`'s plain trim is all-or-nothing over the array, so past a sliding window one wrapped ring made it return zero for *every* leaf, including the trimmable global ones. The commit now leaves behind what it takes to undo itself, and only where a trim would not do. Capture is cheap (a full-range slice reuses the underlying node, which is how `RotatingKVCache.copy()` already works) and measured peak GPU memory is unchanged.

What it leaves behind names cache *slots*, not the objects the commit happened to hold, and the rewind resolves each leaf from the storage and requires its trim to come back exact. So replacing an entry between the commit and the rewind — which is what dynamic compression does — invalidates the record, and the rewind falls back to the plain trim rather than restoring into a leaf the storage no longer owns. Past a wrap that fallback can take nothing back, which is the pre-existing behavior; it is the right side to fail on.

## Telemetry

@aleroot — with the window trigger gone, acceptance statistics describe the whole stream again, so the prefix skew #506 had to disclose (`roundCount > 0` while `emittedTokenCount` kept climbing through passthrough) no longer arises on this path. A round's transients are bounded and small: at most `blockSize` staged rows per sliding layer for the duration of one round, plus at most one linearization of the ring, which in the steady state is a slice rather than a gather because every multi-token write leaves the ring chronological. The restore point is the one addition worth naming to you — it holds a wrapped ring's pre-commit contents for a single round, so its analytic worst case is one extra K+V ring per sliding layer, and measured peak GPU memory came out identical with and without it. Nothing here needs gate awareness.

## What is untouched

The live cache write paths, plain generation, prefill, the classic `SpeculativeTokenIterator`, `#506`'s `isTrimmable(after:)` API and its passthrough machinery, and all public API other than the one added `LMOutput.Key` and the behavior notes above. The classic path's identical init-only trimmability defect remains the separate follow-up #506 promised; folding it in here would mix two arguments.

One thing found while reading and deliberately not fixed: `gemma4AdjustAttentionMask` in MLXVLM suffix-trims an over-long array mask, while its MLXLLM twin in `Gemma4Text.swift` prefix-trims — opposite alignments for the same situation. MTP runs the MLXVLM path, so it is not reachable from this change, but it is a live trap for anyone who wires the text-only backbone to a windowed cache.

## Verification

E4B-it, 4-bit target and bf16 assistant, `blockSize` 4, temperature 0, on an M5 Pro / 64 GB. Each row is one A/B: the same harness, the same prompts, `main` at `c97539d` versus this branch. The reported figure is MTP tok/s over plain-decode tok/s **measured within the same run**, so machine drift cancels — absolute rates moved up to 15% between runs and should not be compared across rows.

| Shape | Total context | `main` | This branch |
|---|---|---|---|
| short — 31-token prompt, 200 generated | 231, inside the window | **1.39×** | **1.43×** |
| crossing — 266-token prompt, 600 generated | 866, crosses at ~250 generated | **0.84×**, stands down | **1.17×** |
| long — 266-token prompt, ~1500 generated | ~1770 | **0.83×**, stands down | **1.06×** |

The short row is the control: identical within noise, and acceptance is 0.342 on both arms, which is what output identity should look like from the outside.

The two rows that matter are the ones that cross the window. On `main` the drafter stands down there and `passthroughReason` reports the mid-stream wrap; on this branch it never does. Note that `main`'s crossing row is **slower than not using MTP at all** — 0.84× on an exactly-equal 600 generated tokens on both arms — because the stream pays for ~110 speculative rounds, stands down, and finishes without the speedup. I did not isolate why post-stand-down decoding lands below plain rather than level with it; it is behavior of the code being replaced, and it makes the case for replacing it rather than against.

Two caveats. The long row's arms generated different token counts (1501 versus 1398 here, 1532 versus 1398 on `main`) because greedy MTP and greedy plain decoding diverge on real weights — SDPA kernel ordering differs between a multi-token verify forward and a single-token step, and a near-tie argmax eventually flips. The synthetic suite is what proves algorithmic identity; this row cannot. And tok/s decays with context on a model with unbounded global-attention layers, so unequal lengths bias that row somewhat. The crossing row has exactly 600 generated tokens on all four arms and carries the argument on its own.

An earlier revision of this branch put the transaction in a free-standing type and clamped the shared K/V in the emit hook. Measuring the two back-to-back isolates what the current shape costs: throughput is neutral (ratios move within the 3–7% run-to-run band) and **peak GPU memory is identical at every stage**, so hosting the transaction on the storage and carrying a restore point are free. One expectation of mine did not survive contact with the numbers, so it is not claimed here: correcting the shared-K/V clamp order did *not* measurably raise acceptance (0.467 → 0.461 on the comparable row), because at a 512-entry window the old order cost the drafter at most three rows — 0.6% of its context. It is a correctness fix that would matter at a small window or a large block size, not a throughput win.

Unit suite: `Test run with 480 tests in 40 suites passed` (423 before this change), run at **each of the nine commits**, not just the tip. XCTest side is unchanged from a pristine `upstream/main` checkout on this machine — 13 pre-existing tolerance failures in the Qwen/Nanbeige warm-continuation oracles, same set before and after, none near this code. `pre-commit run --all-files` passes. `scripts/verify-docs.sh` exits 1 identically on this branch and on a clean `upstream/main` with the same build cache, so it is not attributable here.

The four review-fix commits are additive, and the numbers above are the tip's. They do not move the measurements: the view's floor is integer arithmetic on a path that already ran, the slot change touches only what happens after the last token, and the prefill refusal is a branch not taken by any target that emits a source map.

## Tests

Nothing in the repository drove a `RotatingKVCache` ring past its wrap before this, so the rotation in `updateInPlace`, the linearization in `temporalOrder`, and the windowed mask `makeMask` builds over a multi-token presentation were all uncovered — and they are what a staged round rests on. They are pinned here too.

`KVCacheTests` covers the view: chronology past a double wrap, tail clamping, non-mutation of the ring across reads, pinned-prefix splicing at `keep > 0` and the prefix floor at `tail` of zero, below `keep` and at `keep` (including a ring holding fewer entries than `keep` reserves), the property that `logicalView(tail: maxSize - 1)` plus new rows equals the live write path's presentation *and* its mask span, and post-wrap attention parity against a logical-order reference that never rotated.

`KVCacheRoundTests` (new) covers the transaction against real position-encoded K/V at tiny windows, where a permutation error changes the numbers: the live ring is bit-identical across a staged round and after a rollback; the presentation and mask match a cache that really wrote the same rows; attention through a staged round matches the logical-order reference past a wrap; and after accept-none, accept-all, partial prefixes across the wrap, a pinned prefix, an empty start, and rounds wider than the window, the live caches hold exactly what a cache fed only the accepted tokens holds. Also that every layer advances by exactly the accepted count, which is what `KVCacheStorage`'s processed-token timeline audits.

Nine of those are checks against the *other* implementation of the same idea rather than against hand-computed expectations, which is the correctness oracle @aleroot asked for: snapshot the storage with `KVCacheStorage.copy()` before a round, run the round, replay only the accepted tokens into the snapshot through the ordinary write path, and require the two to agree — down to `metaState`, so an `idx` or ring-rotation divergence that the logical view hides is still caught. The same oracle, run after a rewind against a replay of exactly the emitted tokens, is what pins the finalize fix. Removing the restore point makes all of them fail; forcing the rewind back onto the plain trim path fails those *and* the iterator-level check below.

Two more use that oracle to pin which *object* a rewind reaches: two sliding layers at different widths, driven to a timeline where one ring has wrapped and the other has not, so a single commit produces a restore point for the first and a plain trim record for the second; and a rewind attempted after an entry has been replaced, which has to fall back to the plain trim rather than restore into a leaf the storage no longer owns. The first traps on the alignment assert if the record names the round's staged wrapper instead of the slot — at unit and at iterator level — and the exact-match trim precondition catches that wrapper's no-op directly.

`MTPSpeculativeTokenIteratorTests` — the three stand-down tests #506 added are rewritten rather than deleted, since the behavior they pinned is the behavior being removed. They now pin that speculation survives a prompt longer than the window and a mid-stream crossing, and that the stream stays token-identical to a plain `TokenIterator` with prefill below, at, and above the window and generation several multiples past it. That last one needed a target mock scripted by absolute position rather than by forward-call index, because the old mock only stays in step with a greedy run when every draft is accepted — too weak to test an accept/reject path. Plus: the drafter receives exactly the window it can attend over — `min(timeline, window)`, not merely no more than it — across a long run, an unstageable cache is refused at `init`, one that stops being stageable mid-stream falls back stickily and still completes the stream, and the block-size clamp is exact.

And a target that emits shared K/V without saying where it came from stands the drafter down during `init` — once for each shape `prepare` can return, since each reconciles at a different site — with the stream still token-identical to plain greedy decoding, and without the re-prime forward that only exists to fetch state this stream has stopped having a use for.

Also at iterator level: after every `next()` the leaves and the timeline stay in step, and after a consumer stops partway through a round the timeline describes what the consumer actually saw. That bound is two-sided on purpose — the familiar `- 1` holds only when the last emitted token was a verifier sample, whose K/V is deliberately not cached in its own round, and stopping mid-buffer ends on an accepted draft instead.

Coverage boundary, stated in the test file so it is not overread: the iterator tests pin bookkeeping — offsets, spans, commit counts, token identity — not K/V content, because that mock scripts by position rather than by values. Content is `KVCacheRoundTests`' job.

## Ceilings worth naming

`KVCacheRoundStrategy` cannot be a requirement on `KVCache` itself: that protocol is public, so a `package` requirement cannot be added to it and a public one would be new API. Strategy selection is therefore a type switch, and a `KVCache` conformer from outside this package can never opt into staging — it gets write-through if it can prove it stays trimmable, and refusal otherwise. Fail-closed, but permanent until someone wants to lift it.

Hosting the transaction on `KVCacheStorage` fixes no *observed* bug today, because nothing shares the storage: the MTP iterator builds its own and it never escapes, and `ChatSession` has no MTP path. The value is structural — the timeline update cannot be forgotten or reordered — and it is what makes an MTP `ChatSession` path safe to add later. Worth saying plainly rather than overselling.

Nested `CacheList` topologies stay refused. `KVCacheTree.rewrite` mutates the live list in place, so supporting them means a transaction inside a transaction; no shipped model needs it.

Snapshot/replay is not built as a strategy, per @aleroot's framing — it is the fallback for a future leaf that cannot be staged, and it is already earning its keep as the correctness oracle.

Thanks again @sihayas for giving this a kick. 
