### PR TITLE
Add single-dispatch TurboFlash for short contexts

### DIFF
--- a/Libraries/MLXLMCommon/TurboQuantKernels.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKernels.swift
@@ -541,6 +541,123 @@ enum TurboQuantMetalKernels {
         }
         """
 
+    /// TurboFlashAttention bounded decode path: score, online softmax, value
+    /// accumulation, normalization, and optional inverse value rotation in one
+    /// dispatch. One SIMD group owns one query row and walks the cache in token
+    /// order. This avoids allocating pass-1 partials and launching pass 2 when
+    /// the context is short enough that cross-block parallelism is unnecessary.
+    ///
+    /// Grid: (32, totalQueries, 1)
+    /// Threadgroup: (32, 1, 1)
+    ///
+    /// Template params: KeyBits, ValueBits, Dim, KeyPackedWidth,
+    ///                  ValuePackedWidth, ApplyRotation
+    static let turboFlashSinglePassSource = """
+        const uint token_count = params[0];
+        const uint repeat_count = params[1];
+        constexpr uint KEY_MASK = (1u << KeyBits) - 1u;
+        constexpr uint KEY_LEVELS = 1u << KeyBits;
+        constexpr uint VAL_MASK = (1u << ValueBits) - 1u;
+        constexpr uint VAL_LEVELS = 1u << ValueBits;
+        constexpr uint DIMS_PER_LANE = (Dim + 31) / 32;
+
+        uint lane = thread_position_in_grid.x;
+        uint q_idx = thread_position_in_grid.y;
+        uint kv_idx = q_idx / repeat_count;
+
+        float key_cb[KEY_LEVELS];
+        for (uint i = 0; i < KEY_LEVELS; i++) {
+            key_cb[i] = key_codebook[i];
+        }
+        float val_cb[VAL_LEVELS];
+        for (uint i = 0; i < VAL_LEVELS; i++) {
+            val_cb[i] = val_codebook[i];
+        }
+
+        float q_vals[DIMS_PER_LANE];
+        for (uint i = 0; i < DIMS_PER_LANE; i++) {
+            uint d = lane + i * 32;
+            q_vals[i] = (d < Dim) ? q_rot[q_idx * Dim + d] : 0.0f;
+        }
+
+        float m = -INFINITY;
+        float l = 0.0f;
+        float o[DIMS_PER_LANE];
+        for (uint i = 0; i < DIMS_PER_LANE; i++) o[i] = 0.0f;
+
+        for (uint t = 0; t < token_count; t++) {
+            const device uint32_t* k_packed_ptr =
+                key_packed + kv_idx * token_count * KeyPackedWidth + t * KeyPackedWidth;
+            float k_norm = key_norms[kv_idx * token_count + t];
+
+            float dot_partial = 0.0f;
+            for (uint i = 0; i < DIMS_PER_LANE; i++) {
+                uint d = lane + i * 32;
+                if (d >= Dim) break;
+                uint bit_offset = d * KeyBits;
+                uint word_idx = bit_offset / 32;
+                uint shift = bit_offset % 32;
+                uint value = k_packed_ptr[word_idx] >> shift;
+                int spill = (int)shift + (int)KeyBits - 32;
+                if (spill > 0) {
+                    value |= k_packed_ptr[word_idx + 1] << ((uint)KeyBits - (uint)spill);
+                }
+                value &= KEY_MASK;
+                dot_partial += q_vals[i] * key_cb[value];
+            }
+            float score = simd_sum(dot_partial) * k_norm;
+
+            float new_m = max(m, score);
+            float exp_diff = exp(m - new_m);
+            float exp_score = exp(score - new_m);
+
+            const device uint32_t* v_packed_ptr =
+                val_packed + kv_idx * token_count * ValuePackedWidth + t * ValuePackedWidth;
+            float v_norm = val_norms[kv_idx * token_count + t];
+            for (uint i = 0; i < DIMS_PER_LANE; i++) {
+                uint d = lane + i * 32;
+                if (d >= Dim) break;
+                uint bit_offset = d * ValueBits;
+                uint word_idx = bit_offset / 32;
+                uint shift = bit_offset % 32;
+                uint value = v_packed_ptr[word_idx] >> shift;
+                int spill = (int)shift + (int)ValueBits - 32;
+                if (spill > 0) {
+                    value |= v_packed_ptr[word_idx + 1] << ((uint)ValueBits - (uint)spill);
+                }
+                value &= VAL_MASK;
+                o[i] = o[i] * exp_diff + exp_score * (val_cb[value] * v_norm);
+            }
+            l = l * exp_diff + exp_score;
+            m = new_m;
+        }
+
+        float inv_l = (l > 0.0f) ? (1.0f / l) : 0.0f;
+        if (ApplyRotation != 0) {
+            threadgroup float shared_out[Dim];
+            for (uint i = 0; i < DIMS_PER_LANE; i++) {
+                uint d = lane + i * 32;
+                if (d < Dim) shared_out[d] = o[i] * inv_l;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            for (uint i = 0; i < DIMS_PER_LANE; i++) {
+                uint d = lane + i * 32;
+                if (d < Dim) {
+                    float acc = 0.0f;
+                    for (uint j = 0; j < Dim; j++) {
+                        acc += shared_out[j] * val_rotation[j * Dim + d];
+                    }
+                    output[q_idx * Dim + d] = acc;
+                }
+            }
+        } else {
+            for (uint i = 0; i < DIMS_PER_LANE; i++) {
+                uint d = lane + i * 32;
+                if (d < Dim) output[q_idx * Dim + d] = o[i] * inv_l;
+            }
+        }
+        """
+
     /// TurboFlashAttention Pass 1 (Causal): Per-block partial attention with causal masking.
     ///
     /// Same as turboFlashPass1Source but supports L>1 query chunks with causal masking.
@@ -1606,6 +1723,8 @@ enum TurboQuantKernelOps {
     nonisolated(unsafe) private static var flashPass1NR0Kernels: [String: MLXFast.MLXFastKernel] =
         [:]
     nonisolated(unsafe) private static var flashPass2Kernels: [String: MLXFast.MLXFastKernel] = [:]
+    nonisolated(unsafe) private static var flashSinglePassKernels: [String: MLXFast.MLXFastKernel] =
+        [:]
 
     /// NR0: number of query rows processed per SIMD group in the multi-row amortized kernel.
     ///
@@ -1630,6 +1749,65 @@ enum TurboQuantKernelOps {
     /// Tuned for M1 Max via sweep: B=64 wins or ties at all token counts (512-8192+).
     /// Smaller blocks = more parallelism but more pass-2 merge work.
     static let flashBlockSize = 64
+
+    /// Short-context ceiling for the single-dispatch decode path. Longer
+    /// contexts retain the established block-parallel two-pass implementation.
+    static let flashSinglePassMaxTokens = 128
+
+    private static func dispatchFlashSinglePass(
+        rotatedQueries: MLXArray,
+        keyPacked: MLXArray, keyNorms: MLXArray, keyCodebook: MLXArray,
+        valPacked: MLXArray, valNorms: MLXArray, valCodebook: MLXArray,
+        tokenCount: Int, repeatCount: Int,
+        keyBits: Int, valueBits: Int, dim: Int,
+        valRotation: MLXArray?
+    ) -> MLXArray {
+        let kpw = TurboQuantPacking.packedWidth(count: dim, bits: keyBits)
+        let vpw = TurboQuantPacking.packedWidth(count: dim, bits: valueBits)
+        let appliesRotation = valRotation != nil
+        let key = "flash_single_\(keyBits)_\(valueBits)_\(dim)_\(appliesRotation)"
+        let kernel: MLXFast.MLXFastKernel
+        lock.lock()
+        if let cached = flashSinglePassKernels[key] {
+            kernel = cached
+            lock.unlock()
+        } else {
+            lock.unlock()
+            let k = MLXFast.metalKernel(
+                name: "turbo_flash_single_\(keyBits)_\(valueBits)_\(dim)_\(appliesRotation)",
+                inputNames: [
+                    "q_rot", "key_packed", "key_norms", "key_codebook",
+                    "val_packed", "val_norms", "val_codebook", "val_rotation", "params",
+                ],
+                outputNames: ["output"],
+                source: TurboQuantMetalKernels.turboFlashSinglePassSource,
+                ensureRowContiguous: true
+            )
+            lock.lock()
+            flashSinglePassKernels[key] = k
+            lock.unlock()
+            kernel = k
+        }
+
+        let totalQ = rotatedQueries.dim(0)
+        let params = MLXArray([UInt32(tokenCount), UInt32(repeatCount)])
+        let rotation = valRotation.map(f32) ?? MLXArray.zeros([1])
+        return kernel(
+            [
+                f32(rotatedQueries), keyPacked, f32(keyNorms), f32(keyCodebook),
+                valPacked, f32(valNorms), f32(valCodebook), rotation, params,
+            ],
+            template: [
+                ("KeyBits", keyBits), ("ValueBits", valueBits),
+                ("Dim", dim), ("KeyPackedWidth", kpw), ("ValuePackedWidth", vpw),
+                ("ApplyRotation", appliesRotation ? 1 : 0),
+            ],
+            grid: (32, totalQ, 1),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[totalQ, dim]],
+            outputDTypes: [.float32]
+        )[0]
+    }
 
     /// Shared pass 1 dispatch, used by both causal and non-causal variants.
     private static func dispatchFlashPass1(
@@ -2128,8 +2306,31 @@ enum TurboQuantKernelOps {
         valueBits: Int,
         dim: Int,
         valRotation: MLXArray? = nil,
-        blockSize: Int? = nil
+        blockSize: Int? = nil,
+        singleDispatch: Bool? = nil
     ) -> MLXArray {
+        // An explicit block size is used by block-sweep callers and therefore
+        // always selects the two-pass implementation. The optional override is
+        // internal test/benchmark plumbing; normal callers use the conservative
+        // context ceiling above.
+        let kernelSupportsSingleDispatch =
+            tokenCount > 0
+            && (2 ... 4).contains(keyBits) && (2 ... 4).contains(valueBits)
+            && dim > 0 && dim <= 256 && blockSize == nil
+        let defaultSingleDispatch =
+            kernelSupportsSingleDispatch && tokenCount <= flashSinglePassMaxTokens
+        let useSingleDispatch =
+            singleDispatch.map { $0 && kernelSupportsSingleDispatch } ?? defaultSingleDispatch
+        if useSingleDispatch {
+            return dispatchFlashSinglePass(
+                rotatedQueries: rotatedQueries,
+                keyPacked: keyPacked, keyNorms: keyNorms, keyCodebook: keyCodebook,
+                valPacked: valPacked, valNorms: valNorms, valCodebook: valCodebook,
+                tokenCount: tokenCount, repeatCount: repeatCount,
+                keyBits: keyBits, valueBits: valueBits, dim: dim,
+                valRotation: valRotation)
+        }
+
         let blockSize = blockSize ?? flashBlockSize
         let numBlocks = (tokenCount + blockSize - 1) / blockSize
         let totalQ = rotatedQueries.dim(0)

--- a/Tests/MLXLMTests/TurboQuantTests.swift
+++ b/Tests/MLXLMTests/TurboQuantTests.swift
@@ -620,6 +620,127 @@ struct TurboFlashAttentionTests {
         #expect(maxDiff < 1e-3, "Max diff \(maxDiff) exceeds tolerance for asymmetric bits")
     }
 
+    /// The bounded path intentionally changes only scheduling: it must agree
+    /// with the established block-parallel implementation, including when the
+    /// inverse value rotation is fused into the same dispatch.
+    @Test func singleDispatchMatchesTwoPass() {
+        let dim = 128
+        let keyBits = 4
+        let valueBits = 2
+        let nQHeads = 8
+        let nKVHeads = 2
+        let tokenCount = 193  // spans multiple 64-token blocks in the reference path
+        let repeatCount = nQHeads / nKVHeads
+        let keyCodec = MSECodec(dim: dim, bits: keyBits, seed: 91)
+        let valCodec = MSECodec(dim: dim, bits: valueBits, seed: 92)
+
+        let rawKeys = MLXRandom.normal([nKVHeads * tokenCount, dim])
+        let rawValues = MLXRandom.normal([nKVHeads * tokenCount, dim])
+        let (keyPacked, keyNorms) = TurboQuantKernelOps.fusedEncodeWHT(
+            input: rawKeys, whtSigns: keyCodec.whtSigns!,
+            boundaries: keyCodec.boundaries, codebook: keyCodec.codebook,
+            bits: keyBits, dim: dim)
+        let (valPacked, valNorms) = TurboQuantKernelOps.fusedEncodeWHT(
+            input: rawValues, whtSigns: valCodec.whtSigns!,
+            boundaries: valCodec.boundaries, codebook: valCodec.codebook,
+            bits: valueBits, dim: dim)
+        let kpw = TurboQuantPacking.packedWidth(count: dim, bits: keyBits)
+        let vpw = TurboQuantPacking.packedWidth(count: dim, bits: valueBits)
+        let keys = keyPacked.reshaped(nKVHeads, tokenCount, kpw)
+        let keyNormsByHead = keyNorms.reshaped(nKVHeads, tokenCount)
+        let values = valPacked.reshaped(nKVHeads, tokenCount, vpw)
+        let valNormsByHead = valNorms.reshaped(nKVHeads, tokenCount)
+        let queries = MLXRandom.normal([nQHeads, dim]) / sqrt(Float(dim))
+
+        func attention(singleDispatch: Bool, rotation: MLXArray? = nil) -> MLXArray {
+            TurboQuantKernelOps.turboFlashAttention(
+                rotatedQueries: queries,
+                keyPacked: keys, keyNorms: keyNormsByHead,
+                keyCodebook: keyCodec.codebook,
+                valPacked: values, valNorms: valNormsByHead,
+                valCodebook: valCodec.codebook,
+                tokenCount: tokenCount, repeatCount: repeatCount,
+                keyBits: keyBits, valueBits: valueBits, dim: dim,
+                valRotation: rotation, singleDispatch: singleDispatch)
+        }
+
+        let single = attention(singleDispatch: true)
+        let twoPass = attention(singleDispatch: false)
+        let identity = MLXArray.eye(dim)
+        let singleRotated = attention(singleDispatch: true, rotation: identity)
+        let twoPassRotated = attention(singleDispatch: false, rotation: identity)
+        eval(single, twoPass, singleRotated, twoPassRotated)
+
+        let maxDiff = abs(single - twoPass).max().item(Float.self)
+        let rotatedMaxDiff = abs(singleRotated - twoPassRotated).max().item(Float.self)
+        #expect(maxDiff < 1e-4, "single/two-pass max diff \(maxDiff) exceeds 1e-4")
+        #expect(
+            rotatedMaxDiff < 1e-4,
+            "single/two-pass rotated max diff \(rotatedMaxDiff) exceeds 1e-4")
+    }
+
+    @Test func microbenchSingleDispatchVsTwoPass() {
+        let dim = 128
+        let keyBits = 4
+        let valueBits = 2
+        let nQHeads = 24
+        let nKVHeads = 4
+        let repeatCount = nQHeads / nKVHeads
+        let iterations = 300
+        let keyCodec = MSECodec(dim: dim, bits: keyBits, seed: 93)
+        let valCodec = MSECodec(dim: dim, bits: valueBits, seed: 94)
+
+        for tokenCount in [1, 8, 16, 32, 64, 128, 256] {
+            let rawKeys = MLXRandom.normal([nKVHeads * tokenCount, dim])
+            let rawValues = MLXRandom.normal([nKVHeads * tokenCount, dim])
+            let (keyPacked, keyNorms) = TurboQuantKernelOps.fusedEncodeWHT(
+                input: rawKeys, whtSigns: keyCodec.whtSigns!,
+                boundaries: keyCodec.boundaries, codebook: keyCodec.codebook,
+                bits: keyBits, dim: dim)
+            let (valPacked, valNorms) = TurboQuantKernelOps.fusedEncodeWHT(
+                input: rawValues, whtSigns: valCodec.whtSigns!,
+                boundaries: valCodec.boundaries, codebook: valCodec.codebook,
+                bits: valueBits, dim: dim)
+            let kpw = TurboQuantPacking.packedWidth(count: dim, bits: keyBits)
+            let vpw = TurboQuantPacking.packedWidth(count: dim, bits: valueBits)
+            let keys = keyPacked.reshaped(nKVHeads, tokenCount, kpw)
+            let values = valPacked.reshaped(nKVHeads, tokenCount, vpw)
+            let keyNormsByHead = keyNorms.reshaped(nKVHeads, tokenCount)
+            let valNormsByHead = valNorms.reshaped(nKVHeads, tokenCount)
+            let queries = MLXRandom.normal([nQHeads, dim]) / sqrt(Float(dim))
+
+            func run(singleDispatch: Bool) -> MLXArray {
+                TurboQuantKernelOps.turboFlashAttention(
+                    rotatedQueries: queries,
+                    keyPacked: keys,
+                    keyNorms: keyNormsByHead,
+                    keyCodebook: keyCodec.codebook,
+                    valPacked: values,
+                    valNorms: valNormsByHead,
+                    valCodebook: valCodec.codebook,
+                    tokenCount: tokenCount, repeatCount: repeatCount,
+                    keyBits: keyBits, valueBits: valueBits, dim: dim,
+                    singleDispatch: singleDispatch)
+            }
+
+            for _ in 0 ..< 20 {
+                eval(run(singleDispatch: true), run(singleDispatch: false))
+            }
+            let singleStart = Date()
+            for _ in 0 ..< iterations { eval(run(singleDispatch: true)) }
+            let singleMs = Date().timeIntervalSince(singleStart) * 1000 / Double(iterations)
+            let twoPassStart = Date()
+            for _ in 0 ..< iterations { eval(run(singleDispatch: false)) }
+            let twoPassMs = Date().timeIntervalSince(twoPassStart) * 1000 / Double(iterations)
+            let singleText = String(format: "%.3f", singleMs)
+            let twoPassText = String(format: "%.3f", twoPassMs)
+            let speedupText = String(format: "%.2f", twoPassMs / singleMs)
+            print(
+                "[MICROBENCH single] T=\(tokenCount): single=\(singleText)ms, "
+                    + "two-pass=\(twoPassText)ms, speedup=\(speedupText)x")
+        }
+    }
+
     /// Microbenchmark: fused vs separated at various token counts
     @Test func microbenchFlashVsSeparated() {
         let dim = 128


### PR DESCRIPTION
## Proposed changes

This PR improves generation speed for models using a TurboQuant-compressed KV cache.

For short contexts of up to 128 tokens, TurboFlash attention now completes its work in a single GPU operation instead of using separate calculation and reduction operations. Longer contexts and unsupported configurations continue using the existing implementation.

The optimized path is used while the combined prompt, conversation history, and generated response contain no more than 128 tokens.

Typical examples include:

- A short question followed by a concise answer
- Rewriting a short email or message
- Classification or information extraction from a few sentences
- Brief summaries
- Short code completions
- The first turn of a lightweight chat session

If generation grows beyond 128 tokens, it automatically switches to the existing implementation. Therefore, the beginning of a longer response may still benefit, while long documents, large system prompts, and established multi-turn conversations generally will not.

### Benchmark

Tested on an Apple M2 with 16 GB unified memory using:

- `mlx-community/Qwen3-4B-4bit`
- TurboQuant K4/V4 cache
- 30 prompt tokens
- 96 generated tokens
- 2 warm-up runs and 7 measured runs

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Median generation speed | 21.341 tok/s | 22.491 tok/s | **+5.39%** |
| Mean generation speed | 21.313 tok/s | 22.535 tok/s | **+5.74%** |

This is approximately one additional generated token per second on the tested machine. Prefill and longer-context performance are not affected by this optimization.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
  - The documented manual formatter was run on every changed file using the repository’s `.swift-format` configuration and produced no diff.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed) — no documentation changes were required