### PR TITLE
Add Qwen 3.8 support for text, VLM, and MTP speculative decoding

### DIFF
--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -246,6 +246,7 @@ public enum IntegrationTestModelIDs {
     public static let mistral3 = "mlx-community/Ministral-3-3B-Instruct-2512-4bit"
     public static let nemotron = "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit"
     public static let qwen35 = "mlx-community/Qwen3.5-2B-4bit"
+    public static let qwen38 = "mlx-community/Qwen3.8-27B-4bit"
 }
 
 // MARK: - Model Loading

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -45,6 +45,9 @@ public enum LLMTypeRegistry {
         "qwen3_5": create(Qwen35Configuration.self, Qwen35Model.init),
         "qwen3_5_moe": create(Qwen35Configuration.self, Qwen35MoEModel.init),
         "qwen3_5_text": create(Qwen35TextConfiguration.self, Qwen35TextModel.init),
+        "qwen3_8": create(Qwen35Configuration.self, Qwen35Model.init),
+        "qwen3_8_moe": create(Qwen35Configuration.self, Qwen35MoEModel.init),
+        "qwen3_8_text": create(Qwen35TextConfiguration.self, Qwen35TextModel.init),
         "nanbeige": create(NanbeigeConfiguration.self, NanbeigeModel.init),
         "minicpm": create(MiniCPMConfiguration.self, MiniCPMModel.init),
         "starcoder2": create(Starcoder2Configuration.self, Starcoder2Model.init),
@@ -335,6 +338,18 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         extraEOSTokens: ["<|im_end|>"]
     )
 
