### PR TITLE
Fix MLXFoundationModels compilation against the Xcode 27 beta 5 SDK

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/PlatformAvailability/CompatibilityProbes.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/PlatformAvailability/CompatibilityProbes.swift
@@ -80,7 +80,7 @@ struct PlatformCompatibilityProbes {
             lmAvailable = true
             #if canImport(FoundationModels, _version: 2)
             // Touch the OS-27 surface to prove it is genuinely reachable here.
-            _ = LanguageModelCapabilities(capabilities: [])
+            _ = LanguageModelCapabilities([])
             _ = (any LanguageModel).self
             #endif
         }

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
@@ -164,7 +164,7 @@ func makeExecutorRequest(
     schema: GenerationSchema? = nil,
     generationOptions: GenerationOptions = GenerationOptions(),
     contextOptions: ContextOptions = ContextOptions(),
-    metadata: [String: any Sendable & Codable & Equatable] = [:]
+    metadata: [String: any ConvertibleToGeneratedContent & Sendable] = [:]
 ) -> LanguageModelExecutorGenerationRequest {
     LanguageModelExecutorGenerationRequest(
         id: id,

--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -562,7 +562,7 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
         load: @escaping ContainerLoader
     ) {
         self.configuration = configuration
-        self.capabilities = LanguageModelCapabilities(capabilities: capabilities)
+        self.capabilities = LanguageModelCapabilities(capabilities)
         self.configurationResolver = configurationResolver
         self.weightsLocation = weightsLocation
         self.load = load
@@ -683,7 +683,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             enum Destination: Sendable { case response, reasoning }
             case appendText(String, entryID: String?, destination: Destination)
             case toolCall(id: String, name: String, arguments: String)
-            case updateMetadata([String: any Sendable & Codable & Equatable], entryID: String?)
+            case updateMetadata(
+                [String: any ConvertibleToGeneratedContent & Sendable], entryID: String?)
             case updateUsage(
                 input: LanguageModelExecutorGenerationChannel.Usage.Input,
                 output: LanguageModelExecutorGenerationChannel.Usage.Output,
@@ -711,7 +712,7 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
         }
 
         static func emitMetadata(
-            _ values: [String: any Sendable & Codable & Equatable], entryID: String?,
+            _ values: [String: any ConvertibleToGeneratedContent & Sendable], entryID: String?,
             into channel: LanguageModelExecutorGenerationChannel
         ) async {
             generationObserver?(.updateMetadata(values, entryID: entryID))

--- a/Tests/MLXFoundationModelsTests/TestHelpers.swift
+++ b/Tests/MLXFoundationModelsTests/TestHelpers.swift
@@ -109,7 +109,7 @@ func makeExecutorRequest(
     schema: GenerationSchema? = nil,
     generationOptions: GenerationOptions = GenerationOptions(),
     contextOptions: ContextOptions = ContextOptions(),
-    metadata: [String: any Sendable & Codable & Equatable] = [:]
+    metadata: [String: any ConvertibleToGeneratedContent & Sendable] = [:]
 ) -> LanguageModelExecutorGenerationRequest {
     LanguageModelExecutorGenerationRequest(
         id: id,


### PR DESCRIPTION
Two FoundationModels API shapes the adapter uses are not present in the macOS 27 SDK shipped with Xcode 27.0 beta 5 (27A5237l).

LanguageModelCapabilities declares a single unlabeled initializer, init(_ capabilities:). Two call sites passed `capabilities:`. The unlabeled spelling was already in the tree - GenerationOptionsForwardingTests has used it since PR #456, "Support multi-round tool calling in MLXFoundationModels" - so the two forms disagreed without anything noticing, because everything behind canImport(FoundationModels, _version: 2) compiles to nothing on the Xcode 26 CI.

Metadata dictionaries across the framework are now [String: any ConvertibleToGeneratedContent] rather than [String: any Sendable & Codable & Equatable], covering Action.updateMetadata, Action.updateUsage,
LanguageModelExecutorGenerationRequest.init, LanguageModelSession.Usage.init and the streamResponse family.

ConvertibleToGeneratedContent does not refine Sendable, so the internal GenerationEvent mirror cannot adopt the framework's exact spelling and stay Sendable. It takes [String: any ConvertibleToGeneratedContent & Sendable] instead, which upcasts implicitly at the SDK boundary. Every emitMetadata call site passes a String or Bool literal, both Generable and therefore ConvertibleToGeneratedContent, so no call site changes.

This is orthogonal to the Generation.rejectedToolCall exhaustive-switch failures, which are reported in issue #537, "MLXFoundationModels does not compile against the Xcode 27 / macOS 27 SDK", and issue #536, "IntegrationTesting project no longer compiles", and fixed by PR #538, "Add an Xcode 27 compile check and handle Generation.rejectedToolCall". Both changes are needed for a green beta 5 build: with this one applied, the only errors left from `xcodebuild -scheme MLXFoundationModels` are the two switch sites PR #538 covers.

Fixes issue #543, "MLXFoundationModels does not compile against Xcode 27 beta 5 (27A5237l)".

Co-Authored-By: Claude

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
