### PR TITLE
Fix nested tool grammar schema test

### DIFF
--- a/Tests/MLXFoundationModelsTests/ToolCallingSchemaTests.swift
+++ b/Tests/MLXFoundationModelsTests/ToolCallingSchemaTests.swift
@@ -262,7 +262,7 @@ struct ToolCallingSchemaTests {
     }
 
     @Test
-    func grammarBuilderHoistsNestedDefsInBothArms() throws {
+    func grammarBuilderRetainsNestedDefsInBothPerToolArms() throws {
         guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
         let bookTrip = Transcript.ToolDefinition(
             name: "book_trip",
@@ -277,13 +277,19 @@ struct ToolCallingSchemaTests {
         let elements = try #require(format["elements"] as? [[String: Any]])
         try #require(elements.count == 2)
 
-        let wrappedSchema = try #require(
-            (elements[0]["content"] as? [String: Any])?["json_schema"] as? [String: Any]
-        )
-        let bareSchema = try #require(elements[1]["json_schema"] as? [String: Any])
+        let wrappedDispatch = try #require(elements[0]["content"] as? [String: Any])
+        let wrappedTags = try #require(wrappedDispatch["elements"] as? [[String: Any]])
+        let wrappedContent = try #require(wrappedTags.first?["content"] as? [String: Any])
+        let wrappedSchema = try #require(wrappedContent["json_schema"] as? [String: Any])
+
+        let bareTags = try #require(elements[1]["elements"] as? [[String: Any]])
+        let bareContent = try #require(bareTags.first?["content"] as? [String: Any])
+        let bareSchema = try #require(bareContent["json_schema"] as? [String: Any])
         for schema in [wrappedSchema, bareSchema] {
             let defs = try #require(schema["$defs"] as? [String: Any])
-            #expect(defs["book_trip__Traveler"] != nil)
+            #expect(defs["Traveler"] != nil)
+            #expect(defs["Passport"] != nil)
+            #expect(collectRefs(in: schema).allSatisfy { $0.hasPrefix("#/$defs/") })
         }
     }
 


### PR DESCRIPTION
## Proposed changes

`SchemaConverter.encodeToolCallingGrammar(tools:)` currently emits per-tool dispatch in both the wrapped and bare structural-tag arms, while the existing nested-definition test still reads the former direct schema shape.

This test-only correction follows both current dispatch arms, verifies that `Traveler` and `Passport` remain in each local `$defs`, and checks that every nested `$ref` stays rooted at `#/$defs/`.

There is no public API or runtime behavior change.

## Validation

- Current `main` focused baseline: 11/12 `ToolCallingSchemaTests`, with only the stale structural lookup failing
- This branch focused suite: 12/12 `ToolCallingSchemaTests`
- Complete `xcodebuild test` comparison: zero branch-only failing cases or crash suites; this branch matches the current `main` failure set, while the baseline additionally failed `TurboQuantIntegrationTests.testRawKeyModeBFloat16MatchesReference()`
- `pre-commit run --all-files`: passed
- `scripts/verify-docs.sh`: passed for every documentation target

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files`
- [x] I have added tests that prove the correction is effective
- [x] Documentation changes are not needed for this test-only correction