### PR TITLE
Add protocol-aware thinking budget enforcement

### DIFF
--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -358,7 +358,7 @@ extension NanbeigeModel {
     // the chat template also supports JSON.
     public var toolCallFormat: ToolCallFormat? { .xmlFunction }
 
-    // <think>/</think>, toggled via `enable_thinking` (template default true),
-    // same contract as the Qwen3 family.
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    // Nanbeige shares Qwen's thinking tags and tool-call boundary, but not the
+    // original Qwen3 family's documented hard-budget transition.
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -284,5 +284,5 @@ extension Qwen3Model: LoRAModel {
 // MARK: - Chat conventions
 
 extension Qwen3Model {
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.qwen3 }
 }

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1175,10 +1175,10 @@ extension Qwen35Model: LoRAModel {
 // `Qwen35MoEModel` subclasses `Qwen35Model` and inherits both declarations.
 extension Qwen35Model {
     public var toolCallFormat: ToolCallFormat? { .xmlFunction }
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }
 
 extension Qwen35TextModel {
     public var toolCallFormat: ToolCallFormat? { .xmlFunction }
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -368,5 +368,5 @@ extension Qwen3MoEModel: LoRAModel {
 // MARK: - Chat conventions
 
 extension Qwen3MoEModel {
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.qwen3 }
 }

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -686,5 +686,5 @@ extension Qwen3NextModel: LoRAModel {
 
 extension Qwen3NextModel {
     public var toolCallFormat: ToolCallFormat? { .xmlFunction }
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -748,6 +748,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.y = input.text
         self.cacheStorage = cacheStorage
 
+        try components.validate(parameters: parameters)
         self.processor = components.logitProcessor(parameters: parameters)
         self.sampler = parameters.sampler()
         self.maxTokens = parameters.maxTokens
@@ -1050,6 +1051,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         self.draftCacheStorage = draftCacheStorage
 
         self.sampler = parameters.sampler()
+        try components.validate(parameters: parameters)
         self.processor = components.logitProcessor(parameters: parameters)
 
         self.maxTokens = parameters.maxTokens

--- a/Libraries/MLXLMCommon/GenerationComponents.swift
+++ b/Libraries/MLXLMCommon/GenerationComponents.swift
@@ -9,7 +9,8 @@ import MLX
 /// generate (sampling temperature, penalties, token limits, …).
 /// `GenerationComponents` carries the *behavioral* hooks that shape generation
 /// but are not themselves simple values -- for example a custom
-/// ``LogitProcessor``. Keeping these out of ``GenerateParameters`` lets that
+/// ``LogitProcessor`` or parameter validation. Keeping these out of
+/// ``GenerateParameters`` lets that
 /// type stay a pure value while still letting callers inject custom behavior
 /// through the same parameters-driven APIs (``TokenIterator``, ``ChatSession``,
 /// the speculative iterators and the `generate(...)` free functions).
@@ -19,8 +20,9 @@ import MLX
 /// without changing existing results.
 ///
 /// ```swift
-/// var components = GenerationComponents()
-/// components.logitProcessorFactory = { GrammarProcessor(grammar: grammar) }
+/// let components = GenerationComponents().appendingLogitProcessor {
+///     GrammarProcessor(grammar: grammar)
+/// }
 /// let session = ChatSession(model, components: components)
 /// ```
 public struct GenerationComponents: Sendable {
@@ -40,10 +42,61 @@ public struct GenerationComponents: Sendable {
     /// `GenerationComponents` `Sendable`.
     public var logitProcessorFactory: (@Sendable () -> any LogitProcessor)?
 
+    /// Optional validation for constraints that depend on generation parameters.
+    ///
+    /// Validation runs before a token iterator performs prefill, so an invalid
+    /// configuration fails without spending model work or mutating a cache.
+    public var parameterValidator: (@Sendable (GenerateParameters) throws -> Void)?
+
     public init(
-        logitProcessorFactory: (@Sendable () -> any LogitProcessor)? = nil
+        logitProcessorFactory: (@Sendable () -> any LogitProcessor)? = nil,
+        parameterValidator: (@Sendable (GenerateParameters) throws -> Void)? = nil
     ) {
         self.logitProcessorFactory = logitProcessorFactory
+        self.parameterValidator = parameterValidator
+    }
+
+    /// Return a copy with another custom ``LogitProcessor`` appended.
+    ///
+    /// Processors are applied in insertion order. The returned component keeps
+    /// factories—not processor instances—so every generation receives a fresh
+    /// stateful chain. This is the generic composition primitive used by
+    /// higher-level features such as
+    /// ``applyingThinkingBudget(_:reasoning:tokenizer:diagnosticHandler:)``.
+    public func appendingLogitProcessor(
+        _ factory: @escaping @Sendable () -> any LogitProcessor
+    ) -> Self {
+        let existingFactory = logitProcessorFactory
+        return Self(
+            logitProcessorFactory: {
+                guard let existing = existingFactory?() else {
+                    return factory()
+                }
+                return ChainedLogitProcessor(processors: [existing, factory()])
+            },
+            parameterValidator: parameterValidator)
+    }
+
+    /// Return a copy with an additional generation-parameter validator.
+    ///
+    /// Validators run in insertion order. This composes independently from the
+    /// logit-processor chain so behavioral components can reject incompatible
+    /// token limits before generation starts.
+    public func appendingParameterValidator(
+        _ validator: @escaping @Sendable (GenerateParameters) throws -> Void
+    ) -> Self {
+        let existingValidator = parameterValidator
+        return Self(
+            logitProcessorFactory: logitProcessorFactory,
+            parameterValidator: { parameters in
+                try existingValidator?(parameters)
+                try validator(parameters)
+            })
+    }
+
+    /// Validate generation parameters for every configured component.
+    public func validate(parameters: GenerateParameters) throws {
+        try parameterValidator?(parameters)
     }
 
     /// Build the ``LogitProcessor`` for a single generation.

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -130,6 +130,7 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         self.mainCacheStorage = KVCacheStorage(mainCache, plan: kvCachePlan)
 
         self.sampler = parameters.sampler()
+        try components.validate(parameters: parameters)
         self.processor = components.logitProcessor(parameters: parameters)
 
         self.maxTokens = parameters.maxTokens

--- a/Libraries/MLXLMCommon/QwenReasoningProtocol.swift
+++ b/Libraries/MLXLMCommon/QwenReasoningProtocol.swift
@@ -1,0 +1,33 @@
+// Copyright © 2026 Apple Inc.
+
+/// Qwen-family reasoning protocol declarations.
+///
+/// Model-specific wire behavior lives here rather than in ``ReasoningConfig``.
+/// The generic configuration only describes a protocol; this adapter decides
+/// which Qwen families have a validated hard-budget transition.
+public enum QwenReasoningProtocol {
+    /// Qwen-compatible `<think>` tags and tool-call boundary, without claiming
+    /// that a hard-budget transition is safe for the model.
+    public static let tagged = ReasoningConfig(
+        startDelimiter: "<think>", endDelimiter: "</think>",
+        promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
+        isSpecialToken: true,
+        implicitEndDelimiters: ["<tool_call>"])
+
+    /// The original hybrid Qwen3 protocol and its published budget transition.
+    ///
+    /// The exact leading space after the two newlines is part of Qwen's
+    /// `early_stopping_text`. Keeping this adapter family-specific prevents a
+    /// later Qwen-derived model from inheriting the transition merely because it
+    /// happens to use the same delimiters.
+    public static let qwen3 = ReasoningConfig(
+        startDelimiter: "<think>", endDelimiter: "</think>",
+        promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
+        isSpecialToken: true,
+        implicitEndDelimiters: ["<tool_call>"],
+        budgetTransition: ReasoningBudgetTransition(
+            beforeEndDelimiter:
+                "\n\n Considering the limited time by the user, I have to give the solution based on the thinking directly now.\n",
+            afterEndDelimiter: "\n\n"))
+
+}

--- a/Libraries/MLXLMCommon/ReasoningConfig.swift
+++ b/Libraries/MLXLMCommon/ReasoningConfig.swift
@@ -91,39 +91,55 @@ public struct ReasoningConfig: Sendable, Equatable {
     /// How a thinking on / off preference is expressed to the chat template.
     public var promptStrategy: ReasoningPromptStrategy
 
-    /// Diagnostic only: whether ``startDelimiter`` is a registered special token
-    /// for this model's tokenizer.
+    /// Markers that implicitly leave reasoning without emitting ``endDelimiter``.
     ///
-    /// Not load-bearing in v1 — detection is always string-scan based (the
-    /// decoded stream renders the delimiter as literal text whether or not it is
-    /// a special token, because `decode(tokenIds:)` defaults
-    /// `skipSpecialTokens: false`). Reserved for a future token-ID-stream
-    /// optimization.
+    /// These markers remain part of the generated stream. They are boundaries,
+    /// not replacements for the canonical closing delimiter. For example,
+    /// Qwen3.5 may begin `<tool_call>` directly from its thinking block.
+    public var implicitEndDelimiters: [String]
+
+    /// How this model safely transitions to its answer when a reasoning budget
+    /// is exhausted, or `nil` when hard budget enforcement is unsupported.
+    public var budgetTransition: ReasoningBudgetTransition?
+
+    /// Diagnostic only: whether ``startDelimiter`` is a registered special token
+    /// for this model's tokenizer. Budget enforcement compiles every boundary
+    /// with the active tokenizer and does not rely on this hint.
     public var isSpecialToken: Bool
 
     public init(
         startDelimiter: String,
         endDelimiter: String,
         promptStrategy: ReasoningPromptStrategy,
-        isSpecialToken: Bool = false
+        isSpecialToken: Bool = false,
+        implicitEndDelimiters: [String] = [],
+        budgetTransition: ReasoningBudgetTransition? = nil
     ) {
         self.startDelimiter = startDelimiter
         self.endDelimiter = endDelimiter
         self.promptStrategy = promptStrategy
         self.isSpecialToken = isSpecialToken
+        self.implicitEndDelimiters = implicitEndDelimiters
+        self.budgetTransition = budgetTransition
     }
 
     // MARK: - Presets
 
-    /// `<think>`/`</think>`, toggled by the `enable_thinking` chat-template flag
-    /// (default on). The contract shared by the Qwen3 family and Nanbeige4.2+.
+    /// Generic `<think>`/`</think>` protocol toggled by the `enable_thinking`
+    /// chat-template flag (default on).
+    ///
+    /// This deliberately declares no budget transition. Sharing delimiters and
+    /// a template flag does not imply that two model families were trained to
+    /// respond to the same forced early-stop sequence.
     public static let thinkTagsWithEnableThinking = ReasoningConfig(
         startDelimiter: "<think>", endDelimiter: "</think>",
         promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
         isSpecialToken: true)
 
     /// Always-on `<think>`/`</think>` with no prompt-level off switch
-    /// (DeepSeek-R1 and its distills).
+    /// (DeepSeek-R1 and its distills). The protocol does not claim a known-safe
+    /// hard-budget transition; applications may opt into one explicitly after
+    /// validating it for their exact model and tokenizer.
     public static let alwaysOnThinking = ReasoningConfig(
         startDelimiter: "<think>", endDelimiter: "</think>",
         promptStrategy: .alwaysOn)

--- a/Libraries/MLXLMCommon/ReasoningEventEmitter.swift
+++ b/Libraries/MLXLMCommon/ReasoningEventEmitter.swift
@@ -1,7 +1,8 @@
 // Copyright © 2025 Apple Inc.
 
 /// Routes a model's decoded generation stream into reasoning (chain-of-thought)
-/// vs response segments by scanning for the model's reasoning delimiters.
+/// vs response segments by scanning for the model's reasoning delimiters and
+/// any protocol-declared implicit exits.
 ///
 /// A value-type streaming scanner: feed it
 /// each decoded chunk via ``process(_:)`` and it returns the routed segments,
@@ -34,6 +35,7 @@ public struct ReasoningEventEmitter: Sendable {
 
     private let startDelimiter: String
     private let endDelimiter: String
+    private let endDelimiters: [String]
 
     /// Whether the scanner is currently inside a reasoning span.
     private var inside: Bool
@@ -47,9 +49,9 @@ public struct ReasoningEventEmitter: Sendable {
     /// following `<think>`/`</think>` are dropped (mirrors `unwrapToolCallMarkers`).
     private var pendingLeadingTrim: Bool = false
 
-    /// True once an end delimiter has been consumed, i.e. a reasoning span has
-    /// closed at least once. Unlike ``isInsideReasoning``, this latches — so a
-    /// caller (e.g. a think-then-call token collector) can detect a close even
+    /// True once a canonical or implicit end boundary has been observed, i.e. a
+    /// reasoning span has closed at least once. Unlike ``isInsideReasoning``,
+    /// this latches — so a caller (e.g. a think-then-call token collector) can detect a close even
     /// when an empty `<think></think>` resolves within a single ``process(_:)``
     /// call, where sampling ``isInsideReasoning`` afterward reads `false` both
     /// before and after and the transient open is invisible.
@@ -58,6 +60,11 @@ public struct ReasoningEventEmitter: Sendable {
     public init(config: ReasoningConfig, primedInside: Bool) {
         self.startDelimiter = config.startDelimiter
         self.endDelimiter = config.endDelimiter
+        self.endDelimiters =
+            [config.endDelimiter]
+            + config.implicitEndDelimiters.filter {
+                $0 != config.endDelimiter
+            }
         self.inside = primedInside
     }
 
@@ -79,12 +86,18 @@ public struct ReasoningEventEmitter: Sendable {
     public static func promptEndsInsideReasoning(
         renderedPromptTail tail: String, config: ReasoningConfig
     ) -> Bool {
+        guard !config.startDelimiter.isEmpty else { return false }
         var trimmed = Substring(tail)
         while let last = trimmed.last, last.isWhitespace { trimmed = trimmed.dropLast() }
         guard let lastStart = trimmed.range(of: config.startDelimiter, options: .backwards) else {
             return false
         }
-        return trimmed[lastStart.upperBound...].range(of: config.endDelimiter) == nil
+        let afterStart = trimmed[lastStart.upperBound...]
+        return ([config.endDelimiter] + config.implicitEndDelimiters)
+            .filter { !$0.isEmpty }
+            .allSatisfy {
+                afterStart.range(of: $0) == nil
+            }
     }
 
     /// Whether the scanner is currently inside a reasoning span.
@@ -104,25 +117,39 @@ public struct ReasoningEventEmitter: Sendable {
         pendingPrefix = ""
 
         while true {
-            let delimiter = inside ? endDelimiter : startDelimiter
-            if let range = working.range(of: delimiter) {
+            let delimiters = inside ? endDelimiters : [startDelimiter]
+            if let match = firstMatch(in: working, delimiters: delimiters) {
                 // Text before the marker belongs to the current mode; trim the
                 // whitespace immediately preceding the marker.
                 appendSegment(
-                    String(working[working.startIndex ..< range.lowerBound]),
+                    String(working[working.startIndex ..< match.range.lowerBound]),
                     trimmingTrailing: true, into: &output)
-                // Consume the marker and trim whitespace immediately after it.
-                working = working[range.upperBound...]
-                pendingLeadingTrim = true
-                // Matching while `inside` means we just consumed an *end*
-                // delimiter (`delimiter == endDelimiter`) — a close.
-                if inside { hasClosedReasoning = true }
-                inside.toggle()
+
+                if inside {
+                    hasClosedReasoning = true
+                    inside = false
+                    if match.delimiter == endDelimiter {
+                        // Canonical delimiters are framing and do not belong to
+                        // either routed segment.
+                        working = working[match.range.upperBound...]
+                        pendingLeadingTrim = true
+                    } else {
+                        // An implicit delimiter is answer/tool content. Keep it
+                        // in the stream and reprocess it while outside reasoning.
+                        working = working[match.range.lowerBound...]
+                    }
+                } else {
+                    // Opening delimiters are framing and do not belong to the
+                    // routed reasoning content.
+                    working = working[match.range.upperBound...]
+                    pendingLeadingTrim = true
+                    inside = true
+                }
                 // Re-scan the remainder in the new mode.
             } else {
                 // No full marker. Hold back any suffix that could begin one on
                 // the next chunk; emit the rest in the current mode.
-                let tail = heldBackTailLength(working, delimiter: delimiter)
+                let tail = heldBackTailLength(working, delimiters: delimiters)
                 let splitIndex = working.index(working.endIndex, offsetBy: -tail)
                 appendSegment(
                     String(working[working.startIndex ..< splitIndex]),
@@ -175,10 +202,28 @@ public struct ReasoningEventEmitter: Sendable {
         }
     }
 
-    /// The length of the longest suffix of `text` that is a *proper* prefix of
-    /// `delimiter` (and therefore might complete into the delimiter on the next
-    /// chunk). Returns 0 when no suffix could begin the delimiter.
+    private func firstMatch(
+        in text: Substring, delimiters: [String]
+    ) -> (delimiter: String, range: Range<String.Index>)? {
+        var first: (delimiter: String, range: Range<String.Index>)?
+        for delimiter in delimiters where !delimiter.isEmpty {
+            guard let range = text.range(of: delimiter) else { continue }
+            if let first, range.lowerBound >= first.range.lowerBound { continue }
+            first = (delimiter, range)
+        }
+        return first
+    }
+
+    /// The length of the longest suffix of `text` that is a proper prefix of any
+    /// watched delimiter and may complete in the next chunk.
+    private func heldBackTailLength(_ text: Substring, delimiters: [String]) -> Int {
+        delimiters.reduce(0) { longest, delimiter in
+            max(longest, heldBackTailLength(text, delimiter: delimiter))
+        }
+    }
+
     private func heldBackTailLength(_ text: Substring, delimiter: String) -> Int {
+        guard !delimiter.isEmpty else { return 0 }
         let textChars = Array(text)
         let delimiterChars = Array(delimiter)
         var k = min(textChars.count, delimiterChars.count - 1)

--- a/Libraries/MLXLMCommon/ThinkingBudget.swift
+++ b/Libraries/MLXLMCommon/ThinkingBudget.swift
@@ -1,0 +1,669 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// Errors raised while configuring a reasoning-token budget.
+public enum ThinkingBudgetError: Equatable, LocalizedError, Sendable {
+    /// A token budget cannot be negative. Zero means close reasoning immediately.
+    case invalidMaximumTokenCount(Int)
+
+    /// The answer reserve cannot be negative.
+    case invalidMinimumAnswerTokenCount(Int)
+
+    /// The model declares reasoning, but neither it nor the caller supplied a
+    /// safe budget transition.
+    case unsupportedReasoningProtocol
+
+    /// A protocol boundary could not be represented by the tokenizer.
+    case unencodableBoundary(String)
+
+    /// The tokenizer could not represent the model's forced transition.
+    case unencodableTransition(String)
+
+    /// The tokenizer produced an ID that cannot be represented by MLX token tensors.
+    case invalidTokenID(Int)
+
+    /// `maxTokens` cannot contain the budget, protocol headroom and answer reserve.
+    case insufficientGenerationTokenLimit(required: Int, actual: Int)
+
+    /// The configured budget and reserves cannot be represented by `Int`.
+    case generationTokenRequirementOverflow
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidMaximumTokenCount(let count):
+            "Thinking budget maximumTokenCount must be non-negative; received \(count)."
+        case .invalidMinimumAnswerTokenCount(let count):
+            "Thinking budget minimumAnswerTokenCount must be non-negative; received \(count)."
+        case .unsupportedReasoningProtocol:
+            """
+            This model's reasoning protocol does not declare a safe budget transition. \
+            Supply ThinkingBudgetConfiguration.transitionOverride to opt in explicitly.
+            """
+        case .unencodableBoundary(let boundary):
+            "The tokenizer could not encode reasoning boundary \(boundary.debugDescription)."
+        case .unencodableTransition(let transition):
+            "The tokenizer could not encode thinking-budget transition \(transition.debugDescription)."
+        case .invalidTokenID(let tokenID):
+            "The tokenizer produced invalid thinking-budget token ID \(tokenID)."
+        case .insufficientGenerationTokenLimit(let required, let actual):
+            """
+            Thinking budget requires maxTokens >= \(required) to leave room for the budget, \
+            Unicode/protocol headroom and answer reserve; received \(actual).
+            """
+        case .generationTokenRequirementOverflow:
+            "Thinking budget, protocol headroom and answer reserve exceed the supported token count."
+        }
+    }
+}
+
+/// A model-protocol transition used when a reasoning budget is exhausted.
+///
+/// The value is model-agnostic: model-family adapters provide the actual text.
+/// Models without a validated transition leave
+/// ``ReasoningConfig/budgetTransition`` unset, while applications can opt in
+/// through ``ThinkingBudgetConfiguration/transitionOverride``.
+public struct ReasoningBudgetTransition: Sendable, Equatable {
+    /// Text forced immediately before ``ReasoningConfig/endDelimiter``.
+    public var beforeEndDelimiter: String
+
+    /// Text forced immediately after ``ReasoningConfig/endDelimiter``.
+    public var afterEndDelimiter: String
+
+    public init(
+        beforeEndDelimiter: String = "",
+        afterEndDelimiter: String = ""
+    ) {
+        self.beforeEndDelimiter = beforeEndDelimiter
+        self.afterEndDelimiter = afterEndDelimiter
+    }
+
+    /// Close the reasoning span with no additional model-specific text.
+    public static let immediate = ReasoningBudgetTransition()
+}
+
+/// Diagnostics emitted when a hard reasoning budget cannot remain authoritative.
+public enum ThinkingBudgetDiagnostic: Sendable, Equatable {
+    /// Another processor or a tokenizer/model mismatch produced a token outside
+    /// the constraint. Enforcement was disabled to avoid corrupting generation.
+    case enforcementDisabled(expectedTokenIDs: [Int], sampledTokenID: Int)
+
+    /// The tokenizer still produced incomplete Unicode after the maximum
+    /// possible UTF-8 continuation length. Enforcement was disabled rather
+    /// than injecting a protocol transition into malformed text.
+    case unicodeBoundaryCompletionFailed(sampledTokenCount: Int)
+}
+
+/// A hard upper bound for model-selected reasoning tokens.
+///
+/// Protocol tokens used to enter or leave reasoning are not charged to the
+/// budget. If a byte-fallback token ends mid-scalar, generation may consume the
+/// minimum additional tokens needed to complete valid Unicode before forcing
+/// the transition. Forced transition tokens still count toward
+/// ``GenerateParameters/maxTokens``; callers must leave room for the transition
+/// and the final answer in their overall generation limit.
+public struct ThinkingBudgetConfiguration: Sendable, Equatable {
+    /// Maximum number of model-selected tokens allowed inside a reasoning span.
+    /// Zero closes a prompt-primed reasoning span before it generates content.
+    public let maximumTokenCount: Int
+
+    /// Tokens reserved for the final answer after the worst-case transition.
+    ///
+    /// Parameter-driven generation rejects a finite `maxTokens` that cannot fit
+    /// the reasoning budget, transition and this reserve. The default guarantees
+    /// at least one answer token; applications should choose a larger product-
+    /// appropriate reserve.
+    public let minimumAnswerTokenCount: Int
+
+    /// Replaces the model's ``ReasoningConfig/budgetTransition``.
+    ///
+    /// Most reasoning protocols ship with no declared transition, because
+    /// sharing `<think>`/`</think>` with Qwen3 does not mean a family was
+    /// trained to answer from a truncated reasoning span. Supplying a
+    /// transition here is how an application opts a model in anyway, after
+    /// validating the behavior for its exact weights and tokenizer.
+    ///
+    /// ``ReasoningBudgetTransition/immediate`` is the conservative choice: it
+    /// closes the span with the model's own end delimiter and adds nothing else.
+    public let transitionOverride: ReasoningBudgetTransition?
+
+    public init(
+        maximumTokenCount: Int,
+        minimumAnswerTokenCount: Int = 1,
+        transitionOverride: ReasoningBudgetTransition? = nil
+    ) throws {
+        guard maximumTokenCount >= 0 else {
+            throw ThinkingBudgetError.invalidMaximumTokenCount(maximumTokenCount)
+        }
+        guard minimumAnswerTokenCount >= 0 else {
+            throw ThinkingBudgetError.invalidMinimumAnswerTokenCount(minimumAnswerTokenCount)
+        }
+        self.maximumTokenCount = maximumTokenCount
+        self.minimumAnswerTokenCount = minimumAnswerTokenCount
+        self.transitionOverride = transitionOverride
+    }
+}
+
+/// A token-level, protocol-aware reasoning budget.
+///
+/// The processor observes compiled start and end token sequences instead of
+/// repeatedly decoding generated text. At the budget boundary it either lets a
+/// partially sampled natural end finish, or forces the model-specific
+/// ``ReasoningBudgetTransition``. Every forced token passes through the normal
+/// generation loop and therefore remains coherent with KV cache, history,
+/// speculative verification, and the emitted stream.
+///
+/// ### Pipelining
+///
+/// `TokenIterator` samples a token, hands it to the processor, and only then
+/// calls `asyncEval`, so that the *previous* token is what gets read back on
+/// the CPU. Reading the newest token instead would block on the in-flight
+/// forward pass and collapse that one-step lookahead — the same hazard
+/// `TokenRing` avoids for the penalty processors. This processor therefore
+/// keeps the freshest sampled token in flight and only drains it when a budget
+/// decision is actually within reach. See ``didSample(token:)``.
+public struct ThinkingBudgetProcessor: LogitProcessor {
+    /// Once the budget token has supplied the first byte, a valid UTF-8 scalar
+    /// needs at most three more one-byte fallback tokens.
+    static let maximumUnicodeCompletionTokenCount = 3
+
+    private let plan: ThinkingBudgetPlan
+
+    private var boundaries: ReasoningBoundaryTracker
+    private var detokenizer: NaiveStreamingDetokenizer
+    private var reasoningTokenCount = 0
+    private var state: State = .observing
+    private let diagnosticHandler: (@Sendable (ThinkingBudgetDiagnostic) -> Void)?
+
+    /// Sampled tokens whose IDs have not been read back from the GPU yet.
+    ///
+    /// Everything except the last element was async-evaluated during an earlier
+    /// step, so reading it costs nothing.
+    private var deferredTokens: [MLXArray] = []
+
+    /// Whether the processor stood down because a sampled token did not match
+    /// the constraint it had applied.
+    ///
+    /// That happens when another component overrides this one, or when the
+    /// tokenizer disagrees with the model vocabulary. Standing down is the
+    /// correct conservative response — the budget stops interfering and the
+    /// model finishes under its own control — so this is a diagnostic, not an
+    /// error. It is deliberately not a trap: a `precondition` here would crash a
+    /// shipping generation loop, and an `assertionFailure` would crash debug
+    /// builds of client apps.
+    public private(set) var didStandDown = false
+
+    /// Sampled tokens still in flight on the GPU. Pins the pipelining contract
+    /// in tests; see ``didSample(token:)``.
+    var deferredTokenCount: Int { deferredTokens.count }
+
+    private enum State {
+        case observing
+        case completingUnicode(additionalTokenCount: Int)
+        case forcing(index: Int)
+        case finished
+    }
+
+    /// Creates a processor for direct use with a token iterator.
+    ///
+    /// Prefer
+    /// ``GenerationComponents/applyingThinkingBudget(_:reasoning:tokenizer:diagnosticHandler:)``
+    /// for `ChatSession` and the parameter-driven generation APIs. That path
+    /// also validates that `maxTokens` leaves transition and answer headroom.
+    public init(
+        configuration: ThinkingBudgetConfiguration,
+        reasoning: ReasoningConfig,
+        tokenizer: any Tokenizer,
+        diagnosticHandler: (@Sendable (ThinkingBudgetDiagnostic) -> Void)? = nil
+    ) throws {
+        self.init(
+            plan: try ThinkingBudgetPlan(
+                configuration: configuration, reasoning: reasoning, tokenizer: tokenizer),
+            diagnosticHandler: diagnosticHandler)
+    }
+
+    init(
+        plan: ThinkingBudgetPlan,
+        diagnosticHandler: (@Sendable (ThinkingBudgetDiagnostic) -> Void)? = nil
+    ) {
+        self.plan = plan
+        self.diagnosticHandler = diagnosticHandler
+        self.boundaries = ReasoningBoundaryTracker(
+            start: plan.startTokenIDs, ends: plan.endTokenSequences)
+        self.detokenizer = NaiveStreamingDetokenizer(tokenizer: plan.tokenizer)
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {
+        boundaries.reset(with: prompt.asArray(Int.self))
+        detokenizer = NaiveStreamingDetokenizer(tokenizer: plan.tokenizer)
+        deferredTokens.removeAll(keepingCapacity: true)
+        reasoningTokenCount = 0
+        state =
+            boundaries.isInsideReasoning && plan.configuration.maximumTokenCount == 0
+            ? .forcing(index: 0)
+            : .observing
+    }
+
+    public func process(logits: MLXArray) -> MLXArray {
+        switch state {
+        case .forcing(let index):
+            return constrain(logits, to: [plan.forcedTransitionTokenIDs[index]])
+
+        case .observing:
+            let remaining = plan.configuration.maximumTokenCount - reasoningTokenCount
+            guard
+                let continuation = boundaries.requiredEndContinuation(
+                    remainingReasoningTokens: remaining)
+            else { return logits }
+            return constrain(logits, to: continuation, preservingAllowedLogits: true)
+
+        case .completingUnicode, .finished:
+            return logits
+        }
+    }
+
+    /// Records a sampled token, deferring the CPU←GPU read when it is safe.
+    ///
+    /// The newest `MLXArray` has not been evaluated yet: `item(_:)` on it blocks
+    /// until the current forward pass finishes, which idles the GPU for every
+    /// subsequent graph build. Holding it back for one step makes boundary
+    /// detection lag by one token — unobservable while no decision can be taken
+    /// inside the lag window. Once the budget comes within
+    /// `ThinkingBudgetPlan.exactTrackingWindow` tokens the processor drains
+    /// completely, accepting one stall per token, and stays exact through the
+    /// forced transition. After the reasoning span closes it stops reading
+    /// tokens altogether.
+    public mutating func didSample(token: MLXArray) {
+        if case .finished = state { return }
+
+        deferredTokens.append(token)
+
+        while deferredTokens.count > (needsExactTracking ? 0 : 1) {
+            consume(deferredTokens.removeFirst().item(Int.self))
+            if case .finished = state {
+                // Nothing will ever be observed again, so release whatever is
+                // still in flight rather than pinning its buffers for the rest
+                // of the generation.
+                deferredTokens.removeAll(keepingCapacity: true)
+                return
+            }
+        }
+    }
+
+    /// Whether the state machine must see every sampled token immediately.
+    ///
+    /// True whenever a transition is in progress, and once the remaining budget
+    /// is small enough that a decision could fall inside the deferred window.
+    private var needsExactTracking: Bool {
+        guard case .observing = state else { return true }
+        let remaining = plan.configuration.maximumTokenCount - reasoningTokenCount
+        return remaining <= deferredTokens.count + plan.exactTrackingWindow
+    }
+
+    /// Whether the boundary detokenizer is being fed.
+    ///
+    /// Only the transition decision needs to know whether a token completed a
+    /// Unicode scalar, and `NaiveStreamingDetokenizer` re-decodes its whole
+    /// current line on every token. Warming it up
+    /// `ThinkingBudgetPlan.exactTrackingWindow` tokens before the budget
+    /// gives it far more than the four bytes a scalar can span, so at the
+    /// boundary it answers exactly as a stream-long detokenizer would.
+    private var tracksTextBoundaries: Bool {
+        guard case .observing = state else { return true }
+        return plan.configuration.maximumTokenCount - reasoningTokenCount
+            <= plan.exactTrackingWindow
+    }
+
+    private mutating func consume(_ tokenID: Int) {
+        switch state {
+        case .finished:
+            return
+
+        case .forcing(let index):
+            guard tokenID == plan.forcedTransitionTokenIDs[index] else {
+                standDown(
+                    expectedTokenIDs: [plan.forcedTransitionTokenIDs[index]],
+                    sampledTokenID: tokenID)
+                return
+            }
+
+            let nextIndex = index + 1
+            state =
+                nextIndex == plan.forcedTransitionTokenIDs.count
+                ? .finished
+                : .forcing(index: nextIndex)
+
+        case .observing:
+            if let required = boundaries.requiredEndContinuation(
+                remainingReasoningTokens:
+                    plan.configuration.maximumTokenCount - reasoningTokenCount),
+                !required.contains(tokenID)
+            {
+                standDown(expectedTokenIDs: required, sampledTokenID: tokenID)
+                return
+            }
+
+            let wasInsideReasoning = boundaries.isInsideReasoning
+            let observation = boundaries.observe(tokenID)
+            let completesText = trackTextBoundary(tokenID)
+
+            guard !observation.endedReasoning else {
+                state = .finished
+                return
+            }
+
+            guard wasInsideReasoning else {
+                if observation.startedReasoning
+                    && plan.configuration.maximumTokenCount == 0
+                {
+                    state = .forcing(index: 0)
+                }
+                return
+            }
+
+            reasoningTokenCount += observation.committedReasoningTokenCount
+            guard reasoningTokenCount >= plan.configuration.maximumTokenCount else {
+                return
+            }
+
+            // A proper prefix of a natural end has reached the boundary. Leave
+            // the processor observing: process(logits:) now constrains sampling
+            // to valid continuations, avoiding malformed double-closes.
+            guard !boundaries.hasPendingEndPrefix else { return }
+            state =
+                completesText
+                ? .forcing(index: 0)
+                : .completingUnicode(additionalTokenCount: 0)
+
+        case .completingUnicode(let additionalTokenCount):
+            let observation = boundaries.observe(tokenID)
+            let completesText = trackTextBoundary(tokenID)
+            guard !observation.endedReasoning else {
+                state = .finished
+                return
+            }
+            if completesText {
+                state = boundaries.hasPendingEndPrefix ? .observing : .forcing(index: 0)
+                return
+            }
+
+            let nextCount = additionalTokenCount + 1
+            guard nextCount < Self.maximumUnicodeCompletionTokenCount else {
+                standDown(.unicodeBoundaryCompletionFailed(sampledTokenCount: nextCount))
+                return
+            }
+            state = .completingUnicode(additionalTokenCount: nextCount)
+        }
+    }
+
+    /// Stop enforcing and stop observing, leaving generation untouched.
+    ///
+    /// The fail-safe: if the processor loses sync with the sampler, getting out
+    /// of the way preserves valid model output, whereas trapping would take the
+    /// host application down mid-generation. See ``didStandDown``.
+    private mutating func standDown(expectedTokenIDs: [Int], sampledTokenID: Int) {
+        standDown(
+            .enforcementDisabled(
+                expectedTokenIDs: expectedTokenIDs, sampledTokenID: sampledTokenID))
+    }
+
+    private mutating func standDown(_ diagnostic: ThinkingBudgetDiagnostic) {
+        didStandDown = true
+        state = .finished
+        deferredTokens.removeAll(keepingCapacity: true)
+        diagnosticHandler?(diagnostic)
+    }
+
+    private mutating func trackTextBoundary(_ tokenID: Int) -> Bool {
+        guard tracksTextBoundaries else { return false }
+        detokenizer.append(token: tokenID)
+        return detokenizer.next() != nil
+    }
+
+    private func constrain(
+        _ logits: MLXArray,
+        to tokenIDs: [Int],
+        preservingAllowedLogits: Bool = false
+    ) -> MLXArray {
+        let vocabularySize = logits.dim(-1)
+        guard !tokenIDs.isEmpty,
+            tokenIDs.allSatisfy({ $0 >= 0 && $0 < vocabularySize })
+        else {
+            // The compiled boundary is not in this model's vocabulary, so the
+            // tokenizer and the weights disagree. Masking to a token the model
+            // cannot emit would leave the sampler nothing to pick, so leave the
+            // logits alone; `consume(_:)` then stands the processor down when
+            // the resulting token does not match the intended constraint.
+            return logits
+        }
+
+        // Scatter rather than compare against a full vocabulary range: this is
+        // O(vocabulary) once plus O(constraint), and matches how the penalty
+        // processors address logits (`takeAlong` / `putAlong`).
+        var indices = MLXArray(tokenIDs.map(Int32.init))
+        if logits.ndim > 1 {
+            indices = indices.reshaped(
+                Array(repeating: 1, count: logits.ndim - 1) + [tokenIDs.count])
+        }
+
+        let masked = MLXArray.full(
+            logits.shape, values: MLXArray.maskFill(for: logits.dtype), dtype: logits.dtype)
+
+        // Forced transition tokens intentionally override preceding processors.
+        // When more than one natural boundary continuation is possible, retain
+        // the model's relative preference (for example `</think>` versus
+        // `<tool_call>`) while masking every non-protocol token.
+        let allowedValues =
+            preservingAllowedLogits
+            ? takeAlong(logits, indices, axis: -1)
+            : MLXArray.zeros(indices.shape, dtype: logits.dtype)
+
+        return putAlong(masked, indices, values: allowedValues, axis: -1)
+    }
+}
+
+extension GenerationComponents {
+    /// Return a copy that enforces a reasoning-token budget for every generation.
+    ///
+    /// The reasoning protocol must declare a ``ReasoningBudgetTransition``, or
+    /// the caller must supply one via
+    /// ``ThinkingBudgetConfiguration/transitionOverride``. Unknown protocols
+    /// fail during setup rather than receiving a guessed `</think>` sequence.
+    /// The configured generation limit must include enough headroom for a
+    /// Unicode boundary completion, the longest possible protocol transition,
+    /// and the answer.
+    public func applyingThinkingBudget(
+        _ configuration: ThinkingBudgetConfiguration,
+        reasoning: ReasoningConfig,
+        tokenizer: any Tokenizer,
+        diagnosticHandler: (@Sendable (ThinkingBudgetDiagnostic) -> Void)? = nil
+    ) throws -> Self {
+        let plan = try ThinkingBudgetPlan(
+            configuration: configuration, reasoning: reasoning, tokenizer: tokenizer)
+        let protocolHeadroom = max(
+            plan.forcedTransitionTokenIDs.count,
+            (plan.endTokenSequences.map(\.count).max() ?? 1) - 1)
+        let (budgetAndUnicode, unicodeOverflow) =
+            configuration.maximumTokenCount.addingReportingOverflow(
+                ThinkingBudgetProcessor.maximumUnicodeCompletionTokenCount)
+        let (budgetAndProtocol, protocolOverflow) =
+            budgetAndUnicode.addingReportingOverflow(protocolHeadroom)
+        let (requiredTokenCount, answerOverflow) =
+            budgetAndProtocol.addingReportingOverflow(configuration.minimumAnswerTokenCount)
+        guard !unicodeOverflow, !protocolOverflow, !answerOverflow else {
+            throw ThinkingBudgetError.generationTokenRequirementOverflow
+        }
+
+        return appendingParameterValidator { parameters in
+            guard let maxTokens = parameters.maxTokens else { return }
+            guard maxTokens >= requiredTokenCount else {
+                throw ThinkingBudgetError.insufficientGenerationTokenLimit(
+                    required: requiredTokenCount, actual: maxTokens)
+            }
+        }.appendingLogitProcessor {
+            ThinkingBudgetProcessor(plan: plan, diagnosticHandler: diagnosticHandler)
+        }
+    }
+}
+
+struct ThinkingBudgetPlan: Sendable {
+    let configuration: ThinkingBudgetConfiguration
+    let tokenizer: any Tokenizer
+    let startTokenIDs: [Int]
+    let endTokenSequences: [[Int]]
+    let forcedTransitionTokenIDs: [Int]
+
+    /// Tokens of slack before the budget within which tracking becomes exact.
+    ///
+    /// Covers the longest end delimiter — a partial natural close may straddle
+    /// the boundary — plus the four bytes a UTF-8 scalar can span.
+    let exactTrackingWindow: Int
+
+    init(
+        configuration: ThinkingBudgetConfiguration,
+        reasoning: ReasoningConfig,
+        tokenizer: any Tokenizer
+    ) throws {
+        guard let transition = configuration.transitionOverride ?? reasoning.budgetTransition
+        else {
+            throw ThinkingBudgetError.unsupportedReasoningProtocol
+        }
+
+        let startTokenIDs = try Self.encodeBoundary(reasoning.startDelimiter, tokenizer: tokenizer)
+        let endDelimiters = [reasoning.endDelimiter] + reasoning.implicitEndDelimiters
+        var endTokenSequences: [[Int]] = []
+        for delimiter in endDelimiters {
+            let sequence = try Self.encodeBoundary(delimiter, tokenizer: tokenizer)
+            if !endTokenSequences.contains(sequence) {
+                endTokenSequences.append(sequence)
+            }
+        }
+
+        let forcedTransition =
+            transition.beforeEndDelimiter + reasoning.endDelimiter
+            + transition.afterEndDelimiter
+        let forcedTransitionTokenIDs = tokenizer.encode(
+            text: forcedTransition, addSpecialTokens: false)
+        guard !forcedTransitionTokenIDs.isEmpty else {
+            throw ThinkingBudgetError.unencodableTransition(forcedTransition)
+        }
+        try Self.validate(forcedTransitionTokenIDs)
+
+        self.configuration = configuration
+        self.tokenizer = tokenizer
+        self.startTokenIDs = startTokenIDs
+        self.endTokenSequences = endTokenSequences
+        self.forcedTransitionTokenIDs = forcedTransitionTokenIDs
+        self.exactTrackingWindow = (endTokenSequences.map(\.count).max() ?? 1) + 4
+    }
+
+    private static func encodeBoundary(
+        _ boundary: String, tokenizer: any Tokenizer
+    ) throws -> [Int] {
+        let tokenIDs = tokenizer.encode(text: boundary, addSpecialTokens: false)
+        guard !tokenIDs.isEmpty else {
+            throw ThinkingBudgetError.unencodableBoundary(boundary)
+        }
+        try validate(tokenIDs)
+        return tokenIDs
+    }
+
+    private static func validate(_ tokenIDs: [Int]) throws {
+        if let invalidTokenID = tokenIDs.first(where: { $0 < 0 || $0 > Int(Int32.max) }) {
+            throw ThinkingBudgetError.invalidTokenID(invalidTokenID)
+        }
+    }
+}
+
+private struct ReasoningBoundaryTracker: Sendable {
+    struct Observation {
+        var startedReasoning = false
+        var endedReasoning = false
+        var committedReasoningTokenCount = 0
+    }
+
+    private let start: [Int]
+    private let ends: [[Int]]
+    private var pending: [Int] = []
+
+    private(set) var isInsideReasoning = false
+
+    init(start: [Int], ends: [[Int]]) {
+        precondition(!start.isEmpty && !ends.isEmpty)
+        self.start = start
+        self.ends = ends
+    }
+
+    var hasPendingEndPrefix: Bool {
+        isInsideReasoning && !pending.isEmpty
+    }
+
+    mutating func reset(with tokens: [Int]) {
+        pending.removeAll(keepingCapacity: true)
+        isInsideReasoning = false
+        for token in tokens {
+            _ = observe(token)
+        }
+    }
+
+    mutating func observe(_ token: Int) -> Observation {
+        var observation = Observation()
+        pending.append(token)
+
+        if isInsideReasoning {
+            if ends.contains(pending) {
+                pending.removeAll(keepingCapacity: true)
+                isInsideReasoning = false
+                observation.endedReasoning = true
+                return observation
+            }
+
+            let held = longestSuffixThatIsProperPrefix(of: ends)
+            observation.committedReasoningTokenCount = pending.count - held.count
+            pending = held
+        } else {
+            if pending == start {
+                pending.removeAll(keepingCapacity: true)
+                isInsideReasoning = true
+                observation.startedReasoning = true
+                return observation
+            }
+            pending = longestSuffixThatIsProperPrefix(of: [start])
+        }
+
+        return observation
+    }
+
+    /// When a possible natural end consumes the remaining budget, constrain
+    /// the next sample to a valid continuation instead of letting the prefix
+    /// become reasoning text and then injecting a second closing sequence.
+    func requiredEndContinuation(remainingReasoningTokens: Int) -> [Int]? {
+        guard isInsideReasoning, !pending.isEmpty,
+            pending.count >= max(0, remainingReasoningTokens)
+        else { return nil }
+
+        let next = ends.compactMap { sequence -> Int? in
+            guard sequence.count > pending.count,
+                sequence.starts(with: pending)
+            else { return nil }
+            return sequence[pending.count]
+        }
+        let unique = Array(Set(next)).sorted()
+        return unique.isEmpty ? nil : unique
+    }
+
+    private func longestSuffixThatIsProperPrefix(of sequences: [[Int]]) -> [Int] {
+        let maximumLength = sequences.map(\.count).max() ?? 0
+        let upperBound = min(pending.count, max(0, maximumLength - 1))
+        guard upperBound > 0 else { return [] }
+
+        for length in stride(from: upperBound, through: 1, by: -1) {
+            let suffix = Array(pending.suffix(length))
+            if sequences.contains(where: { $0.count > length && $0.starts(with: suffix) }) {
+                return suffix
+            }
+        }
+        return []
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1302,5 +1302,5 @@ extension Qwen35 {
 // `Qwen35MoE` subclasses `Qwen35` and inherits both declarations.
 extension Qwen35 {
     public var toolCallFormat: ToolCallFormat? { .xmlFunction }
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1917,5 +1917,7 @@ public struct Qwen3VLMessageGenerator: MessageGenerator {
 // MARK: - Chat conventions
 
 extension Qwen3VL {
-    public var reasoningConfig: ReasoningConfig? { .thinkTagsWithEnableThinking }
+    // Qwen3-VL shares Qwen's tags and tool-call boundary, but does not declare
+    // the original Qwen3 family's model-specific hard-budget transition.
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Libraries/MLXVLM/Models/Qwen3VLMoE.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VLMoE.swift
@@ -831,3 +831,11 @@ public final class Qwen3VLMoE: Module, VLMModel, KVCacheDimensionProvider {
         return false
     }
 }
+
+// MARK: - Chat conventions
+
+extension Qwen3VLMoE {
+    // Qwen3-VL shares Qwen's tags and tool-call boundary, but does not declare
+    // the original Qwen3 family's model-specific hard-budget transition.
+    public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
+}

--- a/Tests/MLXFoundationModelsTests/AllowedToolOutputRouterTests.swift
+++ b/Tests/MLXFoundationModelsTests/AllowedToolOutputRouterTests.swift
@@ -103,6 +103,24 @@ struct AllowedToolOutputRouterTests {
         #expect(!router.isInsideReasoning)
     }
 
+    @Test func implicitReasoningEndFlowsIntoToolParser() {
+        let config = ReasoningConfig(
+            startDelimiter: "<think>", endDelimiter: "</think>",
+            promptStrategy: .templateFlag(key: "enable_thinking", defaultOn: true),
+            implicitEndDelimiters: ["<tool_call>"])
+        var router = AllowedToolOutputRouter(
+            format: .json, tools: tools,
+            reasoning: (config: config, primedInside: true))
+
+        let events = router.process(
+            #"check live data<tool_call>{"name":"get_weather","arguments":{"location":"Rome"}}</tool_call>"#
+        )
+
+        #expect(events.contains(.reasoning("check live data")))
+        #expect(events.contains { if case .toolCall = $0 { true } else { false } })
+        #expect(!router.isInsideReasoning)
+    }
+
     @Test func eosFlushesNonToolJSONAsResponse() {
         var router = AllowedToolOutputRouter(format: .json, tools: tools)
         #expect(router.process(#"{"answer":"hello"}"#) == [.response(#"{"answer":"hello"}"#)])

--- a/Tests/MLXLMTests/ChatConventionsTests.swift
+++ b/Tests/MLXLMTests/ChatConventionsTests.swift
@@ -79,7 +79,7 @@ final class ChatConventionsModelTests: XCTestCase {
             """
         let model = try await LLMTypeRegistry.shared.createModel(
             configuration: Data(json.utf8), modelType: "qwen3")
-        XCTAssertEqual(model.reasoningConfig, .thinkTagsWithEnableThinking)
+        XCTAssertEqual(model.reasoningConfig, QwenReasoningProtocol.qwen3)
         // Qwen3 (unlike Qwen3.5) declares no tool-call format.
         XCTAssertNil(model.toolCallFormat)
     }
@@ -117,11 +117,27 @@ struct ChatConventionsTests {
         #expect(config.endDelimiter == "</think>")
         #expect(config.promptStrategy == .templateFlag(key: "enable_thinking", defaultOn: true))
         #expect(config.isSpecialToken)
+        #expect(config.budgetTransition == nil)
+        #expect(config.implicitEndDelimiters.isEmpty)
+    }
+
+    @Test func qwenTaggedProtocol() {
+        let config = QwenReasoningProtocol.tagged
+        // Qwen surface syntax without the Qwen3 training recipe: no transition.
+        #expect(config.budgetTransition == nil)
+        #expect(config.implicitEndDelimiters == ["<tool_call>"])
+    }
+
+    @Test func qwen3BudgetProtocol() {
+        let config = QwenReasoningProtocol.qwen3
+        #expect(config.budgetTransition != nil)
+        #expect(config.implicitEndDelimiters == ["<tool_call>"])
     }
 
     @Test func alwaysOnPreset() {
         #expect(ReasoningConfig.alwaysOnThinking.promptStrategy == .alwaysOn)
         #expect(ReasoningConfig.alwaysOnThinking.startDelimiter == "<think>")
+        #expect(ReasoningConfig.alwaysOnThinking.budgetTransition == nil)
     }
 
     // MARK: - Declaration inheritance

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -771,6 +771,32 @@ public class ChatSessionTests: XCTestCase {
         XCTAssertEqual(counter.value, 2)
     }
 
+    /// Parameter-dependent components must fail through the real session API
+    /// before prompt prefill starts.
+    func testChatSessionRunsGenerationComponentValidation() async throws {
+        let inputProcessor = TestInputProcessor()
+        let components = try GenerationComponents().applyingThinkingBudget(
+            ThinkingBudgetConfiguration(
+                maximumTokenCount: 100,
+                transitionOverride: .immediate),
+            reasoning: .alwaysOnThinking,
+            tokenizer: inputProcessor.tokenizer)
+        let session = ChatSession(
+            model(processor: inputProcessor),
+            generateParameters: GenerateParameters(maxTokens: 1),
+            components: components)
+
+        do {
+            _ = try await session.respond(to: "hello")
+            XCTFail("Expected generation-component validation to reject maxTokens")
+        } catch let error as ThinkingBudgetError {
+            guard case .insufficientGenerationTokenLimit = error else {
+                XCTFail("Unexpected thinking-budget error: \(error)")
+                return
+            }
+        }
+    }
+
     /// Passing an empty ``GenerationComponents()`` must be non-breaking: the
     /// session still generates normally, exactly as when no components are
     /// supplied. (The exact processor-equivalence guarantee is proven

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -193,14 +193,13 @@ final class NanbeigeTests: XCTestCase {
         XCTAssertEqual(model.toolCallFormat, .xmlFunction)
     }
 
-    /// <think>/</think>, toggled via `enable_thinking` (template default true).
-    func testDeclaresQwen3StyleReasoningConfig() throws {
+    /// Qwen-compatible thinking tags and tool-call boundary, without claiming
+    /// support for the original Qwen3 family's hard-budget transition.
+    func testDeclaresTaggedReasoningProtocol() throws {
         let model = NanbeigeModel(try makeConfig())
         let config = try XCTUnwrap(model.reasoningConfig)
-        XCTAssertEqual(config.startDelimiter, "<think>")
-        XCTAssertEqual(config.endDelimiter, "</think>")
-        XCTAssertEqual(
-            config.promptStrategy, .templateFlag(key: "enable_thinking", defaultOn: true))
-        XCTAssertTrue(config.isSpecialToken)
+        XCTAssertEqual(config, QwenReasoningProtocol.tagged)
+        XCTAssertEqual(config.implicitEndDelimiters, ["<tool_call>"])
+        XCTAssertNil(config.budgetTransition)
     }
 }

--- a/Tests/MLXLMTests/Qwen3VLMoETests.swift
+++ b/Tests/MLXLMTests/Qwen3VLMoETests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
 import Foundation
+import MLXLMCommon
 import MLXVLM
 import XCTest
 
@@ -78,5 +79,16 @@ final class Qwen3VLMoETests: XCTestCase {
         XCTAssertEqual(config.textConfiguration.moeIntermediateSize, 12)
         XCTAssertEqual(config.textConfiguration.numKeyValueHeads, 1)
         XCTAssertFalse(config.textConfiguration.tieWordEmbeddings)
+    }
+
+    func testDeclaresQwen3GenerationReasoningProtocol() throws {
+        let reasoning = try XCTUnwrap(Qwen3VLMoE(makeMinimalConfig()).reasoningConfig)
+
+        XCTAssertEqual(reasoning, QwenReasoningProtocol.tagged)
+        XCTAssertEqual(reasoning.startDelimiter, "<think>")
+        XCTAssertEqual(reasoning.implicitEndDelimiters, ["<tool_call>"])
+        // Sharing Qwen's delimiters does not automatically opt a distinct
+        // post-training family into Qwen3's model-specific transition.
+        XCTAssertNil(reasoning.budgetTransition)
     }
 }

--- a/Tests/MLXLMTests/ReasoningEventEmitterTests.swift
+++ b/Tests/MLXLMTests/ReasoningEventEmitterTests.swift
@@ -12,6 +12,11 @@ struct ReasoningEventEmitterTests {
     private static let thinkConfig = ReasoningConfig(
         startDelimiter: "<think>", endDelimiter: "</think>", promptStrategy: .alwaysOn)
 
+    private static let thinkThenToolConfig = ReasoningConfig(
+        startDelimiter: "<think>", endDelimiter: "</think>",
+        promptStrategy: .alwaysOn,
+        implicitEndDelimiters: ["<tool_call>"])
+
     private typealias Segment = ReasoningEventEmitter.Segment
 
     /// Feeds all chunks through the emitter and appends `finalize()`.
@@ -68,6 +73,24 @@ struct ReasoningEventEmitterTests {
             segments == [
                 .reasoning("a"), .response("mid"), .reasoning("b"), .response("end"),
             ])
+    }
+
+    @Test func implicitEndRemainsInResponseForToolParsing() {
+        let segments = run(
+            config: Self.thinkThenToolConfig,
+            [#"<think>check data<tool_call>{"name":"search"}</tool_call>"#])
+        #expect(reasoningText(segments) == "check data")
+        #expect(
+            responseText(segments)
+                == #"<tool_call>{"name":"search"}</tool_call>"#)
+    }
+
+    @Test func implicitEndCanSpanChunks() {
+        let segments = run(
+            config: Self.thinkThenToolConfig,
+            ["<think>check<tool_", "call>{}</tool_call>"])
+        #expect(reasoningText(segments) == "check")
+        #expect(responseText(segments) == "<tool_call>{}</tool_call>")
     }
 
     // MARK: - Primed state
@@ -201,10 +224,25 @@ struct ReasoningEventEmitterTests {
                 renderedPromptTail: "<|im_start|>assistant\n", config: Self.thinkConfig))
     }
 
+    @Test func emptyStartDelimiterDoesNotPrimeReasoning() {
+        let invalid = ReasoningConfig(
+            startDelimiter: "", endDelimiter: "</think>", promptStrategy: .alwaysOn)
+        #expect(
+            !ReasoningEventEmitter.promptEndsInsideReasoning(
+                renderedPromptTail: "assistant", config: invalid))
+    }
+
     @Test func closedBlockInPromptIsNotInside() {
         #expect(
             !ReasoningEventEmitter.promptEndsInsideReasoning(
                 renderedPromptTail: "<think>cached</think>\nanswer", config: Self.thinkConfig))
+    }
+
+    @Test func implicitEndInPromptIsNotInside() {
+        #expect(
+            !ReasoningEventEmitter.promptEndsInsideReasoning(
+                renderedPromptTail: "<think>cached<tool_call>{}",
+                config: Self.thinkThenToolConfig))
     }
 
     @Test func prefillWithMultipleTrailingNewlinesAndSpaces() {
@@ -249,5 +287,13 @@ struct ReasoningEventEmitterTests {
         #expect(!e.hasClosedReasoning)
         _ = e.process("thinking</think>answer")
         #expect(e.hasClosedReasoning)
+    }
+
+    @Test func hasClosedReasoningFiresForImplicitEnd() {
+        var e = ReasoningEventEmitter(config: Self.thinkThenToolConfig, primedInside: true)
+        let segments = e.process("thinking<tool_call>{}")
+        #expect(e.hasClosedReasoning)
+        #expect(!e.isInsideReasoning)
+        #expect(segments == [.reasoning("thinking"), .response("<tool_call>{}")])
     }
 }

--- a/Tests/MLXLMTests/ThinkingBudgetTests.swift
+++ b/Tests/MLXLMTests/ThinkingBudgetTests.swift
@@ -1,0 +1,812 @@
+// Copyright © 2026 Apple Inc.
+
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+
+final class ThinkingBudgetTests: XCTestCase {
+    private let tokenizer = ByteTokenizer()
+    private let reasoning = QwenReasoningProtocol.qwen3
+
+    func testConfigurationRejectsNegativeBudgetAndAcceptsZero() throws {
+        XCTAssertThrowsError(
+            try ThinkingBudgetConfiguration(maximumTokenCount: -1)
+        ) { error in
+            XCTAssertEqual(error as? ThinkingBudgetError, .invalidMaximumTokenCount(-1))
+        }
+        XCTAssertEqual(
+            try ThinkingBudgetConfiguration(maximumTokenCount: 0).maximumTokenCount, 0)
+        XCTAssertThrowsError(
+            try ThinkingBudgetConfiguration(
+                maximumTokenCount: 1, minimumAnswerTokenCount: -1)
+        ) { error in
+            XCTAssertEqual(
+                error as? ThinkingBudgetError, .invalidMinimumAnswerTokenCount(-1))
+        }
+    }
+
+    func testForcesModelDeclaredTransitionAfterExactBudget() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 2),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("B")), ascii("B"))
+
+        let transition = tokenizer.encode(
+            text: qwenEarlyStopText, addSpecialTokens: false)
+        let forced = transition.map { expected in
+            let actual = sample(&processor, modelToken: ascii("Z"))
+            XCTAssertEqual(actual, expected)
+            return actual
+        }
+        XCTAssertEqual(forced, transition)
+
+        // The budget is terminal after closing; answer generation is untouched.
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+    }
+
+    func testNaturalCloseDisablesBudgetWithoutInjectingAnotherDelimiter() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 32),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for token in tokenizer.encode(text: "short</think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+
+        for _ in 0 ..< 40 {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        }
+    }
+
+    func testPartialNaturalCloseAtBudgetBoundaryIsNotDoubleClosed() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 2),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        for token in tokenizer.encode(text: "</think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+
+        // No forced newline or duplicate close remains after the natural close.
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+    }
+
+    func testPotentialNaturalCloseIsCompletedInsteadOfDuplicated() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 2),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("<")), ascii("<"))
+
+        // The `<` may be the final reasoning token or the beginning of the
+        // natural close. At the boundary the processor safely completes the
+        // latter, even when the model proposes a divergent token.
+        for expected in tokenizer.encode(text: "/think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("X")), expected)
+        }
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+    }
+
+    func testImplicitToolCallBoundaryStopsBudgetEnforcement() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 32),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for token in tokenizer.encode(text: "plan<tool_call>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+
+        // Tool arguments must never be corrupted by an injected reasoning end.
+        for token in tokenizer.encode(text: #"{"name":"search"}"#, addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+    }
+
+    func testPotentialToolCallAtBudgetBoundaryIsCompletedWithoutCorruptingArguments() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 2),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("<")), ascii("<"))
+
+        for expected in tokenizer.encode(text: "tool_call>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: expected), expected)
+        }
+        for token in tokenizer.encode(text: #"{"name":"search"}"#, addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+    }
+
+    func testDoesNotBudgetOrdinaryAnswerWhenReasoningNeverStarts() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 1),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n"))
+
+        for _ in 0 ..< 5 {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        }
+    }
+
+    func testDetectsGeneratedOpeningDelimiterAcrossTokens() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 1),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n"))
+
+        for token in tokenizer.encode(text: "<think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("\n"))
+    }
+
+    func testZeroBudgetClosesPromptPrimedReasoningImmediately() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 0),
+            reasoning: ReasoningConfig(
+                startDelimiter: "<think>", endDelimiter: "</think>",
+                promptStrategy: .alwaysOn, budgetTransition: .immediate),
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for expected in tokenizer.encode(text: "</think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), expected)
+        }
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+    }
+
+    func testGenerationComponentsComposesBudgetAfterExistingProcessor() throws {
+        let components = try GenerationComponents()
+            .appendingLogitProcessor { AdditiveProcessor(amount: 1) }
+            .applyingThinkingBudget(
+                ThinkingBudgetConfiguration(maximumTokenCount: 1),
+                reasoning: reasoning,
+                tokenizer: tokenizer)
+
+        var processor = try XCTUnwrap(
+            components.logitProcessor(parameters: GenerateParameters()))
+        XCTAssertTrue(processor is ChainedLogitProcessor)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("\n"))
+    }
+
+    func testComponentsProduceFreshBudgetStateForEveryGeneration() throws {
+        let components = try GenerationComponents().applyingThinkingBudget(
+            ThinkingBudgetConfiguration(maximumTokenCount: 1),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+
+        var first = try XCTUnwrap(components.logitProcessor(parameters: .init()))
+        first.prompt(tokens("assistant\n<think>\n"))
+        XCTAssertEqual(sample(&first, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&first, modelToken: ascii("Z")), ascii("\n"))
+
+        var second = try XCTUnwrap(components.logitProcessor(parameters: .init()))
+        second.prompt(tokens("assistant\n<think>\n"))
+        XCTAssertEqual(sample(&second, modelToken: ascii("B")), ascii("B"))
+    }
+
+    func testComponentsRejectGenerationLimitWithoutTransitionAndAnswerHeadroom() throws {
+        let configuration = try ThinkingBudgetConfiguration(
+            maximumTokenCount: 8, minimumAnswerTokenCount: 4)
+        let components = try GenerationComponents().applyingThinkingBudget(
+            configuration, reasoning: reasoning, tokenizer: tokenizer)
+        let transitionCount = tokenizer.encode(
+            text: qwenEarlyStopText, addSpecialTokens: false
+        ).count
+        let maximumUnicodeCompletionTokenCount = 3
+        let required = 8 + maximumUnicodeCompletionTokenCount + transitionCount + 4
+
+        XCTAssertThrowsError(
+            try components.validate(parameters: .init(maxTokens: required - 1))
+        ) { error in
+            XCTAssertEqual(
+                error as? ThinkingBudgetError,
+                .insufficientGenerationTokenLimit(required: required, actual: required - 1))
+        }
+        XCTAssertNoThrow(try components.validate(parameters: .init(maxTokens: required)))
+        XCTAssertNoThrow(try components.validate(parameters: .init(maxTokens: nil)))
+    }
+
+    func testRejectsUnrepresentableGenerationTokenRequirement() throws {
+        let configuration = try ThinkingBudgetConfiguration(
+            maximumTokenCount: Int.max, minimumAnswerTokenCount: 1)
+
+        XCTAssertThrowsError(
+            try GenerationComponents().applyingThinkingBudget(
+                configuration, reasoning: reasoning, tokenizer: tokenizer)
+        ) { error in
+            XCTAssertEqual(
+                error as? ThinkingBudgetError, .generationTokenRequirementOverflow)
+        }
+    }
+
+    func testRejectsProtocolWithoutDeclaredBudgetTransition() throws {
+        let unsupported = ReasoningConfig(
+            startDelimiter: "<reasoning>", endDelimiter: "</reasoning>",
+            promptStrategy: .none)
+
+        XCTAssertThrowsError(
+            try GenerationComponents().applyingThinkingBudget(
+                ThinkingBudgetConfiguration(maximumTokenCount: 1),
+                reasoning: unsupported, tokenizer: tokenizer)
+        ) { error in
+            XCTAssertEqual(error as? ThinkingBudgetError, .unsupportedReasoningProtocol)
+        }
+    }
+
+    func testRejectsUnencodableBoundary() throws {
+        let noDelimiter = ReasoningConfig(
+            startDelimiter: "<think>", endDelimiter: "",
+            promptStrategy: .alwaysOn,
+            budgetTransition: .immediate)
+
+        XCTAssertThrowsError(
+            try GenerationComponents().applyingThinkingBudget(
+                ThinkingBudgetConfiguration(maximumTokenCount: 1),
+                reasoning: noDelimiter, tokenizer: tokenizer)
+        ) { error in
+            XCTAssertEqual(error as? ThinkingBudgetError, .unencodableBoundary(""))
+        }
+    }
+
+    /// Qwen's published `early_stopping_text`, byte-for-byte.
+    ///
+    /// Source: Qwen3 quickstart, "Thinking Budget". The space after the two
+    /// newlines is part of the published string and therefore part of its token
+    /// sequence.
+    private static let qwenCanonicalEarlyStoppingText =
+        "\n\n Considering the limited time by the user, I have to give the solution based on the thinking directly now.\n</think>\n\n"
+
+    func testQwen3PresetUsesOfficialEarlyStopTransition() throws {
+        let reasoning = QwenReasoningProtocol.qwen3
+        let transition = try XCTUnwrap(reasoning.budgetTransition)
+
+        XCTAssertEqual(
+            transition.beforeEndDelimiter + reasoning.endDelimiter
+                + transition.afterEndDelimiter,
+            Self.qwenCanonicalEarlyStoppingText)
+    }
+
+    /// Guards the exact token sequence, not just the characters.
+    ///
+    /// Qwen3 encodes the canonical prefix as `[271, 55777]` (`"\n\n"`,
+    /// `" Considering"`). `QwenLikeTokenizer` reproduces that distinction with
+    /// the real IDs.
+    func testQwen3TransitionEncodesToQwensCanonicalTokenSequence() throws {
+        let tokenizer = QwenLikeTokenizer()
+        let plan = try ThinkingBudgetPlan(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 8),
+            reasoning: QwenReasoningProtocol.qwen3,
+            tokenizer: tokenizer)
+
+        XCTAssertEqual(plan.forcedTransitionTokenIDs.count, 24)
+        XCTAssertEqual(plan.forcedTransitionTokenIDs.prefix(2), [271, 55777])
+        XCTAssertFalse(plan.forcedTransitionTokenIDs.contains(82796))
+
+        // `</think>` is a single special token, and it is inside the sequence.
+        XCTAssertEqual(plan.endTokenSequences, [[151668], [151657]])
+        XCTAssertTrue(plan.forcedTransitionTokenIDs.contains(151668))
+    }
+
+    // MARK: - Single-token delimiters
+    //
+    // `ByteTokenizer` makes every delimiter multi-token, which is the opposite
+    // regime from real Qwen weights where `<think>` and `</think>` are single
+    // special tokens. These pin that shape so the prefix/suffix machinery in
+    // `ReasoningBoundaryTracker` is never the only path under test.
+
+    func testSingleTokenDelimitersForceTransitionAtExactBudget() throws {
+        let qwen = QwenLikeTokenizer()
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 3),
+            reasoning: QwenReasoningProtocol.qwen3,
+            tokenizer: qwen)
+
+        // Qwen primes the opening delimiter in the rendered prompt.
+        processor.prompt(qwenTokens("<think>\n", qwen))
+
+        let filler = 279  // " the"
+        for _ in 0 ..< 3 {
+            XCTAssertEqual(qwenSample(&processor, modelToken: filler), filler)
+        }
+
+        let transition = qwen.encode(
+            text: Self.qwenCanonicalEarlyStoppingText, addSpecialTokens: false)
+        for expected in transition {
+            XCTAssertEqual(qwenSample(&processor, modelToken: filler), expected)
+        }
+
+        // Terminal: the answer generates freely.
+        XCTAssertEqual(qwenSample(&processor, modelToken: filler), filler)
+        XCTAssertFalse(processor.didStandDown)
+    }
+
+    func testSingleTokenNaturalCloseSuppressesTheBudget() throws {
+        let qwen = QwenLikeTokenizer()
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 3),
+            reasoning: QwenReasoningProtocol.qwen3,
+            tokenizer: qwen)
+        processor.prompt(qwenTokens("<think>\n", qwen))
+
+        XCTAssertEqual(qwenSample(&processor, modelToken: 279), 279)
+        // `</think>` on its own token closes the span before the budget binds.
+        XCTAssertEqual(qwenSample(&processor, modelToken: 151_668), 151_668)
+
+        for _ in 0 ..< 10 {
+            XCTAssertEqual(qwenSample(&processor, modelToken: 279), 279)
+        }
+    }
+
+    // MARK: - Pipelining
+    //
+    // `TokenIterator` hands the processor a token that has not been evaluated
+    // yet, then calls `asyncEval`. Reading that token back would stall the GPU
+    // for every subsequent graph build, so the processor must keep it in flight
+    // whenever no budget decision can depend on it.
+
+    func testKeepsNewestSampledTokenInFlightAwayFromTheBudget() throws {
+        var processor = try makeProcessor(budget: 64)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for _ in 0 ..< 20 {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+            XCTAssertEqual(
+                processor.deferredTokenCount, 1,
+                "the freshest sampled token must not be read back mid-generation")
+        }
+    }
+
+    func testStopsReadingTokensOnceTheReasoningSpanCloses() throws {
+        var processor = try makeProcessor(budget: 64)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for token in tokenizer.encode(text: "done</think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: token), token)
+        }
+
+        // The answer is usually far longer than the reasoning span, so a stall
+        // per token here would dominate. Nothing is retained and nothing is read.
+        for _ in 0 ..< 20 {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+            XCTAssertEqual(processor.deferredTokenCount, 0)
+        }
+    }
+
+    /// Deferring must not move the boundary: a budget well beyond the exact
+    /// tracking window still fires on exactly the configured token.
+    func testDeferredTrackingStillFiresOnTheExactBudgetToken() throws {
+        let budget = 40
+        var processor = try makeProcessor(budget: budget)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for _ in 0 ..< budget {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        }
+
+        let transition = tokenizer.encode(text: qwenEarlyStopText, addSpecialTokens: false)
+        for expected in transition {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("A")), expected)
+        }
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+    }
+
+    func testCompletesUnicodeScalarBeforeForcingTransition() throws {
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(
+                maximumTokenCount: 1, transitionOverride: .immediate),
+            reasoning: .alwaysOnThinking,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        let emojiBytes = Array("😀".utf8).map(Int.init)
+        XCTAssertEqual(sample(&processor, modelToken: emojiBytes[0]), emojiBytes[0])
+        for continuation in emojiBytes.dropFirst() {
+            XCTAssertEqual(sample(&processor, modelToken: continuation), continuation)
+        }
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("<"))
+        XCTAssertFalse(processor.didStandDown)
+    }
+
+    func testStandsDownWhenTokenizerCannotCompleteUnicodeBoundary() throws {
+        let diagnostics = DiagnosticRecorder()
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(
+                maximumTokenCount: 1, transitionOverride: .immediate),
+            reasoning: .alwaysOnThinking,
+            tokenizer: tokenizer,
+            diagnosticHandler: diagnostics.record)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        for _ in 0 ..< 4 {
+            XCTAssertEqual(sample(&processor, modelToken: 0xF0), 0xF0)
+        }
+
+        XCTAssertTrue(processor.didStandDown)
+        XCTAssertEqual(
+            diagnostics.events,
+            [.unicodeBoundaryCompletionFailed(sampledTokenCount: 3)])
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+    }
+
+    // MARK: - Speculative decoding
+
+    /// In `SpeculativeTokenIterator.speculateRound` the canonical processor only
+    /// ever receives `didSample` for accepted tokens — a throwaway copy does the
+    /// `process`/`didSample` pairing for the verify window. The budget must
+    /// produce an identical stream either way, and must not stand down.
+    func testMatchesAutoregressiveRunUnderSpeculativeAcceptance() throws {
+        let steps = 40
+
+        var reference = try makeProcessor(budget: 6)
+        reference.prompt(tokens("assistant\n<think>\n"))
+        var referenceOutput: [Int] = []
+        for _ in 0 ..< steps {
+            referenceOutput.append(sample(&reference, modelToken: ascii("A")))
+        }
+
+        var canonical = try makeProcessor(budget: 6)
+        canonical.prompt(tokens("assistant\n<think>\n"))
+        var speculativeOutput: [Int] = []
+        while speculativeOutput.count < steps {
+            var verify = canonical
+            var window: [MLXArray] = []
+            for _ in 0 ..< 4 {
+                let logits = verify.process(logits: oneHotLogits(for: ascii("A")))
+                let token = ArgMaxSampler().sample(logits: logits)
+                verify.didSample(token: token)
+                window.append(token)
+            }
+            // The iterator evaluates the whole verify window before comparing.
+            MLX.eval(window)
+
+            for token in window {
+                canonical.didSample(token: token)
+                speculativeOutput.append(token.item(Int.self))
+            }
+        }
+
+        XCTAssertEqual(Array(speculativeOutput.prefix(steps)), referenceOutput)
+        XCTAssertFalse(canonical.didStandDown)
+    }
+
+    /// Verification may run the processor several tokens ahead, then reject
+    /// the first proposal. Only the correction token is committed to the
+    /// canonical processor; discarded verify state must not consume budget.
+    func testSpeculativeRejectionDoesNotAdvanceCanonicalBudgetState() throws {
+        let steps = 20
+        var reference = try makeProcessor(budget: 3)
+        reference.prompt(tokens("assistant\n<think>\n"))
+        let referenceOutput = (0 ..< steps).map { _ in
+            sample(&reference, modelToken: ascii("A"))
+        }
+
+        var canonical = try makeProcessor(budget: 3)
+        canonical.prompt(tokens("assistant\n<think>\n"))
+        var speculativeOutput: [Int] = []
+        for _ in 0 ..< steps {
+            var verify = canonical
+            var verified: [MLXArray] = []
+            for _ in 0 ..< 4 {
+                let logits = verify.process(logits: oneHotLogits(for: ascii("A")))
+                let token = ArgMaxSampler().sample(logits: logits)
+                verify.didSample(token: token)
+                verified.append(token)
+            }
+
+            // Pretend the first draft proposal differed. The iterator discards
+            // the speculative processor copy and commits only the correction.
+            let correction = verified[0]
+            canonical.didSample(token: correction)
+            speculativeOutput.append(correction.item(Int.self))
+        }
+
+        XCTAssertEqual(speculativeOutput, referenceOutput)
+        XCTAssertFalse(canonical.didStandDown)
+    }
+
+    // MARK: - Caller-supplied transitions
+
+    func testTransitionOverrideEnablesBudgetOnProtocolWithoutOne() throws {
+        // DeepSeek-R1 declares no transition; an application may still opt in.
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(
+                maximumTokenCount: 2, transitionOverride: .immediate),
+            reasoning: .alwaysOnThinking,
+            tokenizer: tokenizer)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("B")), ascii("B"))
+
+        // `.immediate` closes the span and adds nothing else.
+        for expected in tokenizer.encode(text: "</think>", addSpecialTokens: false) {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), expected)
+        }
+        XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+    }
+
+    func testTransitionOverrideTakesPrecedenceOverModelDeclaration() throws {
+        let plan = try ThinkingBudgetPlan(
+            configuration: ThinkingBudgetConfiguration(
+                maximumTokenCount: 4, transitionOverride: .immediate),
+            reasoning: QwenReasoningProtocol.qwen3,
+            tokenizer: tokenizer)
+
+        XCTAssertEqual(
+            plan.forcedTransitionTokenIDs,
+            tokenizer.encode(text: "</think>", addSpecialTokens: false))
+    }
+
+    // MARK: - Fail-safe
+
+    /// Losing sync with the sampler must never trap. `precondition` would take
+    /// a shipping app down mid-generation and `assertionFailure` would take down
+    /// debug builds of client apps, so the processor stands down instead and
+    /// leaves the model's own output untouched.
+    func testStandsDownInsteadOfTrappingWhenTheForcedTokenIsIgnored() throws {
+        let diagnostics = DiagnosticRecorder()
+        var processor = try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: 2),
+            reasoning: reasoning,
+            tokenizer: tokenizer,
+            diagnosticHandler: diagnostics.record)
+        processor.prompt(tokens("assistant\n<think>\n"))
+
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("B")), ascii("B"))
+
+        // A downstream component overrides the constraint.
+        processor.didSample(token: MLXArray([Int32(ascii("Q"))]))
+
+        XCTAssertTrue(processor.didStandDown)
+        XCTAssertEqual(
+            diagnostics.events,
+            [.enforcementDisabled(expectedTokenIDs: [ascii("\n")], sampledTokenID: ascii("Q"))]
+        )
+        XCTAssertEqual(processor.deferredTokenCount, 0)
+        for _ in 0 ..< 5 {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+        }
+    }
+
+    /// A tokenizer that does not match the model's vocabulary cannot mask to a
+    /// token the model is able to emit. Rather than leaving the sampler with an
+    /// all-masked row, the constraint is skipped and the budget stands down.
+    func testStandsDownWhenBoundaryTokensExceedTheModelVocabulary() throws {
+        var processor = try makeProcessor(budget: 1)
+        processor.prompt(tokens("assistant\n<think>\n"))
+        XCTAssertEqual(sample(&processor, modelToken: ascii("A")), ascii("A"))
+
+        // The transition opens with `\n` (10), outside this 8-token vocabulary.
+        let processed = processor.process(logits: oneHotLogits(for: 5, vocabularySize: 8))
+        XCTAssertEqual(
+            ArgMaxSampler().sample(logits: processed).item(Int.self), 5,
+            "an unsatisfiable constraint must leave the logits untouched")
+
+        processor.didSample(token: MLXArray([Int32(5)]))
+        XCTAssertTrue(processor.didStandDown)
+
+        for _ in 0 ..< 5 {
+            XCTAssertEqual(sample(&processor, modelToken: ascii("Z")), ascii("Z"))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeProcessor(budget: Int) throws -> ThinkingBudgetProcessor {
+        try ThinkingBudgetProcessor(
+            configuration: ThinkingBudgetConfiguration(maximumTokenCount: budget),
+            reasoning: reasoning,
+            tokenizer: tokenizer)
+    }
+
+    private func tokens(_ text: String) -> MLXArray {
+        MLXArray(tokenizer.encode(text: text, addSpecialTokens: false).map(Int32.init))
+    }
+
+    private func qwenTokens(_ text: String, _ qwen: QwenLikeTokenizer) -> MLXArray {
+        MLXArray(qwen.encode(text: text, addSpecialTokens: false).map(Int32.init))
+    }
+
+    private func qwenSample(
+        _ processor: inout ThinkingBudgetProcessor, modelToken: Int
+    ) -> Int {
+        sample(&processor, modelToken: modelToken, vocabularySize: 152_064)
+    }
+
+    private func oneHotLogits(for token: Int, vocabularySize: Int = 256) -> MLXArray {
+        var values = [Float](repeating: -10, count: vocabularySize)
+        values[token] = 10
+        return MLXArray(values)[.newAxis, 0...]
+    }
+
+    private func ascii(_ character: Character) -> Int {
+        Int(character.asciiValue!)
+    }
+
+    private var qwenEarlyStopText: String {
+        let transition = reasoning.budgetTransition!
+        return transition.beforeEndDelimiter + reasoning.endDelimiter
+            + transition.afterEndDelimiter
+    }
+
+    private func sample<P: LogitProcessor>(
+        _ processor: inout P, modelToken: Int, vocabularySize: Int = 256
+    ) -> Int {
+        var values = [Float](repeating: -10, count: vocabularySize)
+        values[modelToken] = 10
+        let logits = MLXArray(values)[.newAxis, 0...]
+        let token = ArgMaxSampler().sample(logits: processor.process(logits: logits))
+        processor.didSample(token: token)
+        return token.item(Int.self)
+    }
+}
+
+private struct AdditiveProcessor: LogitProcessor {
+    let amount: Float
+
+    func prompt(_ prompt: MLXArray) {}
+    func process(logits: MLXArray) -> MLXArray { logits + amount }
+    func didSample(token: MLXArray) {}
+}
+
+private final class DiagnosticRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [ThinkingBudgetDiagnostic] = []
+
+    func record(_ diagnostic: ThinkingBudgetDiagnostic) {
+        lock.withLock { storage.append(diagnostic) }
+    }
+
+    var events: [ThinkingBudgetDiagnostic] {
+        lock.withLock { storage }
+    }
+}
+
+/// A tokenizer that reproduces Qwen3's real token IDs for the strings these
+/// tests exercise.
+///
+/// `ByteTokenizer` makes every delimiter multi-token. Real Qwen weights are the
+/// opposite: `<think>`, `</think>` and `<tool_call>` are single special tokens,
+/// and the early-stop text is a specific 24-token BPE sequence. Both regimes
+/// need coverage, so this fixture carries the actual IDs from
+/// `Qwen/Qwen3-0.6B` for the pieces involved and falls back to a disjoint byte
+/// range for anything else.
+private struct QwenLikeTokenizer: Tokenizer {
+    /// Disjoint from every ID in ``pieces`` so decoding stays unambiguous.
+    private static let byteFallbackBase = 100_000
+
+    /// Real `Qwen/Qwen3-0.6B` IDs. Matched longest-first, as BPE would.
+    private static let pieces: [(text: String, id: Int)] = [
+        ("<think>", 151_667),
+        ("</think>", 151_668),
+        ("<tool_call>", 151_657),
+        ("\n\n", 271),
+        ("Considering", 82_796),
+        (" Considering", 55_777),
+        (" the", 279),
+        (" limited", 7_199),
+        (" time", 882),
+        (" by", 553),
+        (" user", 1_196),
+        (",", 11),
+        (" I", 358),
+        (" have", 614),
+        (" to", 311),
+        (" give", 2_968),
+        (" solution", 6_291),
+        (" based", 3_118),
+        (" on", 389),
+        (" thinking", 7_274),
+        (" directly", 5_961),
+        (" now", 1_431),
+        (".\n", 624),
+    ].sorted { $0.text.count > $1.text.count }
+
+    private static let textByID = Dictionary(
+        uniqueKeysWithValues: pieces.map { ($0.id, $0.text) })
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        var ids: [Int] = []
+        var rest = Substring(text)
+        while !rest.isEmpty {
+            if let piece = Self.pieces.first(where: { rest.hasPrefix($0.text) }) {
+                ids.append(piece.id)
+                rest = rest.dropFirst(piece.text.count)
+                continue
+            }
+            for byte in String(rest.removeFirst()).utf8 {
+                ids.append(Self.byteFallbackBase + Int(byte))
+            }
+        }
+        return ids
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        var bytes: [UInt8] = []
+        for id in tokenIds {
+            if let text = Self.textByID[id] {
+                bytes.append(contentsOf: Array(text.utf8))
+            } else if (Self.byteFallbackBase ... Self.byteFallbackBase + 255).contains(id) {
+                bytes.append(UInt8(id - Self.byteFallbackBase))
+            }
+        }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        Self.pieces.first { $0.text == token }?.id
+    }
+
+    func convertIdToToken(_ id: Int) -> String? { Self.textByID[id] }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        []
+    }
+}
+
+/// A deterministic tokenizer whose token IDs are UTF-8 bytes.
+private struct ByteTokenizer: Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        text.utf8.map(Int.init)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        String(decoding: tokenIds.map(UInt8.init), as: UTF8.self)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        guard token.utf8.count == 1 else { return nil }
+        return token.utf8.first.map(Int.init)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        guard (0 ... 255).contains(id) else { return nil }
+        return String(decoding: [UInt8(id)], as: UTF8.self)
+    }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        []
+    }
+}


### PR DESCRIPTION
## Proposed changes

Reasoning models can spend most or all of their output limit “thinking,” leaving too little space for the answer shown to the user. This PR adds a configurable thinking budget that limits reasoning while reserving space for the final response.

The implementation is model-aware and does not assume that every model using `<think>` tags supports the same early-stop behavior like mlx-vlm does...


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)