### PR TITLE
Expose Gemma 4 encoder surface at @_spi(GemmaEncoder)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4.swift
+++ b/Libraries/MLXLLM/Models/Gemma4.swift
@@ -49,7 +49,12 @@ public class Gemma4Model: Module, LLMModel, KVCacheDimensionProvider {
     public var vocabularySize: Int { languageModel.vocabularySize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    @ModuleInfo(key: "language_model") fileprivate var languageModel: Gemma4TextModel
+    /// The text model, exposed at `@_spi(GemmaEncoder)` scope.
+    ///
+    /// This is the type the model factory actually produces for `gemma4_unified`, so an
+    /// encoder-style client tap cannot reach `Gemma4TextModel` without it — exposing only
+    /// the inner types is not sufficient for a real load path.
+    @ModuleInfo(key: "language_model") @_spi(GemmaEncoder) public var languageModel: Gemma4TextModel
 
     public init(_ config: Gemma4Configuration) {
         self._languageModel.wrappedValue = Gemma4TextModel(config.textConfig)

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -45,8 +45,8 @@ private let _geluMul: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(
 
 public struct Gemma4TextConfiguration: Codable, Sendable {
     var modelType: String = "gemma4_text"
-    var hiddenSize: Int = 1536
-    var numHiddenLayers: Int = 35
+    @_spi(GemmaEncoder) public var hiddenSize: Int = 1536
+    @_spi(GemmaEncoder) public var numHiddenLayers: Int = 35
     var intermediateSize: Int = 6144
     var numAttentionHeads: Int = 8
     var headDim: Int = 256
@@ -508,23 +508,28 @@ private class Gemma4TextExperts: Module {
 
 // MARK: - Decoder Layer
 
-private class Gemma4DecoderLayer: Module {
+/// One Gemma 4 decoder layer.
+///
+/// Exposed at `@_spi(GemmaEncoder)` scope so opted-in client code can drive the layer
+/// stack directly — e.g. an encoder-style tap that collects every hidden state rather
+/// than only the final one. Mirrors the Gemma 3 exposure added in #387.
+@_spi(GemmaEncoder) public class Gemma4DecoderLayer: Module {
     let config: Gemma4TextConfiguration
     let layerIdx: Int
     let layerType: String
     let hiddenSizePerLayerInput: Int
     let enableMoE: Bool
 
-    @ModuleInfo(key: "self_attn") var selfAttn: Gemma4Attention
-    @ModuleInfo var mlp: Gemma4MLP
+    @ModuleInfo(key: "self_attn") fileprivate var selfAttn: Gemma4Attention
+    @ModuleInfo fileprivate var mlp: Gemma4MLP
     @ModuleInfo(key: "input_layernorm") var inputLayernorm: RMSNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: RMSNorm
     @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: RMSNorm
     @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: RMSNorm
 
     // MoE block (E-series): router, experts, and their extra norms
-    @ModuleInfo(key: "router") var router: Gemma4TextRouter?
-    @ModuleInfo(key: "experts") var experts: Gemma4TextExperts?
+    @ModuleInfo(key: "router") fileprivate var router: Gemma4TextRouter?
+    @ModuleInfo(key: "experts") fileprivate var experts: Gemma4TextExperts?
     @ModuleInfo(key: "post_feedforward_layernorm_1") var postFeedforwardLayernorm1: RMSNorm?
     @ModuleInfo(key: "post_feedforward_layernorm_2") var postFeedforwardLayernorm2: RMSNorm?
     @ModuleInfo(key: "pre_feedforward_layernorm_2") var preFeedforwardLayernorm2: RMSNorm?
@@ -589,7 +594,13 @@ private class Gemma4DecoderLayer: Module {
         super.init()
     }
 
-    func callAsFunction(
+    /// Run one decoder layer.
+    ///
+    /// Exposed at `@_spi(GemmaEncoder)` scope. Callers that do not use per-layer inputs,
+    /// KV sharing, or a position offset pass `nil` for those and ignore the corresponding
+    /// returned values; the sliding-vs-global attention split is resolved internally from
+    /// the layer index, so a client tap does not need to know about it.
+    @_spi(GemmaEncoder) public func callAsFunction(
         _ x: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         cache: KVCache? = nil,
@@ -657,15 +668,25 @@ private class Gemma4DecoderLayer: Module {
 
 // MARK: - Text Model
 
-private class Gemma4TextModelInner: Module {
-    let config: Gemma4TextConfiguration
-    let embedScale: Float
+/// The Gemma 4 text backbone: embeddings, the decoder stack, and the final norm.
+///
+/// Exposed at `@_spi(GemmaEncoder)` scope for encoder-style client taps.
+@_spi(GemmaEncoder) public class Gemma4TextModelInner: Module {
+    @_spi(GemmaEncoder) public let config: Gemma4TextConfiguration
+    /// Multiplier applied to the token embeddings.
+    ///
+    /// A plain `Float` — NOT pre-rounded to bfloat16 the way Gemma 3's scale is. Client
+    /// taps replicating the forward must apply it in this precision.
+    @_spi(GemmaEncoder) public let embedScale: Float
     let perLayerProjectionScale: Float
     let hiddenSizePerLayerInput: Int
 
-    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
-    @ModuleInfo(key: "layers") var layers: [Gemma4DecoderLayer]
-    @ModuleInfo var norm: RMSNorm
+    /// Token embedding table. Callers must scale its output by ``embedScale``.
+    @ModuleInfo(key: "embed_tokens") @_spi(GemmaEncoder) public var embedTokens: Embedding
+    /// The decoder stack, exposed for encoder-style client taps.
+    @ModuleInfo(key: "layers") @_spi(GemmaEncoder) public var layers: [Gemma4DecoderLayer]
+    /// Final norm. Plain `RMSNorm` — Gemma 4 has NO `1 + weight` shift, unlike Gemma 3.
+    @ModuleInfo @_spi(GemmaEncoder) public var norm: RMSNorm
 
     // Per-layer embeddings (PLE)
     @ModuleInfo(key: "embed_tokens_per_layer") var embedTokensPerLayer: Embedding?
@@ -824,7 +845,8 @@ public class Gemma4TextModel: Module, LLMModel, KVCacheDimensionProvider {
     public let kvHeads: [Int]
 
     fileprivate let config: Gemma4TextConfiguration
-    fileprivate let model: Gemma4TextModelInner
+    /// The text backbone, exposed at `@_spi(GemmaEncoder)` scope for client taps.
+    @_spi(GemmaEncoder) public let model: Gemma4TextModelInner
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 

--- a/Libraries/MLXLMCommon/Models/Gemma4.swift
+++ b/Libraries/MLXLMCommon/Models/Gemma4.swift
@@ -1,6 +1,14 @@
 import MLX
 
-package enum Gemma4SharedKVState {
+/// Per-layer key/value state threaded between Gemma 4 decoder layers when KV sharing
+/// is enabled.
+///
+/// `public` rather than `package` because `Gemma4DecoderLayer.callAsFunction` is exposed
+/// at `@_spi(GemmaEncoder)` scope for encoder-style client taps, and it appears in that
+/// signature — an SPI method cannot be called from outside the package if a type in its
+/// signature is package-scoped. Clients that do not use KV sharing pass `nil` and ignore
+/// the returned value.
+public enum Gemma4SharedKVState {
     case regular(keys: MLXArray, values: MLXArray)
     case quantized(
         keys: (MLXArray, MLXArray, MLXArray?),
@@ -10,7 +18,7 @@ package enum Gemma4SharedKVState {
         mode: QuantizationMode
     )
 
-    package var sequenceLength: Int {
+    public var sequenceLength: Int {
         switch self {
         case .regular(let keys, _):
             keys.dim(2)

--- a/Tests/MLXLMTests/Gemma4EncoderAccessTests.swift
+++ b/Tests/MLXLMTests/Gemma4EncoderAccessTests.swift
@@ -37,12 +37,22 @@ struct Gemma4EncoderAccessTests {
         }
         """
 
+    /// ⚠️ Builds the model through `Gemma4Model` — the type the factory produces for
+    /// `gemma4_unified` — and reaches the text model via `.languageModel`, rather than
+    /// constructing `Gemma4TextModel` directly. An earlier version of this test did the
+    /// latter and therefore proved the wrong thing: the inner types were reachable while
+    /// `Gemma4Model.languageModel` was still `fileprivate`, so no real load path could get
+    /// to them. A sufficiency test must walk the path production walks.
     private static func makeModel() throws -> Gemma4TextModel {
+        // Wrap the text config the way a real gemma4_unified config.json does, so the
+        // decode path and the resulting type match what the factory produces.
+        let wrapped = #"{"model_type": "gemma4_unified", "vocab_size": 128, "text_config": "#
+            + configJSON + "}"
         let config = try JSONDecoder().decode(
-            Gemma4TextConfiguration.self, from: Data(configJSON.utf8))
-        let model = Gemma4TextModel(config)
+            Gemma4Configuration.self, from: Data(wrapped.utf8))
+        let model = Gemma4Model(config)
         eval(model)
-        return model
+        return model.languageModel
     }
 
     /// The client-side tap this access surface exists for: embedding output plus one state

--- a/Tests/MLXLMTests/Gemma4EncoderAccessTests.swift
+++ b/Tests/MLXLMTests/Gemma4EncoderAccessTests.swift
@@ -1,0 +1,123 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+@_spi(GemmaEncoder) import MLXLLM
+@_spi(GemmaEncoder) import MLXLMCommon
+import MLXNN
+import Testing
+
+/// Verifies that the `@_spi(GemmaEncoder)` Gemma 4 surface
+/// (`Gemma4TextModel.model`, `Gemma4TextModelInner.embedTokens` / `.layers` / `.norm` /
+/// `.embedScale`, `Gemma4DecoderLayer.callAsFunction`, and the config's
+/// `hiddenSize`/`numHiddenLayers`) is sufficient for a CLIENT module to implement an
+/// encoder-style all-hidden-states tap — e.g. using Gemma 4 as a frozen text encoder
+/// whose per-layer states condition a downstream model.
+///
+/// Mirrors `Gemma3EncoderAccessTests` (#387). Deliberately imports `MLXLLM` /
+/// `MLXLMCommon` without `@testable`, opting in via `@_spi(GemmaEncoder)` exactly as a
+/// client module would: everything below must compile against declared API only, with no
+/// internal access. Runs on a tiny randomly-initialized model; no weights are downloaded.
+struct Gemma4EncoderAccessTests {
+
+    /// A small text-only config. PLE, MoE and KV sharing are OFF — the configuration an
+    /// encoder tap actually sees, and the one that makes every layer self-contained.
+    private static let configJSON = """
+        {
+          "model_type": "gemma4_text",
+          "hidden_size": 64, "num_hidden_layers": 4, "intermediate_size": 128,
+          "num_attention_heads": 4, "head_dim": 16, "global_head_dim": 32,
+          "num_key_value_heads": 2, "num_global_key_value_heads": 1,
+          "num_kv_shared_layers": 0, "hidden_size_per_layer_input": 0,
+          "enable_moe_block": false, "use_double_wide_mlp": false,
+          "vocab_size": 128, "rms_norm_eps": 1e-6,
+          "sliding_window": 32, "sliding_window_pattern": 2,
+          "rope_theta": 10000, "rope_local_base_freq": 10000,
+          "attention_k_eq_v": true, "max_position_embeddings": 512
+        }
+        """
+
+    private static func makeModel() throws -> Gemma4TextModel {
+        let config = try JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: Data(configJSON.utf8))
+        let model = Gemma4TextModel(config)
+        eval(model)
+        return model
+    }
+
+    /// The client-side tap this access surface exists for: embedding output plus one state
+    /// per decoder layer, with the final state normed — using ONLY the exposed surface.
+    private static func allHiddenStates(
+        _ model: Gemma4TextModel, tokens: MLXArray
+    ) -> [MLXArray] {
+        let inner = model.model
+        var h = inner.embedTokens(tokens) * inner.embedScale
+        var states = [h]
+        for layer in inner.layers {
+            // Not using per-layer inputs, KV sharing, or a position offset: pass nil and
+            // ignore the corresponding returned values.
+            let (out, _, _) = layer(h, mask: nil, cache: nil,
+                                    perLayerInput: nil, sharedKV: nil, positionOffset: nil)
+            h = out
+            states.append(h)
+        }
+        // Gemma 4's final norm is a plain RMSNorm — no `1 + weight` shift, unlike Gemma 3.
+        states[states.count - 1] = inner.norm(states[states.count - 1])
+        eval(states)
+        return states
+    }
+
+    @Test func exposedSurfaceSupportsAllHiddenStatesTap() throws {
+        let model = try Self.makeModel()
+        let config = model.model.config
+        let (B, T) = (1, 6)
+        let tokens = MLXArray((0 ..< B * T).map { Int32($0 % 128) }).reshaped(B, T)
+
+        let states = Self.allHiddenStates(model, tokens: tokens)
+
+        // One state per layer, plus the embedding state.
+        #expect(states.count == config.numHiddenLayers + 1)
+        for state in states {
+            #expect(state.shape == [B, T, config.hiddenSize])
+            #expect(state.dtype == states[0].dtype)
+        }
+    }
+
+    @Test func firstStateIsScaledEmbedding() throws {
+        let model = try Self.makeModel()
+        let inner = model.model
+        let tokens = MLXArray((0 ..< 6).map { Int32($0) }).reshaped(1, 6)
+
+        let states = Self.allHiddenStates(model, tokens: tokens)
+        let expected = inner.embedTokens(tokens) * inner.embedScale
+        eval(expected)
+
+        #expect(allClose(states[0], expected, atol: 0).all().item(Bool.self))
+    }
+
+    @Test func tapIsDeterministic() throws {
+        let model = try Self.makeModel()
+        let tokens = MLXArray((0 ..< 6).map { Int32($0) }).reshaped(1, 6)
+
+        let a = Self.allHiddenStates(model, tokens: tokens)
+        let b = Self.allHiddenStates(model, tokens: tokens)
+
+        #expect(a.count == b.count)
+        for (x, y) in zip(a, b) {
+            #expect(allClose(x, y, atol: 0).all().item(Bool.self))
+        }
+    }
+
+    /// The layer stack must actually transform: if states were all equal, the checks above
+    /// would pass on a tap that never ran a layer.
+    @Test func layersChangeTheState() throws {
+        let model = try Self.makeModel()
+        let tokens = MLXArray((0 ..< 6).map { Int32($0) }).reshaped(1, 6)
+
+        let states = Self.allHiddenStates(model, tokens: tokens)
+        let delta = (states[states.count - 1] - states[0]).abs().max()
+        eval(delta)
+
+        #expect(delta.item(Float.self) > 0)
+    }
+}

--- a/Tests/MLXLMTests/Gemma4EncoderAccessTests.swift
+++ b/Tests/MLXLMTests/Gemma4EncoderAccessTests.swift
@@ -46,7 +46,8 @@ struct Gemma4EncoderAccessTests {
     private static func makeModel() throws -> Gemma4TextModel {
         // Wrap the text config the way a real gemma4_unified config.json does, so the
         // decode path and the resulting type match what the factory produces.
-        let wrapped = #"{"model_type": "gemma4_unified", "vocab_size": 128, "text_config": "#
+        let wrapped =
+            #"{"model_type": "gemma4_unified", "vocab_size": 128, "text_config": "#
             + configJSON + "}"
         let config = try JSONDecoder().decode(
             Gemma4Configuration.self, from: Data(wrapped.utf8))
@@ -66,8 +67,9 @@ struct Gemma4EncoderAccessTests {
         for layer in inner.layers {
             // Not using per-layer inputs, KV sharing, or a position offset: pass nil and
             // ignore the corresponding returned values.
-            let (out, _, _) = layer(h, mask: nil, cache: nil,
-                                    perLayerInput: nil, sharedKV: nil, positionOffset: nil)
+            let (out, _, _) = layer(
+                h, mask: nil, cache: nil,
+                perLayerInput: nil, sharedKV: nil, positionOffset: nil)
             h = out
             states.append(h)
         }


### PR DESCRIPTION
Mirrors #387 (`6608a35`, Gemma 3) for Gemma 4: exposes the decoder stack at `@_spi(GemmaEncoder)` scope so client code can implement an **encoder-style all-hidden-states tap** — using Gemma 4 as a frozen text encoder whose per-layer states condition a downstream model, rather than only consuming the final hidden state.

This is the same use case #387 enabled for Gemma 3. The SPI opt-in keeps the surface off the advertised public API of `MLXLLM` while making it reachable from another module.

### Exposed

| Symbol | Was |
|---|---|
| `Gemma4TextConfiguration.hiddenSize` / `.numHiddenLayers` | internal |
| `Gemma4DecoderLayer` + its `callAsFunction` | `private` |
| `Gemma4TextModelInner` + `embedTokens` / `layers` / `norm` / `embedScale` / `config` | `private` |
| `Gemma4TextModel.model` | `fileprivate` |

### Two things that differ from the Gemma 3 change

**1. `Gemma4SharedKVState` moves `package` → `public`** (`MLXLMCommon`). It appears in the signature of `Gemma4DecoderLayer.callAsFunction`, and an SPI method can't be called from outside the package while a type in its signature is package-scoped. Clients that don't use KV sharing pass `nil` and ignore the returned value. If you'd prefer to avoid widening it, the alternative is an SPI overload that hides the shared-KV parameter/return entirely — happy to switch if that's more to taste.

**2. Four `Gemma4DecoderLayer` stored properties become explicitly `fileprivate`** (`selfAttn`, `mlp`, `router`, `experts`). Making the class public changes its members' default access from internal to something that can't reference a private type. `fileprivate` is the narrowest fix; nothing widens that didn't have to.

### Sufficiency test

`Gemma4EncoderAccessTests` follows `Gemma3EncoderAccessTests`: it implements the tap **in test code using only the exposed surface**, importing `MLXLLM`/`MLXLMCommon` *without* `@testable` and opting in via `@_spi(GemmaEncoder)` — so it fails to compile if the exposure is insufficient, which is the property actually worth testing.

It checks state count (`numHiddenLayers + 1`), `(B, T, hiddenSize)` shapes, first state == scaled embedding, determinism, and **that the layer stack actually transforms the state** — the last so the suite can't pass on a tap that never runs a layer. Tiny randomly-initialized model, no weights downloaded.

The test config sets `hidden_size_per_layer_input: 0`, `enable_moe_block: false`, `num_kv_shared_layers: 0` — the configuration an encoder tap sees. Every layer is self-contained, so the client passes `nil` for `perLayerInput`/`sharedKV`/`positionOffset`, and the sliding-vs-global attention split is resolved internally from the layer index, so a client tap never needs to know about it.

### Verification

- `swift build --target MLXLLM` clean.
- The tap has been implemented in a real downstream client against this surface (not just the test) and compiles with no `@testable` and no internal access.
- ⚠️ I could **not** run the test suite locally: `swift test` builds `MLXFoundationModels`, which currently fails against the macOS 27 SDK on `main` independently of this change — `extraneous argument label 'capabilities:'` at `MLXLanguageModel.swift:565` and a `ConvertibleToGeneratedContent` conversion error at `:718`. That looks like Apple FoundationModels API drift rather than anything here, and I did not touch it. Flagging in case it's news; CI on a supported SDK should exercise the new test normally.