+    static public let qwen3_8_27b_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.8-27B-4bit",
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"]
+    )
+
+    static public let qwen3_8_27b_8bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.8-27B-8bit",
+        defaultPrompt: "Why is the sky blue?",
+        extraEOSTokens: ["<|im_end|>"]
+    )
+
     static public let openelm270m4bit = ModelConfiguration(
         id: "mlx-community/OpenELM-270M-Instruct",
         // https://huggingface.co/apple/OpenELM
@@ -520,6 +535,8 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
             qwen3MoE_30b_a3b_4bit,
             qwen3_5_2b_4bit,
             qwen3_6_27b_4bit,
+            qwen3_8_27b_4bit,
+            qwen3_8_27b_8bit,
             smolLM_135M_4bit,
             deepseek_r1_4bit,
             mimo_7b_sft_4bit,

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -143,6 +143,9 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
     var headDim: Int?
     var ropeScaling: [String: StringOrNumber]?
     var fullAttentionInterval: Int = 4
+    var layerTypes: [String]?
+    var resolvedLayerTypes: [String] = []
+    var fullAttentionLayerIndex: Int? = nil
     var mtpNumHiddenLayers: Int = 0
     var mtpUseDedicatedEmbeddings: Bool = false
 
@@ -176,6 +179,7 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
         case headDim = "head_dim"
         case ropeScaling = "rope_scaling"
         case fullAttentionInterval = "full_attention_interval"
+        case layerTypes = "layer_types"
         case mtpNumHiddenLayers = "mtp_num_hidden_layers"
         case mtpUseDedicatedEmbeddings = "mtp_use_dedicated_embeddings"
         case numExperts = "num_experts"
@@ -224,6 +228,14 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
         self.headDim = try container.decodeIfPresent(Int.self, forKey: .headDim)
         self.fullAttentionInterval =
             try container.decodeIfPresent(Int.self, forKey: .fullAttentionInterval) ?? 4
+        self.layerTypes = try container.decodeIfPresent([String].self, forKey: .layerTypes)
+        let layerSchedule = try HybridAttentionSchedule(
+            hiddenLayerCount: hiddenLayers,
+            fullAttentionInterval: fullAttentionInterval,
+            explicitLayerTypes: layerTypes
+        )
+        self.resolvedLayerTypes = layerSchedule.layerTypes
+        self.fullAttentionLayerIndex = layerSchedule.firstFullAttentionIndex
         self.mtpNumHiddenLayers =
             try container.decodeIfPresent(Int.self, forKey: .mtpNumHiddenLayers) ?? 0
         self.mtpUseDedicatedEmbeddings =
@@ -723,7 +735,8 @@ final class Qwen35DecoderLayer: Module {
 
     init(_ args: Qwen35TextConfiguration, layerIdx: Int, forceFullAttention: Bool = false) {
         self.isLinear =
-            forceFullAttention ? false : (layerIdx + 1) % args.fullAttentionInterval != 0
+            forceFullAttention
+            ? false : args.resolvedLayerTypes[layerIdx] == HybridAttentionSchedule.linearAttention
 
         if isLinear {
             _linearAttn.wrappedValue = Qwen35GatedDeltaNet(args)
@@ -903,7 +916,7 @@ final class Qwen35DecoderLayer: Module {
 public class Qwen35TextModelInner: Module {
     @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
 
-    fileprivate let layers: [Qwen35DecoderLayer]
+    let layers: [Qwen35DecoderLayer]
     let norm: RMSNorm
 
     let ssmIdx: Int
@@ -925,8 +938,7 @@ public class Qwen35TextModelInner: Module {
         self.norm = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
 
         self.ssmIdx = 0
-        self.faIdx = args.fullAttentionInterval - 1
-
+        self.faIdx = args.fullAttentionLayerIndex ?? (args.fullAttentionInterval - 1)
         let segments = Self.decodeSchedule(for: layers)
         self.decodeSegments = segments
         self.compiledSegments = Array(repeating: nil, count: segments.count)
@@ -1307,7 +1319,9 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         var sanitized = [String: MLXArray]()
         for (key, value) in weights {
-            if key.hasPrefix("vision_tower") || key.hasPrefix("model.visual") {
+            if key.hasPrefix("vision_tower") || key.hasPrefix("model.visual")
+                || key.hasPrefix("visual.")
+            {
                 continue
             }
 

--- a/Libraries/MLXLLM/Models/Qwen35MTP.swift
+++ b/Libraries/MLXLLM/Models/Qwen35MTP.swift
@@ -17,6 +17,11 @@ final class Qwen35MTPPredictor: Module {
         var mtpArgs = args
         mtpArgs.hiddenLayers = max(args.mtpNumHiddenLayers, 1)
         mtpArgs.fullAttentionInterval = 1
+        let layerTypes = Array(
+            repeating: HybridAttentionSchedule.fullAttention, count: mtpArgs.hiddenLayers)
+        mtpArgs.layerTypes = layerTypes
+        mtpArgs.resolvedLayerTypes = layerTypes
+        mtpArgs.fullAttentionLayerIndex = 0
 
         if args.mtpUseDedicatedEmbeddings {
             _embedTokens.wrappedValue = Embedding(
@@ -94,6 +99,10 @@ public final class Qwen35MTPDraftModel: Module, StatefulMTPDrafterModel {
 
     public func makeState(parameters: GenerateParameters?) -> MTPDrafterState {
         MTPDrafterState(cache: mtp.newCache())
+    }
+
+    public func isCompatible(with target: any LanguageModel) -> Bool {
+        target is Qwen35Model || target is Qwen35TextModel
     }
 
     public func prepareDrafterState(

--- a/Libraries/MLXLLM/Qwen35TextMTPRegistration.swift
+++ b/Libraries/MLXLLM/Qwen35TextMTPRegistration.swift
@@ -3,53 +3,44 @@
 import Foundation
 import MLXLMCommon
 
-/// Registers Qwen3.5/Qwen3.6 text MTP drafter model types.
+/// Registers Qwen3.5-family text MTP drafter model types.
 ///
-/// Callers should invoke this once before loading a Qwen text drafter through
-/// `MTPDrafterModelFactory`.
+/// Standalone Qwen MTP checkpoints do not identify the verifier architecture:
+/// their `vision_config` is empty for both text and multimodal use. Text and
+/// multimodal drafters therefore use separate registries instead of relying
+/// on config-shape predicates or registration order.
 public enum Qwen35TextMTPRegistration {
     public static func register() async {
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5_text",
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35TextConfiguration.self, from: data)
-                return Qwen35MTPDraftModel(config)
-            }
-        )
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5_mtp",
-            matches: qwen35TextMTPConfiguration,
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35Configuration.self, from: data)
-                return Qwen35MTPDraftModel(config, preconvertedNorms: true)
-            }
-        )
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5",
-            matches: qwen35TextMTPConfiguration,
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35Configuration.self, from: data)
-                return Qwen35MTPDraftModel(config)
-            }
-        )
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5_moe",
-            matches: qwen35TextMTPConfiguration,
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35Configuration.self, from: data)
-                return Qwen35MTPDraftModel(config)
-            }
-        )
-    }
-}
+        let registry = MTPDrafterTypeRegistry.shared
 
-private func qwen35TextMTPConfiguration(_ data: Data) -> Bool {
-    guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let vision = root["vision_config"] as? [String: Any]
-    else { return true }
-    return vision.isEmpty
+        for modelType in ["qwen3_5_text", "qwen3_8_text"] {
+            await registry.registerModelType(
+                modelType,
+                creator: { data in
+                    let config = try JSONDecoder.json5().decode(
+                        Qwen35TextConfiguration.self, from: data)
+                    return Qwen35MTPDraftModel(config)
+                })
+        }
+
+        for modelType in ["qwen3_5", "qwen3_5_moe", "qwen3_8", "qwen3_8_moe"] {
+            await registry.registerModelType(
+                modelType,
+                creator: { data in
+                    let config = try JSONDecoder.json5().decode(
+                        Qwen35Configuration.self, from: data)
+                    return Qwen35MTPDraftModel(config)
+                })
+        }
+
+        for modelType in ["qwen3_5_mtp", "qwen3_8_mtp"] {
+            await registry.registerModelType(
+                modelType,
+                creator: { data in
+                    let config = try JSONDecoder.json5().decode(
+                        Qwen35Configuration.self, from: data)
+                    return Qwen35MTPDraftModel(config, preconvertedNorms: true)
+                })
+        }
+    }
 }

--- a/Libraries/MLXLMCommon/HybridAttentionSchedule.swift
+++ b/Libraries/MLXLMCommon/HybridAttentionSchedule.swift
@@ -1,0 +1,56 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// A validated hybrid decoder schedule shared by text and multimodal models.
+///
+/// Explicit `layer_types` metadata is authoritative. When it is absent, the
+/// legacy interval pattern is expanded once so downstream model code does not
+/// need to maintain two scheduling paths.
+package struct HybridAttentionSchedule: Sendable, Equatable {
+    package static let linearAttention = "linear_attention"
+    package static let fullAttention = "full_attention"
+
+    package let layerTypes: [String]
+
+    package var firstFullAttentionIndex: Int? {
+        layerTypes.firstIndex(of: Self.fullAttention)
+    }
+
+    package init(
+        hiddenLayerCount: Int,
+        fullAttentionInterval: Int,
+        explicitLayerTypes: [String]?
+    ) throws {
+        guard hiddenLayerCount >= 0 else {
+            throw ModelFactoryError.invalidConfiguration(
+                "num_hidden_layers must be non-negative, got \(hiddenLayerCount)")
+        }
+
+        if let explicitLayerTypes {
+            guard explicitLayerTypes.count == hiddenLayerCount else {
+                throw ModelFactoryError.invalidConfiguration(
+                    "layer_types contains \(explicitLayerTypes.count) entries, but "
+                        + "num_hidden_layers is \(hiddenLayerCount)")
+            }
+
+            let supported = [Self.linearAttention, Self.fullAttention]
+            guard let unsupported = explicitLayerTypes.first(where: { !supported.contains($0) })
+            else {
+                self.layerTypes = explicitLayerTypes
+                return
+            }
+            throw ModelFactoryError.invalidConfiguration(
+                "unsupported Qwen hybrid layer type '\(unsupported)'")
+        }
+
+        guard fullAttentionInterval > 0 else {
+            throw ModelFactoryError.invalidConfiguration(
+                "full_attention_interval must be positive, got \(fullAttentionInterval)")
+        }
+        self.layerTypes = (0 ..< hiddenLayerCount).map { index in
+            (index + 1).isMultiple(of: fullAttentionInterval)
+                ? Self.fullAttention : Self.linearAttention
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/MTPDrafterModel.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModel.swift
@@ -26,6 +26,10 @@ import MLXNN
 /// instance. Drafters that need their own per-stream state additionally
 /// conform to ``StatefulMTPDrafterModel``.
 public protocol MTPDrafterModel: BaseLanguageModel {
+    /// Whether the drafter can consume hidden states and model-owned values
+    /// from this target architecture.
+    func isCompatible(with target: any LanguageModel) -> Bool
+
     /// Largest total verification block the drafter can produce efficiently.
     /// `nil` means the caller may choose any block size.
     var maximumBlockSize: Int? { get }
@@ -85,6 +89,7 @@ public protocol MTPDrafterModel: BaseLanguageModel {
 }
 
 extension MTPDrafterModel {
+    public func isCompatible(with target: any LanguageModel) -> Bool { true }
     public var maximumBlockSize: Int? { nil }
     public var requiresSharedTargetKV: Bool { true }
     public var requiresPromptPrefill: Bool { false }

--- a/Libraries/MLXLMCommon/MTPDrafterModelFactory.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModelFactory.swift
@@ -18,6 +18,12 @@ public enum MTPDrafterTypeRegistry {
     /// Shared registry. Empty until a downstream module registers a drafter
     /// type via `await MTPDrafterTypeRegistry.shared.registerModelType(...)`.
     public static let shared: ModelTypeRegistry<any MTPDrafterModel> = .init()
+
+    /// Registry for drafters whose forward pass consumes multimodal position
+    /// state. It is separate from ``shared`` because standalone Qwen MTP
+    /// checkpoints intentionally ship an empty `vision_config`, so their
+    /// target architecture cannot be inferred from drafter metadata alone.
+    public static let visionLanguage: ModelTypeRegistry<any MTPDrafterModel> = .init()
 }
 
 /// Registry of model id (e.g. `"mlx-community/gemma-4-31B-it-assistant-bf16"`)
@@ -32,9 +38,12 @@ public class MTPDrafterRegistry: AbstractModelRegistry, @unchecked Sendable {
     public static let gemma4_31B_assistant_bf16 = ModelConfiguration(
         id: "mlx-community/gemma-4-31B-it-assistant-bf16"
     )
+    public static let qwen3_8_27b_mtp_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.8-27B-MTP-4bit"
+    )
 
     private static func all() -> [ModelConfiguration] {
-        [gemma4_26B_assistant_bf16, gemma4_31B_assistant_bf16]
+        [gemma4_26B_assistant_bf16, gemma4_31B_assistant_bf16, qwen3_8_27b_mtp_4bit]
     }
 }
 
@@ -48,6 +57,13 @@ public final class MTPDrafterModelFactory: GenericModelFactory {
 
     public static let shared = MTPDrafterModelFactory(
         typeRegistry: MTPDrafterTypeRegistry.shared,
+        modelRegistry: MTPDrafterRegistry.shared
+    )
+
+    /// Loader for multimodal drafters. Use this factory when the verifier was
+    /// loaded by `VLMModelFactory` and can emit multimodal RoPE deltas.
+    public static let visionLanguage = MTPDrafterModelFactory(
+        typeRegistry: MTPDrafterTypeRegistry.visionLanguage,
         modelRegistry: MTPDrafterRegistry.shared
     )
 

--- a/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
+++ b/Libraries/MLXLMCommon/MTPSpeculativeTokenIterator.swift
@@ -115,6 +115,11 @@ public struct MTPSpeculativeTokenIterator: TokenIteratorProtocol {
         precondition(
             blockSize >= 2,
             "MTPSpeculativeTokenIterator requires blockSize >= 2 (1 bonus + K-1 drafted)")
+        guard drafter.isCompatible(with: mainModel) else {
+            throw ModelFactoryError.invalidConfiguration(
+                "MTP drafter \(type(of: drafter)) is incompatible with target "
+                    + "\(type(of: mainModel))")
+        }
 
         let kvCachePlan = try parameters.kvCachePlan()
         let mainCache = try kvCachePlan.validated(

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -47,6 +47,9 @@ public struct Qwen35Configuration: Codable, Sendable {
         public var headDim: Int?
         public var ropeParameters: [String: StringOrNumber]?
         public var fullAttentionInterval: Int = 4
+        public var layerTypes: [String]?
+        var resolvedLayerTypes: [String] = []
+        var fullAttentionLayerIndex: Int? = nil
         public var mtpNumHiddenLayers: Int = 0
         public var mtpUseDedicatedEmbeddings: Bool = false
 
@@ -80,6 +83,7 @@ public struct Qwen35Configuration: Codable, Sendable {
             case headDim = "head_dim"
             case ropeParameters = "rope_parameters"
             case fullAttentionInterval = "full_attention_interval"
+            case layerTypes = "layer_types"
             case mtpNumHiddenLayers = "mtp_num_hidden_layers"
             case mtpUseDedicatedEmbeddings = "mtp_use_dedicated_embeddings"
             case numExperts = "num_experts"
@@ -123,6 +127,14 @@ public struct Qwen35Configuration: Codable, Sendable {
             self.headDim = try container.decodeIfPresent(Int.self, forKey: .headDim)
             self.fullAttentionInterval =
                 try container.decodeIfPresent(Int.self, forKey: .fullAttentionInterval) ?? 4
+            self.layerTypes = try container.decodeIfPresent([String].self, forKey: .layerTypes)
+            let layerSchedule = try HybridAttentionSchedule(
+                hiddenLayerCount: hiddenLayers,
+                fullAttentionInterval: fullAttentionInterval,
+                explicitLayerTypes: layerTypes
+            )
+            self.resolvedLayerTypes = layerSchedule.layerTypes
+            self.fullAttentionLayerIndex = layerSchedule.firstFullAttentionIndex
             self.mtpNumHiddenLayers =
                 try container.decodeIfPresent(Int.self, forKey: .mtpNumHiddenLayers) ?? 0
             self.mtpUseDedicatedEmbeddings =
@@ -692,7 +704,8 @@ enum Qwen35Language {
         ) {
             self.isLinear =
                 forceFullAttention
-                ? false : (layerIdx + 1) % args.fullAttentionInterval != 0
+                ? false
+                : args.resolvedLayerTypes[layerIdx] == HybridAttentionSchedule.linearAttention
 
             if isLinear {
                 _linearAttn.wrappedValue = GatedDeltaNet(args)
@@ -756,7 +769,7 @@ enum Qwen35Language {
             _norm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
 
             self.ssmIdx = 0
-            self.faIdx = args.fullAttentionInterval - 1
+            self.faIdx = args.fullAttentionLayerIndex ?? (args.fullAttentionInterval - 1)
             super.init()
         }
 
@@ -1371,6 +1384,8 @@ public class Qwen35: Module, VLMModel {
                 }
             } else if key.contains("lm_head") {
                 key = key.replacingOccurrences(of: "lm_head", with: "language_model.lm_head")
+            } else if key.hasPrefix("visual.") {
+                key = key.replacingOccurrences(of: "visual.", with: "vision_tower.")
             }
 
             if key.contains("conv1d.weight") && value.dim(-1) != 1 {

--- a/Libraries/MLXVLM/Models/Qwen35MTP.swift
+++ b/Libraries/MLXVLM/Models/Qwen35MTP.swift
@@ -17,6 +17,11 @@ final class Qwen35VLMNextNPredictor: Module {
         var mtpArgs = args
         mtpArgs.hiddenLayers = max(args.mtpNumHiddenLayers, 1)
         mtpArgs.fullAttentionInterval = 1
+        let layerTypes = Array(
+            repeating: HybridAttentionSchedule.fullAttention, count: mtpArgs.hiddenLayers)
+        mtpArgs.layerTypes = layerTypes
+        mtpArgs.resolvedLayerTypes = layerTypes
+        mtpArgs.fullAttentionLayerIndex = 0
 
         if args.mtpUseDedicatedEmbeddings {
             _embedTokens.wrappedValue = Embedding(
@@ -106,6 +111,10 @@ public final class Qwen35VLMNextNDraftModel: Module, StatefulMTPDrafterModel {
 
     public func makeState(parameters: GenerateParameters?) -> MTPDrafterState {
         MTPDrafterState(cache: mtp.newCache())
+    }
+
+    public func isCompatible(with target: any LanguageModel) -> Bool {
+        target is Qwen35
     }
 
     public func prepareDrafterState(

--- a/Libraries/MLXVLM/Qwen35VLMMTPRegistration.swift
+++ b/Libraries/MLXVLM/Qwen35VLMMTPRegistration.swift
@@ -3,47 +3,42 @@
 import Foundation
 import MLXLMCommon
 
-/// Registers Qwen3.5/Qwen3.6 VLM MTP drafter model types.
+/// Registers Qwen3.5-family multimodal MTP drafter model types.
 ///
-/// Callers should invoke this once before loading a Qwen VLM drafter through
-/// `MTPDrafterModelFactory`. The `"qwen3_5"` names overlap with the text
-/// registration; config-shape predicates keep both registrations usable in
-/// the same process.
+/// These creators live in the target-specific `visionLanguage` registry so a
+/// standalone MTP config with an empty `vision_config` still selects the
+/// M-RoPE-aware drafter deterministically.
 public enum Qwen35VLMMTPRegistration {
     public static func register() async {
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5",
-            matches: qwen35VLMMTPConfiguration,
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35Configuration.self, from: data)
-                return Qwen35VLMNextNDraftModel(config)
-            }
-        )
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5_mtp",
-            matches: qwen35VLMMTPConfiguration,
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35Configuration.self, from: data)
-                return Qwen35VLMNextNDraftModel(config, preconvertedNorms: true)
-            }
-        )
-        await MTPDrafterTypeRegistry.shared.registerModelType(
-            "qwen3_5_moe",
-            matches: qwen35VLMMTPConfiguration,
-            creator: { data in
-                let config = try JSONDecoder.json5().decode(
-                    Qwen35Configuration.self, from: data)
-                return Qwen35VLMNextNDraftModel(config)
-            }
-        )
+        let registry = MTPDrafterTypeRegistry.visionLanguage
+
+        for modelType in ["qwen3_5", "qwen3_5_moe", "qwen3_8", "qwen3_8_moe"] {
+            await registry.registerModelType(
+                modelType,
+                creator: { data in
+                    let config = try JSONDecoder.json5().decode(
+                        Qwen35MTPTextConfiguration.self, from: data)
+                    return Qwen35VLMNextNDraftModel(config.textConfiguration)
+                })
+        }
+
+        for modelType in ["qwen3_5_mtp", "qwen3_8_mtp"] {
+            await registry.registerModelType(
+                modelType,
+                creator: { data in
+                    let config = try JSONDecoder.json5().decode(
+                        Qwen35MTPTextConfiguration.self, from: data)
+                    return Qwen35VLMNextNDraftModel(
+                        config.textConfiguration, preconvertedNorms: true)
+                })
+        }
     }
 }
 
-private func qwen35VLMMTPConfiguration(_ data: Data) -> Bool {
-    guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let vision = root["vision_config"] as? [String: Any]
-    else { return false }
-    return !vision.isEmpty
+private struct Qwen35MTPTextConfiguration: Decodable {
+    let textConfiguration: Qwen35Configuration.TextConfiguration
+
+    enum CodingKeys: String, CodingKey {
+        case textConfiguration = "text_config"
+    }
 }

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -94,6 +94,8 @@ public enum VLMTypeRegistry {
         "qwen3_vl_moe": create(Qwen3VLMoEConfiguration.self, Qwen3VLMoE.init),
         "qwen3_5": create(Qwen35Configuration.self, Qwen35.init),
         "qwen3_5_moe": create(Qwen35Configuration.self, Qwen35MoE.init),
+        "qwen3_8": create(Qwen35Configuration.self, Qwen35.init),
+        "qwen3_8_moe": create(Qwen35Configuration.self, Qwen35MoE.init),
         "idefics3": create(Idefics3Configuration.self, Idefics3.init),
         "gemma3": create(Gemma3Configuration.self, Gemma3.init),
         "gemma4": create(Gemma4Configuration.self, Gemma4.init),
@@ -121,6 +123,14 @@ public enum VLMProcessorTypeRegistry {
         "Qwen2_5_VLProcessor": create(
             Qwen25VLProcessorConfiguration.self, Qwen25VLProcessor.init),
         "Qwen3VLProcessor": create(
+            Qwen3VLProcessorConfiguration.self, Qwen3VLProcessor.init),
+        "Qwen3_5VLProcessor": create(
+            Qwen3VLProcessorConfiguration.self, Qwen3VLProcessor.init),
+        "Qwen3_5_VLProcessor": create(
+            Qwen3VLProcessorConfiguration.self, Qwen3VLProcessor.init),
+        "Qwen3_8VLProcessor": create(
+            Qwen3VLProcessorConfiguration.self, Qwen3VLProcessor.init),
+        "Qwen3_8_VLProcessor": create(
             Qwen3VLProcessorConfiguration.self, Qwen3VLProcessor.init),
         "Idefics3Processor": create(
             Idefics3ProcessorConfiguration.self, Idefics3Processor.init),
@@ -272,6 +282,18 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         extraEOSTokens: ["<|im_end|>"]
     )
 
+    static public let qwen3_8_27B_4bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.8-27B-4bit",
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"]
+    )
+
+    static public let qwen3_8_27B_8bit = ModelConfiguration(
+        id: "mlx-community/Qwen3.8-27B-8bit",
+        defaultPrompt: "Describe the image in English",
+        extraEOSTokens: ["<|im_end|>"]
+    )
+
     static public let museGlimmer30B4bit = ModelConfiguration(
         id: "mlx-community/Muse-Glimmer-30B-4bit",
         defaultPrompt: "Describe the image in English",
@@ -303,6 +325,8 @@ public class VLMRegistry: AbstractModelRegistry, @unchecked Sendable {
             fastvlm,
             qwen3_5_27B_4bit,
             qwen3_5_35B_A3B_4bit,
+            qwen3_8_27B_4bit,
+            qwen3_8_27B_8bit,
             museGlimmer30B4bit,
         ]
     }

--- a/Tests/MLXLMTests/Qwen35MTPTests.swift
+++ b/Tests/MLXLMTests/Qwen35MTPTests.swift
@@ -391,7 +391,7 @@ struct Qwen35MTPRegistrationTests {
             modelType: "qwen3_5")
         #expect(wrappedTextModel is MLXLLM.Qwen35MTPDraftModel)
 
-        let vlmModel = try await MTPDrafterTypeRegistry.shared.createModel(
+        let vlmModel = try await MTPDrafterTypeRegistry.visionLanguage.createModel(
             configuration: Data(qwen35VLMConfigJSON(mtpLayers: 1).utf8),
             modelType: "qwen3_5")
         #expect(vlmModel is MLXVLM.Qwen35VLMNextNDraftModel)
@@ -404,14 +404,33 @@ struct Qwen35MTPRegistrationTests {
         #expect(standalone.requiresPromptPrefill)
         #expect(!standalone.requiresSharedTargetKV)
         #expect(standalone.requiresGreedySampling)
+
+        let standaloneVLM = try await MTPDrafterTypeRegistry.visionLanguage.createModel(
+            configuration: Data(qwen35StandaloneMTPConfigJSON().utf8),
+            modelType: "qwen3_5_mtp")
+        #expect(standaloneVLM is MLXVLM.Qwen35VLMNextNDraftModel)
+
+        let textConfig = try JSONDecoder.json5().decode(
+            MLXLLM.Qwen35TextConfiguration.self,
+            from: Data(qwen35TextConfigJSON(mtpLayers: 1).utf8))
+        let vlmConfig = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self,
+            from: Data(qwen35VLMConfigJSON(mtpLayers: 1).utf8))
+        let textTarget = MLXLLM.Qwen35TextModel(textConfig)
+        let vlmTarget = MLXVLM.Qwen35(vlmConfig)
+
+        #expect(standalone.isCompatible(with: textTarget))
+        #expect(!standalone.isCompatible(with: vlmTarget))
+        #expect(standaloneVLM.isCompatible(with: vlmTarget))
+        #expect(!standaloneVLM.isCompatible(with: textTarget))
     }
 
     @Test
-    func registrationsAreOrderIndependentForSharedModelTypes() async throws {
+    func registrationsAreIsolatedByTargetArchitecture() async throws {
         await MLXVLM.Qwen35VLMMTPRegistration.register()
         await MLXLLM.Qwen35TextMTPRegistration.register()
 
-        let vlmModel = try await MTPDrafterTypeRegistry.shared.createModel(
+        let vlmModel = try await MTPDrafterTypeRegistry.visionLanguage.createModel(
             configuration: Data(qwen35VLMConfigJSON(mtpLayers: 1).utf8),
             modelType: "qwen3_5")
         #expect(vlmModel is MLXVLM.Qwen35VLMNextNDraftModel)

--- a/Tests/MLXLMTests/Qwen38Tests.swift
+++ b/Tests/MLXLMTests/Qwen38Tests.swift
@@ -1,0 +1,348 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXVLM
+
+final class Qwen38Tests: XCTestCase {
+
+    private func releasedQwen38ConfigJSON() -> String {
+        """
+        {
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "hidden_size": 16,
+                "num_hidden_layers": 4,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 1,
+                "linear_key_head_dim": 8,
+                "linear_value_head_dim": 8,
+                "linear_conv_kernel_dim": 4,
+                "vocab_size": 64,
+                "full_attention_interval": 4,
+                "layer_types": [
+                    "linear_attention",
+                    "linear_attention",
+                    "linear_attention",
+                    "full_attention"
+                ]
+            },
+            "vision_config": {
+                "model_type": "qwen3_5",
+                "depth": 2,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "out_hidden_size": 16,
+                "num_heads": 2,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+                "num_position_embeddings": 64
+            }
+        }
+        """
+    }
+
+    private func qwen38TextConfigJSON() -> String {
+        """
+        {
+            "architectures": ["Qwen3_5ForCausalLM"],
+            "model_type": "qwen3_8",
+            "hidden_size": 16,
+            "num_hidden_layers": 4,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "linear_num_value_heads": 2,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 8,
+            "linear_value_head_dim": 8,
+            "linear_conv_kernel_dim": 4,
+            "vocab_size": 64,
+            "full_attention_interval": 4,
+            "layer_types": [
+                "linear_attention",
+                "full_attention",
+                "linear_attention",
+                "full_attention"
+            ],
+            "mtp_num_hidden_layers": 1,
+            "rope_parameters": {
+                "rope_type": "default",
+                "rope_theta": 10000000.0,
+                "partial_rotary_factor": 0.25
+            }
+        }
+        """
+    }
+
+    private func qwen38VLMConfigJSON() -> String {
+        """
+        {
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "model_type": "qwen3_8",
+            "image_token_id": 248056,
+            "video_token_id": 248057,
+            "vision_start_token_id": 248053,
+            "vision_end_token_id": 248054,
+            "text_config": {
+                "model_type": "qwen3_8_text",
+                "hidden_size": 16,
+                "num_hidden_layers": 4,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "linear_num_value_heads": 2,
+                "linear_num_key_heads": 1,
+                "linear_key_head_dim": 8,
+                "linear_value_head_dim": 8,
+                "linear_conv_kernel_dim": 4,
+                "vocab_size": 64,
+                "full_attention_interval": 2,
+                "rope_parameters": {
+                    "rope_type": "default",
+                    "rope_theta": 10000000.0,
+                    "partial_rotary_factor": 0.25
+                }
+            },
+            "vision_config": {
+                "model_type": "qwen3_8",
+                "depth": 2,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "out_hidden_size": 16,
+                "num_heads": 2,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+                "num_position_embeddings": 64
+            }
+        }
+        """
+    }
+
+    // MARK: - Configuration & Type Registry Tests
+
+    func testReleasedQwen38MetadataRoutesThroughExistingQwen35Architecture() async throws {
+        let data = Data(releasedQwen38ConfigJSON().utf8)
+        let base = try JSONDecoder.json5().decode(BaseConfiguration.self, from: data)
+        XCTAssertEqual(base.modelType, "qwen3_5")
+
+        let textModel = try await LLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: base.modelType)
+        let vlmModel = try await VLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: base.modelType)
+
+        XCTAssertTrue(textModel is MLXLLM.Qwen35Model)
+        XCTAssertTrue(vlmModel is MLXVLM.Qwen35)
+        let textBackbone = (textModel as! MLXLLM.Qwen35Model).languageModel.model
+        let vlmBackbone = (vlmModel as! MLXVLM.Qwen35).languageModel.model
+        XCTAssertEqual(textBackbone.ssmIdx, 0)
+        XCTAssertEqual(textBackbone.faIdx, 3)
+        XCTAssertEqual(vlmBackbone.ssmIdx, 0)
+        XCTAssertEqual(vlmBackbone.faIdx, 3)
+    }
+
+    func testQwen38LLMTypeRegistryCreatesModel() async throws {
+        let json = qwen38TextConfigJSON()
+        let data = Data(json.utf8)
+
+        for type in ["qwen3_8", "qwen3_8_text"] {
+            let model = try await LLMTypeRegistry.shared.createModel(
+                configuration: data, modelType: type)
+            XCTAssertEqual(model.toolCallFormat, .qwen35)
+            XCTAssertEqual(model.reasoningConfig, QwenReasoningProtocol.tagged)
+        }
+    }
+
+    func testQwen38VLMTypeRegistryCreatesModel() async throws {
+        let json = qwen38VLMConfigJSON()
+        let data = Data(json.utf8)
+
+        let model = try await VLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: "qwen3_8")
+        XCTAssertEqual(model.toolCallFormat, .qwen35)
+        XCTAssertEqual(model.reasoningConfig, QwenReasoningProtocol.tagged)
+    }
+
+    func testQwen38ExplicitLayerTypes() throws {
+        let json = qwen38TextConfigJSON()
+        let config = try JSONDecoder.json5().decode(
+            MLXLLM.Qwen35TextConfiguration.self, from: Data(json.utf8))
+        XCTAssertEqual(
+            config.layerTypes,
+            [
+                "linear_attention",
+                "full_attention",
+                "linear_attention",
+                "full_attention",
+            ])
+
+        let model = MLXLLM.Qwen35TextModel(config)
+        XCTAssertEqual(model.model.layers.count, 4)
+        XCTAssertTrue(model.model.layers[0].isLinear)
+        XCTAssertFalse(model.model.layers[1].isLinear)
+        XCTAssertTrue(model.model.layers[2].isLinear)
+        XCTAssertFalse(model.model.layers[3].isLinear)
+        XCTAssertEqual(model.model.ssmIdx, 0)
+        XCTAssertEqual(model.model.faIdx, 1)
+    }
+
+    func testQwen38ExplicitLayerTypesMustDescribeEveryLayer() throws {
+        let json = """
+            {
+                "num_hidden_layers": 4,
+                "full_attention_interval": 2,
+                "layer_types": [
+                    "linear_attention",
+                    "full_attention",
+                    "linear_attention"
+                ]
+            }
+            """
+
+        XCTAssertThrowsError(
+            try JSONDecoder.json5().decode(
+                MLXLLM.Qwen35TextConfiguration.self, from: Data(json.utf8))
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("layer_types"))
+        }
+    }
+
+    func testQwen38RejectsUnknownLayerTypesAndInvalidFallbackInterval() throws {
+        let unknownLayerType = """
+            {
+                "num_hidden_layers": 1,
+                "layer_types": ["sliding_attention"]
+            }
+            """
+        XCTAssertThrowsError(
+            try JSONDecoder.json5().decode(
+                MLXLLM.Qwen35TextConfiguration.self, from: Data(unknownLayerType.utf8))
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("sliding_attention"))
+        }
+
+        let invalidInterval = """
+            {
+                "num_hidden_layers": 1,
+                "full_attention_interval": 0
+            }
+            """
+        XCTAssertThrowsError(
+            try JSONDecoder.json5().decode(
+                MLXLLM.Qwen35TextConfiguration.self, from: Data(invalidInterval.utf8))
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("full_attention_interval"))
+        }
+    }
+
+    // MARK: - Registry Presets
+
+    func testQwen38LLMRegistryConfigurations() {
+        let config4bit = LLMRegistry.qwen3_8_27b_4bit
+        XCTAssertEqual(config4bit.name, "mlx-community/Qwen3.8-27B-4bit")
+        XCTAssertEqual(config4bit.extraEOSTokens, ["<|im_end|>"])
+
+        let config8bit = LLMRegistry.qwen3_8_27b_8bit
+        XCTAssertEqual(config8bit.name, "mlx-community/Qwen3.8-27B-8bit")
+        XCTAssertEqual(config8bit.extraEOSTokens, ["<|im_end|>"])
+
+        XCTAssertTrue(LLMRegistry.shared.contains(id: "mlx-community/Qwen3.8-27B-4bit"))
+        XCTAssertTrue(LLMRegistry.shared.contains(id: "mlx-community/Qwen3.8-27B-8bit"))
+    }
+
+    func testQwen38VLMRegistryConfigurations() {
+        let config4bit = VLMRegistry.qwen3_8_27B_4bit
+        XCTAssertEqual(config4bit.name, "mlx-community/Qwen3.8-27B-4bit")
+        XCTAssertEqual(config4bit.extraEOSTokens, ["<|im_end|>"])
+
+        let config8bit = VLMRegistry.qwen3_8_27B_8bit
+        XCTAssertEqual(config8bit.name, "mlx-community/Qwen3.8-27B-8bit")
+        XCTAssertEqual(config8bit.extraEOSTokens, ["<|im_end|>"])
+
+        XCTAssertTrue(VLMRegistry.shared.contains(id: "mlx-community/Qwen3.8-27B-4bit"))
+        XCTAssertTrue(VLMRegistry.shared.contains(id: "mlx-community/Qwen3.8-27B-8bit"))
+    }
+
+    func testQwen38MTPRegistryConfiguration() {
+        let config = MTPDrafterRegistry.qwen3_8_27b_mtp_4bit
+        XCTAssertEqual(config.name, "mlx-community/Qwen3.8-27B-MTP-4bit")
+        XCTAssertTrue(MTPDrafterRegistry.shared.contains(id: config.name))
+    }
+
+    // MARK: - Weight Sanitization Tests
+
+    func testQwen38TextModelSanitizeStripsVisualPrefixes() throws {
+        let config = try JSONDecoder.json5().decode(
+            MLXLLM.Qwen35Configuration.self, from: Data(qwen38TextConfigJSON().utf8))
+        let model = MLXLLM.Qwen35Model(config)
+
+        let mockWeights: [String: MLXArray] = [
+            "model.embed_tokens.weight": MLXArray.zeros([64, 16]),
+            "visual.patch_embed.proj.weight": MLXArray.zeros([16, 3, 16, 16]),
+            "model.visual.blocks.0.attn.qkv.weight": MLXArray.zeros([16, 16]),
+            "vision_tower.blocks.0.norm.weight": MLXArray.zeros([16]),
+        ]
+
+        let sanitized = model.sanitize(weights: mockWeights)
+        XCTAssertNotNil(sanitized["language_model.model.embed_tokens.weight"])
+        XCTAssertNil(sanitized["visual.patch_embed.proj.weight"])
+        XCTAssertNil(sanitized["language_model.visual.patch_embed.proj.weight"])
+        XCTAssertNil(sanitized["model.visual.blocks.0.attn.qkv.weight"])
+        XCTAssertNil(sanitized["vision_tower.blocks.0.norm.weight"])
+    }
+
+    func testQwen38VLMModelSanitizeRemapsVisualPrefixes() throws {
+        let config = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self, from: Data(qwen38VLMConfigJSON().utf8))
+        let model = MLXVLM.Qwen35(config)
+
+        let mockWeights: [String: MLXArray] = [
+            "language_model.model.embed_tokens.weight": MLXArray.zeros([64, 16]),
+            "visual.merger.mlp.0.weight": MLXArray.zeros([16, 16]),
+            "model.visual.merger.mlp.1.weight": MLXArray.zeros([16, 16]),
+        ]
+
+        let sanitized = model.sanitize(weights: mockWeights)
+        XCTAssertNotNil(sanitized["language_model.model.embed_tokens.weight"])
+        XCTAssertNotNil(sanitized["vision_tower.merger.mlp.0.weight"])
+        XCTAssertNotNil(sanitized["vision_tower.merger.mlp.1.weight"])
+    }
+
+    // MARK: - MTP Speculative Decoding Registration Tests
+
+    func testQwen38MTPRegistrations() async throws {
+        await Qwen35TextMTPRegistration.register()
+        await Qwen35VLMMTPRegistration.register()
+
+        let textData = Data(qwen38TextConfigJSON().utf8)
+        let vlmData = Data(qwen38VLMConfigJSON().utf8)
+
+        // Text drafter matches
+        let textDrafter = try await MTPDrafterTypeRegistry.shared.createModel(
+            configuration: textData, modelType: "qwen3_8_text")
+        XCTAssertNotNil(textDrafter)
+
+        let textMTPDrafter = try await MTPDrafterTypeRegistry.shared.createModel(
+            configuration: textData, modelType: "qwen3_8_mtp")
+        XCTAssertNotNil(textMTPDrafter)
+
+        // VLM drafter matches
+        let vlmMTPDrafter = try await MTPDrafterTypeRegistry.visionLanguage.createModel(
+            configuration: vlmData, modelType: "qwen3_8_mtp")
+        XCTAssertTrue(vlmMTPDrafter is Qwen35VLMNextNDraftModel)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds support for **Qwen 3.8** (e.g. `mlx-community/Qwen3.8-27B-4bit` and `mlx-community/Qwen3.8-27B-8bit`) across text LLM, multimodal VLM, and Multi-Token Prediction (MTP) speculative decoding pipelines.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)