### PR TITLE
Remove the untyped staged-cache fallback

### DIFF
--- a/Libraries/MLXLMCommon/RotatingStagedKVCache.swift
+++ b/Libraries/MLXLMCommon/RotatingStagedKVCache.swift
@@ -38,9 +38,11 @@ final class RotatingStagedKVCache: KVCache {
     var maxSize: Int? { live.maxSize }
 
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
-        stagedKeys = stagedKeys.map { concatenated([$0, keys], axis: 2) } ?? keys
-        stagedValues = stagedValues.map { concatenated([$0, values], axis: 2) } ?? values
-        return presentation()
+        let stagedKeys = stagedKeys.map { concatenated([$0, keys], axis: 2) } ?? keys
+        let stagedValues = stagedValues.map { concatenated([$0, values], axis: 2) } ?? values
+        self.stagedKeys = stagedKeys
+        self.stagedValues = stagedValues
+        return presentation(stagedKeys: stagedKeys, stagedValues: stagedValues)
     }
 
     /// The live cache's own mask.
@@ -70,10 +72,9 @@ final class RotatingStagedKVCache: KVCache {
             values: stagedValues[.ellipsis, ..<keep, 0...])
     }
 
-    private func presentation() -> (MLXArray, MLXArray) {
-        guard let stagedKeys, let stagedValues else {
-            return live.logicalView(tail: live.offset) ?? emptyPresentation()
-        }
+    private func presentation(
+        stagedKeys: MLXArray, stagedValues: MLXArray
+    ) -> (MLXArray, MLXArray) {
         // `maxSize - 1` is the same bound the multi-token write path front-trims to, so the first
         // staged query still reaches back a full window.
         let bound = Swift.min(live.offset, (live.maxSize ?? Int.max) - 1)
@@ -84,11 +85,6 @@ final class RotatingStagedKVCache: KVCache {
             concatenated([view.0, stagedKeys], axis: 2),
             concatenated([view.1, stagedValues], axis: 2)
         )
-    }
-
-    private func emptyPresentation() -> (MLXArray, MLXArray) {
-        let empty = MLXArray.zeros([1, 1, 0, 1])
-        return (empty, empty)
     }
 
     func innerState() -> [MLXArray] {

--- a/Tests/MLXLMTests/KVCacheRoundTests.swift
+++ b/Tests/MLXLMTests/KVCacheRoundTests.swift
@@ -452,6 +452,22 @@ private final class ProbeCache: KVCache {
 
 // MARK: - Adapter surface
 
+@Test func testFirstStagedPresentationPreservesInputDTypeAndShape() throws {
+    let live = RotatingKVCache(maxSize: 8, keep: 0)
+    let overlay = try #require(StagedRound([live]))
+    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+    let keys = MLXArray.ones([1, 2, 3, 4], dtype: .bfloat16)
+    let values = MLXArray.zeros([1, 2, 3, 4], dtype: .bfloat16)
+
+    let presented = adapter.update(keys: keys, values: values)
+
+    #expect(presented.0.dtype == .bfloat16)
+    #expect(presented.1.dtype == .bfloat16)
+    #expect(presented.0.shape == keys.shape)
+    #expect(presented.1.shape == values.shape)
+    #expect(live.offset == 0, "staging the first rows must not initialize the live ring")
+}
+
 @Test func testOverlayAdapterReportsStagedPositionsInItsOffset() throws {
     let live = RotatingKVCache(maxSize: 8, keep: 0)
     let (k, v) = positionedKV(0 ..< 5)


### PR DESCRIPTION
Follow-up to #516 and [David's review comment](https://github.com/ml-explore/mlx-swift-lm/pull/516#discussion_r3760049169).

`RotatingStagedKVCache.update(keys:values:)` always stages its inputs before constructing a presentation. Its private `presentation()` helper nevertheless had a no-staged-input branch that manufactured empty `float32` arrays. That branch was unreachable, but it left a latent dtype hazard if the helper's call order ever changed.

This removes the fallback by making the invariant structural:

- pass the staged K/V arrays into `presentation` as non-optionals;
- delete `emptyPresentation()`; and
- pin the first empty-live-cache presentation to its staged `bfloat16` dtype and shape.

The new test passes before the refactor because the fallback was already unreachable. This is hazard removal, not a reproduced behavior bug.

No public API changes.

## Testing

- Full `MLXLMTests.xctest` bundle: all 494 Swift Testing tests pass; no new XCTest failures relative to the fresh `upstream/main@2af378b` baseline.
- `pre-commit run --all-files`
