### PR TITLE
Add Qwen 3.5 JSON tool-call fallback

### DIFF
--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -979,8 +979,8 @@ public enum ToolCallTests {
     public static func qwen35FormatAutoDetection(container: LLModelContainer) async throws {
         let config = await container.configuration
         try check(
-            config.toolCallFormat == ToolCallFormat.xmlFunction,
-            "Expected .xmlFunction tool call format, got: \(String(describing: config.toolCallFormat))"
+            config.toolCallFormat == ToolCallFormat.qwen35,
+            "Expected .qwen35 tool call format, got: \(String(describing: config.toolCallFormat))"
         )
     }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1340,11 +1340,11 @@ extension Qwen35Model: SpeculativeCacheRewindModel {
 
 // `Qwen35MoEModel` subclasses `Qwen35Model` and inherits both declarations.
 extension Qwen35Model {
-    public var toolCallFormat: ToolCallFormat? { .xmlFunction }
+    public var toolCallFormat: ToolCallFormat? { .qwen35 }
     public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }
 
 extension Qwen35TextModel {
-    public var toolCallFormat: ToolCallFormat? { .xmlFunction }
+    public var toolCallFormat: ToolCallFormat? { .qwen35 }
     public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -34,20 +34,7 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
         guard let toolCall else { return nil }
 
         // If tool schemas are provided, only accept calls to declared tools.
-        if let tools, !tools.isEmpty {
-            var isDeclaredTool = false
-            for tool in tools {
-                let functionSpec = tool["function"] as? [String: any Sendable]
-                if functionSpec?["name"] as? String == toolCall.function.name {
-                    isDeclaredTool = true
-                    break
-                }
-            }
-
-            guard isDeclaredTool else {
-                return nil
-            }
-        }
+        guard isDeclaredTool(toolCall.function.name, tools: tools) else { return nil }
 
         return toolCall
     }

--- a/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
@@ -134,6 +134,18 @@ func extractTypesFromSchema(_ schema: [String: any Sendable]?) -> [String] {
 
 // MARK: - Type Conversion
 
+/// Whether a generated function name belongs to the caller-provided tool set.
+/// An absent or empty schema list preserves parser-only use cases.
+func isDeclaredTool(
+    _ functionName: String, tools: [[String: any Sendable]]?
+) -> Bool {
+    guard let tools, !tools.isEmpty else { return true }
+    return tools.contains { tool in
+        let function = tool["function"] as? [String: any Sendable]
+        return function?["name"] as? String == functionName
+    }
+}
+
 /// Convert parameter value based on multiple possible types.
 /// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/minimax_m2.py
 func convertValueWithTypes(_ value: String, types: [String]) -> any Sendable {

--- a/Libraries/MLXLMCommon/Tool/Parsers/Qwen35ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Qwen35ToolCallParser.swift
@@ -1,0 +1,101 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Parser for Qwen 3.5's two observed tool-call payload dialects.
+///
+/// Qwen 3.5's chat template requests the XML function dialect, but the model can
+/// occasionally emit the Qwen/Hermes JSON dialect used by earlier Qwen releases.
+/// Both payloads are framed by `<tool_call>` tags. Dialect selection is structural
+/// and deterministic: XML must begin with `<function=`, while JSON must begin with
+/// `{`. Malformed or ambiguous payloads are never repaired into executable calls.
+public struct Qwen35ToolCallParser: ToolCallParser, Sendable {
+    public let startTag: String?
+    public let endTag: String?
+
+    private let xmlParser: XMLFunctionParser
+    private let jsonParser: JSONToolCallParser
+
+    public init(startTag: String, endTag: String) {
+        self.startTag = startTag
+        self.endTag = endTag
+        self.xmlParser = XMLFunctionParser(startTag: startTag, endTag: endTag)
+        self.jsonParser = JSONToolCallParser(startTag: startTag, endTag: endTag)
+    }
+
+    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        guard let payload = payloadBody(in: content) else { return nil }
+
+        let call: ToolCall?
+        if payload.hasPrefix("<function=") {
+            guard isCanonicalXMLPayload(payload) else { return nil }
+            call = xmlParser.parse(content: payload, tools: tools)
+        } else if payload.hasPrefix("{") {
+            call = jsonParser.parse(content: payload, tools: tools)
+        } else {
+            return nil
+        }
+
+        guard let call, isDeclaredTool(call.function.name, tools: tools) else {
+            return nil
+        }
+        return call
+    }
+
+    /// Returns the body used only to select a parser. The concrete parser remains
+    /// responsible for validating the entire payload.
+    private func payloadBody(in content: String) -> String? {
+        var payload = content.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let startTag, payload.hasPrefix(startTag) {
+            payload.removeFirst(startTag.count)
+            payload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let endTag {
+            if payload.hasSuffix(endTag) {
+                payload.removeLast(endTag.count)
+                payload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else if payload.contains(endTag) {
+                // The streaming processor normally separates trailing content.
+                // Direct parser callers must not have it silently discarded.
+                return nil
+            }
+        }
+
+        return payload
+    }
+
+    /// Validate the whole XML body before delegating value conversion to the
+    /// existing parser. This prevents a recognizable prefix plus unrelated or
+    /// mixed-dialect text from becoming an executable call.
+    private func isCanonicalXMLPayload(_ payload: String) -> Bool {
+        var remainder = payload[...]
+        guard consumeNamedOpeningTag("<function=", from: &remainder) else { return false }
+
+        while true {
+            remainder = remainder.drop(while: { $0.isWhitespace })
+            if remainder.hasPrefix("</function>") {
+                remainder = remainder.dropFirst("</function>".count)
+                return remainder.allSatisfy(\.isWhitespace)
+            }
+
+            guard consumeNamedOpeningTag("<parameter=", from: &remainder),
+                let parameterEnd = remainder.range(of: "</parameter>")
+            else { return false }
+            remainder = remainder[parameterEnd.upperBound...]
+        }
+    }
+
+    private func consumeNamedOpeningTag(
+        _ prefix: String, from text: inout Substring
+    ) -> Bool {
+        guard text.hasPrefix(prefix) else { return false }
+        text = text.dropFirst(prefix.count)
+        guard let closingAngle = text.firstIndex(of: ">") else { return false }
+
+        let name = text[..<closingAngle]
+        guard !name.isEmpty, !name.contains(where: \.isWhitespace) else { return false }
+        text = text[text.index(after: closingAngle)...]
+        return true
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -70,9 +70,17 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// Example: `<|tool_call_start|>[func(arg='value')]<|tool_call_end|>`
     case lfm2
 
-    /// XML function format used by Nemotron, Qwen3 Coder, Qwen3.5, and similar models.
+    /// XML function format used by Nemotron, Qwen3 Coder, Qwen3 Next, and similar models.
     /// Example: `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>`
     case xmlFunction = "xml_function"
+
+    /// Qwen 3.5's XML function format with a framed Hermes-JSON compatibility dialect.
+    ///
+    /// Qwen 3.5 is prompted to emit `xmlFunction`, but can sporadically emit the
+    /// Qwen/Hermes JSON dialect used by earlier Qwen models instead. Both dialects
+    /// use the same `<tool_call>` frame; this format accepts either payload without
+    /// enabling bare JSON recovery.
+    case qwen35 = "qwen3_5"
 
     /// GLM4 format with arg_key/arg_value tags.
     /// Example: `func<arg_key>k</arg_key><arg_value>v</arg_value>`
@@ -127,6 +135,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
                 startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
         case .xmlFunction:
             return XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        case .qwen35:
+            return Qwen35ToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
         case .glm4:
             return GLM4ToolCallParser()
         case .gemma:
@@ -188,7 +198,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return OnyxStreamAdapter(
                 tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
 
-        case .json, .lfm2, .xmlFunction, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
+        case .json, .lfm2, .xmlFunction, .qwen35, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
             .mistral, .llama3:
             return nil
         }
@@ -210,7 +220,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return HarmonyToolRestartRule(tokenizer: tokenizer).map { [$0] } ?? []
         case .atem:
             return OnyxToolRestartRule(tokenizer: tokenizer).map { [$0] } ?? []
-        case .json, .lfm2, .xmlFunction, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
+        case .json, .lfm2, .xmlFunction, .qwen35, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
             .mistral,
             .llama3:
             return []
@@ -232,7 +242,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
                     count += message.tool?.calls?.count ?? 0
                 }
             }
-        case .json, .lfm2, .xmlFunction, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
+        case .json, .lfm2, .xmlFunction, .qwen35, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
             .mistral, .llama3:
             0
         }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1413,6 +1413,6 @@ extension Qwen35 {
 
 // `Qwen35MoE` subclasses `Qwen35` and inherits both declarations.
 extension Qwen35 {
-    public var toolCallFormat: ToolCallFormat? { .xmlFunction }
+    public var toolCallFormat: ToolCallFormat? { .qwen35 }
     public var reasoningConfig: ReasoningConfig? { QwenReasoningProtocol.tagged }
 }

--- a/Tests/MLXLMTests/ChatConventionsTests.swift
+++ b/Tests/MLXLMTests/ChatConventionsTests.swift
@@ -84,6 +84,33 @@ final class ChatConventionsModelTests: XCTestCase {
         XCTAssertNil(model.toolCallFormat)
     }
 
+    func testQwen35DeclaresDualDialectToolFormat() throws {
+        let json = """
+            {
+                "model_type": "qwen3_5",
+                "hidden_size": 16,
+                "num_hidden_layers": 2,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 1,
+                "linear_key_head_dim": 8,
+                "linear_value_head_dim": 8,
+                "linear_conv_kernel_dim": 4,
+                "vocab_size": 32,
+                "full_attention_interval": 2
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Data(json.utf8))
+        let model = Qwen35TextModel(config)
+
+        XCTAssertEqual(model.toolCallFormat, .qwen35)
+        XCTAssertEqual(model.reasoningConfig, QwenReasoningProtocol.tagged)
+    }
+
     // MARK: Registry injection
 
     /// The factories take a `ChatConventionsRegistry` rather than reaching for

--- a/Tests/MLXLMTests/Qwen35ContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen35ContinuationTests.swift
@@ -84,6 +84,12 @@ final class Qwen35ContinuationTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testDeclaresDualDialectToolFormat() throws {
+        let model = try makeTinyModel()
+        XCTAssertEqual(model.toolCallFormat, .qwen35)
+        XCTAssertEqual(model.reasoningConfig, QwenReasoningProtocol.tagged)
+    }
+
     /// A warm continuation (prefix already in the cache, remainder prefilled
     /// on top — the ChatSession cross-turn / tool-restart flow) must produce
     /// the same next-token logits as one cold prefill of the concatenation.

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -781,7 +781,7 @@ struct ToolTests {
 
     @Test("Test Qwen3.5 XML Function Parser - With tool_call Tags")
     func testQwen35Parser() throws {
-        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let parser = Qwen35ToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
         let content = """
             <tool_call>
             <function=get_weather>
@@ -804,7 +804,7 @@ struct ToolTests {
 
     @Test("Test Qwen3.5 Format via ToolCallProcessor")
     func testQwen35FormatProcessor() throws {
-        let processor = ToolCallProcessor(format: .xmlFunction)
+        let processor = ToolCallProcessor(format: .qwen35)
         let chunks: [String] = [
             "<tool", "_call>", "\n<function=get_weather>\n",
             "<parameter=location>\nTokyo\n</parameter>",
@@ -823,7 +823,7 @@ struct ToolTests {
 
     @Test("Test Qwen3.5 Format - No Arguments")
     func testQwen35FormatNoArgs() throws {
-        let processor = ToolCallProcessor(format: .xmlFunction)
+        let processor = ToolCallProcessor(format: .qwen35)
         let content = "<tool_call>\n<function=get_current_datetime>\n</function>\n</tool_call>"
 
         _ = processor.processChunk(content)
@@ -833,6 +833,99 @@ struct ToolTests {
         #expect(toolCall.function.name == "get_current_datetime")
         #expect(toolCall.function.arguments.isEmpty)
     }
+
+    @Test("Qwen3.5 accepts framed Qwen/Hermes JSON fallback")
+    func testQwen35JSONFallback() throws {
+        let processor = ToolCallProcessor(format: .qwen35, tools: Self.qwen35Tools)
+        let content =
+            #"<tool_call>{"name":"lampo_mcp_call_tool","arguments":{"action":"start","instructions":"Initialize interactive coding session","title":"filo server start","worker":"default"}}</tool_call>"#
+
+        #expect(processor.processChunk(content) == nil)
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.toolCalls.count == 1)
+        #expect(call.function.name == "lampo_mcp_call_tool")
+        #expect(call.function.arguments["action"] == .string("start"))
+        #expect(call.function.arguments["worker"] == .string("default"))
+    }
+
+    @Test("Qwen3.5 JSON fallback is streaming-boundary invariant")
+    func testQwen35JSONFallbackEverySplitBoundary() throws {
+        let content =
+            #"<tool_call>{"name":"lampo_mcp_call_tool","arguments":{"message":"a } brace, a quote: \"ok\", and <function=fake>"}}</tool_call>"#
+        let characters = Array(content)
+
+        for split in 1 ..< characters.count {
+            let processor = ToolCallProcessor(format: .qwen35, tools: Self.qwen35Tools)
+            let first = String(characters[..<split])
+            let second = String(characters[split...])
+
+            #expect(processor.processChunk(first) == nil, "split at \(split)")
+            #expect(processor.processChunk(second) == nil, "split at \(split)")
+            #expect(processor.toolCalls.count == 1, "split at \(split)")
+            #expect(
+                processor.toolCalls.first?.function.name == "lampo_mcp_call_tool",
+                "split at \(split)")
+        }
+    }
+
+    @Test("Qwen3.5 commits a complete JSON body at EOS without a closing frame")
+    func testQwen35JSONFallbackAtEOS() throws {
+        let processor = ToolCallProcessor(format: .qwen35, tools: Self.qwen35Tools)
+        let content =
+            #"<tool_call>{"name":"lampo_mcp_call_tool","arguments":{"action":"start"}}"#
+
+        #expect(processor.processChunk(content) == nil)
+        #expect(processor.toolCalls.isEmpty)
+        processor.processEOS()
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.toolCalls.count == 1)
+        #expect(call.function.name == "lampo_mcp_call_tool")
+        #expect(call.function.arguments["action"] == .string("start"))
+    }
+
+    @Test("Qwen3.5 applies the declared-tool boundary to canonical XML too")
+    func testQwen35XMLRejectsUndeclaredTool() {
+        let parser = Qwen35ToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content =
+            "<tool_call><function=erase_everything></function></tool_call>"
+
+        #expect(parser.parse(content: content, tools: Self.qwen35Tools) == nil)
+    }
+
+    @Test("Qwen3.5 fallback never authorizes undeclared JSON tools")
+    func testQwen35JSONFallbackRejectsUndeclaredTool() {
+        let parser = Qwen35ToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content = #"<tool_call>{"name":"erase_everything","arguments":{}}</tool_call>"#
+
+        #expect(parser.parse(content: content, tools: Self.qwen35Tools) == nil)
+    }
+
+    @Test("Qwen3.5 fallback rejects malformed and mixed-dialect payloads")
+    func testQwen35JSONFallbackRejectsMalformedPayloads() {
+        let parser = Qwen35ToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let malformed = [
+            #"<tool_call>{"name":"lampo_mcp_call_tool","arguments":{}</tool_call>"#,
+            #"<tool_call>prefix {"name":"lampo_mcp_call_tool","arguments":{}}</tool_call>"#,
+            #"<tool_call><function=lampo_mcp_call_tool>{"arguments":{}}</function></tool_call>"#,
+            "<tool_call><function=lampo_mcp_call_tool><parameter=action>start</parameter>garbage</function></tool_call>",
+            #"<tool_call>{"name":"lampo_mcp_call_tool","arguments":{}}</tool_call>trailing"#,
+        ]
+
+        for content in malformed {
+            #expect(parser.parse(content: content, tools: Self.qwen35Tools) == nil)
+        }
+    }
+
+    private static let qwen35Tools: [[String: any Sendable]] = [
+        [
+            "type": "function",
+            "function": [
+                "name": "lampo_mcp_call_tool",
+                "parameters": ["type": "object"],
+            ] as [String: any Sendable],
+        ]
+    ]
 
     // MARK: - GLM4 Format Tests
 
@@ -1069,6 +1162,7 @@ struct ToolTests {
         #expect(ToolCallFormat.json.rawValue == "json")
         #expect(ToolCallFormat.lfm2.rawValue == "lfm2")
         #expect(ToolCallFormat.xmlFunction.rawValue == "xml_function")
+        #expect(ToolCallFormat.qwen35.rawValue == "qwen3_5")
         #expect(ToolCallFormat.glm4.rawValue == "glm4")
         #expect(ToolCallFormat.gemma.rawValue == "gemma")
         #expect(ToolCallFormat.kimiK2.rawValue == "kimi_k2")

--- a/skills/mlx-swift-lm/references/tool-calling.md
+++ b/skills/mlx-swift-lm/references/tool-calling.md
@@ -30,7 +30,8 @@ mlx-swift-lm supports function calling / tool use with multiple model-specific f
 |--------|--------|----------------|
 | `.json` | Llama, Qwen, most models | `<tool_call>{"name":"f","arguments":{...}}</tool_call>` |
 | `.lfm2` | LFM2 | `<\|tool_call_start\|>{"name":"f",...}<\|tool_call_end\|>` |
-| `.xmlFunction` | Nemotron, Qwen3 Coder, Qwen3.5 | `<tool_call><function=name><parameter=k>v</parameter></function></tool_call>` |
+| `.xmlFunction` | Nemotron, Qwen3 Coder, Qwen3 Next | `<tool_call><function=name><parameter=k>v</parameter></function></tool_call>` |
+| `.qwen35` | Qwen 3.5 | Same `<tool_call>` frame as `.xmlFunction`, but also accepts a framed Qwen/Hermes JSON payload (`<tool_call>{"name":"f","arguments":{...}}</tool_call>`) that Qwen 3.5 sporadically emits instead of XML. Bare (unframed) JSON is not recovered. |
 | `.glm4` | GLM4 | `func<arg_key>k</arg_key><arg_value>v</arg_value>` |
 | `.gemma` | Gemma | `call:name{key:value}` |
 | `.kimiK2` | Kimi K2 | `functions.name:0<\|tool_call_argument_begin\|>{...}` |


### PR DESCRIPTION
## Proposed changes

Qwen 3.5 is instructed (via its chat template) to format tool/function calls using a specific XML-like syntax, e.g.:

```
<tool_call><function=get_weather><parameter=city>Tokyo</parameter></function></tool_call>
```

In practice, the model sometimes ignores this instruction and emits an older JSON-style format instead (the same style used by earlier Qwen and Llama models):

```
<tool_call>{"name": "get_weather", "arguments": {"city": "Tokyo"}}</tool_call>
```

Previously, this library only understood the XML format for Qwen 3.5, so whenever the model slipped into the JSON style, the tool call would fail to parse and the app would treat it as plain text instead of actually calling the tool.

This PR teaches the Qwen 3.5 parser to recognize and accept **both** formats. It still requires the call to be wrapped in the standard `<tool_call>...</tool_call>` tags, and it only accepts tools that were actually declared to the model, so this does not loosen validation — it just widens what "a correctly formatted call" is allowed to look like. Malformed or mixed-up payloads (e.g. XML tags with JSON content jammed inside, or trailing garbage after the call) are still rejected rather than guessed at.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
