### PR TITLE
Enforce copy semantics on LogitProcessor for speculative decoding (#508)

### DIFF
--- a/Libraries/MLXGuidedGeneration/CompositeLogitProcessor.swift
+++ b/Libraries/MLXGuidedGeneration/CompositeLogitProcessor.swift
@@ -19,6 +19,10 @@ public struct CompositeLogitProcessor: LogitProcessor {
         self.processors = processors
     }
 
+    public func copy() -> Self {
+        CompositeLogitProcessor(processors.map { $0.copy() })
+    }
+
     public mutating func prompt(_ prompt: MLXArray) {
         for i in processors.indices {
             processors[i].prompt(prompt)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -41,6 +41,31 @@ public protocol LogitProcessor {
 
     /// Called to provide the sampled token
     mutating func didSample(token: MLXArray)
+
+    /// Returns an independent copy of this processor.
+    ///
+    /// Value types (structs) obtain an independent copy via standard value semantics
+    /// by default. Reference types (classes) must explicitly implement this method to
+    /// produce a distinct instance; classes that do not provide an implementation trap.
+    func copy() -> Self
+}
+
+extension LogitProcessor {
+    public func copy() -> Self {
+        self
+    }
+}
+
+extension LogitProcessor where Self: AnyObject {
+    public func copy() -> Self {
+        fatalError(
+            """
+            \(Self.self) is a reference type conforming to LogitProcessor but does not implement copy(). \
+            Reference-type processors must explicitly implement copy() to support isolated state scoping \
+            in speculative decoding and verification passes.
+            """
+        )
+    }
 }
 
 /// Parameters for text generation, see ``TokenIterator``.
@@ -607,6 +632,10 @@ public struct ChainedLogitProcessor: LogitProcessor {
         self.processors = processors
     }
 
+    public func copy() -> Self {
+        Self(processors: processors.map { $0.copy() })
+    }
+
     mutating public func prompt(_ prompt: MLXArray) {
         for index in processors.indices {
             processors[index].prompt(prompt)
@@ -1155,7 +1184,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         // Draft generation: autoregressive loop with draft model
-        var draftProcessor = processor  // Copy to discard later
+        var draftProcessor = processor?.copy()  // Copy to discard later
         var draftTokens = [MLXArray]()
         var draftState: LMOutput.State?
         for _ in 0 ..< numDraft {
@@ -1182,7 +1211,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         state = mainResult.state
 
         let mainTokens: MLXArray
-        if var verifyProcessor = processor {
+        if var verifyProcessor = processor?.copy() {
             // Process each position sequentially so that the processor sees tokens sampled at earlier positions
             var sampled = [MLXArray]()
             for i in 0 ..< (numDraft + 1) {

--- a/Tests/MLXGuidedGenerationTests/CompositeLogitProcessorTests.swift
+++ b/Tests/MLXGuidedGenerationTests/CompositeLogitProcessorTests.swift
@@ -125,4 +125,18 @@ struct CompositeLogitProcessorTests {
         let result = composite.process(logits: input)
         #expect(result.shape == input.shape)
     }
+
+    @Test
+    func copyProducesIndependentProcessors() {
+        var first = AddConstantProcessor(constant: 1.0)
+        var composite = CompositeLogitProcessor([first])
+        var cloned = composite.copy()
+
+        cloned.didSample(token: MLXArray(UInt32(10)))
+
+        let origResult = composite.process(logits: MLXArray([0.0] as [Float]))
+        let clonedResult = cloned.process(logits: MLXArray([0.0] as [Float]))
+        #expect(origResult.asArray(Float.self) == [1.0])
+        #expect(clonedResult.asArray(Float.self) == [1.0])
+    }
 }

--- a/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
+++ b/Tests/MLXLMTests/MTPSpeculativeTokenIteratorTests.swift
@@ -562,6 +562,12 @@ private final class EmissionLog: LogitProcessor {
     func didSample(token: MLXArray) {
         recordedTokens.append(token.item(Int.self))
     }
+
+    func copy() -> Self {
+        let copy = EmissionLog()
+        copy.recordedTokens = recordedTokens
+        return copy as! Self
+    }
 }
 
 /// The canonical processor advances only for emitted tokens. In particular,

--- a/Tests/MLXLMTests/SampleTests.swift
+++ b/Tests/MLXLMTests/SampleTests.swift
@@ -472,4 +472,79 @@ public class SampleTests: XCTestCase {
         XCTAssertEqual(values[2], 3.0, accuracy: 1e-6)
         XCTAssertEqual(values[3], 3.25, accuracy: 1e-6)
     }
+
+    private struct StatefulStructProcessor: LogitProcessor {
+        var seenTokens: [Int] = []
+
+        mutating func prompt(_ prompt: MLXArray) {
+            seenTokens.append(contentsOf: prompt.asArray(Int.self))
+        }
+
+        func process(logits: MLXArray) -> MLXArray { logits }
+
+        mutating func didSample(token: MLXArray) {
+            seenTokens.append(token.item(Int.self))
+        }
+    }
+
+    private final class StatefulClassProcessorWithCopy: LogitProcessor {
+        var seenTokens: [Int]
+
+        init(seenTokens: [Int] = []) {
+            self.seenTokens = seenTokens
+        }
+
+        func prompt(_ prompt: MLXArray) {
+            seenTokens.append(contentsOf: prompt.asArray(Int.self))
+        }
+
+        func process(logits: MLXArray) -> MLXArray { logits }
+
+        func didSample(token: MLXArray) {
+            seenTokens.append(token.item(Int.self))
+        }
+
+        func copy() -> Self {
+            StatefulClassProcessorWithCopy(seenTokens: seenTokens) as! Self
+        }
+    }
+
+    func testStructLogitProcessorCopyValueSemantics() {
+        var original = StatefulStructProcessor()
+        original.prompt(MLXArray([1, 2]))
+
+        var copy = original.copy()
+        copy.didSample(token: MLXArray([3]))
+
+        XCTAssertEqual(original.seenTokens, [1, 2])
+        XCTAssertEqual(copy.seenTokens, [1, 2, 3])
+    }
+
+    func testClassLogitProcessorCopyWithExplicitImplementation() {
+        let original = StatefulClassProcessorWithCopy(seenTokens: [1, 2])
+        let copy = original.copy()
+
+        XCTAssertFalse(original === copy, "copy() must return a distinct instance")
+        copy.didSample(token: MLXArray([3]))
+
+        XCTAssertEqual(original.seenTokens, [1, 2])
+        XCTAssertEqual(copy.seenTokens, [1, 2, 3])
+    }
+
+    func testChainedLogitProcessorCopyClonesNestedProcessors() {
+        let classProcessor = StatefulClassProcessorWithCopy(seenTokens: [10])
+        var structProcessor = StatefulStructProcessor()
+        structProcessor.prompt(MLXArray([20]))
+
+        let chained = ChainedLogitProcessor(processors: [classProcessor, structProcessor])
+        var clonedChained = chained.copy()
+
+        clonedChained.didSample(token: MLXArray([99]))
+
+        XCTAssertEqual(
+            classProcessor.seenTokens, [10],
+            "Original class processor should not be modified by clone's didSample")
+        let origLogits = MLXArray([1.0 as Float, 2.0 as Float])[.newAxis, .ellipsis]
+        _ = chained.process(logits: origLogits)
+    }
 }

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -259,6 +259,57 @@ struct SpeculativeDecodingTests {
         #expect(iterator.mainCacheStorage.nativeAttentionOffsetsAreAligned)
         #expect(iterator.draftCacheStorage.nativeAttentionOffsetsAreAligned)
     }
+
+    @Test
+    func `SpeculativeTokenIterator scopes class logit processor state via copy`() throws {
+        final class RecordingClassProcessor: LogitProcessor, @unchecked Sendable {
+            var sampledTokens: [Int]
+
+            init(sampledTokens: [Int] = []) {
+                self.sampledTokens = sampledTokens
+            }
+
+            func prompt(_ prompt: MLXArray) {}
+            func process(logits: MLXArray) -> MLXArray { logits }
+
+            func didSample(token: MLXArray) {
+                sampledTokens.append(token.item(Int.self))
+            }
+
+            func copy() -> Self {
+                RecordingClassProcessor(sampledTokens: sampledTokens) as! Self
+            }
+        }
+
+        let recordingProcessor = RecordingClassProcessor()
+        var components = GenerationComponents()
+        components.logitProcessorFactory = { recordingProcessor }
+
+        let vocabularySize = 100
+        // Mismatching draft model so some draft tokens are rejected
+        let mainModel = StableTransitionLanguageModel(vocabularySize: vocabularySize)
+        let draftModel = DivergentTransitionLanguageModel(vocabularySize: vocabularySize)
+
+        var iterator = try SpeculativeTokenIterator(
+            input: LMInput(tokens: MLXArray([10])),
+            mainModel: mainModel,
+            draftModel: draftModel,
+            parameters: GenerateParameters(maxTokens: 5, temperature: 0.0),
+            numDraftTokens: 3,
+            components: components
+        )
+
+        var emittedTokens: [Int] = []
+        while let token = iterator.next() {
+            emittedTokens.append(token)
+        }
+
+        #expect(emittedTokens.count == 5)
+        #expect(
+            recordingProcessor.sampledTokens == emittedTokens,
+            "Canonical processor didSample must match emitted tokens exactly; draft and verify copies must not pollute canonical state."
+        )
+    }
 }
 
 /// ``StableTransitionLanguageModel`` variant that maintains a real KV cache,
@@ -339,5 +390,38 @@ private final class StableTransitionLanguageModel: Module, LanguageModel, KVCach
 
     private func nextToken(after token: Int) -> Int {
         (token * 31 + 7) % vocabularySize
+    }
+}
+
+/// Deterministic causal model predicting different transitions to induce rejections in speculative decoding.
+private final class DivergentTransitionLanguageModel: Module, LanguageModel,
+    KVCacheDimensionProvider
+{
+    let vocabularySize: Int
+    var kvHeads: [Int] { [] }
+
+    init(vocabularySize: Int) {
+        self.vocabularySize = vocabularySize
+        super.init()
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenIds = inputs.asArray(Int.self)
+        var logits = Array(
+            repeating: Float(-100),
+            count: tokenIds.count * vocabularySize
+        )
+
+        for (position, token) in tokenIds.enumerated() {
+            logits[position * vocabularySize + ((token * 17 + 13) % vocabularySize)] = 100
+        }
+
+        return MLXArray(logits, [1, tokenIds.count, vocabularySize])
     }
 }


### PR DESCRIPTION
## Proposed changes

Add copy() requirement to LogitProcessor with default value semantics for structs and a fail-fast trap for reference types. Scope draft and verify passes in SpeculativeTokenIterator using copied processor state, preventing unaccepted draft and verification tokens from polluting canonical state. 

Fix #508 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
