### PR TITLE
Add LoRA dropout and training mode support

### DIFF
--- a/Libraries/MLXLLM/LoraTrain.swift
+++ b/Libraries/MLXLLM/LoraTrain.swift
@@ -240,6 +240,9 @@ public enum LoRATrain {
         try model.update(
             parameters: ModuleParameters.unflattened(weights),
             verify: .noUnusedKeys)
+        // `loadArrays` is lazy. Realize the installed weights before the caller
+        // trains, evaluates, or otherwise reads them.
+        eval(model)
     }
 
     public enum Progress: CustomStringConvertible, Sendable {

--- a/Libraries/MLXLLM/LoraTrain.swift
+++ b/Libraries/MLXLLM/LoraTrain.swift
@@ -134,11 +134,15 @@ public enum LoRATrain {
         /// save path for the adapter `.safetensors`
         public var adapterURL: URL?
 
+        /// number of iterations already completed when resuming from saved adapter weights
+        public var completedIterations = 0
+
         public init(
             batchSize: Int = 4, iterations: Int = 1000, stepsPerReport: Int = 10,
             stepsPerEval: Int = 100, validationBatches: Int = 10, saveEvery: Int = 100,
-            adapterURL: URL? = nil
+            adapterURL: URL? = nil, completedIterations: Int = 0
         ) {
+            precondition(completedIterations >= 0)
             self.batchSize = batchSize
             self.iterations = iterations
             self.stepsPerReport = stepsPerReport
@@ -146,6 +150,7 @@ public enum LoRATrain {
             self.validationBatches = validationBatches
             self.saveEvery = saveEvery
             self.adapterURL = adapterURL
+            self.completedIterations = completedIterations
         }
     }
 
@@ -180,12 +185,19 @@ public enum LoRATrain {
     ///   - batchCount: number of batch elements to evaluate, 0 for all
     /// - Returns: the loss over the enumerate data
     ///
+    /// The model is temporarily placed in evaluation mode and its previous mode is restored
+    /// before this function returns.
+    ///
     /// ### See Also
     /// - ``loadLoRAData(directory:name:)``
     public static func evaluate(
         model: Module, dataset: [String], loss: LoraLossFunction = loss, tokenizer: Tokenizer,
         batchSize: Int, batchCount: Int
     ) -> Float {
+        let wasTraining = model.training
+        model.train(false)
+        defer { model.train(wasTraining) }
+
         var allLosses = [Float]()
         var tokenCount = 0
 
@@ -213,6 +225,21 @@ public enum LoRATrain {
         let parameters = Dictionary(
             uniqueKeysWithValues: model.trainableParameters().flattened())
         try save(arrays: parameters, url: url)
+    }
+
+    /// Load saved LoRA weights into a model that already has matching adapter layers applied.
+    ///
+    /// Use `LoRAContainer.from(model:configuration:)` to construct and freeze the adapter
+    /// layers before calling this method. Set ``Parameters/completedIterations`` when continuing
+    /// a run whose `iterations` value is the desired total number of iterations. This restores
+    /// adapter parameters only; callers that require exact optimizer continuation must persist and
+    /// restore optimizer state separately. The file must not contain keys that are absent from the
+    /// model's adapter structure.
+    public static func loadLoRAWeights(model: Module, url: URL) throws {
+        let weights = try MLX.loadArrays(url: url)
+        try model.update(
+            parameters: ModuleParameters.unflattened(weights),
+            verify: .noUnusedKeys)
     }
 
     public enum Progress: CustomStringConvertible, Sendable {
@@ -255,12 +282,21 @@ public enum LoRATrain {
     ///   - tokenizer: tokenizer
     ///   - parameters: training parameters
     ///   - progress: progress callback
+    ///
+    /// The model is temporarily placed in training mode and its previous mode is restored before
+    /// this function returns.
     public static func train(
         model: Module, train: [String], validate: [String], optimizer: Optimizer,
         loss: @escaping LoraLossFunction = loss, tokenizer: Tokenizer, parameters: Parameters,
         progress: (Progress) -> ProgressDisposition
     ) throws {
         // def train(model, train_set, val_set, optimizer, loss, tokenizer, args)
+
+        guard parameters.completedIterations < parameters.iterations else { return }
+
+        let wasTraining = model.training
+        model.train()
+        defer { model.train(wasTraining) }
 
         let lossValueGrad = valueAndGrad(model: model) { model, arrays in
             let (ce, ntoks) = loss(model, arrays[0], arrays[1], arrays[2])
@@ -272,9 +308,11 @@ public enum LoRATrain {
 
         var start = Date.timeIntervalSinceReferenceDate
 
-        for (iteration, (inputs, targets, lengths)) in LoRABatchIterator(
+        for (iterationOffset, (inputs, targets, lengths)) in LoRABatchIterator(
             dataset: train, tokenizer: tokenizer, batchSize: parameters.batchSize, train: true
         ).enumerated() {
+            let iteration = parameters.completedIterations + iterationOffset
+
             // forward and backward pass
             let (resultArray, grad) = lossValueGrad(model, [inputs, targets, lengths])
             let lvalue = resultArray[0]
@@ -293,7 +331,7 @@ public enum LoRATrain {
                 let trainingLoss = MLXArray(losses).mean(stream: .cpu).item(Float.self)
                 let now = Date.timeIntervalSinceReferenceDate
 
-                let iterationsPerSecond = Double(parameters.stepsPerReport) / (now - start)
+                let iterationsPerSecond = Double(losses.count) / (now - start)
                 let tokensPerSecond = Double(tokenCount) / (now - start)
 
                 if progress(

--- a/Libraries/MLXLMCommon/Adapters/LoRA/DoRA+Layers.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/DoRA+Layers.swift
@@ -11,16 +11,16 @@ import MLXNN
 
 /// Performs the forward pass for a DoRA linear layer.
 private func forward(
-    x: MLXArray, y: MLXArray,
+    x: MLXArray, loraInput: MLXArray, y: MLXArray,
     weight: MLXArray, bias: MLXArray?,
     loraA: MLXArray, loraB: MLXArray,
     scale: Float, magnitude: MLXArray
 ) -> MLXArray {
-    let z = matmul(matmul(x, loraA), loraB)
+    let z = matmul(matmul(loraInput, loraA), loraB)
     var out = y + (scale * z).asType(x.dtype)
 
     let adapted = weight + matmul(scale * loraB.T, loraA.T)
-    let denom = norm(adapted, axis: 1)
+    let denom = stopGradient(norm(adapted, axis: 1))
     out *= (magnitude / denom).asType(x.dtype)
 
     return if let bias {
@@ -64,17 +64,23 @@ private func filterFreezeKeys(from module: Module, keys: [String]?) -> [String] 
 public class DoRALinear: Linear, LoRALayer {
 
     let scale: Float
+    let dropout: Dropout
     public var loraEnabled: Bool = true
 
     @ParameterInfo(key: "lora_a") var loraA: MLXArray
     @ParameterInfo(key: "lora_b") var loraB: MLXArray
     @ParameterInfo(key: "m") var magnitude: MLXArray
 
-    required public init(linear: Linear, rank: Int = 8, scale: Float = 20.0) {
+    required public convenience init(linear: Linear, rank: Int = 8, scale: Float = 20.0) {
+        self.init(linear: linear, rank: rank, scale: scale, dropout: 0.0)
+    }
+
+    public init(linear: Linear, rank: Int = 8, scale: Float = 20.0, dropout: Float) {
         let (outputDimensions, inputDimensions) = linear.shape
         let loraScale = 1 / sqrt(Float(inputDimensions))
 
         self.scale = scale
+        self.dropout = Dropout(p: dropout)
         self._loraA.wrappedValue = MLXRandom.uniform(
             low: -loraScale, high: loraScale, [inputDimensions, rank])
         self._loraB.wrappedValue = MLXArray.zeros([rank, outputDimensions])
@@ -85,12 +91,17 @@ public class DoRALinear: Linear, LoRALayer {
         freeze()
     }
 
-    public static func from(linear: Linear, rank: Int = 8, scale: Float = 20.0) -> LoRALayer {
+    public static func from(
+        linear: Linear, rank: Int = 8, scale: Float = 20.0, dropout: Float = 0.0
+    ) -> LoRALayer {
+        let result: LoRALayer
         if let linear = linear as? QuantizedLinear {
-            QDoRALinear(linear: linear, rank: rank, scale: scale)
+            result = QDoRALinear(linear: linear, rank: rank, scale: scale, dropout: dropout)
         } else {
-            DoRALinear(linear: linear, rank: rank, scale: scale)
+            result = DoRALinear(linear: linear, rank: rank, scale: scale, dropout: dropout)
         }
+        result.train(linear.training)
+        return result
     }
 
     public override func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false)
@@ -114,7 +125,7 @@ public class DoRALinear: Linear, LoRALayer {
         }
         let y = matmul(x, weight.T)
         return forward(
-            x: x, y: y,
+            x: x, loraInput: dropout(x), y: y,
             weight: weight, bias: bias,
             loraA: loraA, loraB: loraB,
             scale: scale, magnitude: magnitude
@@ -131,17 +142,27 @@ public class DoRALinear: Linear, LoRALayer {
 public class QDoRALinear: QuantizedLinear, LoRALayer {
 
     let scale: Float
+    let dropout: Dropout
     public var loraEnabled: Bool = true
 
     @ParameterInfo(key: "lora_a") var loraA: MLXArray
     @ParameterInfo(key: "lora_b") var loraB: MLXArray
     @ParameterInfo(key: "m") var magnitude: MLXArray
 
-    required public init(linear: QuantizedLinear, rank: Int = 8, scale: Float = 20.0) {
+    required public convenience init(
+        linear: QuantizedLinear, rank: Int = 8, scale: Float = 20.0
+    ) {
+        self.init(linear: linear, rank: rank, scale: scale, dropout: 0.0)
+    }
+
+    public init(
+        linear: QuantizedLinear, rank: Int = 8, scale: Float = 20.0, dropout: Float
+    ) {
         let (outputDimensions, inputDimensions) = linear.shape
         let loraScale = 1 / sqrt(Float(inputDimensions))
 
         self.scale = scale
+        self.dropout = Dropout(p: dropout)
         self._loraA.wrappedValue = MLXRandom.uniform(
             low: -loraScale, high: loraScale, [inputDimensions, rank])
         self._loraB.wrappedValue = MLXArray.zeros([rank, outputDimensions])
@@ -169,7 +190,7 @@ public class QDoRALinear: QuantizedLinear, LoRALayer {
             weight: fuse(
                 weight: dequantizedWeight, loraA: loraA, loraB: loraB, scale: scale,
                 magnitude: magnitude),
-            bias: bias, groupSize: groupSize, bits: bits
+            bias: bias, groupSize: groupSize, bits: bits, mode: mode
         )
     }
 
@@ -181,7 +202,7 @@ public class QDoRALinear: QuantizedLinear, LoRALayer {
             x, weight, scales: scales, biases: biases, groupSize: groupSize, bits: bits,
             mode: mode)
         return forward(
-            x: x, y: y,
+            x: x, loraInput: dropout(x), y: y,
             weight: dequantizedWeight, bias: bias,
             loraA: loraA, loraB: loraB,
             scale: scale, magnitude: magnitude

--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRA+Layers.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRA+Layers.swift
@@ -12,6 +12,7 @@ import MLXOptimizers
 /// - converting `Linear` or `QuantizedLinear` layers to ``LoRALinear`` / ``QLoRALinear``
 /// - converting ``LoRALinear`` back to `Linear` or `QuantizedLinear` via ``LoRALinear/fused()``
 /// - implementing the LoRA evaluation
+/// - applying optional dropout to the LoRA branch during training
 ///
 /// ``QLoRALinear`` is the equivalent class for `QuantizedLinear`.
 ///
@@ -25,17 +26,28 @@ import MLXOptimizers
 public class LoRALinear: Linear, LoRALayer {
 
     let scale: Float
+    let dropout: Dropout
     public var loraEnabled: Bool = true
 
     @ParameterInfo(key: "lora_a") var loraA: MLXArray
     @ParameterInfo(key: "lora_b") var loraB: MLXArray
 
-    required public init(
+    required public convenience init(
         _ inputDimensions: Int, _ outputDimensions: Int, rank: Int = 8, bias: Bool = false,
         scale: Float = 20.0, linear: Linear
     ) {
+        self.init(
+            inputDimensions, outputDimensions, rank: rank, bias: bias, scale: scale,
+            dropout: 0.0, linear: linear)
+    }
+
+    public init(
+        _ inputDimensions: Int, _ outputDimensions: Int, rank: Int = 8, bias: Bool = false,
+        scale: Float = 20.0, dropout: Float, linear: Linear
+    ) {
         // Scale for low-rank update
         self.scale = scale
+        self.dropout = Dropout(p: dropout)
 
         // Low rank lora weights
         let loraScale = 1 / sqrt(Float(inputDimensions))
@@ -67,14 +79,20 @@ public class LoRALinear: Linear, LoRALayer {
     /// This is typically called via `LoRATrain.convert(model:layers:)`.
     ///
     /// ### See Also
-    /// - ``QLoRALinear/from(linear:rank:scale:)``
-    public static func from(linear: Linear, rank: Int = 8, scale: Float = 20.0) -> LoRALayer {
+    /// - ``QLoRALinear/from(linear:rank:scale:dropout:)``
+    public static func from(
+        linear: Linear, rank: Int = 8, scale: Float = 20.0, dropout: Float = 0.0
+    ) -> LoRALayer {
         if let linear = linear as? QuantizedLinear {
-            return QLoRALinear.from(linear: linear, rank: rank, scale: scale)
+            return QLoRALinear.from(
+                linear: linear, rank: rank, scale: scale, dropout: dropout)
         }
         let (outputDimensions, inputDimensions) = linear.shape
-        return LoRALinear(
-            inputDimensions, outputDimensions, rank: rank, scale: scale, linear: linear)
+        let result = LoRALinear(
+            inputDimensions, outputDimensions, rank: rank, scale: scale, dropout: dropout,
+            linear: linear)
+        result.train(linear.training)
+        return result
     }
 
     /// Convert back into a fused `Linear` layer.
@@ -91,7 +109,7 @@ public class LoRALinear: Linear, LoRALayer {
     public override func callAsFunction(_ x: MLXArray) -> MLXArray {
         let y = super.callAsFunction(x.asType(weight.dtype))
         if !loraEnabled { return y }
-        let z = matmul(matmul(x, self.loraA), self.loraB)
+        let z = matmul(matmul(dropout(x), self.loraA), self.loraB)
         return y + scale * z
     }
 }
@@ -102,18 +120,29 @@ public class LoRALinear: Linear, LoRALayer {
 public class QLoRALinear: QuantizedLinear, LoRALayer {
 
     let scale: Float
+    let dropout: Dropout
     public var loraEnabled: Bool = true
 
     @ParameterInfo(key: "lora_a") var loraA: MLXArray
     @ParameterInfo(key: "lora_b") var loraB: MLXArray
 
-    required public init(
+    required public convenience init(
         _ inputDimensions: Int, _ outputDimensions: Int, rank: Int = 8, bias: Bool = false,
         scale: Float = 20.0, linear: QuantizedLinear
+    ) {
+        self.init(
+            inputDimensions, outputDimensions, rank: rank, bias: bias, scale: scale,
+            dropout: 0.0, linear: linear)
+    }
+
+    public init(
+        _ inputDimensions: Int, _ outputDimensions: Int, rank: Int = 8, bias: Bool = false,
+        scale: Float = 20.0, dropout: Float, linear: QuantizedLinear
     ) {
 
         // Scale for low-rank update
         self.scale = scale
+        self.dropout = Dropout(p: dropout)
 
         // Low rank lora weights
         let loraScale = 1 / sqrt(Float(inputDimensions))
@@ -123,7 +152,7 @@ public class QLoRALinear: QuantizedLinear, LoRALayer {
 
         super.init(
             weight: linear.weight, bias: linear.bias, scales: linear.scales, biases: linear.biases,
-            groupSize: linear.groupSize, bits: linear.bits)
+            groupSize: linear.groupSize, bits: linear.bits, mode: linear.mode)
 
         // start frozen except for the lora keys
         freeze()
@@ -148,13 +177,16 @@ public class QLoRALinear: QuantizedLinear, LoRALayer {
     /// This is typically called via `LoRATrain.convert(model:layers:)`.
     ///
     /// ### See Also
-    /// - ``LoRALinear/from(linear:rank:scale:)``
-    public static func from(linear: QuantizedLinear, rank: Int = 8, scale: Float = 20.0)
-        -> LoRALayer
-    {
+    /// - ``LoRALinear/from(linear:rank:scale:dropout:)``
+    public static func from(
+        linear: QuantizedLinear, rank: Int = 8, scale: Float = 20.0, dropout: Float = 0.0
+    ) -> LoRALayer {
         let (outputDimensions, inputDimensions) = linear.shape
-        return QLoRALinear(
-            inputDimensions, outputDimensions, rank: rank, scale: scale, linear: linear)
+        let result = QLoRALinear(
+            inputDimensions, outputDimensions, rank: rank, scale: scale, dropout: dropout,
+            linear: linear)
+        result.train(linear.training)
+        return result
     }
 
     /// Convert back into a fused `QuantizedLinear` layer.
@@ -170,14 +202,15 @@ public class QLoRALinear: QuantizedLinear, LoRALayer {
             weight: weight + matmul(loraB, loraA),
             bias: bias,
             groupSize: groupSize,
-            bits: bits
+            bits: bits,
+            mode: mode
         )
     }
 
     public override func callAsFunction(_ x: MLXArray) -> MLXArray {
         let y = super.callAsFunction(x.asType(scales.dtype))
         if !loraEnabled { return y }
-        let z = matmul(matmul(x, self.loraA), self.loraB)
+        let z = matmul(matmul(dropout(x), self.loraA), self.loraB)
         return y + scale * z
     }
 }

--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
@@ -20,6 +20,7 @@ import MLXNN
 ///   "num_layers": 28,
 ///   "lora_parameters": {
 ///     "rank": 16,
+///     "dropout": 0.05,
 ///     "scale": 20.0
 ///   }
 /// }
@@ -35,12 +36,46 @@ public struct LoRAConfiguration: Sendable, Codable {
 
         public let rank: Int
         public let scale: Float
+        /// Probability of dropping LoRA inputs during training. Disabled in evaluation mode.
+        public let dropout: Float
         public let keys: [String]?
 
-        public init(rank: Int = 8, scale: Float = 10.0, keys: [String]? = nil) {
+        public init(
+            rank: Int = 8, scale: Float = 10.0, dropout: Float = 0.0,
+            keys: [String]? = nil
+        ) {
+            precondition(
+                Self.isValidDropout(dropout),
+                "LoRA dropout must be greater than or equal to 0 and less than 1")
             self.rank = rank
             self.scale = scale
+            self.dropout = dropout
             self.keys = keys
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case rank
+            case scale
+            case dropout
+            case keys
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            rank = try container.decode(Int.self, forKey: .rank)
+            scale = try container.decode(Float.self, forKey: .scale)
+            let dropout = try container.decodeIfPresent(Float.self, forKey: .dropout) ?? 0.0
+            guard Self.isValidDropout(dropout) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .dropout, in: container,
+                    debugDescription: "LoRA dropout must be in the range [0, 1)")
+            }
+            self.dropout = dropout
+            keys = try container.decodeIfPresent([String].self, forKey: .keys)
+        }
+
+        static func isValidDropout(_ dropout: Float) -> Bool {
+            (0.0 ..< 1.0).contains(dropout)
         }
     }
 
@@ -137,7 +172,9 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
     ///
     /// This method replaces target layers in the model with corresponding
     /// adapter layers based on the configuration. It also loads adapter-specific
-    /// weights into the model.
+    /// weights into the model. Replacement layers preserve the model's current
+    /// training or evaluation mode. Models placed in a ``ModelContext`` are in
+    /// evaluation mode by default.
     public func load(into model: LanguageModel) throws {
         guard let lora = model as? LoRAModel else {
             throw ModelAdapterError.incompatibleModelType
@@ -198,13 +235,15 @@ private func createReplacementLayer(
         return LoRALinear.from(
             linear: linear,
             rank: configuration.loraParameters.rank,
-            scale: configuration.loraParameters.scale
+            scale: configuration.loraParameters.scale,
+            dropout: configuration.loraParameters.dropout
         )
     case (let linear as Linear, .dora):
         return DoRALinear.from(
             linear: linear,
             rank: configuration.loraParameters.rank,
-            scale: configuration.loraParameters.scale
+            scale: configuration.loraParameters.scale,
+            dropout: configuration.loraParameters.dropout
         )
     default:
         return nil

--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAModel.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAModel.swift
@@ -99,7 +99,7 @@ extension LoRALayer where Self: Linear {
             return QuantizedLinear(
                 weight: quantized.weight, bias: quantized.bias,
                 scales: quantized.scales, biases: quantized.biases,
-                groupSize: quantized.groupSize, bits: quantized.bits
+                groupSize: quantized.groupSize, bits: quantized.bits, mode: quantized.mode
             )
         } else {
             return Linear(weight: weight, bias: bias)

--- a/Libraries/MLXLMCommon/Adapters/LoRA/PEFTAdapter.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/PEFTAdapter.swift
@@ -16,6 +16,7 @@ public struct PEFTAdapterConfiguration: Codable, Sendable {
     public let peftType: String
     public let r: Int
     public let loraAlpha: Float
+    public let loraDropout: Float
     public let targetModules: [String]
     public let useDora: Bool
 
@@ -23,6 +24,7 @@ public struct PEFTAdapterConfiguration: Codable, Sendable {
         case peftType = "peft_type"
         case r = "r"
         case loraAlpha = "lora_alpha"
+        case loraDropout = "lora_dropout"
         case targetModules = "target_modules"
         case useDora = "use_dora"
     }
@@ -32,6 +34,13 @@ public struct PEFTAdapterConfiguration: Codable, Sendable {
         peftType = try c.decodeIfPresent(String.self, forKey: .peftType) ?? "LORA"
         r = try c.decode(Int.self, forKey: .r)
         loraAlpha = try c.decode(Float.self, forKey: .loraAlpha)
+        let loraDropout = try c.decodeIfPresent(Float.self, forKey: .loraDropout) ?? 0.0
+        guard LoRAConfiguration.LoRAParameters.isValidDropout(loraDropout) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .loraDropout, in: c,
+                debugDescription: "PEFT LoRA dropout must be in the range [0, 1)")
+        }
+        self.loraDropout = loraDropout
         targetModules = try c.decode([String].self, forKey: .targetModules)
         useDora = try c.decodeIfPresent(Bool.self, forKey: .useDora) ?? false
     }
@@ -102,7 +111,7 @@ extension LoRAContainer {
             numLayers: numLayers,
             fineTuneType: .lora,
             loraParameters: LoRAConfiguration.LoRAParameters(
-                rank: peft.r, scale: scale, keys: keys))
+                rank: peft.r, scale: scale, dropout: peft.loraDropout, keys: keys))
 
         return LoRAContainer(
             configuration: configuration,

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 import Foundation
+import MLXNN
 
 /// File patterns required to resolve a tokenizer without downloading model weights.
 package let tokenizerDownloadPatterns = ["*.json", "*.jinja"]
@@ -60,7 +61,7 @@ public protocol ModelConfigurationValidating {
     func validateModelConfiguration() throws
 }
 
-/// Context of types that work together to provide a ``LanguageModel``.
+/// Context of types that work together to provide a ``LanguageModel`` for inference.
 ///
 /// A ``ModelContext`` is created by ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:)``.
 /// This contains the following:
@@ -82,6 +83,10 @@ public struct ModelContext {
         configuration: ModelConfiguration, model: any LanguageModel,
         processor: any UserInputProcessor, tokenizer: any Tokenizer
     ) {
+        // MLX modules default to training mode.  A ModelContext is the inference boundary used by
+        // generation, so normalize the complete module tree to evaluation mode.  Training APIs
+        // explicitly enable training for their duration and restore this state afterwards.
+        model.train(false)
         self.configuration = configuration
         self.model = model
         self.processor = processor

--- a/Tests/MLXLMTests/LoRADropoutTests.swift
+++ b/Tests/MLXLMTests/LoRADropoutTests.swift
@@ -1,0 +1,406 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import MLXOptimizers
+import XCTest
+
+final class LoRADropoutTests: XCTestCase {
+
+    func testConfigurationDefaultsMissingDropoutToZero() throws {
+        let data = Data(
+            """
+            {
+              "num_layers": 4,
+              "fine_tune_type": "lora",
+              "lora_parameters": {
+                "rank": 8,
+                "scale": 2.0
+              }
+            }
+            """.utf8)
+
+        let configuration = try JSONDecoder().decode(LoRAConfiguration.self, from: data)
+
+        XCTAssertEqual(configuration.loraParameters.dropout, 0.0)
+    }
+
+    func testConfigurationRoundTripsDropout() throws {
+        let configuration = LoRAConfiguration(
+            loraParameters: .init(rank: 16, scale: 2.0, dropout: 0.25))
+
+        let data = try JSONEncoder().encode(configuration)
+        let decoded = try JSONDecoder().decode(LoRAConfiguration.self, from: data)
+
+        XCTAssertEqual(decoded.loraParameters.dropout, 0.25)
+    }
+
+    func testConfigurationRejectsInvalidDropout() throws {
+        for dropout in [-0.1, 1.0] {
+            let data = Data(
+                """
+                {
+                  "num_layers": 4,
+                  "fine_tune_type": "lora",
+                  "lora_parameters": {
+                    "rank": 8,
+                    "scale": 2.0,
+                    "dropout": \(dropout)
+                  }
+                }
+                """.utf8)
+
+            XCTAssertThrowsError(try JSONDecoder().decode(LoRAConfiguration.self, from: data)) {
+                error in
+                guard case DecodingError.dataCorrupted = error else {
+                    return XCTFail("expected dataCorrupted, got \(error)")
+                }
+            }
+        }
+    }
+
+    func testPEFTDropoutIsPreserved() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(component: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configuration = Data(
+            """
+            {
+              "peft_type": "LORA",
+              "r": 4,
+              "lora_alpha": 8,
+              "lora_dropout": 0.2,
+              "target_modules": ["q_proj"],
+              "use_dora": false
+            }
+            """.utf8)
+        try configuration.write(to: directory.appending(component: "adapter_config.json"))
+        try save(
+            arrays: [
+                "base_model.model.encoder.layers.0.self_attn.q_proj.lora_A.weight":
+                    MLXArray.zeros([4, 8]),
+                "base_model.model.encoder.layers.0.self_attn.q_proj.lora_B.weight":
+                    MLXArray.zeros([8, 4]),
+            ],
+            url: directory.appending(component: "adapter_model.safetensors"))
+
+        let adapter = try LoRAContainer.fromPEFT(directory: directory)
+
+        XCTAssertEqual(adapter.configuration.loraParameters.dropout, 0.2)
+    }
+
+    func testPEFTConfigurationRejectsInvalidDropout() throws {
+        let data = Data(
+            """
+            {
+              "peft_type": "LORA",
+              "r": 4,
+              "lora_alpha": 8,
+              "lora_dropout": 1.0,
+              "target_modules": ["q_proj"],
+              "use_dora": false
+            }
+            """.utf8)
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(PEFTAdapterConfiguration.self, from: data)
+        ) { error in
+            guard case DecodingError.dataCorrupted = error else {
+                return XCTFail("expected dataCorrupted, got \(error)")
+            }
+        }
+    }
+
+    func testLoRALinearAppliesDropoutOnlyDuringTraining() throws {
+        let base = Linear(weight: MLXArray.eye(32))
+        let layer = try XCTUnwrap(
+            LoRALinear.from(linear: base, rank: 32, scale: 1.0, dropout: 0.5)
+                as? LoRALinear)
+
+        try assertDropoutMode(on: layer)
+    }
+
+    func testConversionPreservesEvaluationMode() throws {
+        let base = Linear(weight: MLXArray.eye(32))
+        base.train(false)
+
+        let lora = try XCTUnwrap(
+            LoRALinear.from(linear: base, dropout: 0.5) as? LoRALinear)
+        let dora = try XCTUnwrap(
+            DoRALinear.from(linear: base, dropout: 0.5) as? DoRALinear)
+
+        XCTAssertFalse(lora.training)
+        XCTAssertFalse(dora.training)
+    }
+
+    func testModelContextDisablesLoadedAdapterDropoutForInference() throws {
+        let configuration = LoRAConfiguration(
+            numLayers: 1,
+            loraParameters: .init(
+                rank: 32, scale: 1.0, dropout: 0.5, keys: ["projection"]))
+        let adapter = LoRAContainer(
+            configuration: configuration,
+            parameters: ModuleParameters.unflattened([
+                "projection.lora_a": MLXArray.eye(32),
+                "projection.lora_b": MLXArray.eye(32),
+            ]))
+        let model = DropoutInferenceModel()
+        let processor = TestInputProcessor()
+        let context = ModelContext(
+            configuration: processor.configuration,
+            model: model,
+            processor: processor,
+            tokenizer: processor.tokenizer)
+
+        try adapter.load(into: model)
+
+        XCTAssertFalse(context.model.training)
+        let layer = try XCTUnwrap(model.projection as? LoRALinear)
+        XCTAssertFalse(layer.training)
+
+        let input = MLXArray.ones([1, 32])
+        let first = model(input, cache: nil)
+        eval(first)
+        let second = model(input, cache: nil)
+        eval(second)
+        XCTAssertTrue(allClose(first, second, rtol: 0, atol: 0).item(Bool.self))
+    }
+
+    func testQLoRALinearAppliesDropoutOnlyDuringTraining() throws {
+        let base = Linear(weight: MLXArray.eye(32))
+        let quantized = try XCTUnwrap(
+            base.toQuantized(groupSize: 32, bits: 4, mode: .affine) as? QuantizedLinear)
+        let layer = try XCTUnwrap(
+            LoRALinear.from(linear: quantized, rank: 32, scale: 1.0, dropout: 0.5)
+                as? QLoRALinear)
+
+        try assertDropoutMode(on: layer)
+    }
+
+    func testDoRALinearAppliesDropoutOnlyDuringTraining() throws {
+        let base = Linear(weight: MLXArray.eye(32))
+        let layer = try XCTUnwrap(
+            DoRALinear.from(linear: base, rank: 32, scale: 1.0, dropout: 0.5)
+                as? DoRALinear)
+
+        try assertDropoutMode(on: layer)
+    }
+
+    func testDoRAWeightNormIsDetachedFromGradient() throws {
+        let base = Linear(weight: MLXArray([Float(2.0)], [1, 1]))
+        let layer = DoRALinear(linear: base, rank: 1, scale: 1.0, dropout: 0.0)
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                "lora_a": MLXArray.ones([1, 1]),
+                "lora_b": MLXArray.ones([1, 1]),
+            ]),
+            verify: [])
+
+        let valueAndGradient = valueAndGrad(model: layer) { model, inputs in
+            [model(inputs[0]).sum()]
+        }
+        let (_, gradients) = valueAndGradient(layer, [MLXArray.ones([1, 1])])
+        let flattened = Dictionary(uniqueKeysWithValues: gradients.flattened())
+        let loraAGradient = try XCTUnwrap(flattened["lora_a"])
+        let loraBGradient = try XCTUnwrap(flattened["lora_b"])
+
+        // With stopGradient(norm(weight + B @ A)), each low-rank gradient is 2 / 3.
+        // Without detaching the norm, the scalar DoRA output algebraically cancels and both
+        // gradients are zero, so this directly guards parity with mlx-lm.
+        XCTAssertEqual(loraAGradient.item(Float.self), 2.0 / 3.0, accuracy: 1e-5)
+        XCTAssertEqual(loraBGradient.item(Float.self), 2.0 / 3.0, accuracy: 1e-5)
+    }
+
+    func testQDoRALinearAppliesDropoutOnlyDuringTraining() throws {
+        let base = Linear(weight: MLXArray.eye(32))
+        let quantized = try XCTUnwrap(
+            base.toQuantized(groupSize: 32, bits: 4, mode: .affine) as? QuantizedLinear)
+        let layer = try XCTUnwrap(
+            DoRALinear.from(linear: quantized, rank: 32, scale: 1.0, dropout: 0.5)
+                as? QDoRALinear)
+
+        try assertDropoutMode(on: layer)
+    }
+
+    func testQuantizedAdaptersPreserveQuantizationMode() throws {
+        let base = Linear(weight: MLXArray.eye(32))
+        let quantized = try XCTUnwrap(
+            base.toQuantized(groupSize: 32, bits: 4, mode: .mxfp4) as? QuantizedLinear)
+        let lora = try XCTUnwrap(LoRALinear.from(linear: quantized) as? QLoRALinear)
+        let dora = try XCTUnwrap(DoRALinear.from(linear: quantized) as? QDoRALinear)
+
+        XCTAssertEqual(lora.mode, .mxfp4)
+        XCTAssertEqual((lora.reverted() as? QuantizedLinear)?.mode, .mxfp4)
+        XCTAssertEqual((lora.fused() as? QuantizedLinear)?.mode, .mxfp4)
+        XCTAssertEqual(dora.mode, .mxfp4)
+        XCTAssertEqual((dora.reverted() as? QuantizedLinear)?.mode, .mxfp4)
+        XCTAssertEqual((dora.fused() as? QuantizedLinear)?.mode, .mxfp4)
+    }
+
+    func testEvaluateUsesEvaluationModeAndRestoresMode() {
+        let model = Module()
+        model.train()
+        var observedTraining: Bool?
+
+        _ = LoRATrain.evaluate(
+            model: model,
+            dataset: ["sample"],
+            loss: { model, _, _, _ in
+                observedTraining = model.training
+                return (MLXArray(0.0), MLXArray(1))
+            },
+            tokenizer: TestTokenizer(),
+            batchSize: 1,
+            batchCount: 1)
+
+        XCTAssertEqual(observedTraining, false)
+        XCTAssertTrue(model.training)
+    }
+
+    func testTrainUsesTrainingModeAndRestoresMode() throws {
+        let model = Linear(1, 1, bias: false)
+        model.train(false)
+        var observedModes = Set<Bool>()
+
+        try LoRATrain.train(
+            model: model,
+            train: ["sample"],
+            validate: ["sample"],
+            optimizer: SGD(learningRate: 0.01),
+            loss: { model, _, _, _ in
+                observedModes.insert(model.training)
+                let prediction = (model as! Linear)(MLXArray.ones([1, 1]))
+                return ((prediction * prediction).mean(), MLXArray(1))
+            },
+            tokenizer: TestTokenizer(),
+            parameters: .init(
+                batchSize: 1, iterations: 1, stepsPerReport: 1, stepsPerEval: 1,
+                validationBatches: 1),
+            progress: { _ in
+                XCTAssertTrue(model.training)
+                return .more
+            })
+
+        XCTAssertEqual(observedModes, [false, true])
+        XCTAssertFalse(model.training)
+    }
+
+    func testTrainingResumesFromCompletedIteration() throws {
+        let model = Linear(1, 1, bias: false)
+        var reportedIterations = [Int]()
+
+        try LoRATrain.train(
+            model: model,
+            train: ["sample"],
+            validate: ["sample"],
+            optimizer: SGD(learningRate: 0.01),
+            loss: { model, _, _, _ in
+                let prediction = (model as! Linear)(MLXArray.ones([1, 1]))
+                return ((prediction * prediction).mean(), MLXArray(1))
+            },
+            tokenizer: TestTokenizer(),
+            parameters: .init(
+                batchSize: 1, iterations: 4, stepsPerReport: 1, stepsPerEval: 100,
+                validationBatches: 1, completedIterations: 2),
+            progress: { progress in
+                if case .train(let iteration, _, _, _) = progress {
+                    reportedIterations.append(iteration)
+                }
+                return .more
+            })
+
+        XCTAssertEqual(reportedIterations, [2, 3])
+    }
+
+    func testLoadLoRAWeightsRestoresSavedAdapter() throws {
+        let layer = try XCTUnwrap(
+            LoRALinear.from(linear: Linear(weight: MLXArray.eye(4)), rank: 4)
+                as? LoRALinear)
+        let url = FileManager.default.temporaryDirectory
+            .appending(component: UUID().uuidString)
+            .appendingPathExtension("safetensors")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                "lora_a": MLXArray.eye(4),
+                "lora_b": MLXArray.eye(4),
+            ]),
+            verify: [])
+        try LoRATrain.saveLoRAWeights(model: layer, url: url)
+
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                "lora_a": MLXArray.zeros([4, 4]),
+                "lora_b": MLXArray.zeros([4, 4]),
+            ]),
+            verify: [])
+        try LoRATrain.loadLoRAWeights(model: layer, url: url)
+
+        let restored = Dictionary(uniqueKeysWithValues: layer.trainableParameters().flattened())
+        XCTAssertTrue(
+            allClose(restored["lora_a"]!, MLXArray.eye(4), rtol: 0, atol: 0).item(Bool.self))
+        XCTAssertTrue(
+            allClose(restored["lora_b"]!, MLXArray.eye(4), rtol: 0, atol: 0).item(Bool.self))
+    }
+
+    private func assertDropoutMode(on layer: Linear) throws {
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                "lora_a": MLXArray.eye(32),
+                "lora_b": MLXArray.eye(32),
+            ]),
+            verify: [])
+
+        let input = MLXArray.ones([1, 32])
+
+        layer.train(false)
+        let firstEvaluationOutput = layer(input)
+        eval(firstEvaluationOutput)
+
+        layer.train()
+        let trainingOutput = layer(input)
+        eval(trainingOutput)
+
+        layer.train(false)
+        let secondEvaluationOutput = layer(input)
+        eval(secondEvaluationOutput)
+
+        XCTAssertTrue(
+            allClose(firstEvaluationOutput, secondEvaluationOutput, rtol: 0, atol: 0)
+                .item(Bool.self))
+        XCTAssertFalse(
+            allClose(firstEvaluationOutput, trainingOutput, rtol: 0, atol: 0).item(Bool.self))
+    }
+}
+
+private final class DropoutInferenceModel: Module, LanguageModel, LoRAModel,
+    KVCacheDimensionProvider
+{
+    @ModuleInfo(key: "projection") var projection: Linear
+
+    let kvHeads: [Int] = []
+
+    var loraLayers: [Module] { [self] }
+    var loraDefaultKeys: [String] { ["projection"] }
+
+    override init() {
+        _projection.wrappedValue = Linear(weight: MLXArray.eye(32))
+        super.init()
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        projection(inputs)
+    }
+}

--- a/skills/mlx-swift-lm/references/lora-adapters.md
+++ b/skills/mlx-swift-lm/references/lora-adapters.md
@@ -34,6 +34,7 @@ public struct LoRAConfiguration: Sendable, Codable {
     public struct LoRAParameters: Sendable, Codable {
         public let rank: Int         // Low-rank dimension (default: 8)
         public let scale: Float      // Scaling factor (default: 10.0)
+        public let dropout: Float    // Training-only input dropout (default: 0.0)
         public let keys: [String]?   // Layer keys to adapt (nil = all Linear)
     }
 
@@ -61,6 +62,7 @@ let config = LoRAConfiguration(
     loraParameters: .init(
         rank: 16,
         scale: 20.0,
+        dropout: 0.05,
         keys: ["self_attn.q_proj", "self_attn.v_proj"]
     )
 )
@@ -75,6 +77,7 @@ let config = LoRAConfiguration(
   "lora_parameters": {
     "rank": 16,
     "scale": 20.0,
+    "dropout": 0.05,
     "keys": ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"]
   }
 }
@@ -94,6 +97,10 @@ let adapter = try LoRAContainer.from(directory: adapterURL)
 // Apply to model
 try adapter.load(into: model)
 ```
+
+`ModelContext` places its model in evaluation mode, so adapters with nonzero dropout are
+deterministic during normal generation. If you invoke a model directly without a `ModelContext`,
+call `model.train(false)` before inference. `LoRATrain.train` enables training mode while it runs.
 
 ### From Model (Create New Adapter)
 
@@ -153,7 +160,7 @@ public class LoRALinear: Linear, LoRALayer {
     @ParameterInfo(key: "lora_a") var loraA: MLXArray
     @ParameterInfo(key: "lora_b") var loraB: MLXArray
 
-    // Forward: y = Wx + scale * (x @ A @ B)
+    // Forward: y = Wx + scale * (dropout(x) @ A @ B)
 }
 ```
 

--- a/skills/mlx-swift-lm/references/training.md
+++ b/skills/mlx-swift-lm/references/training.md
@@ -27,6 +27,7 @@ public struct Parameters: Sendable {
     public var validationBatches: Int = 10   // 0 = full validation set
     public var saveEvery: Int = 100          // Checkpoint frequency
     public var adapterURL: URL?              // Save location
+    public var completedIterations: Int = 0  // Resume progress offset
 
     public init(
         batchSize: Int = 4,
@@ -35,10 +36,27 @@ public struct Parameters: Sendable {
         stepsPerEval: Int = 100,
         validationBatches: Int = 10,
         saveEvery: Int = 100,
-        adapterURL: URL? = nil
+        adapterURL: URL? = nil,
+        completedIterations: Int = 0
     )
 }
 ```
+
+When resuming, apply matching LoRA layers, load the saved weights, and set the number of
+iterations already completed. `iterations` remains the desired total:
+
+```swift
+try LoRATrain.loadLoRAWeights(model: model, url: adapterURL)
+
+let parameters = LoRATrain.Parameters(
+    iterations: 1000,
+    completedIterations: 400
+)
+```
+
+This reloads adapter parameters only. Persist and restore optimizer state separately when exact
+optimizer continuation is required. The saved file must contain only keys present in the model's
+adapter structure.
 
 ## Training Workflow
 


### PR DESCRIPTION
## Proposed changes

Adding dropout support when training LoRA and DoRA adapters:

- Supports dropout values from native MLX and PEFT adapter configurations.
- Rejects invalid dropout values with a clear error.
- Preserves the correct quantization format when converting or combining adapters.
- Adds support for resuming training from saved adapter weights.
- Correctly switches between training and evaluation modes.
- Aligns DoRA calculations with the Python `mlx-lm` implementation.
- Keeps existing behavior unchanged when dropout is omitted or set to `0`.

#### Notes

Dropout temporarily hides a small, random part of the training input. This can help an adapter avoid memorizing its training data too closely. Dropout is automatically disabled when using the model for generation, so normal inference remains stable and repeatable.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
