### PR TITLE
Support video processing options in UserInput and MediaProcessing

### DIFF
--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -189,6 +189,7 @@ public struct UserInput {
     public struct Processing: Sendable {
         public var resize: CGSize?
 
+        public var video = VideoProcessing()
         public var audio = AudioProcessing()
 
         /// Optional per-call overrides for the image resize budget. When set,
@@ -199,10 +200,78 @@ public struct UserInput {
         public var minPixels: Int?
         public var maxPixels: Int?
 
-        public init(resize: CGSize? = nil, minPixels: Int? = nil, maxPixels: Int? = nil) {
+        public init(
+            resize: CGSize? = nil,
+            video: VideoProcessing = VideoProcessing(),
+            audio: AudioProcessing = AudioProcessing(),
+            minPixels: Int? = nil,
+            maxPixels: Int? = nil
+        ) {
             self.resize = resize
+            self.video = video
+            self.audio = audio
             self.minPixels = minPixels
             self.maxPixels = maxPixels
+        }
+    }
+
+    /// Representation of video processing options.
+    public struct VideoProcessing: Sendable, Equatable {
+        /// Strategy for temporal frame sampling.
+        public enum SamplingMethod: Sendable, Equatable {
+            /// Sample a fixed total count of frames distributed evenly across the video duration.
+            case targetFrames(Int)
+
+            /// Derive a target frame count from frames per second, then distribute those frames
+            /// evenly across the video duration.
+            case framesPerSecond(Double)
+        }
+
+        /// The sampling strategy to use, or `nil` to use model default behavior.
+        public var sampling: SamplingMethod?
+
+        public init(sampling: SamplingMethod? = nil) {
+            self.sampling = sampling
+        }
+
+        /// Convenience initializer to sample a fixed number of frames across the video.
+        public init(targetFrames: Int) {
+            self.sampling = .targetFrames(targetFrames)
+        }
+
+        /// Convenience initializer to target a sampling density in frames per second.
+        public init(targetFramesPerSecond: Double) {
+            self.sampling = .framesPerSecond(targetFramesPerSecond)
+        }
+
+        /// Target number of frames to sample from the video, regardless of duration.
+        public var targetFrames: Int? {
+            get {
+                if case .targetFrames(let count) = sampling { return count }
+                return nil
+            }
+            set {
+                if let newValue {
+                    sampling = .targetFrames(newValue)
+                } else if case .targetFrames = sampling {
+                    sampling = nil
+                }
+            }
+        }
+
+        /// Target frame rate (frames per second) to sample from the video.
+        public var targetFramesPerSecond: Double? {
+            get {
+                if case .framesPerSecond(let fps) = sampling { return fps }
+                return nil
+            }
+            set {
+                if let newValue {
+                    sampling = .framesPerSecond(newValue)
+                } else if case .framesPerSecond = sampling {
+                    sampling = nil
+                }
+            }
         }
     }
 

--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -6,6 +6,7 @@ import MLX
 import MLXLMCommon
 
 public typealias VideoFrame = UserInput.VideoFrame
+public typealias VideoProcessing = UserInput.VideoProcessing
 
 public struct ProcessedFrames {
     public let frames: [MLXArray]
@@ -347,70 +348,184 @@ public enum MediaProcessing {
         }
     }
 
-    static public func asProcessedSequence(
-        _ video: UserInput.Video,
-        samplesPerSecond: Int,
-        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
-    ) async throws -> ProcessedFrames {
-        return try await asProcessedSequence(
-            video,
-            targetFPS: { _ in Double(samplesPerSecond) },
-            maxFrames: Int.max,
-            frameProcessing: frameProcessing
-        )
+    static internal func sampleTimes(
+        duration: CMTime,
+        processing: UserInput.VideoProcessing,
+        targetFPS: ((CMTime) -> Double)?,
+        maxFrames: Int,
+        totalAvailableFrames: Int? = nil
+    ) -> [CMTime] {
+        let timescale = duration.timescale
+        let requestedCount: Int
+
+        if let targetFrames = processing.targetFrames {
+            requestedCount = targetFrames
+        } else {
+            let fps: Double
+            if let targetFPS = processing.targetFramesPerSecond {
+                fps = targetFPS
+            } else if let targetFPSClosure = targetFPS {
+                fps = targetFPSClosure(duration)
+            } else {
+                fps = 1.0
+            }
+            requestedCount = Int(round(duration.seconds * fps))
+        }
+
+        var count = max(min(requestedCount, maxFrames), 1)
+        if let totalAvailableFrames {
+            count = min(count, totalAvailableFrames)
+        }
+
+        if count <= 1 {
+            return [CMTime(value: 0, timescale: timescale)]
+        }
+
+        let step = Double(duration.value) / Double(count - 1)
+        return (0 ..< count).map { i in
+            let tick = Int64(round(Double(i) * step))
+            return CMTime(value: tick, timescale: timescale)
+        }
     }
 
-    static public func asProcessedSequence(
+    /// Extract and process a sequence of video frames according to video processing configuration.
+    ///
+    /// - Parameters:
+    ///   - video: The video to extract frames from (`AVAsset`, `URL`, or decoded `VideoFrame`s).
+    ///   - processing: Video processing configuration (such as `targetFrames` or `targetFramesPerSecond`).
+    ///   - targetFPS: Optional closure computing target FPS given duration; used when `processing` has neither `targetFrames` nor `targetFramesPerSecond`.
+    ///   - maxFrames: Maximum frame count budget.
+    ///   - frameProcessing: Transformation applied to each individual video frame.
+    /// - Returns: `ProcessedFrames` containing extracted MLXArray frames, timestamps, and total duration.
+    public static func asProcessedSequence(
         _ video: UserInput.Video,
-        targetFPS: (CMTime) -> Double,
+        processing: UserInput.VideoProcessing = .init(),
+        targetFPS: ((CMTime) -> Double)? = nil,
         maxFrames: Int = Int.max,
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
-
-        switch video
-        {
+        switch video {
         case .avAsset(let asset):
             try await Self.validateAsset(asset)
             return try await _asProcessedSequence(
-                asset, maxFrames: maxFrames, targetFPS: targetFPS, frameProcessing: frameProcessing)
+                asset,
+                processing: processing,
+                targetFPS: targetFPS,
+                maxFrames: maxFrames,
+                frameProcessing: frameProcessing
+            )
 
         case .url(let url):
             let asset = AVAsset(url: url)
             try await Self.validateAsset(asset)
             return try await _asProcessedSequence(
-                asset, maxFrames: maxFrames, targetFPS: targetFPS, frameProcessing: frameProcessing)
+                asset,
+                processing: processing,
+                targetFPS: targetFPS,
+                maxFrames: maxFrames,
+                frameProcessing: frameProcessing
+            )
 
         case .frames(let videoFrames):
             return try await _asProcessedSequence(
-                videoFrames, targetFPS: targetFPS, frameProcessing: frameProcessing)
+                videoFrames,
+                processing: processing,
+                targetFPS: targetFPS,
+                maxFrames: maxFrames,
+                frameProcessing: frameProcessing
+            )
+        }
+    }
+
+    /// Extract and process a sequence of video frames according to `UserInput.Processing` options.
+    public static func asProcessedSequence(
+        _ video: UserInput.Video,
+        userProcessing: UserInput.Processing,
+        targetFPS: ((CMTime) -> Double)? = nil,
+        maxFrames: Int = Int.max,
+        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
+    ) async throws -> ProcessedFrames {
+        try await asProcessedSequence(
+            video,
+            processing: userProcessing.video,
+            targetFPS: targetFPS,
+            maxFrames: maxFrames,
+            frameProcessing: frameProcessing
+        )
+    }
+
+    /// Extract and process a sequence of video frames using a dynamic target FPS function.
+    public static func asProcessedSequence(
+        _ video: UserInput.Video,
+        targetFPS: (CMTime) -> Double,
+        maxFrames: Int = Int.max,
+        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
+    ) async throws -> ProcessedFrames {
+        try await withoutActuallyEscaping(targetFPS) { targetFPS in
+            try await asProcessedSequence(
+                video,
+                processing: .init(),
+                targetFPS: targetFPS,
+                maxFrames: maxFrames,
+                frameProcessing: frameProcessing
+            )
+        }
+    }
+
+    /// Extract and process a sequence of video frames at a constant sample rate.
+    public static func asProcessedSequence(
+        _ video: UserInput.Video,
+        samplesPerSecond: Int,
+        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
+    ) async throws -> ProcessedFrames {
+        try await asProcessedSequence(
+            video,
+            processing: .init(targetFramesPerSecond: Double(samplesPerSecond)),
+            targetFPS: nil,
+            maxFrames: Int.max,
+            frameProcessing: frameProcessing
+        )
+    }
+
+    @available(
+        *, deprecated, message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
+    )
+    public static func asProcessedSequence(
+        _ asset: AVAsset, maxFrames: Int, targetFPS: (CMTime) -> Double,
+        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
+    ) async throws -> ProcessedFrames {
+        try await withoutActuallyEscaping(targetFPS) { targetFPS in
+            try await Self._asProcessedSequence(
+                asset,
+                processing: .init(),
+                targetFPS: targetFPS,
+                maxFrames: maxFrames,
+                frameProcessing: frameProcessing
+            )
         }
     }
 
     @available(
         *, deprecated, message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
     )
-    static public func asProcessedSequence(
-        _ asset: AVAsset, maxFrames: Int, targetFPS: (CMTime) -> Double,
-        frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
-    ) async throws -> ProcessedFrames {
-        return try await Self._asProcessedSequence(
-            asset, maxFrames: maxFrames, targetFPS: targetFPS, frameProcessing: frameProcessing)
-    }
-
-    @available(
-        *, deprecated, message: "Use MediaProcessing.asProcessedSequence() with the Video directly"
-    )
-    static public func asProcessedSequence(
+    public static func asProcessedSequence(
         _ asset: AVAsset, samplesPerSecond: Int,
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
         return try await _asProcessedSequence(
-            asset, maxFrames: Int.max, targetFPS: { _ in Double(samplesPerSecond) },
-            frameProcessing: frameProcessing)
+            asset,
+            processing: .init(targetFramesPerSecond: Double(samplesPerSecond)),
+            targetFPS: nil,
+            maxFrames: Int.max,
+            frameProcessing: frameProcessing
+        )
     }
 
     static private func _asProcessedSequence(
-        _ asset: AVAsset, maxFrames: Int, targetFPS: (CMTime) -> Double,
+        _ asset: AVAsset,
+        processing: UserInput.VideoProcessing,
+        targetFPS: ((CMTime) -> Double)?,
+        maxFrames: Int,
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
         // Use AVAssetImageGenerator to extract frames
@@ -424,19 +539,13 @@ public enum MediaProcessing {
                 domain: "MediaProcessing", code: -1,
                 userInfo: [NSLocalizedDescriptionKey: "Failed to load the asset's duration"])
         }
-        let fps = targetFPS(duration)
-        // Note: the round was not present in `asCIImageSequence`, so we may now be passing 1 more frame to Qwen depending on video duration.
-        let estimatedFrames = Int(round(fps * duration.seconds))
-        let desiredFrames = min(estimatedFrames, maxFrames)
-        let finalFrameCount = max(desiredFrames, 1)
 
-        let sampledTimeValues = MLXArray.linspace(
-            0, duration.value, count: Int(finalFrameCount)
-        ).asArray(Int64.self)
-
-        // Construct a CMTime using the sampled CMTimeValue's and the asset's timescale
-        let timescale = duration.timescale
-        let sampledTimes = sampledTimeValues.map { CMTime(value: $0, timescale: timescale) }
+        let sampledTimes = sampleTimes(
+            duration: duration,
+            processing: processing,
+            targetFPS: targetFPS,
+            maxFrames: maxFrames
+        )
 
         // Collect the frames
         var ciImages: [CIImage] = []
@@ -465,11 +574,13 @@ public enum MediaProcessing {
 
     static private func _asProcessedSequence(
         _ videoFrames: [VideoFrame],
-        targetFPS: (CMTime) -> Double,
+        processing: UserInput.VideoProcessing,
+        targetFPS: ((CMTime) -> Double)?,
+        maxFrames: Int,
         frameProcessing: (VideoFrame) throws -> VideoFrame = { $0 }
     ) async throws -> ProcessedFrames {
 
-        precondition(videoFrames.isEmpty == false)
+        precondition(!videoFrames.isEmpty)
 
         let startTime = videoFrames.first?.timeStamp ?? .zero
         let endTime = videoFrames.last?.timeStamp ?? .zero
@@ -477,18 +588,13 @@ public enum MediaProcessing {
 
         let duration = timeRangeOfVideoFrames.duration
 
-        let fps = targetFPS(duration)
-        // Note: the round was not present in `asCIImageSequence`, so we may now be passing 1 more frame to Qwen depending on video duration.
-        let estimatedFrames = Int(round(fps * duration.seconds))
-        let desiredFrames = min(estimatedFrames, videoFrames.count)
-        let finalFrameCount = max(desiredFrames, 1)
-
-        let sampledTimeValues = MLXArray.linspace(
-            0, duration.value, count: Int(finalFrameCount)
-        ).asArray(Int64.self)
-
-        // Construct a CMTime using the sampled CMTimeValue's and the asset's timescale
-        let timescale = duration.timescale
+        let sampledTimes = sampleTimes(
+            duration: duration,
+            processing: processing,
+            targetFPS: targetFPS,
+            maxFrames: maxFrames,
+            totalAvailableFrames: videoFrames.count
+        )
 
         // Collect the frames
         var ciImages: [CIImage] = []
@@ -498,9 +604,7 @@ public enum MediaProcessing {
         // for rationalle for the follwing timing code
 
         var frameIndex = videoFrames.startIndex
-        for value in sampledTimeValues {
-            let targetTime = CMTime(value: value, timescale: timescale)
-
+        for targetTime in sampledTimes {
             // find the last frame <= the targetTime
             var targetIndex: Int?
             while frameIndex < videoFrames.endIndex {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2747,7 +2747,10 @@ public struct Gemma4Processor: UserInputProcessor {
         var frameCounts: [Int] = []
         for video in videos {
             let sequence = try await MediaProcessing.asProcessedSequence(
-                video, targetFPS: { _ in 1.0 }, maxFrames: config.videoMaxFrames
+                video,
+                processing: processing?.video ?? .init(),
+                targetFPS: { _ in 1.0 },
+                maxFrames: config.videoMaxFrames
             ) { frame in
                 var userProcessing = processing ?? UserInput.Processing()
                 userProcessing.resize = targetSize

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -862,7 +862,9 @@ public struct Qwen25VLProcessor: UserInputProcessor {
                 var resizedSize: CGSize = .zero
 
                 let imageSequence = try await MediaProcessing.asProcessedSequence(
-                    video, targetFPS: { _ in Double(2) }
+                    video,
+                    processing: input.processing.video,
+                    targetFPS: { _ in Double(2) }
                 ) { frame in
                     // first apply the user requested resizing, etc. if any
                     let resizedImage = MediaProcessing.apply(

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -870,7 +870,9 @@ public struct Qwen2VLProcessor: UserInputProcessor {
                 var resizedSize: CGSize = .zero
 
                 let imageSequence = try await MediaProcessing.asProcessedSequence(
-                    video, targetFPS: { _ in Double(2) }
+                    video,
+                    processing: input.processing.video,
+                    targetFPS: { _ in Double(2) }
                 ) { frame in
                     // first apply the user requested resizing, etc. if any
                     let resizedImage = MediaProcessing.apply(

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -146,7 +146,9 @@ public struct Qwen3VLProcessor: UserInputProcessor {
             for video in input.videos {
                 var resizedSize: CGSize = .zero
                 let sequence = try await MediaProcessing.asProcessedSequence(
-                    video, targetFPS: { _ in Double(2) }
+                    video,
+                    processing: input.processing.video,
+                    targetFPS: { _ in Double(2) }
                 ) { frame in
                     let processed = MediaProcessing.apply(
                         try frame.image.asCIImage(), processing: input.processing)

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -321,6 +321,7 @@ public struct SmolVLMProcessor: UserInputProcessor {
 
             let processedFrames = try await MediaProcessing.asProcessedSequence(
                 video,
+                processing: input.processing.video,
                 targetFPS: { duration in
                     // 1 fps for duration >= 10s, apply a multiplier if smaller
                     max((10 - 0.9 * duration.seconds) * targetVideoFPS, 1)

--- a/Tests/MLXLMTests/MediaProcessingTests.swift
+++ b/Tests/MLXLMTests/MediaProcessingTests.swift
@@ -5,22 +5,25 @@ import CoreMedia
 import Foundation
 import MLX
 import MLXLMCommon
-import MLXVLM
 import XCTest
+
+@testable import MLXVLM
 
 public class MediaProcesingTests: XCTestCase {
 
     func testResize() {
-        // resampleBicubic should produce an image with the desired dimensions
-        let inputFilter = CIFilter(name: "CIConstantColorGenerator")!
-        inputFilter.setValue(CIColor.red, forKey: "inputColor")
-        let input = inputFilter.outputImage!.cropped(
-            to: CGRect(x: 0, y: 0, width: 1536, height: 1106))
+        Device.withDefaultDevice(.cpu) {
+            // resampleBicubic should produce an image with the desired dimensions
+            let inputFilter = CIFilter(name: "CIConstantColorGenerator")!
+            inputFilter.setValue(CIColor.red, forKey: "inputColor")
+            let input = inputFilter.outputImage!.cropped(
+                to: CGRect(x: 0, y: 0, width: 1536, height: 1106))
 
-        let target = CGSize(width: 1540, height: 1120)
-        let output = MediaProcessing.resampleBicubic(input, to: target)
+            let target = CGSize(width: 1540, height: 1120)
+            let output = MediaProcessing.resampleBicubic(input, to: target)
 
-        XCTAssertEqual(output.extent.size, target)
+            XCTAssertEqual(output.extent.size, target)
+        }
     }
 
     func testVideoFileAsSimpleProcessedSequence() async throws {
@@ -31,10 +34,11 @@ public class MediaProcesingTests: XCTestCase {
 
         let video = UserInput.Video.url(fileURL)
 
-        // We know video is exactly 5 seconds long, expect 5 samples
-        let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 1)
-
-        XCTAssert(frames.frames.count == 5)
+        try await Device.withDefaultDevice(.cpu) {
+            // We know video is exactly 5 seconds long, expect 5 samples
+            let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 1)
+            XCTAssert(frames.frames.count == 5)
+        }
     }
 
     func testVideoFileValidationThisShouldFail() async throws {
@@ -46,10 +50,12 @@ public class MediaProcesingTests: XCTestCase {
 
         let video = UserInput.Video.url(fileURL)
 
-        do {
-            let _ = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 1)
-        } catch {
-            XCTAssertEqual(error as? VLMError, VLMError.noVideoTrackFound)
+        try await Device.withDefaultDevice(.cpu) {
+            do {
+                let _ = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 1)
+            } catch {
+                XCTAssertEqual(error as? VLMError, VLMError.noVideoTrackFound)
+            }
         }
     }
 
@@ -69,17 +75,19 @@ public class MediaProcesingTests: XCTestCase {
 
         let video = UserInput.Video.url(fileURL)
 
-        // We know video is exactly 5 seconds long, expect 10 samples
-        let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
-            frame in
-            let image = preprocess(
-                image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
+        try await Device.withDefaultDevice(.cpu) {
+            // We know video is exactly 5 seconds long, expect 10 samples
+            let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
+                frame in
+                let image = preprocess(
+                    image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
 
-            return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
+                return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
+            }
+
+            XCTAssert(frames.frames.count == 10)
+            XCTAssert(frames.frames[0].shape == [1, 3, 224, 224])
         }
-
-        XCTAssert(frames.frames.count == 10)
-        XCTAssert(frames.frames[0].shape == [1, 3, 224, 224])
     }
 
     func testVideoFramesAsProcessedSequence() async throws {
@@ -115,16 +123,238 @@ public class MediaProcesingTests: XCTestCase {
 
         let video = UserInput.Video.frames(rawFrames)
 
-        // We know video is exactly 5 seconds long, expect 10 samples
-        let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
-            frame in
-            let image = preprocess(
-                image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
+        try await Device.withDefaultDevice(.cpu) {
+            // We know video is exactly 5 seconds long, expect 10 samples
+            let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 2) {
+                frame in
+                let image = preprocess(
+                    image: try frame.image.asCIImage(), resizedSize: .init(width: 224, height: 224))
 
-            return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
+                return VideoFrame.init(image: .ciImage(image), timeStamp: frame.timeStamp)
+            }
+
+            XCTAssert(frames.frames.count == 10)
+            XCTAssert(frames.frames[0].shape == [1, 3, 224, 224])
+        }
+    }
+
+    // MARK: - VideoProcessing Option Tests
+
+    func testVideoFileAsProcessedSequenceWithTargetFrames() async throws {
+        guard let fileURL = Bundle.module.url(forResource: "1080p_30", withExtension: "mov") else {
+            XCTFail("Missing file: 1080p_30.mov")
+            return
         }
 
-        XCTAssert(frames.frames.count == 10)
-        XCTAssert(frames.frames[0].shape == [1, 3, 224, 224])
+        let video = UserInput.Video.url(fileURL)
+        let videoProcessing = UserInput.VideoProcessing(targetFrames: 3)
+
+        try await Device.withDefaultDevice(.cpu) {
+            let frames = try await MediaProcessing.asProcessedSequence(
+                video,
+                processing: videoProcessing
+            )
+
+            XCTAssertEqual(frames.frames.count, 3)
+            XCTAssertEqual(frames.timestamps.count, 3)
+        }
+    }
+
+    func testVideoFileAsProcessedSequenceWithTargetFPS() async throws {
+        guard let fileURL = Bundle.module.url(forResource: "1080p_30", withExtension: "mov") else {
+            XCTFail("Missing file: 1080p_30.mov")
+            return
+        }
+
+        let video = UserInput.Video.url(fileURL)
+        let videoProcessing = UserInput.VideoProcessing(targetFramesPerSecond: 3.0)
+
+        try await Device.withDefaultDevice(.cpu) {
+            // 5 seconds @ 3 fps = 15 frames
+            let frames = try await MediaProcessing.asProcessedSequence(
+                video,
+                processing: videoProcessing
+            )
+
+            XCTAssertEqual(frames.frames.count, 15)
+            XCTAssertEqual(frames.timestamps.count, 15)
+        }
+    }
+
+    func testVideoFramesAsProcessedSequenceWithTargetFrames() async throws {
+        func testImage() -> CIImage {
+            let inputFilter = CIFilter(name: "CIConstantColorGenerator")!
+            inputFilter.setValue(CIColor.blue, forKey: "inputColor")
+            return inputFilter.outputImage!.cropped(to: CGRect(x: 0, y: 0, width: 100, height: 100))
+        }
+
+        let framerate = 30
+        var rawFrames: [VideoFrame] = []
+        for i in 0 ..< 150 {
+            let timeStamp = CMTime(value: Int64(i), timescale: Int32(framerate))
+            rawFrames.append(VideoFrame(image: .ciImage(testImage()), timeStamp: timeStamp))
+        }
+
+        let video = UserInput.Video.frames(rawFrames)
+        try await Device.withDefaultDevice(.cpu) {
+            let frames = try await MediaProcessing.asProcessedSequence(
+                video,
+                processing: .init(targetFrames: 6)
+            )
+
+            XCTAssertEqual(frames.frames.count, 6)
+            XCTAssertEqual(frames.timestamps.count, 6)
+        }
+    }
+
+    func testVideoFramesAsProcessedSequenceWithTargetFramesPerSecond() async throws {
+        func testImage() -> CIImage {
+            let inputFilter = CIFilter(name: "CIConstantColorGenerator")!
+            inputFilter.setValue(CIColor.green, forKey: "inputColor")
+            return inputFilter.outputImage!.cropped(to: CGRect(x: 0, y: 0, width: 100, height: 100))
+        }
+
+        let framerate = 30
+        var rawFrames: [VideoFrame] = []
+        for i in 0 ..< 150 {
+            let timeStamp = CMTime(value: Int64(i), timescale: Int32(framerate))
+            rawFrames.append(VideoFrame(image: .ciImage(testImage()), timeStamp: timeStamp))
+        }
+
+        let video = UserInput.Video.frames(rawFrames)
+        try await Device.withDefaultDevice(.cpu) {
+            // 5s duration * 4.0 fps = 20 frames
+            let frames = try await MediaProcessing.asProcessedSequence(
+                video,
+                processing: .init(targetFramesPerSecond: 4.0)
+            )
+
+            XCTAssertEqual(frames.frames.count, 20)
+            XCTAssertEqual(frames.timestamps.count, 20)
+        }
+    }
+
+    func testVideoProcessingWithUserInputProcessingWrapper() async throws {
+        func testImage() -> CIImage {
+            let inputFilter = CIFilter(name: "CIConstantColorGenerator")!
+            inputFilter.setValue(CIColor.red, forKey: "inputColor")
+            return inputFilter.outputImage!.cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64))
+        }
+
+        let rawFrames = (0 ..< 60).map {
+            VideoFrame(
+                image: .ciImage(testImage()), timeStamp: CMTime(value: Int64($0), timescale: 30))
+        }
+        let video = UserInput.Video.frames(rawFrames)
+
+        let userInputProcessing = UserInput.Processing(video: .init(targetFrames: 4))
+        try await Device.withDefaultDevice(.cpu) {
+            let frames = try await MediaProcessing.asProcessedSequence(
+                video,
+                userProcessing: userInputProcessing
+            )
+
+            XCTAssertEqual(frames.frames.count, 4)
+        }
+    }
+
+    func testVideoProcessingAmbiguousInitInference() async throws {
+        func testImage() -> CIImage {
+            let inputFilter = CIFilter(name: "CIConstantColorGenerator")!
+            inputFilter.setValue(CIColor.red, forKey: "inputColor")
+            return inputFilter.outputImage!.cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64))
+        }
+
+        let rawFrames = (0 ..< 60).map {
+            VideoFrame(
+                image: .ciImage(testImage()), timeStamp: CMTime(value: Int64($0), timescale: 30))
+        }
+        let video = UserInput.Video.frames(rawFrames)
+
+        try await Device.withDefaultDevice(.cpu) {
+            // Calling processing: .init() should cleanly and unambiguously resolve to VideoProcessing
+            let frames = try await MediaProcessing.asProcessedSequence(
+                video,
+                processing: .init()
+            )
+
+            XCTAssertGreaterThan(frames.frames.count, 0)
+        }
+    }
+
+    func testSampleTimesHelper() {
+        let timescale: Int32 = 600
+        let duration5s = CMTime(seconds: 5.0, preferredTimescale: timescale)
+
+        // 1. targetFrames spans across endpoints: [0, 2.5s, 5.0s]
+        let times1 = MediaProcessing.sampleTimes(
+            duration: duration5s,
+            processing: .init(targetFrames: 3),
+            targetFPS: nil,
+            maxFrames: 50
+        )
+        XCTAssertEqual(times1.map { $0.seconds }, [0.0, 2.5, 5.0])
+
+        // 2. targetFramesPerSecond derives the count and spans the full duration
+        // 5s @ 2 FPS -> 10 uniformly distributed frames including both endpoints
+        let times2 = MediaProcessing.sampleTimes(
+            duration: duration5s,
+            processing: .init(targetFramesPerSecond: 2.0),
+            targetFPS: nil,
+            maxFrames: 50
+        )
+        XCTAssertEqual(times2.count, 10)
+        XCTAssertEqual(
+            times2.map(\.value), [0, 333, 667, 1000, 1333, 1667, 2000, 2333, 2667, 3000])
+
+        // 3. Fallback targetFPS closure preserves the previous full-duration sampling behavior
+        let times3 = MediaProcessing.sampleTimes(
+            duration: duration5s,
+            processing: .init(),
+            targetFPS: { _ in 1.0 },
+            maxFrames: 50
+        )
+        XCTAssertEqual(times3.map { $0.seconds }, [0.0, 1.25, 2.5, 3.75, 5.0])
+
+        // 4. Clamping with maxFrames still covers the entire video
+        let times4 = MediaProcessing.sampleTimes(
+            duration: duration5s,
+            processing: .init(targetFramesPerSecond: 2.0),
+            targetFPS: nil,
+            maxFrames: 4
+        )
+        XCTAssertEqual(times4.map(\.value), [0, 1000, 2000, 3000])
+
+        // 5. Clamping with totalAvailableFrames
+        let times5 = MediaProcessing.sampleTimes(
+            duration: duration5s,
+            processing: .init(targetFrames: 10),
+            targetFPS: nil,
+            maxFrames: 50,
+            totalAvailableFrames: 2
+        )
+        XCTAssertEqual(times5.count, 2)
+        XCTAssertEqual(times5.map { $0.seconds }, [0.0, 5.0])
+
+        // 6. Clamping FPS sampling to the available frames still covers the entire video
+        let times6 = MediaProcessing.sampleTimes(
+            duration: duration5s,
+            processing: .init(targetFramesPerSecond: 4.0),
+            targetFPS: nil,
+            maxFrames: 50,
+            totalAvailableFrames: 2
+        )
+        XCTAssertEqual(times6.map { $0.seconds }, [0.0, 5.0])
+
+        // 7. Minimum 1 frame guarantee for 0-duration or empty requests
+        let duration0s = CMTime(seconds: 0.0, preferredTimescale: timescale)
+        let times7 = MediaProcessing.sampleTimes(
+            duration: duration0s,
+            processing: .init(targetFrames: 0),
+            targetFPS: nil,
+            maxFrames: 10
+        )
+        XCTAssertEqual(times7.count, 1)
+        XCTAssertEqual(times7[0].value, 0)
     }
 }

--- a/Tests/MLXLMTests/UserInputTests.swift
+++ b/Tests/MLXLMTests/UserInputTests.swift
@@ -447,4 +447,67 @@ public class UserInputTests: XCTestCase {
         XCTAssertNil(messages[0]["tool_calls"])
     }
 
+    // MARK: - VideoProcessing Tests
+
+    public func testVideoProcessingDefaultInit() {
+        let vp = UserInput.VideoProcessing()
+        XCTAssertNil(vp.sampling)
+        XCTAssertNil(vp.targetFrames)
+        XCTAssertNil(vp.targetFramesPerSecond)
+    }
+
+    public func testVideoProcessingTargetFrames() {
+        var vp = UserInput.VideoProcessing(targetFrames: 16)
+        XCTAssertEqual(vp.sampling, .targetFrames(16))
+        XCTAssertEqual(vp.targetFrames, 16)
+        XCTAssertNil(vp.targetFramesPerSecond)
+
+        vp.targetFrames = 32
+        XCTAssertEqual(vp.sampling, .targetFrames(32))
+        XCTAssertEqual(vp.targetFrames, 32)
+
+        vp.targetFrames = nil
+        XCTAssertNil(vp.sampling)
+        XCTAssertNil(vp.targetFrames)
+    }
+
+    public func testVideoProcessingFramesPerSecond() {
+        var vp = UserInput.VideoProcessing(targetFramesPerSecond: 2.5)
+        XCTAssertEqual(vp.sampling, .framesPerSecond(2.5))
+        XCTAssertEqual(vp.targetFramesPerSecond, 2.5)
+        XCTAssertNil(vp.targetFrames)
+
+        vp.targetFramesPerSecond = 5.0
+        XCTAssertEqual(vp.sampling, .framesPerSecond(5.0))
+        XCTAssertEqual(vp.targetFramesPerSecond, 5.0)
+
+        vp.targetFramesPerSecond = nil
+        XCTAssertNil(vp.sampling)
+        XCTAssertNil(vp.targetFramesPerSecond)
+    }
+
+    public func testVideoProcessingSamplingEnum() {
+        let vp1 = UserInput.VideoProcessing(sampling: .targetFrames(8))
+        XCTAssertEqual(vp1.targetFrames, 8)
+        XCTAssertNil(vp1.targetFramesPerSecond)
+
+        let vp2 = UserInput.VideoProcessing(sampling: .framesPerSecond(1.0))
+        XCTAssertEqual(vp2.targetFramesPerSecond, 1.0)
+        XCTAssertNil(vp2.targetFrames)
+    }
+
+    public func testUserInputProcessingWithVideo() {
+        let processing = UserInput.Processing(
+            video: .init(targetFrames: 24),
+            minPixels: 100,
+            maxPixels: 500
+        )
+        XCTAssertEqual(processing.video.targetFrames, 24)
+        XCTAssertEqual(processing.minPixels, 100)
+        XCTAssertEqual(processing.maxPixels, 500)
+
+        let input = UserInput(chat: [.user("hello")], processing: processing)
+        XCTAssertEqual(input.processing.video.targetFrames, 24)
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Add UserInput.VideoProcessing supporting targetFrames and framesPerSecond sampling. Integrate video processing configuration into MediaProcessing.asProcessedSequence and VLM pipelines.

Fixes #429 

Another clean up before release. 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
