### PR TITLE
Add an Xcode 27 compile check and handle Generation.rejectedToolCall

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,3 +108,126 @@ jobs:
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult
             ~/Library/Logs/DiagnosticReports/*
           retention-days: 7
+
+  # Compile the IntegrationTesting project against the macOS 27 SDK.
+  #
+  # Two gaps this closes. First, mac_build_and_test above only builds
+  # `-scheme mlx-swift-lm-Package`, so the IntegrationTesting Xcode project is
+  # never built on the PR path at all and a change that breaks it merges green
+  # (see #512, which left seven exhaustive switches over `Generation` unhandled
+  # in MTPIteratorEndToEndDiagnosticTests.swift). Second, the nightly
+  # integration_tests.yml pins Xcode 26, where everything behind
+  # `canImport(FoundationModels, _version: 2)` -- the whole
+  # MLXFoundationModelsIntegration/ tree and the MLXFoundationModels adapter --
+  # compiles out and therefore cannot break the build. This job builds both.
+  #
+  # This is a COMPILE check, and cannot be anything more on this image. The
+  # hosted `xcode-27` image carries the macOS 27 SDK on a macOS 26 host, and a
+  # test bundle built against the 27 SDK cannot run *any* test there: XCTest
+  # calls objc_copyClassList at startup, which realizes every class including
+  # the @available(macOS 27, *) `TestResponseStream`, whose metadata instantiates
+  # AsyncThrowingStream<MLXLanguageModel.Executor.GenerationEvent, Error> and so
+  # calls through weak-null FoundationModels metadata. The runner segfaults
+  # during test-suite construction, before any test body or #available guard
+  # runs, so no `-only-testing:` selection can dodge it. FM runtime coverage
+  # needs a macOS 27 host, which no hosted image offers yet (see #499).
+  integration_build_xcode27:
+    needs: lint
+    if: github.repository == 'ml-explore/mlx-swift-lm'
+    # Public preview label, see actions/runner-images#14404.
+    runs-on: xcode-27
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Report toolchain and host
+        shell: bash
+        run: |
+          xcodebuild -version
+          swift --version
+          echo "macOS SDK: $(xcrun --sdk macosx --show-sdk-version)"
+          sw_vers
+          # DeviceTier classifies on the *runtime* OS version rather than the
+          # SDK, so printing it here records why this job builds but does not
+          # test: on an OS 26 host the FM surface is unavailable at runtime.
+          case "$(sw_vers -productVersion)" in
+            27.*|2[89].*|3*) echo "Host DeviceTier would be: full (OS >= 27)" ;;
+            26.*)             echo "Host DeviceTier would be: partial (OS 26): the FM surface is @available(macOS 27, *)" ;;
+            *)                echo "Host DeviceTier would be: absent (OS < 26)" ;;
+          esac
+
+      - name: Assert Xcode 27 and the macOS 27 SDK
+        shell: bash
+        run: |
+          # `xcode-27` is a preview label and its default toolchain has moved
+          # before. On a 26 SDK the entire `_version: 2` tree compiles out and
+          # this job goes green while proving nothing, so fail loudly instead.
+          case "$(xcodebuild -version | head -1)" in
+            "Xcode 27"*) ;;
+            *)
+              echo "::error::Expected Xcode 27, got '$(xcodebuild -version | head -1)' (DEVELOPER_DIR=${DEVELOPER_DIR:-default})."
+              exit 1
+              ;;
+          esac
+          case "$(xcrun --sdk macosx --show-sdk-version)" in
+            27.*) ;;
+            *)
+              echo "::error::Expected the macOS 27 SDK, got $(xcrun --sdk macosx --show-sdk-version). The MLXFoundationModels sources are gated on canImport(FoundationModels, _version: 2) and would compile out."
+              exit 1
+              ;;
+          esac
+
+      - name: Install MetalToolchain
+        shell: bash
+        run: |
+          # The self-hosted mac is provisioned with this already, so the jobs
+          # above only assert it. The hosted image ships WITHOUT it, and
+          # mlx-swift compiles .metal sources during the build (mlx-swift_Cmlx).
+          #
+          # Parse `Status:` rather than trusting the exit code: -showComponent
+          # exits 0 and prints "Status: uninstalled" when the component is
+          # absent, so an exit-code guard silently succeeds and the build then
+          # dies much later on the first CompileMetalFile with
+          # "cannot execute tool 'metal'".
+          component_status() {
+            xcodebuild -showComponent MetalToolchain 2>&1 \
+              | awk -F': *' '/^Status:/ { print tolower($2); exit }'
+          }
+          if [ "$(component_status)" = "installed" ]; then
+            echo "MetalToolchain installed."
+          else
+            echo "MetalToolchain reports '$(component_status)'; downloading (839 MB)."
+            xcodebuild -downloadComponent MetalToolchain
+            if [ "$(component_status)" != "installed" ]; then
+              echo "::error::MetalToolchain still reports '$(component_status)' after -downloadComponent."
+              exit 1
+            fi
+            echo "MetalToolchain installed."
+          fi
+
+      - name: Build IntegrationTesting for testing (Xcode, macOS)
+        shell: bash
+        run: |
+          # `build-for-testing` rather than `test`: this compiles both the
+          # ungated suites and the `_version: 2` tree, which is the coverage this
+          # job exists for. Running them is not an option here (see the crash
+          # described above), and a cold-cache `xcodebuild test` would also spend
+          # 2-3 hours downloading Hugging Face models.
+          xcodebuild build-for-testing \
+            -project IntegrationTesting/IntegrationTesting.xcodeproj \
+            -scheme IntegrationTesting \
+            -destination 'platform=macOS' \
+            -skipPackagePluginValidation \
+            -resultBundlePath IntegrationTesting-build.xcresult
+
+      - name: Upload results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-build-xcode27-results
+          path: |
+            IntegrationTesting-build.xcresult
+            ~/Library/Logs/DiagnosticReports/*
+          retention-days: 7

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationBenchmarkTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationBenchmarkTests.swift
@@ -427,7 +427,7 @@ struct GuidedGenerationBenchmarkTests {
                 case .chunk(let text):
                     charCount += text.count
                     deltaCount += 1
-                case .info, .toolCall:
+                case .info, .toolCall, .rejectedToolCall:
                     break
                 }
             }

--- a/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
@@ -150,7 +150,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
             switch event {
             case .chunk(let chunk):
                 text += chunk
-            case .toolCall:
+            case .toolCall, .rejectedToolCall:
                 break
             case .info(let completionInfo):
                 info = completionInfo
@@ -370,7 +370,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in mtpStream {
             switch event {
             case .chunk(let chunk): mtpText += chunk
-            case .toolCall: break
+            case .toolCall, .rejectedToolCall: break
             case .info(let i): mtpInfo = i
             }
         }
@@ -494,7 +494,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in mtpStream {
             switch event {
             case .chunk(let chunk): mtpText += chunk
-            case .toolCall: break
+            case .toolCall, .rejectedToolCall: break
             case .info(let i): mtpInfo = i
             }
         }
@@ -510,7 +510,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in baselineStream {
             switch event {
             case .chunk(let chunk): baselineText += chunk
-            case .toolCall: break
+            case .toolCall, .rejectedToolCall: break
             case .info(let i): baselineInfo = i
             }
         }
@@ -691,7 +691,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in stream {
             switch event {
             case .chunk(let chunk): text += chunk
-            case .toolCall: break
+            case .toolCall, .rejectedToolCall: break
             case .info(let completionInfo): info = completionInfo
             }
         }
@@ -924,7 +924,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in mtpStream {
             switch event {
             case .chunk(let chunk): mtpText += chunk
-            case .toolCall: break
+            case .toolCall, .rejectedToolCall: break
             case .info(let i): mtpInfo = i
             }
         }
@@ -1002,7 +1002,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in stream {
             switch event {
             case .chunk(let chunk): text += chunk
-            case .toolCall: break
+            case .toolCall, .rejectedToolCall: break
             case .info(let completionInfo): info = completionInfo
             }
         }

--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -1617,6 +1617,22 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             return true
         }
 
+        /// Reports a rejected tool call seen on the plain/reasoning streaming path.
+        ///
+        /// That path builds its decoder with `tools: nil`, so a rejection there is a
+        /// protocol anomaly rather than a call the caller could have executed. The
+        /// allowed-tool path treats a rejection as significant and throws
+        /// ``RejectedToolCallError``, but the decoder closures on this path are
+        /// non-throwing, so route the event to the same log channel as
+        /// `.protocolError` instead of dropping it silently. `rawTextPreview` is
+        /// deliberately never logged: it can carry raw model output and argument
+        /// values.
+        private static func logRejectedToolCall(_ rejection: RejectedToolCall) {
+            let toolName = rejection.toolName ?? "<unknown>"
+            protocolLogger.error(
+                "rejected tool call: reason=\(rejection.reason.rawValue) tool=\(toolName)")
+        }
+
         private func consumeAllowedEvents(
             _ events: [AllowedToolOutputRouter.Event],
             result: inout AllowedToolGenerationResult
@@ -1891,6 +1907,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                                 case .reasoning(let text): segments.append(.reasoning(text))
                                 case .response(let text): segments.append(.response(text))
                                 case .toolCall: break
+                                case .rejectedToolCall(let rejection):
+                                    Self.logRejectedToolCall(rejection)
                                 case .protocolError(let message):
                                     Self.protocolLogger.error("\(message)")
                                 case .stop: shouldContinue = false
@@ -1944,6 +1962,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
                     case .reasoning(let text): segments.append(.reasoning(text))
                     case .response(let text): segments.append(.response(text))
                     case .toolCall, .stop: break
+                    case .rejectedToolCall(let rejection):
+                        Self.logRejectedToolCall(rejection)
                     case .protocolError(let message):
                         Self.protocolLogger.error("\(message)")
                     }


### PR DESCRIPTION
Adds a compile-only CI job on GitHub's hosted `xcode-27` image, and fixes the ten
exhaustive `switch` sites that job immediately found.

### The job

`pull_request.yml` gains `integration_build_xcode27` (`needs: lint`, `runs-on: xcode-27`,
60-minute cap). It builds `IntegrationTesting.xcodeproj` with `build-for-testing` against
the macOS 27 SDK.

It closes two distinct gaps:

- `mac_build_and_test` builds only `-scheme mlx-swift-lm-Package`, so the
  `IntegrationTesting` Xcode project is **never built on the PR path**. That is how #536
  landed.
- The nightly `integration_tests.yml` pins Xcode 26, where everything behind
  `canImport(FoundationModels, _version: 2)`, the whole `MLXFoundationModelsIntegration/`
  tree plus the `MLXFoundationModels` adapter, roughly 190 of ~290 integration test
  methods per #499, compiles out and so cannot break the build. That is how #537 landed.

Two guards in the job are load-bearing rather than defensive, and both were confirmed on
the runner:

- **It asserts Xcode 27 and SDK 27 and fails loudly otherwise.** `xcode-27` is a preview
  label ([actions/runner-images#14404](https://github.com/actions/runner-images/issues/14404))
  whose default toolchain has moved before. On a 26 SDK the entire gated tree compiles out
  and the job goes uselessly green.
- **It installs `MetalToolchain`, parsing `Status:`.** The hosted image ships without it
  (the green run below logs `MetalToolchain reports 'uninstalled'; downloading`) and
  mlx-swift compiles `.metal` sources. `xcodebuild -showComponent MetalToolchain` exits
  **0** while printing `Status: uninstalled`, so an exit-code guard passes silently and the
  build dies much later at the first `CompileMetalFile`.

The job is **build-only**, and not by choice, see below.

### The fixes (#536, #537)

#512 added `rejectedToolCall` to `Generation` and `TokenStreamEvent` and updated
`IntegrationTestHelpers`, but ten exhaustive switches were missed.

Eight are text-accumulating diagnostics and a benchmark that already discard `.toolCall`,
so the new case joins that group: `MTPIteratorEndToEndDiagnosticTests.swift` (7 sites) and
`GuidedGenerationBenchmarkTests.swift:426`.

The two `MLXLanguageModel.swift` sites are **not** grouped with `.toolCall`. #512
established in this same file that a rejection is significant: the allowed-tool path
collects into `rejectedToolCalls` and then throws `RejectedToolCallError`. These two sites
are on the plain/reasoning streaming path, whose decoder is built with `tools: nil` and
whose closures are non-throwing (`decoder.push(token) { ... -> Bool }`), so throwing would
require restructuring. They log the rejection through the `Self.protocolLogger.error(...)`
channel the same switch already uses for `.protocolError`, carrying `reason` and
`toolName` and never `rawTextPreview`. That surfaces the anomaly without dropping it
silently and without changing control flow.

**Maintainers may prefer stricter parity with the allowed-tool path**: restructure so
this path can throw `RejectedToolCallError` too. That is a larger change to the streaming
closures, so this PR takes the logging option; happy to switch if you would rather have
the throw.

### Why the job cannot also run tests (new: #539)

The original intent was to also run the tier-aware `PlatformCompatibilityProbes` suite,
which loads no models. That is impossible on this image, and the reason is worth reading:

A test bundle built against the macOS 27 SDK **segfaults before running any test** on the
image's macOS 26.5.2 host. XCTest resolves test classes by name, which calls
`objc_copyClassList` and therefore realizes *every* Swift class in the image. That
realizes `@available(macOS 27, *) TestResponseStream`, completing its metadata instantiates
`AsyncThrowingStream<MLXLanguageModel.Executor.GenerationEvent, Error>`, and
`GenerationEvent`'s metadata lives in weak-linked (null on macOS 26) `FoundationModels`.
Result: `EXC_BAD_ACCESS` at `pc = 0` inside
`+[XCTestSuite prepareContainerSuite:toRunTestIdentifiers:]`. `-only-testing:` cannot dodge
it, because class enumeration precedes test selection. Full backtrace and `otool` evidence
in #539.

So the job builds and stops there. That is not a downgrade of the coverage this PR claims:
compiling the `_version: 2` tree is what found #536 and #537.

### What this does and does not do for #499

It addresses #499 by making the gated tree **compile** in CI, which is the half a public
runner can deliver. Also relevant: Xcode 27.0 beta 4 (`27A5228h`) resolves the blocker that
caused beta 2 to be rejected there: it compiles the adapter with no
`GenerationOptions.SamplingMode.Kind.randomTopK` errors. Provisioning the self-hosted mac
is no longer needed for compile coverage.

It does **not** close #499's runtime goal. #539 sharpens why: on a macOS 26 host the FM
suites do not merely early-return and pass vacuously, the runner does not survive test-suite
construction. Real FM runtime coverage needs a macOS 27 **host**, which no hosted image
offers yet. #499 should stay open for that half.

### Verification

- `pre-commit run --all` clean (swift-format 603.0.0).
- Local build on Xcode 27.0 (`27A5228h`) / macOS 27.0 SDK reaches
  `** TEST BUILD SUCCEEDED **`. Test enumeration confirms the gated suites are genuinely in
  the built bundle (231 tests, including `GuidedGenerationBenchmarkTests`), so the
  `_version: 2` tree compiled rather than compiling out. `PlatformCompatibilityProbes`
  passes locally in 0.028s with no network, this machine is a macOS 27 host, which is
  exactly the difference #539 describes.
- **The job itself, green on the hosted image:**
  https://github.com/CharlieTLe/mlx-swift-lm/actions/runs/31854218828 logs `Xcode 27.0`,
  `Build version 27A5228h`, `macOS SDK: 27.0`, host `26.5.2`,
  `MetalToolchain reports 'uninstalled'; downloading`, then `MetalToolchain installed`, then
  a clean `build-for-testing`. (Run on a fork branch with the repository guard inverted, so
  the job would execute outside `ml-explore`.)
- Earlier runs showing the failures this PR fixes and diagnoses:
  [31849906590](https://github.com/CharlieTLe/mlx-swift-lm/actions/runs/31849906590) (the
  compile breaks),
  [31853566691](https://github.com/CharlieTLe/mlx-swift-lm/actions/runs/31853566691) (the
  #539 crash backtrace).

Relates to #499 and #539. Fixes #536, fixes #537. Origin of the breaks: #512.
