### PR TITLE
Tool call parser hardening

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -672,13 +672,16 @@ public final class LLMModelFactory: GenericModelFactory {
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
         // Chat conventions. Precedence: an explicit value on the configuration
         // (registry entry or caller) wins; then a registered resolver, which sees
-        // the repo id the model cannot; then the model's own declaration.
+        // the repo id the model cannot; then the model's own declaration; and
+        // finally the checkpoint's own tokenizer files, which describe the
+        // dialect even for an architecture that declares nothing.
         let modelId = configuration.name
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat =
                 conventionsRegistry.toolCallFormat(
                     modelId: modelId, modelType: baseConfig.modelType)
                 ?? model.toolCallFormat
+                ?? ToolCallFormat.resolved(forTokenizerDirectory: configuration.tokenizerDirectory)
         }
         if mutableConfiguration.reasoningConfig == nil {
             mutableConfiguration.reasoningConfig =

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -670,18 +670,17 @@ public final class LLMModelFactory: GenericModelFactory {
         var mutableConfiguration = configuration
         mutableConfiguration.eosTokenIds = eosTokenIds
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
-        // Chat conventions. Precedence: an explicit value on the configuration
-        // (registry entry or caller) wins; then a registered resolver, which sees
-        // the repo id the model cannot; then the model's own declaration; and
-        // finally the checkpoint's own tokenizer files, which describe the
-        // dialect even for an architecture that declares nothing.
+        // Chat conventions. An explicit value on the configuration wins, followed
+        // by a registered resolver that sees the repo id. Checkpoint metadata then
+        // resolves the model declaration against the selected tool template.
         let modelId = configuration.name
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat =
                 conventionsRegistry.toolCallFormat(
                     modelId: modelId, modelType: baseConfig.modelType)
-                ?? model.toolCallFormat
-                ?? ToolCallFormat.resolved(forTokenizerDirectory: configuration.tokenizerDirectory)
+                ?? ToolCallFormat.resolved(
+                    forTokenizerDirectory: configuration.tokenizerDirectory,
+                    modelFormat: model.toolCallFormat)
         }
         if mutableConfiguration.reasoningConfig == nil {
             mutableConfiguration.reasoningConfig =

--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -9,86 +9,88 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
     public let endTag: String?
     public let escapeMarker: String?
 
+    /// Values are either wrapped in the escape marker or written as bare JSON,
+    /// so both spans have to be opaque while the argument list is split.
+    private let scanner: StructuredTextScanner
+
     public init(startTag: String, endTag: String, escapeMarker: String) {
         self.startTag = startTag
         self.endTag = endTag
         self.escapeMarker = escapeMarker
+        self.scanner = StructuredTextScanner(quotes: ["\""], escapeMarker: escapeMarker)
     }
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
-        // Unwrap
-        guard let start = startTag, let end = endTag else { return nil }
-        guard let marker = escapeMarker else { return nil }
+        guard let startTag, let endTag, let marker = escapeMarker else { return nil }
 
         // Strip tags if present
-        var text = content
-        if let startRange = text.range(of: start) {
-            text = String(text[startRange.upperBound...])
+        var text = content[...]
+        if let startRange = text.range(of: startTag) {
+            text = text[startRange.upperBound...]
         }
-        if let endRange = text.range(of: end) {
-            text = String(text[..<endRange.lowerBound])
+        if let endRange = text.range(of: endTag) {
+            text = text[..<endRange.lowerBound]
         }
 
-        // Pattern: call:(\w+)\{(.*?)\}
-        // Find "call:" followed by function name and arguments in braces
+        // Pattern: call:(\w+)\{(.*)\}, where the closing brace is the one that
+        // balances the opening brace rather than the first or last in the text.
         guard let callRange = text.range(of: "call:") else { return nil }
+        let remaining = text[callRange.upperBound...]
 
-        let remaining = String(text[callRange.upperBound...])
+        guard let braceStart = scanner.firstTopLevelIndex(of: "{", in: remaining),
+            let braceEnd = scanner.endOfGroup(in: remaining, openedAt: braceStart)
+        else { return nil }
 
-        // Extract function name (word characters until {)
-        guard let braceStart = remaining.firstIndex(of: "{") else { return nil }
         let funcName = String(remaining[..<braceStart])
-
         guard !funcName.isEmpty else { return nil }
 
-        // Extract arguments string (everything between { and })
-        guard let braceEnd = remaining.lastIndex(of: "}") else { return nil }
-        var argsStr = String(remaining[remaining.index(after: braceStart) ..< braceEnd])
-
+        let body = remaining[remaining.index(after: braceStart) ..< braceEnd]
         var arguments: [String: any Sendable] = [:]
 
-        // Parse key:value pairs
-        while !argsStr.isEmpty {
-            // Find the key (everything before :)
-            guard let colonIdx = argsStr.firstIndex(of: ":") else { break }
-            let key = String(argsStr[..<colonIdx])
-            argsStr = String(argsStr[argsStr.index(after: colonIdx)...])
+        // Each field is `key:value`. Splitting at top level keeps a comma that
+        // belongs to an escaped string or a nested object out of the split, so a
+        // value is never truncated and its remainder never becomes a stray key.
+        for field in scanner.splitTopLevel(body, separator: ",") {
+            guard let colon = scanner.firstTopLevelIndex(of: ":", in: field) else { continue }
+            let key = String(field[..<colon])
+            guard !key.isEmpty else { continue }
 
-            // Handle escaped strings
-            if argsStr.hasPrefix(marker) {
-                argsStr = String(argsStr.dropFirst(marker.count))
-                guard let endEscape = argsStr.range(of: marker) else { break }
-                let value = String(argsStr[..<endEscape.lowerBound])
-                arguments[key] = convertParameterValue(
-                    value, paramName: key, funcName: funcName, tools: tools)
-                argsStr = String(argsStr[endEscape.upperBound...])
-                // Skip comma if present
-                if argsStr.hasPrefix(",") {
-                    argsStr = String(argsStr.dropFirst())
-                }
-                continue
-            }
-
-            // Handle regular values (until comma or end)
-            let commaIdx = argsStr.firstIndex(of: ",") ?? argsStr.endIndex
-            let value = String(argsStr[..<commaIdx])
-            argsStr =
-                commaIdx < argsStr.endIndex
-                ? String(argsStr[argsStr.index(after: commaIdx)...]) : ""
-
-            // Try JSON decode, fallback to string
-            if getParameterType(funcName: funcName, paramName: key, tools: tools) != nil {
-                arguments[key] = convertParameterValue(
-                    value, paramName: key, funcName: funcName, tools: tools)
-            } else if let data = value.data(using: .utf8),
-                let json = deserializeJSON(data)
-            {
-                arguments[key] = json
-            } else {
-                arguments[key] = value
-            }
+            let rawValue = field[field.index(after: colon)...].trimmingWhitespace()
+            arguments[key] = value(
+                of: rawValue, key: key, funcName: funcName, marker: marker, tools: tools)
         }
 
         return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+
+    /// Decodes one field value.
+    ///
+    /// A marker-wrapped value is a string the model escaped precisely because it
+    /// may contain protocol punctuation, so it is taken verbatim. Everything else
+    /// is typed from the schema when the parameter is declared, and otherwise
+    /// decoded as JSON, falling back to the literal text.
+    private func value(
+        of rawValue: Substring,
+        key: String,
+        funcName: String,
+        marker: String,
+        tools: [[String: any Sendable]]?
+    ) -> any Sendable {
+        if rawValue.hasPrefix(marker) {
+            let contentStart = rawValue.index(rawValue.startIndex, offsetBy: marker.count)
+            let unescaped =
+                rawValue[contentStart...].range(of: marker)
+                .map { String(rawValue[contentStart ..< $0.lowerBound]) }
+                ?? String(rawValue[contentStart...])
+            return convertParameterValue(
+                unescaped, paramName: key, funcName: funcName, tools: tools)
+        }
+
+        let literal = String(rawValue)
+        if getParameterType(funcName: funcName, paramName: key, tools: tools) != nil {
+            return convertParameterValue(
+                literal, paramName: key, funcName: funcName, tools: tools)
+        }
+        return tryParseJSON(literal) ?? literal
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
@@ -132,6 +132,20 @@ func extractTypesFromSchema(_ schema: [String: any Sendable]?) -> [String] {
     return types.isEmpty ? ["string"] : Array(types)
 }
 
+// MARK: - Slicing
+
+extension Substring {
+    /// The slice without leading or trailing whitespace, avoiding the copy that
+    /// `trimmingCharacters(in:)` makes when the caller only needs a view.
+    func trimmingWhitespace() -> Substring {
+        var slice = drop(while: \.isWhitespace)
+        while let last = slice.last, last.isWhitespace {
+            slice = slice.dropLast()
+        }
+        return slice
+    }
+}
+
 // MARK: - Type Conversion
 
 /// Whether a generated function name belongs to the caller-provided tool set.

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonLiteralParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonLiteralParser.swift
@@ -1,0 +1,188 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Parses the JSON-compatible subset of Python literals used in tool arguments.
+///
+/// Pythonic tool-call formats commonly use single-quoted strings and Python's
+/// `True`, `False`, and `None` spellings. JSONSerialization cannot read those,
+/// so this parser supplies the small recursive grammar the dialect needs while
+/// deliberately rejecting executable Python expressions.
+struct PythonLiteralParser {
+    private let source: Substring
+    private var index: String.Index
+
+    private init(_ source: Substring) {
+        self.source = source
+        self.index = source.startIndex
+    }
+
+    static func parse(_ source: Substring) -> (any Sendable)? {
+        var parser = Self(source)
+        guard let value = parser.parseValue() else { return nil }
+        parser.skipWhitespace()
+        return parser.index == source.endIndex ? value : nil
+    }
+
+    private var current: Character? {
+        index < source.endIndex ? source[index] : nil
+    }
+
+    private mutating func parseValue() -> (any Sendable)? {
+        skipWhitespace()
+
+        switch current {
+        case "'", "\"":
+            return parseString()
+        case "[":
+            return parseArray()
+        case "{":
+            return parseObject()
+        case nil:
+            return nil
+        default:
+            return parseAtom()
+        }
+    }
+
+    private mutating func parseArray() -> (any Sendable)? {
+        guard consume("[") else { return nil }
+        skipWhitespace()
+
+        var values: [any Sendable] = []
+        if consume("]") { return values }
+
+        while true {
+            guard let value = parseValue() else { return nil }
+            values.append(value)
+            skipWhitespace()
+
+            if consume("]") { return values }
+            guard consume(",") else { return nil }
+            skipWhitespace()
+            if consume("]") { return values }
+        }
+    }
+
+    private mutating func parseObject() -> (any Sendable)? {
+        guard consume("{") else { return nil }
+        skipWhitespace()
+
+        var object: [String: any Sendable] = [:]
+        if consume("}") { return object }
+
+        while true {
+            guard let key = parseString() else { return nil }
+            skipWhitespace()
+            guard consume(":"), let value = parseValue() else { return nil }
+            object[key] = value
+            skipWhitespace()
+
+            if consume("}") { return object }
+            guard consume(",") else { return nil }
+            skipWhitespace()
+            if consume("}") { return object }
+        }
+    }
+
+    private mutating func parseString() -> String? {
+        guard let quote = current, quote == "'" || quote == "\"" else { return nil }
+        advance()
+
+        var result = ""
+        while let character = current {
+            advance()
+
+            if character == quote { return result }
+            guard character == "\\" else {
+                result.append(character)
+                continue
+            }
+
+            guard let escaped = current else { return nil }
+            advance()
+
+            switch escaped {
+            case "\\": result.append("\\")
+            case "'": result.append("'")
+            case "\"": result.append("\"")
+            case "n": result.append("\n")
+            case "r": result.append("\r")
+            case "t": result.append("\t")
+            case "b": result.append("\u{8}")
+            case "f": result.append("\u{c}")
+            case "u":
+                guard let scalar = parseUnicodeScalar(digitCount: 4) else { return nil }
+                result.unicodeScalars.append(scalar)
+            case "U":
+                guard let scalar = parseUnicodeScalar(digitCount: 8) else { return nil }
+                result.unicodeScalars.append(scalar)
+            default:
+                // Python preserves an unrecognized escape in the string value.
+                result.append("\\")
+                result.append(escaped)
+            }
+        }
+        return nil
+    }
+
+    private mutating func parseUnicodeScalar(digitCount: Int) -> Unicode.Scalar? {
+        var digits = ""
+        digits.reserveCapacity(digitCount)
+
+        for _ in 0 ..< digitCount {
+            guard let character = current,
+                UInt32(String(character), radix: 16) != nil
+            else { return nil }
+            digits.append(character)
+            advance()
+        }
+
+        guard let value = UInt32(digits, radix: 16) else { return nil }
+        return Unicode.Scalar(value)
+    }
+
+    private mutating func parseAtom() -> (any Sendable)? {
+        let start = index
+        while let character = current,
+            !character.isWhitespace,
+            ![",", "]", "}"].contains(character)
+        {
+            advance()
+        }
+
+        guard start < index else { return nil }
+        let token = String(source[start ..< index])
+
+        switch token {
+        case "True", "true": return true
+        case "False", "false": return false
+        case "None", "null", "nil": return NSNull()
+        default: break
+        }
+
+        let normalizedNumber = token.replacingOccurrences(of: "_", with: "")
+        if let integer = Int(normalizedNumber) { return integer }
+        if let number = Double(normalizedNumber), number.isFinite { return number }
+        return nil
+    }
+
+    private mutating func skipWhitespace() {
+        while current?.isWhitespace == true { advance() }
+    }
+
+    @discardableResult
+    private mutating func consume(_ character: Character) -> Bool {
+        guard current == character else { return false }
+        advance()
+        return true
+    }
+
+    private mutating func advance() {
+        index = source.index(after: index)
+    }
+}
+
+func tryParsePythonLiteral(_ value: String) -> (any Sendable)? {
+    PythonLiteralParser.parse(value[...])
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
@@ -100,9 +100,9 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
 
     /// Parse Pythonic keyword arguments: arg1='value1', arg2="value2", arg3=123
     ///
-    /// Values may themselves be JSON objects/arrays (e.g.
-    /// `properties={"location": "Tokyo", "unit": "c"}`); splitting is bracket-,
-    /// brace-, and quote-aware so commas inside a value do not truncate it.
+    /// Values may be JSON or Python literals, including single-quoted collections
+    /// and the `True`, `False`, and `None` spellings. Splitting is bracket-, brace-,
+    /// and quote-aware so commas inside a value do not truncate it.
     private func parseArguments(
         _ argsString: String,
         funcName: String,
@@ -114,37 +114,41 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
             guard let eq = Self.scanner.firstTopLevelIndex(of: "=", in: pair) else { continue }
             let key = String(pair[..<eq]).trimmingCharacters(in: .whitespacesAndNewlines)
             guard !key.isEmpty else { continue }
-            var value = String(pair[pair.index(after: eq)...])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-
-            // Object / array value: parse as JSON so nested commas are preserved.
-            if value.hasPrefix("{") || value.hasPrefix("[") {
-                if let json = tryParseJSON(value) {
-                    arguments[key] = json
-                    continue
-                }
-            }
-
-            // Quoted string: strip surrounding quotes and unescape, then apply
-            // schema-based typing (e.g. a quoted '25' for an integer parameter).
-            if (value.hasPrefix("'") && value.hasSuffix("'"))
-                || (value.hasPrefix("\"") && value.hasSuffix("\""))
-            {
-                value = String(value.dropFirst().dropLast())
-                value = value.replacingOccurrences(of: "\\'", with: "'")
-                value = value.replacingOccurrences(of: "\\\"", with: "\"")
-                value = value.replacingOccurrences(of: "\\\\", with: "\\")
-                arguments[key] = convertParameterValue(
-                    value, paramName: key, funcName: funcName, tools: tools)
-                continue
-            }
-
-            // Unquoted scalar: convert based on schema type if available.
-            arguments[key] = convertParameterValue(
-                value, paramName: key, funcName: funcName, tools: tools)
+            let value = pair[pair.index(after: eq)...].trimmingWhitespace()
+            arguments[key] = parseArgumentValue(
+                value, key: key, funcName: funcName, tools: tools)
         }
 
         return unwrapArgumentWrapper(arguments, funcName: funcName, tools: tools)
+    }
+
+    /// Converts one argument without letting inferred scalar types override a
+    /// declared schema. Collections retain the parser's historical eager
+    /// decoding behavior, now with Python-literal syntax as a fallback.
+    private func parseArgumentValue(
+        _ value: Substring,
+        key: String,
+        funcName: String,
+        tools: [[String: any Sendable]]?
+    ) -> any Sendable {
+        let literal = String(value)
+
+        if value.first == "{" || value.first == "[" {
+            return tryParseJSON(literal) ?? tryParsePythonLiteral(literal) ?? literal
+        }
+
+        if value.first == "'" || value.first == "\"" {
+            let string = (tryParsePythonLiteral(literal) as? String) ?? literal
+            return convertParameterValue(
+                string, paramName: key, funcName: funcName, tools: tools)
+        }
+
+        if getParameterType(funcName: funcName, paramName: key, tools: tools) != nil {
+            return convertParameterValue(
+                literal, paramName: key, funcName: funcName, tools: tools)
+        }
+
+        return tryParsePythonLiteral(literal) ?? literal
     }
 
     /// Some models wrap all arguments in a single object under a schema key —

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
@@ -9,56 +9,17 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
     public let startTag: String?
     public let endTag: String?
 
+    /// Python string literals use either quote character, and values may nest
+    /// any bracket kind, so every scan of this dialect shares one configuration.
+    private static let scanner = StructuredTextScanner(quotes: ["'", "\""])
+
     public init(startTag: String? = nil, endTag: String? = nil) {
         self.startTag = startTag
         self.endTag = endTag
     }
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
-        var text = content
-
-        // Strip tags if present
-        if let start = startTag, let startRange = text.range(of: start) {
-            text = String(text[startRange.upperBound...])
-        }
-        if let end = endTag, let endRange = text.range(of: end) {
-            text = String(text[..<endRange.lowerBound])
-        }
-
-        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        let funcName: String
-        let argsString: String
-
-        // Required brackets pattern (matches Python reference: r"\[(\w+)\((.*?)\)\]")
-        // The required \] forces .*? to backtrack past nested ) inside argument values.
-        let bracketPattern = #"\[(\w+)\((.*?)\)\]"#
-        if let regex = try? NSRegularExpression(
-            pattern: bracketPattern, options: [.dotMatchesLineSeparators]),
-            let match = regex.firstMatch(
-                in: text, options: [], range: NSRange(text.startIndex..., in: text)),
-            let nameRange = Range(match.range(at: 1), in: text),
-            let argsRange = Range(match.range(at: 2), in: text)
-        {
-            funcName = String(text[nameRange])
-            argsString = String(text[argsRange])
-        } else {
-            // Fallback for without-brackets case: use string indices to find the
-            // outermost parentheses, avoiding the greedy/non-greedy regex pitfall.
-            guard let openParen = text.firstIndex(of: "("),
-                let closeParen = text.lastIndex(of: ")")
-            else { return nil }
-
-            let name = text[text.startIndex ..< openParen]
-            guard !name.isEmpty, name.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" })
-            else { return nil }
-
-            funcName = String(name)
-            argsString = String(text[text.index(after: openParen) ..< closeParen])
-        }
-
-        let arguments = parseArguments(argsString, funcName: funcName, tools: tools)
-        return ToolCall(function: .init(name: funcName, arguments: arguments))
+        parseMultiple(content: content, tools: tools).first
     }
 
     public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
@@ -74,27 +35,67 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
     }
 
     private func parseMultiple(content: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
-        var text = content
+        callBodies(in: unwrapped(content)).compactMap { parseCall($0, tools: tools) }
+    }
 
-        if let end = endTag, let endRange = text.range(of: end) {
-            text = String(text[..<endRange.lowerBound])
+    /// Strips the protocol tags and surrounding whitespace, leaving the call list.
+    private func unwrapped(_ content: String) -> Substring {
+        var text = content[...]
+
+        if let startTag, let startRange = text.range(of: startTag) {
+            text = text[startRange.upperBound...]
+        }
+        if let endTag, let endRange = text.range(of: endTag) {
+            text = text[..<endRange.lowerBound]
         }
 
-        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.trimmingWhitespace()
+    }
 
-        let regex = #/(?s)(\w+)\((.*?)\)/#
-        let matches = text.matches(of: regex)
+    /// Splits a call list into one body per call.
+    ///
+    /// The list may be wrapped in `[...]`, which has to balance: a bracket left
+    /// open means the payload is truncated, not that the calls inside it are
+    /// ready to execute. Bodies are separated by top-level commas, so a comma
+    /// inside an argument value never splits one call into two.
+    private func callBodies(in text: Substring) -> [Substring] {
+        var list = text
 
-        var results: [ToolCall] = []
-        for match in matches {
-            let funcName = String(match.1)
-            let argsString = String(match.2)
-            let arguments = parseArguments(argsString, funcName: funcName, tools: tools)
-
-            results.append(ToolCall(function: .init(name: funcName, arguments: arguments)))
+        if list.first == "[" {
+            guard let end = Self.scanner.endOfGroup(in: list, openedAt: list.startIndex)
+            else { return [] }
+            list = list[list.index(after: list.startIndex) ..< end]
         }
 
-        return results
+        return Self.scanner.splitTopLevel(list, separator: ",")
+    }
+
+    /// Parses one `name(arguments)` body.
+    ///
+    /// The argument list ends at the parenthesis balancing the one that opened
+    /// it, so a value containing `)`, `]`, or `)]` survives intact.
+    private func parseCall(_ body: Substring, tools: [[String: any Sendable]]?) -> ToolCall? {
+        let body = body.trimmingWhitespace()
+        guard let open = Self.scanner.firstTopLevelIndex(of: "(", in: body),
+            let close = Self.scanner.endOfGroup(in: body, openedAt: open)
+        else { return nil }
+
+        let name = identifierEnding(at: open, in: body)
+        guard !name.isEmpty else { return nil }
+
+        let funcName = String(name)
+        let arguments = parseArguments(
+            String(body[body.index(after: open) ..< close]), funcName: funcName, tools: tools)
+        return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+
+    /// The identifier run ending just before `index`, which skips whatever list
+    /// punctuation or qualifier the model emitted ahead of the call.
+    private func identifierEnding(at index: String.Index, in body: Substring) -> Substring {
+        let prefix = body[..<index]
+        let isIdentifier: (Character) -> Bool = { $0.isLetter || $0.isNumber || $0 == "_" }
+        guard let boundary = prefix.lastIndex(where: { !isIdentifier($0) }) else { return prefix }
+        return prefix[prefix.index(after: boundary)...]
     }
 
     /// Parse Pythonic keyword arguments: arg1='value1', arg2="value2", arg3=123
@@ -109,8 +110,8 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
     ) -> [String: any Sendable] {
         var arguments: [String: any Sendable] = [:]
 
-        for pair in splitTopLevel(argsString, separator: ",") {
-            guard let eq = topLevelIndex(of: "=", in: pair) else { continue }
+        for pair in Self.scanner.splitTopLevel(argsString[...], separator: ",") {
+            guard let eq = Self.scanner.firstTopLevelIndex(of: "=", in: pair) else { continue }
             let key = String(pair[..<eq]).trimmingCharacters(in: .whitespacesAndNewlines)
             guard !key.isEmpty else { continue }
             var value = String(pair[pair.index(after: eq)...])
@@ -171,80 +172,5 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
             return arguments
         }
         return object
-    }
-
-    /// Split `text` on `separator` at the top level only, ignoring separators
-    /// inside quotes or `()` / `[]` / `{}` nesting.
-    private func splitTopLevel(_ text: String, separator: Character) -> [String] {
-        var parts: [String] = []
-        var current = ""
-        var depth = 0
-        var quote: Character?
-        var escaped = false
-
-        for character in text {
-            if let activeQuote = quote {
-                current.append(character)
-                if escaped {
-                    escaped = false
-                } else if character == "\\" {
-                    escaped = true
-                } else if character == activeQuote {
-                    quote = nil
-                }
-                continue
-            }
-            switch character {
-            case "'", "\"":
-                quote = character
-                current.append(character)
-            case "(", "[", "{":
-                depth += 1
-                current.append(character)
-            case ")", "]", "}":
-                depth -= 1
-                current.append(character)
-            case separator where depth == 0:
-                parts.append(current)
-                current = ""
-            default:
-                current.append(character)
-            }
-        }
-        if !current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            parts.append(current)
-        }
-        return parts
-    }
-
-    /// Index of the first top-level `character` (not inside quotes or nesting).
-    private func topLevelIndex(of character: Character, in text: String) -> String.Index? {
-        var depth = 0
-        var quote: Character?
-        var escaped = false
-        var index = text.startIndex
-
-        while index < text.endIndex {
-            let current = text[index]
-            if let activeQuote = quote {
-                if escaped {
-                    escaped = false
-                } else if current == "\\" {
-                    escaped = true
-                } else if current == activeQuote {
-                    quote = nil
-                }
-            } else {
-                switch current {
-                case "'", "\"": quote = current
-                case "(", "[", "{": depth += 1
-                case ")", "]", "}": depth -= 1
-                case character where depth == 0: return index
-                default: break
-                }
-            }
-            index = text.index(after: index)
-        }
-        return nil
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/StructuredTextScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/StructuredTextScanner.swift
@@ -1,0 +1,165 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Locates *structural* punctuation in a tool-call payload.
+///
+/// Dialects that separate arguments with punctuation — Pythonic
+/// `[f(a='x', b=2)]`, Gemma `call:f{a:1,b:2}` — all have to answer one question
+/// before they can split anything: is this comma / colon / bracket a separator,
+/// or is it part of a value? Answering it with `firstIndex(of:)` truncates any
+/// value that happens to contain the delimiter, which is how a quoted `")]"` or
+/// a nested `{"a":1,"b":2}` ends up silently mangled.
+///
+/// This type answers that question once, for every such parser. It walks text
+/// while treating three kinds of span as opaque:
+///
+/// - quoted spans, honoring backslash escapes (`'a,b'`),
+/// - marker-delimited spans, where the same multi-character marker both opens
+///   and closes the span (Gemma's `<|"|>`),
+/// - bracket nesting across `()`, `[]`, and `{}`.
+///
+/// Only characters outside every opaque span are reported, each with the
+/// bracket depth it sits at, so callers can ask for *top level* positions and
+/// get exactly those.
+struct StructuredTextScanner: Sendable {
+
+    /// Characters that open and close a quoted span.
+    let quotes: Set<Character>
+
+    /// A marker that both opens and closes an opaque span, if the dialect has one.
+    let escapeMarker: String?
+
+    init(quotes: Set<Character> = [], escapeMarker: String? = nil) {
+        self.quotes = quotes
+        self.escapeMarker = escapeMarker
+    }
+
+    /// Bracket pairs tracked as nesting. All three share one depth counter, so
+    /// a value may mix them freely as long as it is balanced.
+    private static let brackets: [Character: Character] = ["(": ")", "[": "]", "{": "}"]
+    private static let closers: Set<Character> = Set(brackets.values)
+
+    // MARK: - Queries
+
+    /// The first `character` that sits at the top level, or `nil` if it only
+    /// ever appears inside a quoted span, a marker span, or nested brackets.
+    func firstTopLevelIndex(of character: Character, in text: Substring) -> String.Index? {
+        var found: String.Index?
+        scan(text) { index, scanned, depth in
+            guard depth == 0, scanned == character else { return .continue }
+            found = index
+            return .stop
+        }
+        return found
+    }
+
+    /// Splits `text` on every top-level `separator`.
+    ///
+    /// Interior empty fields are preserved so callers can detect malformed
+    /// input; a trailing field is dropped when it is empty or all whitespace,
+    /// which is what a trailing separator produces.
+    func splitTopLevel(_ text: Substring, separator: Character) -> [Substring] {
+        var fields: [Substring] = []
+        var fieldStart = text.startIndex
+
+        scan(text) { index, scanned, depth in
+            guard depth == 0, scanned == separator else { return .continue }
+            fields.append(text[fieldStart ..< index])
+            fieldStart = text.index(after: index)
+            return .continue
+        }
+
+        let last = text[fieldStart...]
+        if !last.allSatisfy(\.isWhitespace) {
+            fields.append(last)
+        }
+        return fields
+    }
+
+    /// The index of the bracket that closes the group opened at `openingIndex`,
+    /// or `nil` when the group is unbalanced or `openingIndex` is not an opener.
+    ///
+    /// Delimiters inside quoted, marker-delimited, or more deeply nested spans
+    /// cannot close the group, so a value containing `)]` or `}` is safe.
+    func endOfGroup(in text: Substring, openedAt openingIndex: String.Index) -> String.Index? {
+        guard openingIndex < text.endIndex,
+            let closingCharacter = Self.brackets[text[openingIndex]]
+        else { return nil }
+
+        var closingIndex: String.Index?
+        scan(text[openingIndex...]) { index, scanned, depth in
+            guard depth == 0, index != openingIndex else { return .continue }
+            guard scanned == closingCharacter else {
+                // A closer of a different kind at this depth means the group is
+                // malformed; refuse rather than guess where it ended.
+                return Self.closers.contains(scanned) ? .stop : .continue
+            }
+            closingIndex = index
+            return .stop
+        }
+        return closingIndex
+    }
+
+    // MARK: - Core scan
+
+    private enum Step {
+        case `continue`
+        case stop
+    }
+
+    /// Visits every character outside an opaque span, with its bracket depth.
+    ///
+    /// Depth is reported *outside* the bracket for both ends of a pair, so in
+    /// `a{b}c` the braces are reported at depth 0 and `b` at depth 1.
+    private func scan(_ text: Substring, _ visit: (String.Index, Character, Int) -> Step) {
+        var index = text.startIndex
+        var depth = 0
+        var activeQuote: Character?
+        var isEscaped = false
+
+        while index < text.endIndex {
+            let character = text[index]
+
+            if let marker = escapeMarker, activeQuote == nil,
+                text[index...].hasPrefix(marker)
+            {
+                // Skip the whole marker span; a value may contain anything.
+                let contentStart = text.index(index, offsetBy: marker.count)
+                guard let closing = text[contentStart...].range(of: marker) else { return }
+                index = closing.upperBound
+                continue
+            }
+
+            if let quote = activeQuote {
+                if isEscaped {
+                    isEscaped = false
+                } else if character == #"\"# {
+                    isEscaped = true
+                } else if character == quote {
+                    activeQuote = nil
+                }
+                index = text.index(after: index)
+                continue
+            }
+
+            if quotes.contains(character) {
+                activeQuote = character
+                index = text.index(after: index)
+                continue
+            }
+
+            if Self.brackets[character] != nil {
+                if visit(index, character, depth) == .stop { return }
+                depth += 1
+            } else if Self.closers.contains(character) {
+                depth = max(0, depth - 1)
+                if visit(index, character, depth) == .stop { return }
+            } else {
+                if visit(index, character, depth) == .stop { return }
+            }
+
+            index = text.index(after: index)
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormatInference.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormatInference.swift
@@ -81,18 +81,50 @@ extension ToolCallFormat {
 
 extension ToolCallFormat {
 
-    /// The dialect a checkpoint declares or implies, read from its tokenizer files.
+    /// Resolves a model declaration against the dialect selected by its checkpoint.
     ///
     /// An explicit `tool_parser_type` wins, matching mlx-lm, because it is the
-    /// checkpoint author correcting what the template alone would imply.
-    package static func resolved(forTokenizerDirectory directory: URL) -> ToolCallFormat? {
+    /// checkpoint author correcting what the template alone would imply. Otherwise,
+    /// the selected tool template refines a model declaration that cannot parse the
+    /// dialect it prompts. This matters for architecture heuristics such as Llama 3:
+    /// Hermes checkpoints use that architecture while prompting framed JSON instead
+    /// of Llama's inline JSON.
+    ///
+    /// A model-declared superset remains selected. For example, Qwen 3.5 prompts XML
+    /// but its parser deliberately accepts both XML and framed Hermes JSON.
+    package static func resolved(
+        forTokenizerDirectory directory: URL,
+        modelFormat: ToolCallFormat? = nil
+    ) -> ToolCallFormat? {
         let configuration = TokenizerToolCallConfiguration(directory: directory)
 
         if let declared = configuration.toolParserType.flatMap(ToolCallFormat.init(toolParserType:))
         {
             return declared
         }
-        return configuration.chatTemplate.flatMap(ToolCallFormat.inferred(fromChatTemplate:))
+
+        guard
+            let templateFormat = configuration.chatTemplate.flatMap(
+                ToolCallFormat.inferred(fromChatTemplate:))
+        else { return modelFormat }
+        guard let modelFormat else { return templateFormat }
+
+        return modelFormat.accepts(templateFormat: templateFormat) ? modelFormat : templateFormat
+    }
+
+    /// Whether a model-selected parser is a superset of the dialect prompted by
+    /// the selected chat template.
+    private func accepts(templateFormat: ToolCallFormat) -> Bool {
+        switch self {
+        case .qwen35:
+            return templateFormat == .xmlFunction || templateFormat == .json
+        case .gptOSS, .atem:
+            // These select complete token-stream protocols, not interchangeable
+            // payload parsers. Incidental textual markers must not reroute them.
+            return true
+        default:
+            return self == templateFormat
+        }
     }
 }
 
@@ -131,8 +163,9 @@ struct TokenizerToolCallConfiguration {
         }
     }
 
-    /// A template is either the template itself or a list of named templates,
-    /// in which case the one named `default` is the one applied to a chat.
+    /// A template is either the template itself or a list of named templates.
+    /// Format inference models a tool-enabled request, so it follows
+    /// swift-transformers by preferring `tool_use` and falling back to `default`.
     enum ChatTemplate: Decodable {
         case single(String)
         case named([Named])
@@ -156,7 +189,8 @@ struct TokenizerToolCallConfiguration {
             case .single(let template):
                 return template
             case .named(let templates):
-                return (templates.first { $0.name == "default" } ?? templates.first)?.template
+                return templates.first { $0.name == "tool_use" }?.template
+                    ?? templates.first { $0.name == "default" }?.template
             }
         }
     }

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormatInference.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormatInference.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Inference from a chat template
+
+extension ToolCallFormat {
+
+    /// Markers that identify a dialect in a chat template.
+    ///
+    /// A signature matches when every marker in any one group is present, which
+    /// covers both dialects identified by a single tag and those that can only
+    /// be told apart by a pair of them.
+    private struct Signature {
+        let format: ToolCallFormat
+        let markerGroups: [[String]]
+
+        init(_ format: ToolCallFormat, anyOf markerGroups: [[String]]) {
+            self.format = format
+            self.markerGroups = markerGroups
+        }
+
+        init(_ format: ToolCallFormat, allOf markers: String...) {
+            self.init(format, anyOf: [markers])
+        }
+
+        func matches(_ template: String) -> Bool {
+            markerGroups.contains { $0.allSatisfy(template.contains) }
+        }
+    }
+
+    /// Ordered most specific first: a template that renders `<|tool_call>` also
+    /// contains `<tool_call>`, so the broader signatures have to come last.
+    ///
+    /// Mirrors `_infer_tool_parser` in mlx-lm's `tokenizer_utils.py`. Protocols
+    /// with token-level framing (Harmony, Onyx) are deliberately absent: they
+    /// are selected by the models that own them, and guessing them from text
+    /// would reroute the whole response protocol rather than one payload shape.
+    private static let signatures: [Signature] = [
+        Signature(.minimaxM2, allOf: "<minimax:tool_call>"),
+        Signature(.gemma4, allOf: "<|tool_call>", "<tool_call|>"),
+        Signature(.gemma, allOf: "<start_function_call>"),
+        Signature(.glm4, allOf: "<arg_key>"),
+        Signature(.lfm2, allOf: "<|tool_list_start|>"),
+        Signature(
+            .xmlFunction, anyOf: [["<tool_call>\n<function="], [#"<tool_call>\n<function="#]]),
+        Signature(.kimiK2, allOf: "<|tool_calls_section_begin|>"),
+        Signature(.mistral, allOf: "[TOOL_CALLS]"),
+        Signature(.json, allOf: "<tool_call>", "tool_call.name"),
+    ]
+
+    /// The dialect a chat template renders, or `nil` when it renders none that
+    /// is recognized.
+    ///
+    /// This is the last resort for a checkpoint whose architecture does not
+    /// declare a format: the template is what actually teaches the model how to
+    /// write a call, so it identifies the dialect even for an unknown model.
+    public static func inferred(fromChatTemplate template: String) -> ToolCallFormat? {
+        signatures.first { $0.matches(template) }?.format
+    }
+
+    /// The format named by a `tool_parser_type` entry, using the parser names
+    /// mlx-lm publishes so a checkpoint carrying one is honored as written.
+    public init?(toolParserType name: String) {
+        switch name.lowercased() {
+        case "minimax_m2": self = .minimaxM2
+        case "gemma4": self = .gemma4
+        case "function_gemma", "gemma": self = .gemma
+        case "glm4", "glm47": self = .glm4
+        case "pythonic", "lfm2": self = .lfm2
+        case "qwen3_coder", "qwen3_xml", "xml_function": self = .xmlFunction
+        case "kimi_k2": self = .kimiK2
+        case "mistral": self = .mistral
+        case "json_tools", "json": self = .json
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Inference from a checkpoint on disk
+
+extension ToolCallFormat {
+
+    /// The dialect a checkpoint declares or implies, read from its tokenizer files.
+    ///
+    /// An explicit `tool_parser_type` wins, matching mlx-lm, because it is the
+    /// checkpoint author correcting what the template alone would imply.
+    package static func resolved(forTokenizerDirectory directory: URL) -> ToolCallFormat? {
+        let configuration = TokenizerToolCallConfiguration(directory: directory)
+
+        if let declared = configuration.toolParserType.flatMap(ToolCallFormat.init(toolParserType:))
+        {
+            return declared
+        }
+        return configuration.chatTemplate.flatMap(ToolCallFormat.inferred(fromChatTemplate:))
+    }
+}
+
+/// The two tokenizer fields that describe tool-call syntax.
+///
+/// Read straight from disk rather than through the tokenizer, which exposes
+/// only whether a chat template exists and not its text.
+struct TokenizerToolCallConfiguration {
+    let chatTemplate: String?
+    let toolParserType: String?
+
+    init(directory: URL) {
+        let file = Self.decodeConfiguration(
+            at: directory.appending(component: "tokenizer_config.json"))
+
+        // Newer checkpoints ship the template as a sibling file instead.
+        let sidecar = try? String(
+            contentsOf: directory.appending(component: "chat_template.jinja"), encoding: .utf8)
+
+        self.chatTemplate = file?.chatTemplate?.text ?? sidecar
+        self.toolParserType = file?.toolParserType
+    }
+
+    private static func decodeConfiguration(at url: URL) -> ConfigurationFile? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(ConfigurationFile.self, from: data)
+    }
+
+    private struct ConfigurationFile: Decodable {
+        let chatTemplate: ChatTemplate?
+        let toolParserType: String?
+
+        enum CodingKeys: String, CodingKey {
+            case chatTemplate = "chat_template"
+            case toolParserType = "tool_parser_type"
+        }
+    }
+
+    /// A template is either the template itself or a list of named templates,
+    /// in which case the one named `default` is the one applied to a chat.
+    enum ChatTemplate: Decodable {
+        case single(String)
+        case named([Named])
+
+        struct Named: Decodable {
+            let name: String
+            let template: String
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let template = try? container.decode(String.self) {
+                self = .single(template)
+            } else {
+                self = .named(try container.decode([Named].self))
+            }
+        }
+
+        var text: String? {
+            switch self {
+            case .single(let template):
+                return template
+            case .named(let templates):
+                return (templates.first { $0.name == "default" } ?? templates.first)?.template
+            }
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -506,33 +506,12 @@ public class ToolCallProcessor {
         return drainOrderedOutputs()
     }
 
+    /// End of the bracketed call list beginning at `start`, ignoring brackets
+    /// that appear inside quoted argument values.
     private func balancedBracketEnd(in text: String, from start: String.Index) -> String.Index? {
-        var depth = 0
-        var stringQuote: Character?
-        var escaped = false
-
-        for index in text.indices[start...] {
-            let character = text[index]
-            if let quote = stringQuote {
-                if escaped {
-                    escaped = false
-                } else if character == "\\" {
-                    escaped = true
-                } else if character == quote {
-                    stringQuote = nil
-                }
-                continue
-            }
-            switch character {
-            case "\"", "'": stringQuote = character
-            case "[": depth += 1
-            case "]":
-                depth -= 1
-                if depth == 0 { return index }
-            default: break
-            }
-        }
-        return nil
+        let tail = text[start...]
+        guard let open = Self.listScanner.firstTopLevelIndex(of: "[", in: tail) else { return nil }
+        return Self.listScanner.endOfGroup(in: tail, openedAt: open)
     }
 
     private func recordEOSResidualOutputs(_ text: String) {
@@ -551,6 +530,8 @@ public class ToolCallProcessor {
             detail: RejectedToolCall.Reason.malformedSyntax.diagnosticDetail)
         recordEOSResidualOutputs(String(text[range.upperBound...]))
     }
+
+    private static let listScanner = StructuredTextScanner(quotes: ["'", "\""])
 
     /// Process chunk for tagged formats.
     private func processTaggedChunk(_ chunk: String) -> String? {

--- a/Libraries/MLXLMCommon/Tool/Value.swift
+++ b/Libraries/MLXLMCommon/Tool/Value.swift
@@ -60,6 +60,8 @@ public enum JSONValue: Hashable, Codable, Sendable {
         switch value {
         case is NSNull:
             return .null
+        case let number as NSNumber:
+            return from(number)
         case let bool as Bool:
             return .bool(bool)
         case let int as Int:
@@ -79,6 +81,23 @@ public enum JSONValue: Hashable, Codable, Sendable {
         default:
             return .string(String(describing: value))
         }
+    }
+
+    /// Classifies a boxed number.
+    ///
+    /// `JSONSerialization` boxes booleans and numbers alike as `NSNumber`, and
+    /// an `NSNumber` holding 0 or 1 bridges to `Bool` successfully. Testing
+    /// `as? Bool` first therefore rewrites every 0 and 1 in a decoded payload —
+    /// `{"limit": 1}` becomes `{"limit": true}` — so the boolean case is keyed
+    /// on the boxed type instead of on a cast that a number also satisfies.
+    private static func from(_ number: NSNumber) -> JSONValue {
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return .bool(number.boolValue)
+        }
+        if let int = number as? Int {
+            return .int(int)
+        }
+        return .double(number.doubleValue)
     }
 
     public var anyValue: Any {

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -406,13 +406,16 @@ public final class VLMModelFactory: GenericModelFactory {
 
         // Chat conventions. Precedence: an explicit value on the configuration
         // (registry entry or caller) wins; then a registered resolver, which sees
-        // the repo id the model cannot; then the model's own declaration.
+        // the repo id the model cannot; then the model's own declaration; and
+        // finally the checkpoint's own tokenizer files, which describe the
+        // dialect even for an architecture that declares nothing.
         let modelId = configuration.name
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat =
                 conventionsRegistry.toolCallFormat(
                     modelId: modelId, modelType: baseConfig.modelType)
                 ?? model.toolCallFormat
+                ?? ToolCallFormat.resolved(forTokenizerDirectory: configuration.tokenizerDirectory)
         }
         if mutableConfiguration.reasoningConfig == nil {
             mutableConfiguration.reasoningConfig =

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -404,18 +404,17 @@ public final class VLMModelFactory: GenericModelFactory {
         mutableConfiguration.eosTokenIds = eosTokenIds
         mutableConfiguration.stopStrings.formUnion(generationConfig?.stopStrings ?? [])
 
-        // Chat conventions. Precedence: an explicit value on the configuration
-        // (registry entry or caller) wins; then a registered resolver, which sees
-        // the repo id the model cannot; then the model's own declaration; and
-        // finally the checkpoint's own tokenizer files, which describe the
-        // dialect even for an architecture that declares nothing.
+        // Chat conventions. An explicit value on the configuration wins, followed
+        // by a registered resolver that sees the repo id. Checkpoint metadata then
+        // resolves the model declaration against the selected tool template.
         let modelId = configuration.name
         if mutableConfiguration.toolCallFormat == nil {
             mutableConfiguration.toolCallFormat =
                 conventionsRegistry.toolCallFormat(
                     modelId: modelId, modelType: baseConfig.modelType)
-                ?? model.toolCallFormat
-                ?? ToolCallFormat.resolved(forTokenizerDirectory: configuration.tokenizerDirectory)
+                ?? ToolCallFormat.resolved(
+                    forTokenizerDirectory: configuration.tokenizerDirectory,
+                    modelFormat: model.toolCallFormat)
         }
         if mutableConfiguration.reasoningConfig == nil {
             mutableConfiguration.reasoningConfig =

--- a/Tests/MLXLMTests/JSONValueConversionTests.swift
+++ b/Tests/MLXLMTests/JSONValueConversionTests.swift
@@ -1,0 +1,83 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("JSONValue conversion")
+struct JSONValueConversionTests {
+
+    /// Values as `JSONSerialization` produces them, which is the path every
+    /// parser that decodes an argument value as JSON goes through.
+    private func decoded(_ json: String) -> JSONValue {
+        let object = try! JSONSerialization.jsonObject(
+            with: Data(json.utf8), options: [.fragmentsAllowed])
+        return JSONValue.from(object)
+    }
+
+    @Test("Decoded 0 and 1 stay integers")
+    func decodedZeroAndOneStayIntegers() {
+        // `NSNumber` bridges to `Bool` whenever it holds 0 or 1, so a boxed
+        // number used to be reported as `false` / `true`.
+        #expect(decoded(#"{"limit": 1}"#) == .object(["limit": .int(1)]))
+        #expect(decoded(#"{"offset": 0}"#) == .object(["offset": .int(0)]))
+        #expect(decoded("[0, 1, 2]") == .array([.int(0), .int(1), .int(2)]))
+    }
+
+    @Test("Decoded booleans stay booleans")
+    func decodedBooleansStayBooleans() {
+        #expect(decoded(#"{"stream": true}"#) == .object(["stream": .bool(true)]))
+        #expect(decoded(#"{"stream": false}"#) == .object(["stream": .bool(false)]))
+    }
+
+    @Test("Other decoded scalars keep their type")
+    func decodedScalarsKeepTheirType() {
+        #expect(decoded("2") == .int(2))
+        #expect(decoded("2.5") == .double(2.5))
+        #expect(decoded("-3") == .int(-3))
+        #expect(decoded(#""text""#) == .string("text"))
+        #expect(decoded("null") == .null)
+    }
+
+    @Test("Native Swift values keep their type")
+    func nativeValuesKeepTheirType() {
+        #expect(JSONValue.from(true) == .bool(true))
+        #expect(JSONValue.from(false) == .bool(false))
+        #expect(JSONValue.from(1) == .int(1))
+        #expect(JSONValue.from(0) == .int(0))
+        #expect(JSONValue.from(2.5) == .double(2.5))
+        #expect(JSONValue.from("text") == .string("text"))
+    }
+
+    @Test("A tool call carries a 0/1 argument through unchanged")
+    func toolCallPreservesZeroAndOne() throws {
+        // XML values are typed from the schema, and object values are decoded as
+        // JSON — the combination that previously rewrote 1 as true.
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "search",
+                    "parameters": [
+                        "properties": [
+                            "page": ["type": "integer"],
+                            "filters": ["type": "object"],
+                        ]
+                    ],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content = """
+            <tool_call><function=search><parameter=page>1</parameter>\
+            <parameter=filters>{"archived": false, "limit": 1}</parameter></function></tool_call>
+            """
+
+        let call = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(call.function.arguments["page"] == .int(1))
+        #expect(
+            call.function.arguments["filters"]
+                == .object(["archived": .bool(false), "limit": .int(1)]))
+    }
+}

--- a/Tests/MLXLMTests/StructuredTextScannerTests.swift
+++ b/Tests/MLXLMTests/StructuredTextScannerTests.swift
@@ -1,0 +1,101 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("StructuredTextScanner")
+struct StructuredTextScannerTests {
+
+    private let pythonic = StructuredTextScanner(quotes: ["'", "\""])
+    private let gemma = StructuredTextScanner(quotes: ["\""], escapeMarker: "<|\"|>")
+
+    // MARK: - Top-level index
+
+    @Test("Finds a delimiter at the top level")
+    func findsTopLevelDelimiter() throws {
+        let text = "a=1"[...]
+        let index = try #require(pythonic.firstTopLevelIndex(of: "=", in: text))
+        #expect(text[..<index] == "a")
+    }
+
+    @Test("Ignores delimiters inside quotes, brackets, and marker spans")
+    func ignoresNonStructuralDelimiters() {
+        #expect(pythonic.firstTopLevelIndex(of: "=", in: "'a=b'"[...]) == nil)
+        #expect(pythonic.firstTopLevelIndex(of: ",", in: "[1, 2]"[...]) == nil)
+        #expect(pythonic.firstTopLevelIndex(of: ":", in: #"{"a": 1}"#[...]) == nil)
+        #expect(gemma.firstTopLevelIndex(of: ",", in: #"<|"|>a, b<|"|>"#[...]) == nil)
+    }
+
+    @Test("An escaped quote does not end a quoted span")
+    func escapedQuoteStaysInsideSpan() {
+        #expect(pythonic.firstTopLevelIndex(of: ",", in: #"'a\',b'"#[...]) == nil)
+    }
+
+    // MARK: - Splitting
+
+    @Test("Splits only on top-level separators")
+    func splitsOnTopLevelSeparators() {
+        let text = #"a='x,y', b=[1, 2], c={"k": 3}"#[...]
+        let fields = pythonic.splitTopLevel(text, separator: ",")
+        #expect(fields.count == 3)
+        #expect(fields[0] == "a='x,y'")
+        #expect(fields[1].trimmingCharacters(in: .whitespaces) == "b=[1, 2]")
+        #expect(fields[2].trimmingCharacters(in: .whitespaces) == #"c={"k": 3}"#)
+    }
+
+    @Test("Marker spans keep separators out of the split")
+    func markerSpansAreOpaque() {
+        let fields = gemma.splitTopLevel(#"note:<|"|>a,b<|"|>,count:2"#[...], separator: ",")
+        #expect(fields.count == 2)
+        #expect(fields[0] == #"note:<|"|>a,b<|"|>"#)
+        #expect(fields[1] == "count:2")
+    }
+
+    @Test("A trailing separator does not produce an empty field")
+    func trailingSeparatorIsDropped() {
+        #expect(pythonic.splitTopLevel("a=1, "[...], separator: ",").count == 1)
+    }
+
+    @Test("Interior empty fields are preserved for malformed input")
+    func interiorEmptyFieldsPreserved() {
+        #expect(pythonic.splitTopLevel("a=1,,b=2"[...], separator: ",").count == 3)
+    }
+
+    // MARK: - Balanced groups
+
+    @Test("Finds the closing bracket of a balanced group")
+    func findsBalancedEnd() throws {
+        let text = "(a, b)tail"[...]
+        let end = try #require(gemma.endOfGroup(in: text, openedAt: text.startIndex))
+        #expect(text[text.index(after: end)...] == "tail")
+    }
+
+    @Test("Nested and quoted delimiters cannot close a group")
+    func nestedAndQuotedDelimitersDoNotClose() throws {
+        for source in [#"(note='a)]b')"#, "(inner=(1, 2))", #"({"k": "}"})"#] {
+            let text = source[...]
+            let end = try #require(
+                pythonic.endOfGroup(in: text, openedAt: text.startIndex), "\(source)")
+            #expect(end == text.index(before: text.endIndex), "\(source)")
+        }
+    }
+
+    @Test("An unbalanced or mismatched group has no end")
+    func unbalancedGroupHasNoEnd() {
+        let unterminated = "(a, b"[...]
+        #expect(pythonic.endOfGroup(in: unterminated, openedAt: unterminated.startIndex) == nil)
+
+        let mismatched = "(a]"[...]
+        #expect(pythonic.endOfGroup(in: mismatched, openedAt: mismatched.startIndex) == nil)
+
+        let notAnOpener = "a)"[...]
+        #expect(pythonic.endOfGroup(in: notAnOpener, openedAt: notAnOpener.startIndex) == nil)
+    }
+
+    @Test("An unterminated marker span consumes the remainder")
+    func unterminatedMarkerSpanIsOpaque() {
+        #expect(gemma.firstTopLevelIndex(of: ",", in: #"a:<|"|>b,c"#[...]) == nil)
+    }
+}

--- a/Tests/MLXLMTests/ToolCallFormatInferenceTests.swift
+++ b/Tests/MLXLMTests/ToolCallFormatInferenceTests.swift
@@ -1,0 +1,164 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Tool-call format inference")
+struct ToolCallFormatInferenceTests {
+
+    // MARK: - Chat template signatures
+
+    @Test(
+        "Each dialect is recognized by its template markers",
+        arguments: [
+            ("<minimax:tool_call>{...}</minimax:tool_call>", ToolCallFormat.minimaxM2),
+            (#"<|tool_call>call:{{ name }}{...}<tool_call|>"#, .gemma4),
+            ("<start_function_call>call:{{ name }}<end_function_call>", .gemma),
+            ("<arg_key>{{ key }}</arg_key><arg_value>{{ value }}</arg_value>", .glm4),
+            ("<|tool_list_start|>[{{ tools }}]<|tool_list_end|>", .lfm2),
+            ("<tool_call>\n<function={{ name }}>", .xmlFunction),
+            ("<|tool_calls_section_begin|>functions.{{ name }}", .kimiK2),
+            ("[TOOL_CALLS]{{ name }}[ARGS]", .mistral),
+            (#"<tool_call>{"name": "{{ tool_call.name }}"}</tool_call>"#, .json),
+        ] as [(String, ToolCallFormat)]
+    )
+    func recognizesDialect(template: String, expected: ToolCallFormat) {
+        #expect(ToolCallFormat.inferred(fromChatTemplate: template) == expected)
+    }
+
+    @Test("A template escaping its newline still selects the XML dialect")
+    func recognizesEscapedNewlineInXMLTemplate() {
+        #expect(
+            ToolCallFormat.inferred(fromChatTemplate: #"<tool_call>\n<function={{ name }}>"#)
+                == .xmlFunction)
+    }
+
+    @Test("The XML dialect outranks the generic JSON signature")
+    func specificSignatureWinsOverGeneric() {
+        // A Qwen3-Coder style template mentions both; the JSON signature is the
+        // broadest and must not shadow the dialect the model actually emits.
+        let template = """
+            {% if tool_call.name %}<tool_call>
+            <function={{ tool_call.name }}></tool_call>{% endif %}
+            """
+        #expect(ToolCallFormat.inferred(fromChatTemplate: template) == .xmlFunction)
+    }
+
+    @Test("A template with no tool syntax infers nothing")
+    func templateWithoutToolSyntaxInfersNothing() {
+        #expect(
+            ToolCallFormat.inferred(fromChatTemplate: "{{ messages[0]['content'] }}") == nil)
+        #expect(ToolCallFormat.inferred(fromChatTemplate: "") == nil)
+    }
+
+    // MARK: - Declared parser names
+
+    @Test(
+        "A declared parser name maps to its dialect",
+        arguments: [
+            ("qwen3_coder", ToolCallFormat.xmlFunction),
+            ("qwen3_xml", .xmlFunction),
+            ("function_gemma", .gemma),
+            ("gemma4", .gemma4),
+            ("glm47", .glm4),
+            ("pythonic", .lfm2),
+            ("kimi_k2", .kimiK2),
+            ("mistral", .mistral),
+            ("minimax_m2", .minimaxM2),
+            ("json_tools", .json),
+        ] as [(String, ToolCallFormat)]
+    )
+    func mapsDeclaredParserName(name: String, expected: ToolCallFormat) {
+        #expect(ToolCallFormat(toolParserType: name) == expected)
+    }
+
+    @Test("An unknown parser name maps to nothing")
+    func unknownParserNameMapsToNothing() {
+        #expect(ToolCallFormat(toolParserType: "not_a_parser") == nil)
+    }
+
+    // MARK: - Reading a checkpoint
+
+    @Test("The chat template in the tokenizer config is used")
+    func readsTemplateFromTokenizerConfig() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"{"chat_template": "[TOOL_CALLS]{{ name }}[ARGS]"}"#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .mistral)
+    }
+
+    @Test("A named template list resolves through its default entry")
+    func readsNamedTemplateList() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"""
+            {"chat_template": [
+                {"name": "tool_use", "template": "<arg_key>x</arg_key>"},
+                {"name": "default", "template": "<|tool_list_start|>"}
+            ]}
+            """#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .lfm2)
+    }
+
+    @Test("A sidecar chat template file is used when the config has none")
+    func readsSidecarTemplateFile() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"{"eos_token": "</s>"}"#,
+            "chat_template.jinja": "<|tool_calls_section_begin|>",
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .kimiK2)
+    }
+
+    @Test("A declared parser type overrides what the template implies")
+    func declaredParserTypeWinsOverTemplate() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"""
+            {"tool_parser_type": "qwen3_coder", "chat_template": "[TOOL_CALLS]"}
+            """#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .xmlFunction)
+    }
+
+    @Test("A checkpoint with nothing to go on resolves to nothing")
+    func missingOrUnreadableFilesResolveToNothing() throws {
+        let empty = try TokenizerFixture.make([:])
+        defer { TokenizerFixture.remove(empty) }
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: empty) == nil)
+
+        let malformed = try TokenizerFixture.make(["tokenizer_config.json": "{not json"])
+        defer { TokenizerFixture.remove(malformed) }
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: malformed) == nil)
+
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: URL(fileURLWithPath: "/nonexistent-checkpoint")) == nil)
+    }
+}
+
+/// A throwaway directory holding tokenizer files.
+private enum TokenizerFixture {
+    static func make(_ files: [String: String]) throws -> URL {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(component: "tool-format-inference-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        for (name, contents) in files {
+            try contents.write(
+                to: directory.appending(component: name), atomically: true, encoding: .utf8)
+        }
+        return directory
+    }
+
+    static func remove(_ directory: URL) {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}

--- a/Tests/MLXLMTests/ToolCallFormatInferenceTests.swift
+++ b/Tests/MLXLMTests/ToolCallFormatInferenceTests.swift
@@ -91,8 +91,8 @@ struct ToolCallFormatInferenceTests {
         #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .mistral)
     }
 
-    @Test("A named template list resolves through its default entry")
-    func readsNamedTemplateList() throws {
+    @Test("A named template list prefers tool_use for format inference")
+    func namedTemplateListPrefersToolUse() throws {
         let directory = try TokenizerFixture.make([
             "tokenizer_config.json": #"""
             {"chat_template": [
@@ -103,7 +103,114 @@ struct ToolCallFormatInferenceTests {
         ])
         defer { TokenizerFixture.remove(directory) }
 
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .glm4)
+    }
+
+    @Test("Hermes tool_use refines the heuristic Llama 3 declaration to framed JSON")
+    func hermesTemplateListRefinesLlama3Format() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"""
+            {"chat_template": [
+                {"name": "default", "template": "{{ bos_token }}{{ messages }}"},
+                {"name": "tool_use", "template": "For each function call return a json object within <tool_call></tool_call>: <tool_call>{\"name\": {{ tool_call.name }}, \"arguments\": {}}</tool_call>"}
+            ]}
+            """#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        let format = ToolCallFormat.resolved(
+            forTokenizerDirectory: directory, modelFormat: .llama3)
+        #expect(format == .json)
+
+        let processor = ToolCallProcessor(format: try #require(format))
+        #expect(processor.processChunk("<tool_call>\n") == nil)
+        #expect(
+            processor.processChunk(
+                #"{"name":"get_weather","arguments":{"location":"Paris"}}"#) == nil)
+        #expect(processor.processChunk("\n</tool_call>") == nil)
+        #expect(processor.toolCalls.count == 1)
+        let call = try #require(processor.toolCalls.first)
+        #expect(call.function.name == "get_weather")
+        #expect(call.function.arguments == ["location": .string("Paris")])
+        #expect(call.id != nil)
+    }
+
+    @Test("A compatible model superset is preserved over template inference")
+    func compatibleModelFormatIsPreserved() throws {
+        let xmlDirectory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"{"chat_template":"<tool_call>\n<function={{ name }}>"}"#
+        ])
+        defer { TokenizerFixture.remove(xmlDirectory) }
+
+        let jsonDirectory = try TokenizerFixture.make([
+            "tokenizer_config.json":
+                #"{"chat_template":"<tool_call>{{ tool_call.name }}</tool_call>"}"#
+        ])
+        defer { TokenizerFixture.remove(jsonDirectory) }
+
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: xmlDirectory, modelFormat: .qwen35) == .qwen35)
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: jsonDirectory, modelFormat: .qwen35) == .qwen35)
+    }
+
+    @Test("A model declaration is used when the selected template has no known dialect")
+    func modelFormatIsFallbackForUnknownTemplate() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"{"chat_template":"{{ messages }}"}"#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: directory, modelFormat: .llama3) == .llama3)
+    }
+
+    @Test("A complete response protocol is not replaced by payload inference")
+    func protocolFormatIsAuthoritative() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json":
+                #"{"chat_template":"<tool_call>{{ tool_call.name }}</tool_call>"}"#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: directory, modelFormat: .gptOSS) == .gptOSS)
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: directory, modelFormat: .atem) == .atem)
+    }
+
+    @Test("A named template list falls back to default without tool_use")
+    func namedTemplateListFallsBackToDefault() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"""
+            {"chat_template": [
+                {"name": "other", "template": "<arg_key>x</arg_key>"},
+                {"name": "default", "template": "<|tool_list_start|>"}
+            ]}
+            """#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
         #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .lfm2)
+    }
+
+    @Test("An unselected named template is not used for inference")
+    func namedTemplateListWithoutAutomaticChoiceResolvesToNothing() throws {
+        let directory = try TokenizerFixture.make([
+            "tokenizer_config.json": #"""
+            {"chat_template": [
+                {"name": "other", "template": "<arg_key>x</arg_key>"}
+            ]}
+            """#
+        ])
+        defer { TokenizerFixture.remove(directory) }
+
+        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == nil)
     }
 
     @Test("A sidecar chat template file is used when the config has none")
@@ -126,7 +233,9 @@ struct ToolCallFormatInferenceTests {
         ])
         defer { TokenizerFixture.remove(directory) }
 
-        #expect(ToolCallFormat.resolved(forTokenizerDirectory: directory) == .xmlFunction)
+        #expect(
+            ToolCallFormat.resolved(
+                forTokenizerDirectory: directory, modelFormat: .llama3) == .xmlFunction)
     }
 
     @Test("A checkpoint with nothing to go on resolves to nothing")

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -859,8 +859,74 @@ struct ToolTests {
         #expect(toolCall.function.name == "search_many")
         #expect(
             toolCall.function.arguments["queries"] == .array([.string("swift"), .string("mlx")]))
-        // Bare scalars are typed from the tool schema; without one they stay literal.
-        #expect(toolCall.function.arguments["limit"] == .string("2"))
+        #expect(toolCall.function.arguments["limit"] == .int(2))
+    }
+
+    @Test("Pythonic collections accept Python literal syntax")
+    func testPythonicParserPythonLiteralCollections() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+        let content = #"""
+            <|tool_call_start|>[configure(settings={'location': 'Tokyo', 'enabled': True, 'fallback': None, 'thresholds': [0, 1.5]})]<|tool_call_end|>
+            """#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(
+            toolCall.function.arguments["settings"]
+                == .object([
+                    "location": .string("Tokyo"),
+                    "enabled": .bool(true),
+                    "fallback": .null,
+                    "thresholds": .array([.int(0), .double(1.5)]),
+                ]))
+    }
+
+    @Test("Pythonic scalars are inferred without a schema")
+    func testPythonicParserUnschematizedScalars() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+        let content = #"""
+            <|tool_call_start|>[configure(count=5, ratio=1.5, enabled=True, disabled=False, fallback=None, mode=fast)]<|tool_call_end|>
+            """#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.arguments["count"] == .int(5))
+        #expect(toolCall.function.arguments["ratio"] == .double(1.5))
+        #expect(toolCall.function.arguments["enabled"] == .bool(true))
+        #expect(toolCall.function.arguments["disabled"] == .bool(false))
+        #expect(toolCall.function.arguments["fallback"] == .null)
+        #expect(toolCall.function.arguments["mode"] == .string("fast"))
+    }
+
+    @Test("Pythonic scalar inference does not override a declared string schema")
+    func testPythonicParserDeclaredStringsRemainStrings() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+        let stringProperties: [String: any Sendable] = [
+            "count": ["type": "string"] as [String: any Sendable],
+            "enabled": ["type": "string"] as [String: any Sendable],
+            "fallback": ["type": "string"] as [String: any Sendable],
+        ]
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "configure",
+                    "parameters": ["properties": stringProperties]
+                        as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content = #"""
+            <|tool_call_start|>[configure(count=5, enabled=True, fallback=None)]<|tool_call_end|>
+            """#
+
+        let toolCall = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(toolCall.function.arguments["count"] == .string("5"))
+        #expect(toolCall.function.arguments["enabled"] == .string("True"))
+        #expect(toolCall.function.arguments["fallback"] == .string("None"))
     }
 
     @Test("Test Pythonic Tool Call Parser - Object Value Is Not Unwrapped Alongside Another")
@@ -1440,7 +1506,7 @@ struct ToolTests {
         let toolCall4 = try #require(parser.parse(content: content4, tools: nil))
         #expect(toolCall4.function.name == "calculate")
         #expect(toolCall4.function.arguments["expression"] == .string("2 + 2"))
-        #expect(toolCall4.function.arguments["precision"] == .string("4"))
+        #expect(toolCall4.function.arguments["precision"] == .int(4))
 
         // Multiple JSON list format via parseEOS
         let content5 = """

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -830,6 +830,84 @@ struct ToolTests {
         #expect(toolCalls2[1].function.arguments["timezone"] == .string("UTC"))
     }
 
+    @Test("Pythonic argument values may contain the closing delimiters")
+    func testPythonicParserDelimitersInsideValue() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+
+        // `)]` closes the call for a scanner that is not quote aware, which
+        // truncated the value and left the stray quote behind.
+        let quoted = "<|tool_call_start|>[notify(note='a)]b')]<|tool_call_end|>"
+        let quotedCall = try #require(parser.parse(content: quoted, tools: nil))
+        #expect(quotedCall.function.name == "notify")
+        #expect(quotedCall.function.arguments["note"] == .string("a)]b"))
+
+        let object = #"<|tool_call_start|>[notify(filters={"x": "a)]b"})]<|tool_call_end|>"#
+        let objectCall = try #require(parser.parse(content: object, tools: nil))
+        #expect(objectCall.function.arguments["filters"] == .object(["x": .string("a)]b")]))
+    }
+
+    @Test("Test Pythonic Tool Call Parser - Array Value With Inner Commas")
+    func testPythonicParserArrayValue() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+        let content =
+            #"<|tool_call_start|>[search_many(queries=["swift", "mlx"], limit=2)]<|tool_call_end|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "search_many")
+        #expect(
+            toolCall.function.arguments["queries"] == .array([.string("swift"), .string("mlx")]))
+        // Bare scalars are typed from the tool schema; without one they stay literal.
+        #expect(toolCall.function.arguments["limit"] == .string("2"))
+    }
+
+    @Test("Test Pythonic Tool Call Parser - Object Value Is Not Unwrapped Alongside Another")
+    func testPythonicParserWrapperGuardWithSecondArgument() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+        // A wrapper name is only a wrapper when it is the *sole* argument.
+        let content =
+            #"<|tool_call_start|>[get_weather(properties={"location": "Paris"}, units='c')]<|tool_call_end|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.arguments.count == 2)
+        #expect(
+            toolCall.function.arguments["properties"] == .object(["location": .string("Paris")]))
+        #expect(toolCall.function.arguments["units"] == .string("c"))
+        #expect(toolCall.function.arguments["location"] == nil)
+    }
+
+    @Test("Test Pythonic Tool Call Parser - Wrapper Object via parseEOS")
+    func testPythonicParserWrapperObjectViaEOS() throws {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+        let content =
+            #"<|tool_call_start|>[get_weather(properties={"location": "Paris"}), current_time(properties={"timezone": "UTC"})]<|tool_call_end|>"#
+
+        let toolCalls = parser.parseEOS(content, tools: nil)
+
+        #expect(toolCalls.count == 2)
+        #expect(toolCalls.first?.function.name == "get_weather")
+        #expect(toolCalls.first?.function.arguments["location"] == .string("Paris"))
+        #expect(toolCalls.last?.function.name == "current_time")
+        #expect(toolCalls.last?.function.arguments["timezone"] == .string("UTC"))
+    }
+
+    @Test("Test Pythonic Tool Call Parser - Unbalanced Bracket Is Not A Call")
+    func testPythonicParserUnbalancedBracket() {
+        let parser = PythonicToolCallParser(
+            startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
+
+        // A truncated list is incomplete output, not a call that is ready to run.
+        #expect(
+            parser.parse(
+                content: "<|tool_call_start|>[notify(note='hi')<|tool_call_end|>", tools: nil)
+                == nil)
+    }
+
     @Test("Test Pythonic Tool Call Parser - Type Conversion")
     func testPythonicParserTypeConversion() throws {
         let parser = PythonicToolCallParser(
@@ -1185,6 +1263,73 @@ struct ToolTests {
         #expect(toolCall.function.arguments["mailbox"] == .string("INBOX"))
         #expect(toolCall.function.arguments["id"] == .int(158_348))
         #expect(toolCall.function.arguments["id"] != .string("158348"))
+    }
+
+    @Test("Gemma keeps a nested object value whole")
+    func testGemmaNestedObjectValue() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let content = #"<|tool_call>call:search{filters:{"city":"Paris","limit":1}}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "search")
+        // The comma inside the object must not split the value, and the tail of
+        // a split value must not become an argument of its own.
+        #expect(toolCall.function.arguments.count == 1)
+        #expect(
+            toolCall.function.arguments["filters"]
+                == .object(["city": .string("Paris"), "limit": .int(1)]))
+    }
+
+    @Test("Gemma keeps an array value whole")
+    func testGemmaArrayValue() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let content = #"<|tool_call>call:notify{ids:[1,2,3],urgent:true}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.arguments.count == 2)
+        // The array survives its inner commas, and `1` stays an integer rather
+        // than being rewritten as a boolean on the way into `JSONValue`.
+        #expect(toolCall.function.arguments["ids"] == .array([.int(1), .int(2), .int(3)]))
+        // Bare scalars are typed from the tool schema; without one they stay literal.
+        #expect(toolCall.function.arguments["urgent"] == .string("true"))
+    }
+
+    @Test("Gemma escaped values may contain protocol punctuation")
+    func testGemmaEscapedValuePunctuation() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let content =
+            #"<|tool_call>call:notify{note:<|"|>a, b} and {c<|"|>,seen:false}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.arguments.count == 2)
+        #expect(toolCall.function.arguments["note"] == .string("a, b} and {c"))
+        #expect(toolCall.function.arguments["seen"] == .string("false"))
+    }
+
+    @Test("Test Gemma 4 Format via ToolCallProcessor")
+    func testGemma4FormatProcessor() throws {
+        let processor = ToolCallProcessor(format: .gemma4)
+        let content = #"<|tool_call>call:get_weather{city:<|"|>Tokyo<|"|>}<tool_call|>"#
+
+        // Delivered one character at a time: the streaming path has to reassemble
+        // the asymmetric Gemma 4 tags before the parser ever sees them.
+        var visible = ""
+        for character in content {
+            if let text = processor.processChunk(String(character)) { visible += text }
+        }
+        processor.processEOS()
+
+        #expect(visible.isEmpty)
+        #expect(processor.toolCalls.count == 1)
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["city"] == .string("Tokyo"))
     }
 
     @Test("Test Gemma Format via ToolCallProcessor")

