### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport


### PR DESCRIPTION
## Proposed changes

This PR fixes #518, by bumping the `swift-tools-version` from `6.1` to `6.2`. This is necessary for the package to be consumed when it declares `unsafeFlags`. To support older versions, this PR could be altered to add a `Package@6.1.swift` which removes the usage of `unsafeFlags`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