--- a/skills/mlx-swift-lm/references/tool-calling.md
+++ b/skills/mlx-swift-lm/references/tool-calling.md
@@ -187,21 +187,23 @@ let processor = ToolCallProcessor(
 
 ## Format Resolution
 
-When a model is loaded, the factories resolve the format in this order and stop
-at the first answer:
+When a model is loaded, the factories resolve the format in this order:
 
 1. an explicit value on the `ModelConfiguration` (registry entry or caller),
 2. a `ChatConventionsResolving` registered with `ChatConventionsRegistry`
    (keyed on repo id / model type, for conventions the model cannot know),
-3. the model's own `ChatConventionsProviding` declaration, e.g.
-   `public var toolCallFormat: ToolCallFormat? { .gemma4 }`,
-4. the checkpoint's tokenizer files — a `tool_parser_type` entry if present,
-   otherwise inference from the chat template.
+3. an explicit `tool_parser_type` in the checkpoint's tokenizer files,
+4. the selected tool template reconciled with the model's own
+   `ChatConventionsProviding` declaration.
 
 Nothing resolved means the default `.json` parser is used.
 
-Step 4 covers checkpoints whose architecture declares no format, since the chat
-template is what teaches the model to emit a given dialect:
+At step 4, the model declaration remains selected when it can parse the template's
+dialect. Otherwise, the template refines it because the template is what teaches
+the model what to emit. This lets Qwen 3.5 keep its dual-dialect parser while a
+Hermes checkpoint can refine the Llama 3 architecture heuristic from inline JSON
+to framed JSON. If the template has no recognizable tool syntax, the model
+declaration remains the fallback.
 
 ```swift
 ToolCallFormat.inferred(fromChatTemplate: template)  // -> .mistral, .glm4, ...

--- a/skills/mlx-swift-lm/references/tool-calling.md
+++ b/skills/mlx-swift-lm/references/tool-calling.md
@@ -185,17 +185,31 @@ let processor = ToolCallProcessor(
 )
 ```
 
-## Format Auto-Detection
+## Format Resolution
 
-Formats are auto-detected from model type:
+When a model is loaded, the factories resolve the format in this order and stop
+at the first answer:
+
+1. an explicit value on the `ModelConfiguration` (registry entry or caller),
+2. a `ChatConventionsResolving` registered with `ChatConventionsRegistry`
+   (keyed on repo id / model type, for conventions the model cannot know),
+3. the model's own `ChatConventionsProviding` declaration, e.g.
+   `public var toolCallFormat: ToolCallFormat? { .gemma4 }`,
+4. the checkpoint's tokenizer files — a `tool_parser_type` entry if present,
+   otherwise inference from the chat template.
+
+Nothing resolved means the default `.json` parser is used.
+
+Step 4 covers checkpoints whose architecture declares no format, since the chat
+template is what teaches the model to emit a given dialect:
 
 ```swift
-// Auto-detected based on model_type in config.json
-ToolCallFormat.infer(from: "lfm2")     // -> .lfm2
-ToolCallFormat.infer(from: "glm4")     // -> .glm4
-ToolCallFormat.infer(from: "gemma")    // -> .gemma
-ToolCallFormat.infer(from: "llama")    // -> nil (use default .json)
+ToolCallFormat.inferred(fromChatTemplate: template)  // -> .mistral, .glm4, ...
+ToolCallFormat(toolParserType: "qwen3_coder")        // -> .xmlFunction
 ```
+
+Protocols with token-level framing (`.gptOSS`, `.atem`) are deliberately not
+inferred from templates — they are selected by the models that own them.
 
 ### Explicit Format in Configuration
 


### PR DESCRIPTION
## Proposed changes

Let's continue after #529.
This PR fixes three bugs in how tool calls are read back from models, and adds a fallback so models that aren't explicitly recognized still get their tool calls parsed. It's one PR because the first two bugs share a single root cause and are fixed by one new shared component.

**1. Argument values were being silently cut off (closes #493)**

Two formats — Pythonic (used by LFM2) and Gemma — write arguments separated by punctuation, like `notify(note='hello', count=2)`. Both used a simple text search to find those separators, so any value that happened to *contain* one was truncated:

- Pythonic: `notify(note='a)]b')` produced `note = "'a"` — the value was cut at `)]` and a stray quote was left behind.
- Gemma: `call:search{filters:{"city":"Paris","limit":1}}` cut the value at the first comma **and turned the leftover text into an invented second argument** that the model never asked for.

Both now use a new shared `StructuredTextScanner`, which understands that text inside quotes, inside Gemma's escape markers, or inside nested brackets is part of a value and not punctuation. This also replaces two other hand-written copies of the same logic elsewhere in the codebase, so there is now one implementation instead of three.

**2. The numbers 0 and 1 were being turned into `false` and `true`**

Found while testing the above. When an argument value was decoded as JSON, `{"limit": 1}` came out as `{"limit": true}`. The cause is a Foundation detail: a boxed number holding 0 or 1 can be read as a boolean, and the conversion tried that first. This affected **nine** of the tool-call formats and broke tool execution whenever a tool declared a whole-number parameter.

**3. Missing test coverage (closes #495)**

Adds the three Pythonic parser tests requested in the issue: an array value containing commas, a two-argument call asserting the object is *not* unwrapped, and the multi-call `parseEOS` path.

**4. Unrecognized models now get their tool calls parsed**

Previously, if a model's architecture didn't explicitly declare which tool-call format it uses, the library assumed plain JSON — so any model using a different format had every tool call silently pass through as ordinary text. The chat template shipped with a model is what teaches it to write calls in a particular format, so it can be used to identify that format. The library now reads it as a **last** resort, only after the existing checks have all come up empty, so no currently-working model changes behavior. This mirrors the equivalent logic in the Python mlx-lm library, and also honors a `tool_parser_type` entry when a model ships one.

@CharlieTLe FYI

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)



