### PR TITLE
Add bounded cross-dialect tool-call recovery

### DIFF
--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -81,17 +81,29 @@ if !toolResults.isEmpty {
 }
 ```
 
-`Generation.toolCall` contains only parsed and authorized calls that may be
-considered for dispatch. Tool-call-shaped output that is malformed, incomplete,
-or names an undeclared function is emitted separately as
+When tool schemas are supplied, `Generation.toolCall` contains only parsed and
+authorized calls that may be considered for dispatch. Tool-call-shaped output
+that is malformed, incomplete, exceeds the parser's bounded safety limit,
+omits a required argument, or names an undeclared function is emitted separately as
 `Generation.rejectedToolCall`; rejected protocol is never returned as a normal
 response chunk. `rawTextPreview` is bounded for diagnostics but can contain
 sensitive argument values, so applications should not log or persist it
 automatically.
 
+Cross-dialect recovery defaults to `ToolCallRecoveryPolicy.conservative`. It
+accepts only structurally complete calls naming an exactly declared tool and
+keeps syntax inside reasoning spans, Markdown code, and ordinary JSON data
+inert. Set `GenerateParameters.toolCallRecoveryPolicy` to `.disabled` to permit
+only the selected native dialect, or `.permissive` to allow the documented
+end-of-stream outer-close repair. `GenerateCompletionInfo` reports both
+`recoveredToolCallCount` and `rejectedToolCallCount` for production telemetry.
+
 The example buffers accepted calls until the generation finishes. This makes
 dispatch atomic at the turn level: if a later call in the same model output is
 rejected, no earlier call has already caused an external side effect.
+`ChatSession` automatic dispatch also fails closed when tool schemas are absent
+or empty: no model-emitted call can reach the dispatch callback without an
+exactly matching declaration.
 
 When `ChatSession` builds its cache from messages, it retains the structured
 transcript and renders the complete conversation for every continuation, as

--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -81,7 +81,7 @@ if !toolResults.isEmpty {
 }
 ```
 
-When tool schemas are supplied, `Generation.toolCall` contains only parsed and
+By default, when tool schemas are supplied, `Generation.toolCall` contains only parsed and
 authorized calls that may be considered for dispatch. Tool-call-shaped output
 that is malformed, incomplete, exceeds the parser's bounded safety limit,
 omits a required argument, or names an undeclared function is emitted separately as
@@ -93,10 +93,14 @@ automatically.
 Cross-dialect recovery defaults to `ToolCallRecoveryPolicy.conservative`. It
 accepts only structurally complete calls naming an exactly declared tool and
 keeps syntax inside reasoning spans, Markdown code, and ordinary JSON data
-inert. Set `GenerateParameters.toolCallRecoveryPolicy` to `.disabled` to permit
+inert. Set `GenerateParameters.toolCallPolicy.recovery` to `.disabled` to permit
 only the selected native dialect, or `.permissive` to allow the documented
 end-of-stream outer-close repair. `GenerateCompletionInfo` reports both
 `recoveredToolCallCount` and `rejectedToolCallCount` for production telemetry.
+
+`GenerateParameters.toolCallPolicy.validation` defaults to `.strict`. Use
+`.permissive` only when the application validates arguments itself; declared-tool
+authorization and native parser requirements still apply.
 
 The example buffers accepted calls until the generation finishes. This makes
 dispatch atomic at the turn level: if a later call in the same model output is

--- a/Libraries/MLXLLM/Documentation.docc/evaluation.md
+++ b/Libraries/MLXLLM/Documentation.docc/evaluation.md
@@ -81,10 +81,10 @@ if !toolResults.isEmpty {
 }
 ```
 
-By default, when tool schemas are supplied, `Generation.toolCall` contains only parsed and
+When tool schemas are supplied, `Generation.toolCall` contains only parsed and
 authorized calls that may be considered for dispatch. Tool-call-shaped output
 that is malformed, incomplete, exceeds the parser's bounded safety limit,
-omits a required argument, or names an undeclared function is emitted separately as
+or names an undeclared function is emitted separately as
 `Generation.rejectedToolCall`; rejected protocol is never returned as a normal
 response chunk. `rawTextPreview` is bounded for diagnostics but can contain
 sensitive argument values, so applications should not log or persist it
@@ -98,9 +98,10 @@ only the selected native dialect, or `.permissive` to allow the documented
 end-of-stream outer-close repair. `GenerateCompletionInfo` reports both
 `recoveredToolCallCount` and `rejectedToolCallCount` for production telemetry.
 
-`GenerateParameters.toolCallPolicy.validation` defaults to `.strict`. Use
-`.permissive` only when the application validates arguments itself; declared-tool
-authorization and native parser requirements still apply.
+`GenerateParameters.toolCallPolicy.validation` defaults to `.permissive`, leaving
+schema validation to the application. Set it to `.strict` to reject proven schema
+violations, including missing required arguments. Declared-tool authorization
+and native parser requirements apply in both modes.
 
 The example buffers accepted calls until the generation finishes. This makes
 dispatch atomic at the turn level: if a later call in the same model output is

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -315,6 +315,12 @@ public final class ChatSession {
 
     public var additionalContext: [String: any Sendable]?
     public var tools: [ToolSpec]?
+
+    /// Optional automatic dispatcher for accepted tool calls.
+    ///
+    /// Automatic dispatch is fail-closed: only calls naming a function declared
+    /// in ``tools`` can reach this callback. If `tools` is `nil` or empty, every
+    /// tool-call-shaped model output is rejected without invoking the callback.
     public var toolDispatch: (@Sendable (ToolCall) async throws -> String)?
 
     /// Speculative decoding configuration, nil if disabled.
@@ -898,6 +904,12 @@ public final class ChatSession {
                 speculativeDecoding
             ] in
             do {
+                // Automatic dispatch must always be schema-authorized. Treat a missing
+                // declaration list as an empty allowlist when a dispatcher is installed,
+                // rather than allowing the processor's schema-less parsing mode.
+                let toolValidationSchemas: [ToolSpec]? =
+                    toolDispatch == nil ? tools : (tools ?? [])
+
                 try await cache.update { cache in
 
                     // these are all Sendable
@@ -1201,7 +1213,8 @@ public final class ChatSession {
                                     modelConfiguration: modelConfiguration,
                                     tokenizer: tokenizer,
                                     iterator: iterator,
-                                    tools: tools)
+                                    tools: toolValidationSchemas,
+                                    recoveryPolicy: generateParameters.toolCallRecoveryPolicy)
                             )
                         }
 
@@ -1324,7 +1337,9 @@ public final class ChatSession {
                                             modelConfiguration: modelConfiguration,
                                             tokenizer: tokenizer,
                                             iterator: iterator,
-                                            tools: tools))
+                                            tools: toolValidationSchemas,
+                                            recoveryPolicy: generateParameters
+                                                .toolCallRecoveryPolicy))
                                 }
                             }
                         } else {

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -1214,7 +1214,7 @@ public final class ChatSession {
                                     tokenizer: tokenizer,
                                     iterator: iterator,
                                     tools: toolValidationSchemas,
-                                    recoveryPolicy: generateParameters.toolCallRecoveryPolicy)
+                                    toolCallPolicy: generateParameters.toolCallPolicy)
                             )
                         }
 
@@ -1338,8 +1338,7 @@ public final class ChatSession {
                                             tokenizer: tokenizer,
                                             iterator: iterator,
                                             tools: toolValidationSchemas,
-                                            recoveryPolicy: generateParameters
-                                                .toolCallRecoveryPolicy))
+                                            toolCallPolicy: generateParameters.toolCallPolicy))
                                 }
                             }
                         } else {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -179,6 +179,11 @@ public struct GenerateParameters: Sendable {
     /// number of tokens to consider for frequency penalty
     public var frequencyContextSize: Int
 
+    /// Governs bounded recovery when a model emits a declared tool call in a
+    /// dialect other than the selected ``ToolCallFormat``. Conservative is the
+    /// production default; set disabled when only the native format may run.
+    public var toolCallRecoveryPolicy: ToolCallRecoveryPolicy
+
     public init(
         maxTokens: Int? = nil,
         maxKVSize: Int? = nil,
@@ -198,7 +203,8 @@ public struct GenerateParameters: Sendable {
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
         prefill: PrefillParameters = .init(),
-        seed: UInt64? = nil
+        seed: UInt64? = nil,
+        toolCallRecoveryPolicy: ToolCallRecoveryPolicy = .conservative
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -219,6 +225,7 @@ public struct GenerateParameters: Sendable {
         self.frequencyContextSize = frequencyContextSize
         self.prefill = prefill
         self.seed = seed
+        self.toolCallRecoveryPolicy = toolCallRecoveryPolicy
     }
 
     @available(
@@ -1759,7 +1766,8 @@ public func generate(
         tokenizer: context.tokenizer,
         iterator: iterator,
         wiredMemoryTicket: wiredMemoryTicket,
-        tools: tools)
+        tools: tools,
+        recoveryPolicy: parameters.toolCallRecoveryPolicy)
     return stream
 }
 
@@ -1813,6 +1821,7 @@ public func generate(
 ///   - numDraftTokens: Number of tokens the draft model proposes per round (default: 2).
 ///   - components: optional behavioral components, e.g. a custom ``LogitProcessor``
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
+///   - tools: Optional tool schemas used to parse arguments and authorize function names.
 /// - Returns: An `AsyncStream` that emits text, accepted or rejected tool calls, and completion
 ///   information as `Generation` values.
 /// - Throws: An error if the iterator initialization fails.
@@ -1826,7 +1835,8 @@ public func generate(
     draftCache: [KVCache]? = nil,
     numDraftTokens: Int = 2,
     components: GenerationComponents = .init(),
-    wiredMemoryTicket: WiredMemoryTicket? = nil
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    tools: [[String: any Sendable]]? = nil
 ) throws -> AsyncStream<Generation> {
     let iterator = try SpeculativeTokenIterator(
         input: input,
@@ -1848,7 +1858,9 @@ public func generate(
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
             stopStrings: context.configuration.effectiveStopStrings,
-            format: context.configuration.toolCallFormat ?? .json
+            format: context.configuration.toolCallFormat ?? .json,
+            tools: tools,
+            recoveryPolicy: parameters.toolCallRecoveryPolicy
         )
     )
     return stream
@@ -1895,7 +1907,8 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
     tokenizer: Tokenizer,
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
-    tools: [[String: any Sendable]]? = nil
+    tools: [[String: any Sendable]]? = nil,
+    recoveryPolicy: ToolCallRecoveryPolicy = .conservative
 ) -> (AsyncStream<Generation>, Task<Void, Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
@@ -1907,7 +1920,8 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
             tokenizer: tokenizer,
             stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
-            tools: tools
+            tools: tools,
+            recoveryPolicy: recoveryPolicy
         )
     )
 }
@@ -1920,7 +1934,8 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
     tokenizer: Tokenizer,
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
-    tools: [[String: any Sendable]]? = nil
+    tools: [[String: any Sendable]]? = nil,
+    recoveryPolicy: ToolCallRecoveryPolicy = .conservative
 ) -> (AsyncStream<Generation>, Task<[Int], Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
@@ -1933,7 +1948,8 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
             tokenizer: tokenizer,
             stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
-            tools: tools
+            tools: tools,
+            recoveryPolicy: recoveryPolicy
         )
     )
 }
@@ -2068,6 +2084,7 @@ public func generateTokens(
 ///     `draft_block_size`. Default 4 matches mlx-vlm's example configs.
 ///   - components: optional behavioral components, e.g. a custom ``LogitProcessor``
 ///   - wiredMemoryTicket: optional wired memory ticket.
+///   - tools: Optional tool schemas used to parse arguments and authorize function names.
 /// - Returns: an `AsyncStream<Generation>` yielding chunks and tool calls.
 /// - Throws: an error if the iterator initialization fails.
 public func generate(
@@ -2078,7 +2095,8 @@ public func generate(
     mtpDrafter: any MTPDrafterModel,
     blockSize: Int = 4,
     components: GenerationComponents = .init(),
-    wiredMemoryTicket: WiredMemoryTicket? = nil
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    tools: [[String: any Sendable]]? = nil
 ) throws -> AsyncStream<Generation> {
     let iterator = try MTPSpeculativeTokenIterator(
         input: input,
@@ -2098,7 +2116,9 @@ public func generate(
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
             stopStrings: context.configuration.effectiveStopStrings,
-            format: context.configuration.toolCallFormat ?? .json
+            format: context.configuration.toolCallFormat ?? .json,
+            tools: tools,
+            recoveryPolicy: parameters.toolCallRecoveryPolicy
         )
     )
     return stream
@@ -2538,6 +2558,10 @@ public struct GenerateCompletionInfo: Sendable {
     /// Number of tool-call-shaped outputs rejected during this generation.
     public let rejectedToolCallCount: Int
 
+    /// Number of accepted calls produced by bounded cross-dialect recovery.
+    /// Native-format calls are intentionally excluded.
+    public let recoveredToolCallCount: Int
+
     /// The rendered prompt length: the reused cache prefix plus the prefilled tokens.
     public var totalPromptTokenCount: Int {
         cachedPromptTokenCount + promptTokenCount
@@ -2570,7 +2594,8 @@ public struct GenerateCompletionInfo: Sendable {
         acceptedDraftTokens: Int? = nil,
         passthroughReason: String? = nil,
         speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? = nil,
-        rejectedToolCallCount: Int = 0
+        rejectedToolCallCount: Int = 0,
+        recoveredToolCallCount: Int = 0
     ) {
         self.promptTokenCount = promptTokenCount
         self.cachedPromptTokenCount = cachedPromptTokenCount
@@ -2583,6 +2608,7 @@ public struct GenerateCompletionInfo: Sendable {
         self.passthroughReason = passthroughReason
         self.speculativeDecodingTelemetry = speculativeDecodingTelemetry
         self.rejectedToolCallCount = rejectedToolCallCount
+        self.recoveredToolCallCount = recoveredToolCallCount
     }
 
     public func summary() -> String {
@@ -2598,7 +2624,7 @@ public struct GenerateCompletionInfo: Sendable {
         return lines.joined(separator: "\n")
     }
 
-    fileprivate func withRejectedToolCallCount(_ count: Int) -> Self {
+    fileprivate func withToolCallCounts(rejected: Int, recovered: Int) -> Self {
         Self(
             promptTokenCount: promptTokenCount,
             cachedPromptTokenCount: cachedPromptTokenCount,
@@ -2610,7 +2636,8 @@ public struct GenerateCompletionInfo: Sendable {
             acceptedDraftTokens: acceptedDraftTokens,
             passthroughReason: passthroughReason,
             speculativeDecodingTelemetry: speculativeDecodingTelemetry,
-            rejectedToolCallCount: count)
+            rejectedToolCallCount: rejected,
+            recoveredToolCallCount: recovered)
     }
 }
 
@@ -2786,10 +2813,12 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
 
     init(
         tokenizer: Tokenizer, stopStrings: Set<String> = [], format: ToolCallFormat,
-        tools: [[String: any Sendable]]? = nil
+        tools: [[String: any Sendable]]? = nil,
+        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
     ) {
         self.decoder = format.makeTokenStreamDecoder(
-            tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
+            tokenizer: tokenizer, tools: tools, stopStrings: stopStrings,
+            recoveryPolicy: recoveryPolicy)
     }
 
     var additionalStopTokenIDs: Set<Int> { decoder.additionalStopTokenIDs }
@@ -2823,7 +2852,10 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
     }
 
     func infoEvent(_ info: GenerateCompletionInfo) -> Generation {
-        .info(info.withRejectedToolCallCount(decoder.rejectedToolCallCount))
+        .info(
+            info.withToolCallCounts(
+                rejected: decoder.rejectedToolCallCount,
+                recovered: decoder.recoveredToolCallCount))
     }
 
     private mutating func process(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -961,7 +961,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
 /// Generator of tokens using speculative decoding.
 ///
-/// This is typically used via a call to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:)``
+/// This is typically used via a call to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:tools:)``
 /// returning `AsyncStream<Generation>`.
 ///
 /// To use it directly:
@@ -1702,7 +1702,7 @@ public func generate(
 /// * Important: if the stream is terminated early (e.g. break from the loop) computation will continue
 /// using the model, parameters, KVCache, etc. for some time (typically a few ms).  This is typically OK for
 /// one-shot calls, but for "chat session" type calls consider using
-/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:tools:)``
+/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:tools:recoveryPolicy:)``
 /// so that the end of the generation task can be observed.
 ///
 /// - Parameters:
@@ -1900,6 +1900,7 @@ public func generate(
 ///   - iterator: a token iterator conforming to ``TokenIteratorProtocol``
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
 ///   - tools: Optional tool schemas used to parse tool-call arguments into their declared types.
+///   - recoveryPolicy: Policy specifying how to recover from malformed tool calls.
 /// - Returns: An `AsyncStream` that emits `Generation` values and a `Task`
 public func generateTask<TOKEN: TokenIteratorProtocol>(
     promptTokenCount: Int,
@@ -2057,7 +2058,7 @@ public func generateTokens(
 
 /// Generates tokens asynchronously using MTP speculative decoding.
 ///
-/// Parallel to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:)``
+/// Parallel to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:tools:)``
 /// but for MTP drafters: the drafter shares K/V with the target model and
 /// produces a block of `blockSize - 1` candidate tokens per round in a
 /// single `draftBlock(...)` call. The drafter shares the target's

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -185,10 +185,8 @@ public struct GenerateParameters: Sendable {
     /// number of tokens to consider for frequency penalty
     public var frequencyContextSize: Int
 
-    /// Governs bounded recovery when a model emits a declared tool call in a
-    /// dialect other than the selected ``ToolCallFormat``. Conservative is the
-    /// production default; set disabled when only the native format may run.
-    public var toolCallRecoveryPolicy: ToolCallRecoveryPolicy
+    /// Recovery and validation rules for generated tool calls.
+    public var toolCallPolicy: ToolCallPolicy
 
     public init(
         maxTokens: Int? = nil,
@@ -210,7 +208,7 @@ public struct GenerateParameters: Sendable {
         frequencyContextSize: Int = 20,
         prefill: PrefillParameters = .init(),
         seed: UInt64? = nil,
-        toolCallRecoveryPolicy: ToolCallRecoveryPolicy = .conservative
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -231,7 +229,7 @@ public struct GenerateParameters: Sendable {
         self.frequencyContextSize = frequencyContextSize
         self.prefill = prefill
         self.seed = seed
-        self.toolCallRecoveryPolicy = toolCallRecoveryPolicy
+        self.toolCallPolicy = toolCallPolicy
     }
 
     @available(
@@ -1708,7 +1706,7 @@ public func generate(
 /// * Important: if the stream is terminated early (e.g. break from the loop) computation will continue
 /// using the model, parameters, KVCache, etc. for some time (typically a few ms).  This is typically OK for
 /// one-shot calls, but for "chat session" type calls consider using
-/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:tools:recoveryPolicy:)``
+/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:tools:toolCallPolicy:)``
 /// so that the end of the generation task can be observed.
 ///
 /// - Parameters:
@@ -1773,7 +1771,7 @@ public func generate(
         iterator: iterator,
         wiredMemoryTicket: wiredMemoryTicket,
         tools: tools,
-        recoveryPolicy: parameters.toolCallRecoveryPolicy)
+        toolCallPolicy: parameters.toolCallPolicy)
     return stream
 }
 
@@ -1866,7 +1864,7 @@ public func generate(
             stopStrings: context.configuration.effectiveStopStrings,
             format: context.configuration.toolCallFormat ?? .json,
             tools: tools,
-            recoveryPolicy: parameters.toolCallRecoveryPolicy
+            toolCallPolicy: parameters.toolCallPolicy
         )
     )
     return stream
@@ -1906,7 +1904,7 @@ public func generate(
 ///   - iterator: a token iterator conforming to ``TokenIteratorProtocol``
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
 ///   - tools: Optional tool schemas used to parse tool-call arguments into their declared types.
-///   - recoveryPolicy: Policy specifying how to recover from malformed tool calls.
+///   - toolCallPolicy: Recovery and validation rules for generated tool calls.
 /// - Returns: An `AsyncStream` that emits `Generation` values and a `Task`
 public func generateTask<TOKEN: TokenIteratorProtocol>(
     promptTokenCount: Int,
@@ -1915,7 +1913,7 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
     tools: [[String: any Sendable]]? = nil,
-    recoveryPolicy: ToolCallRecoveryPolicy = .conservative
+    toolCallPolicy: ToolCallPolicy = .init()
 ) -> (AsyncStream<Generation>, Task<Void, Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
@@ -1928,7 +1926,7 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
             stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
             tools: tools,
-            recoveryPolicy: recoveryPolicy
+            toolCallPolicy: toolCallPolicy
         )
     )
 }
@@ -1942,7 +1940,7 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
     tools: [[String: any Sendable]]? = nil,
-    recoveryPolicy: ToolCallRecoveryPolicy = .conservative
+    toolCallPolicy: ToolCallPolicy = .init()
 ) -> (AsyncStream<Generation>, Task<[Int], Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
@@ -1956,7 +1954,7 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
             stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
             tools: tools,
-            recoveryPolicy: recoveryPolicy
+            toolCallPolicy: toolCallPolicy
         )
     )
 }
@@ -2125,7 +2123,7 @@ public func generate(
             stopStrings: context.configuration.effectiveStopStrings,
             format: context.configuration.toolCallFormat ?? .json,
             tools: tools,
-            recoveryPolicy: parameters.toolCallRecoveryPolicy
+            toolCallPolicy: parameters.toolCallPolicy
         )
     )
     return stream
@@ -2823,11 +2821,11 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
     init(
         tokenizer: Tokenizer, stopStrings: Set<String> = [], format: ToolCallFormat,
         tools: [[String: any Sendable]]? = nil,
-        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
         self.decoder = format.makeTokenStreamDecoder(
             tokenizer: tokenizer, tools: tools, stopStrings: stopStrings,
-            recoveryPolicy: recoveryPolicy)
+            toolCallPolicy: toolCallPolicy)
     }
 
     var additionalStopTokenIDs: Set<Int> { decoder.additionalStopTokenIDs }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -967,7 +967,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
 /// Generator of tokens using speculative decoding.
 ///
-/// This is typically used via a call to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:)``
+/// This is typically used via a call to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:tools:)``
 /// returning `AsyncStream<Generation>`.
 ///
 /// To use it directly:
@@ -1708,7 +1708,7 @@ public func generate(
 /// * Important: if the stream is terminated early (e.g. break from the loop) computation will continue
 /// using the model, parameters, KVCache, etc. for some time (typically a few ms).  This is typically OK for
 /// one-shot calls, but for "chat session" type calls consider using
-/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:tools:)``
+/// ``generateTask(promptTokenCount:modelConfiguration:tokenizer:iterator:wiredMemoryTicket:tools:recoveryPolicy:)``
 /// so that the end of the generation task can be observed.
 ///
 /// - Parameters:
@@ -1906,6 +1906,7 @@ public func generate(
 ///   - iterator: a token iterator conforming to ``TokenIteratorProtocol``
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
 ///   - tools: Optional tool schemas used to parse tool-call arguments into their declared types.
+///   - recoveryPolicy: Policy specifying how to recover from malformed tool calls.
 /// - Returns: An `AsyncStream` that emits `Generation` values and a `Task`
 public func generateTask<TOKEN: TokenIteratorProtocol>(
     promptTokenCount: Int,
@@ -2063,7 +2064,7 @@ public func generateTokens(
 
 /// Generates tokens asynchronously using MTP speculative decoding.
 ///
-/// Parallel to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:)``
+/// Parallel to ``generate(input:cache:state:parameters:context:draftModel:draftCache:numDraftTokens:components:wiredMemoryTicket:tools:)``
 /// but for MTP drafters: the drafter shares K/V with the target model and
 /// produces a block of `blockSize - 1` candidate tokens per round in a
 /// single `draftBlock(...)` call. The drafter shares the target's

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -185,6 +185,11 @@ public struct GenerateParameters: Sendable {
     /// number of tokens to consider for frequency penalty
     public var frequencyContextSize: Int
 
+    /// Governs bounded recovery when a model emits a declared tool call in a
+    /// dialect other than the selected ``ToolCallFormat``. Conservative is the
+    /// production default; set disabled when only the native format may run.
+    public var toolCallRecoveryPolicy: ToolCallRecoveryPolicy
+
     public init(
         maxTokens: Int? = nil,
         maxKVSize: Int? = nil,
@@ -204,7 +209,8 @@ public struct GenerateParameters: Sendable {
         frequencyPenalty: Float? = nil,
         frequencyContextSize: Int = 20,
         prefill: PrefillParameters = .init(),
-        seed: UInt64? = nil
+        seed: UInt64? = nil,
+        toolCallRecoveryPolicy: ToolCallRecoveryPolicy = .conservative
     ) {
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -225,6 +231,7 @@ public struct GenerateParameters: Sendable {
         self.frequencyContextSize = frequencyContextSize
         self.prefill = prefill
         self.seed = seed
+        self.toolCallRecoveryPolicy = toolCallRecoveryPolicy
     }
 
     @available(
@@ -1765,7 +1772,8 @@ public func generate(
         tokenizer: context.tokenizer,
         iterator: iterator,
         wiredMemoryTicket: wiredMemoryTicket,
-        tools: tools)
+        tools: tools,
+        recoveryPolicy: parameters.toolCallRecoveryPolicy)
     return stream
 }
 
@@ -1819,6 +1827,7 @@ public func generate(
 ///   - numDraftTokens: Number of tokens the draft model proposes per round (default: 2).
 ///   - components: optional behavioral components, e.g. a custom ``LogitProcessor``
 ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination.
+///   - tools: Optional tool schemas used to parse arguments and authorize function names.
 /// - Returns: An `AsyncStream` that emits text, accepted or rejected tool calls, and completion
 ///   information as `Generation` values.
 /// - Throws: An error if the iterator initialization fails.
@@ -1832,7 +1841,8 @@ public func generate(
     draftCache: [KVCache]? = nil,
     numDraftTokens: Int = 2,
     components: GenerationComponents = .init(),
-    wiredMemoryTicket: WiredMemoryTicket? = nil
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    tools: [[String: any Sendable]]? = nil
 ) throws -> AsyncStream<Generation> {
     let iterator = try SpeculativeTokenIterator(
         input: input,
@@ -1854,7 +1864,9 @@ public func generate(
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
             stopStrings: context.configuration.effectiveStopStrings,
-            format: context.configuration.toolCallFormat ?? .json
+            format: context.configuration.toolCallFormat ?? .json,
+            tools: tools,
+            recoveryPolicy: parameters.toolCallRecoveryPolicy
         )
     )
     return stream
@@ -1901,7 +1913,8 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
     tokenizer: Tokenizer,
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
-    tools: [[String: any Sendable]]? = nil
+    tools: [[String: any Sendable]]? = nil,
+    recoveryPolicy: ToolCallRecoveryPolicy = .conservative
 ) -> (AsyncStream<Generation>, Task<Void, Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
@@ -1913,7 +1926,8 @@ public func generateTask<TOKEN: TokenIteratorProtocol>(
             tokenizer: tokenizer,
             stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
-            tools: tools
+            tools: tools,
+            recoveryPolicy: recoveryPolicy
         )
     )
 }
@@ -1926,7 +1940,8 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
     tokenizer: Tokenizer,
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
-    tools: [[String: any Sendable]]? = nil
+    tools: [[String: any Sendable]]? = nil,
+    recoveryPolicy: ToolCallRecoveryPolicy = .conservative
 ) -> (AsyncStream<Generation>, Task<[Int], Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
@@ -1939,7 +1954,8 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
             tokenizer: tokenizer,
             stopStrings: modelConfiguration.effectiveStopStrings,
             format: modelConfiguration.toolCallFormat ?? .json,
-            tools: tools
+            tools: tools,
+            recoveryPolicy: recoveryPolicy
         )
     )
 }
@@ -2074,6 +2090,7 @@ public func generateTokens(
 ///     `draft_block_size`. Default 4 matches mlx-vlm's example configs.
 ///   - components: optional behavioral components, e.g. a custom ``LogitProcessor``
 ///   - wiredMemoryTicket: optional wired memory ticket.
+///   - tools: Optional tool schemas used to parse arguments and authorize function names.
 /// - Returns: an `AsyncStream<Generation>` yielding chunks and tool calls.
 /// - Throws: an error if the iterator initialization fails.
 public func generate(
@@ -2084,7 +2101,8 @@ public func generate(
     mtpDrafter: any MTPDrafterModel,
     blockSize: Int = 4,
     components: GenerationComponents = .init(),
-    wiredMemoryTicket: WiredMemoryTicket? = nil
+    wiredMemoryTicket: WiredMemoryTicket? = nil,
+    tools: [[String: any Sendable]]? = nil
 ) throws -> AsyncStream<Generation> {
     let iterator = try MTPSpeculativeTokenIterator(
         input: input,
@@ -2104,7 +2122,9 @@ public func generate(
         handler: TextToolTokenLoopHandler(
             tokenizer: context.tokenizer,
             stopStrings: context.configuration.effectiveStopStrings,
-            format: context.configuration.toolCallFormat ?? .json
+            format: context.configuration.toolCallFormat ?? .json,
+            tools: tools,
+            recoveryPolicy: parameters.toolCallRecoveryPolicy
         )
     )
     return stream
@@ -2546,6 +2566,10 @@ public struct GenerateCompletionInfo: Sendable {
     /// Number of tool-call-shaped outputs rejected during this generation.
     public let rejectedToolCallCount: Int
 
+    /// Number of accepted calls produced by bounded cross-dialect recovery.
+    /// Native-format calls are intentionally excluded.
+    public let recoveredToolCallCount: Int
+
     /// The rendered prompt length: the reused cache prefix plus the prefilled tokens.
     public var totalPromptTokenCount: Int {
         cachedPromptTokenCount + promptTokenCount
@@ -2578,7 +2602,8 @@ public struct GenerateCompletionInfo: Sendable {
         acceptedDraftTokens: Int? = nil,
         passthroughReason: String? = nil,
         speculativeDecodingTelemetry: SpeculativeDecodingTelemetry? = nil,
-        rejectedToolCallCount: Int = 0
+        rejectedToolCallCount: Int = 0,
+        recoveredToolCallCount: Int = 0
     ) {
         self.promptTokenCount = promptTokenCount
         self.cachedPromptTokenCount = cachedPromptTokenCount
@@ -2591,6 +2616,7 @@ public struct GenerateCompletionInfo: Sendable {
         self.passthroughReason = passthroughReason
         self.speculativeDecodingTelemetry = speculativeDecodingTelemetry
         self.rejectedToolCallCount = rejectedToolCallCount
+        self.recoveredToolCallCount = recoveredToolCallCount
     }
 
     public func summary() -> String {
@@ -2606,7 +2632,7 @@ public struct GenerateCompletionInfo: Sendable {
         return lines.joined(separator: "\n")
     }
 
-    fileprivate func withRejectedToolCallCount(_ count: Int) -> Self {
+    fileprivate func withToolCallCounts(rejected: Int, recovered: Int) -> Self {
         Self(
             promptTokenCount: promptTokenCount,
             cachedPromptTokenCount: cachedPromptTokenCount,
@@ -2618,7 +2644,8 @@ public struct GenerateCompletionInfo: Sendable {
             acceptedDraftTokens: acceptedDraftTokens,
             passthroughReason: passthroughReason,
             speculativeDecodingTelemetry: speculativeDecodingTelemetry,
-            rejectedToolCallCount: count)
+            rejectedToolCallCount: rejected,
+            recoveredToolCallCount: recovered)
     }
 }
 
@@ -2794,10 +2821,12 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
 
     init(
         tokenizer: Tokenizer, stopStrings: Set<String> = [], format: ToolCallFormat,
-        tools: [[String: any Sendable]]? = nil
+        tools: [[String: any Sendable]]? = nil,
+        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
     ) {
         self.decoder = format.makeTokenStreamDecoder(
-            tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
+            tokenizer: tokenizer, tools: tools, stopStrings: stopStrings,
+            recoveryPolicy: recoveryPolicy)
     }
 
     var additionalStopTokenIDs: Set<Int> { decoder.additionalStopTokenIDs }
@@ -2831,7 +2860,10 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
     }
 
     func infoEvent(_ info: GenerateCompletionInfo) -> Generation {
-        .info(info.withRejectedToolCallCount(decoder.rejectedToolCallCount))
+        .info(
+            info.withToolCallCounts(
+                rejected: decoder.rejectedToolCallCount,
+                recovered: decoder.recoveredToolCallCount))
     }
 
     private mutating func process(

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -191,13 +191,15 @@ public final class ModelContainer: Sendable {
     ///   - input: Prepared language model input (transferred via `sending`)
     ///   - parameters: Generation parameters
     ///   - wiredMemoryTicket: Optional wired memory ticket for policy-based coordination
+    ///   - tools: Optional tool schemas used to parse arguments and authorize function names
     /// - Returns: An AsyncStream of generation events
     /// - Note: The `sending` parameter indicates the input is transferred (not shared),
     ///   allowing non-Sendable types like `LMInput` to safely cross isolation boundaries.
     public func generate(
         input: consuming sending LMInput,
         parameters: GenerateParameters,
-        wiredMemoryTicket: WiredMemoryTicket? = nil
+        wiredMemoryTicket: WiredMemoryTicket? = nil,
+        tools: [[String: any Sendable]]? = nil
     ) async throws -> AsyncStream<Generation> {
         let input = SendableBox(input)
 
@@ -213,7 +215,8 @@ public final class ModelContainer: Sendable {
                 input: input.consume(),
                 parameters: parameters,
                 context: context,
-                wiredMemoryTicket: wiredMemoryTicket
+                wiredMemoryTicket: wiredMemoryTicket,
+                tools: tools
             )
         }
     }

--- a/Libraries/MLXLMCommon/README.md
+++ b/Libraries/MLXLMCommon/README.md
@@ -8,7 +8,7 @@
 - [MLXVLM](https://swiftpackageindex.com/ml-explore/mlx-swift-lm/main/documentation/mlxvlm) -- vision language model example implementations
 
 Tool-call handling is configured through `GenerateParameters.toolCallPolicy`,
-which defaults to conservative recovery and strict argument validation.
+which defaults to conservative recovery and permissive argument validation.
 
 # Quick Start
 

--- a/Libraries/MLXLMCommon/README.md
+++ b/Libraries/MLXLMCommon/README.md
@@ -7,6 +7,9 @@
 - [MLXLLM](https://swiftpackageindex.com/ml-explore/mlx-swift-lm/main/documentation/mlxllm) -- large language model example implementations
 - [MLXVLM](https://swiftpackageindex.com/ml-explore/mlx-swift-lm/main/documentation/mlxvlm) -- vision language model example implementations
 
+Tool-call handling is configured through `GenerateParameters.toolCallPolicy`,
+which defaults to conservative recovery and strict argument validation.
+
 # Quick Start
 
 Using LLMs and VLMs is as easy as:

--- a/Libraries/MLXLMCommon/Tool/Parsers/HarmonyOutputRouter.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/HarmonyOutputRouter.swift
@@ -28,13 +28,33 @@ package struct HarmonyOutputRouter {
     /// Declared tool names the caller is willing to dispatch. `nil` means no
     /// tools were offered for this generation, so no tool calls are accepted.
     private let allowedToolNames: Set<String>?
+    /// The declared tools, kept for argument schema validation.
+    private let tools: [[String: any Sendable]]?
     private var hasEmittedToolCall = false
     private var reasoningDetokenizer: NaiveStreamingDetokenizer
     private var responseDetokenizer: NaiveStreamingDetokenizer
     private let tokenizer: any Tokenizer
 
+    package init(tokenizer: any Tokenizer, tools: [[String: any Sendable]]?) {
+        self.init(
+            tokenizer: tokenizer,
+            allowedToolNames: Self.allowedToolNames(from: tools),
+            tools: tools)
+    }
+
+    /// Compatibility entry point for package clients that only need the
+    /// authorization boundary. Calls routed through it have no schema to check.
     package init(tokenizer: any Tokenizer, allowedToolNames: Set<String>?) {
+        self.init(tokenizer: tokenizer, allowedToolNames: allowedToolNames, tools: nil)
+    }
+
+    private init(
+        tokenizer: any Tokenizer,
+        allowedToolNames: Set<String>?,
+        tools: [[String: any Sendable]]?
+    ) {
         self.tokenizer = tokenizer
+        self.tools = tools
         self.allowedToolNames = allowedToolNames
         self.reasoningDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         self.responseDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
@@ -128,6 +148,18 @@ package struct HarmonyOutputRouter {
                     rejection(.undeclaredTool, name: name, rawText: payload))
             ]
         }
+        if case .invalid(let violations) = ToolSchemaValidator.validate(
+            arguments: arguments,
+            forToolNamed: name,
+            in: tools)
+        {
+            return [
+                .rejectedToolCall(
+                    rejection(
+                        .invalidArguments, name: name, rawText: payload,
+                        detail: ToolSchemaValidator.describe(violations)))
+            ]
+        }
 
         hasEmittedToolCall = true
         let toolCall = ToolCall(
@@ -139,14 +171,15 @@ package struct HarmonyOutputRouter {
     private func rejection(
         _ reason: RejectedToolCall.Reason,
         name: String?,
-        rawText: String
+        rawText: String,
+        detail: String? = nil
     ) -> RejectedToolCall {
         RejectedToolCall(
             reason: reason,
             format: .gptOSS,
             toolName: name,
             rawText: rawText,
-            detail: reason.diagnosticDetail)
+            detail: detail ?? reason.diagnosticDetail)
     }
 
     private func isAllowed(_ name: String) -> Bool {

--- a/Libraries/MLXLMCommon/Tool/Parsers/HarmonyOutputRouter.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/HarmonyOutputRouter.swift
@@ -30,16 +30,20 @@ package struct HarmonyOutputRouter {
     private let allowedToolNames: Set<String>?
     /// The declared tools, kept for argument schema validation.
     private let tools: [[String: any Sendable]]?
+    private let validationPolicy: ToolCallValidationPolicy
     private var hasEmittedToolCall = false
     private var reasoningDetokenizer: NaiveStreamingDetokenizer
     private var responseDetokenizer: NaiveStreamingDetokenizer
     private let tokenizer: any Tokenizer
 
-    package init(tokenizer: any Tokenizer, tools: [[String: any Sendable]]?) {
+    package init(
+        tokenizer: any Tokenizer, tools: [[String: any Sendable]]?,
+        toolCallPolicy: ToolCallPolicy = .init()
+    ) {
         self.init(
             tokenizer: tokenizer,
             allowedToolNames: Self.allowedToolNames(from: tools),
-            tools: tools)
+            tools: tools, toolCallPolicy: toolCallPolicy)
     }
 
     /// Compatibility entry point for package clients that only need the
@@ -51,10 +55,12 @@ package struct HarmonyOutputRouter {
     private init(
         tokenizer: any Tokenizer,
         allowedToolNames: Set<String>?,
-        tools: [[String: any Sendable]]?
+        tools: [[String: any Sendable]]?,
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
         self.tokenizer = tokenizer
         self.tools = tools
+        self.validationPolicy = toolCallPolicy.validation
         self.allowedToolNames = allowedToolNames
         self.reasoningDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         self.responseDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
@@ -136,7 +142,7 @@ package struct HarmonyOutputRouter {
             // One committed tool call per generation turn.
             return []
         }
-        guard let arguments = strictJSONObject(payload) else {
+        guard var arguments = strictJSONObject(payload) else {
             return [
                 .rejectedToolCall(
                     rejection(.invalidArguments, name: name, rawText: payload))
@@ -148,10 +154,14 @@ package struct HarmonyOutputRouter {
                     rejection(.undeclaredTool, name: name, rawText: payload))
             ]
         }
-        if case .invalid(let violations) = ToolSchemaValidator.validate(
-            arguments: arguments,
-            forToolNamed: name,
-            in: tools)
+        let normalized = ToolArgumentNormalization.normalize(
+            ToolCall(function: .init(name: name, arguments: arguments)), tools: tools)
+        arguments = normalized.function.arguments
+        if validationPolicy == .strict,
+            case .invalid(let violations) = ToolSchemaValidator.validate(
+                arguments: arguments,
+                forToolNamed: name,
+                in: tools)
         {
             return [
                 .rejectedToolCall(

--- a/Libraries/MLXLMCommon/Tool/Parsers/HarmonyStreamAdapter.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/HarmonyStreamAdapter.swift
@@ -23,9 +23,7 @@ struct HarmonyStreamAdapter: TokenStreamDecoder {
             return nil
         }
         self.parser = parser
-        self.router = HarmonyOutputRouter(
-            tokenizer: tokenizer,
-            allowedToolNames: HarmonyOutputRouter.allowedToolNames(from: tools))
+        self.router = HarmonyOutputRouter(tokenizer: tokenizer, tools: tools)
         self.stopStringFilter = StopStringFilter(stopStrings: stopStrings)
         self.additionalStopTokenIDs = parser.semanticStopTokenIDs
     }

--- a/Libraries/MLXLMCommon/Tool/Parsers/HarmonyStreamAdapter.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/HarmonyStreamAdapter.swift
@@ -17,13 +17,15 @@ struct HarmonyStreamAdapter: TokenStreamDecoder {
     init?(
         tokenizer: any Tokenizer,
         tools: [[String: any Sendable]]?,
-        stopStrings: Set<String>
+        stopStrings: Set<String>,
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
         guard let parser = HarmonyFrameParser(tokenizer: tokenizer) else {
             return nil
         }
         self.parser = parser
-        self.router = HarmonyOutputRouter(tokenizer: tokenizer, tools: tools)
+        self.router = HarmonyOutputRouter(
+            tokenizer: tokenizer, tools: tools, toolCallPolicy: toolCallPolicy)
         self.stopStringFilter = StopStringFilter(stopStrings: stopStrings)
         self.additionalStopTokenIDs = parser.semanticStopTokenIDs
     }

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONPrefixScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONPrefixScanner.swift
@@ -1,0 +1,179 @@
+// Copyright © 2026 Apple Inc.
+
+/// Incrementally recognizes one JSON value without allocating decoded values.
+/// Used for context shielding: an impossible prefix is prose, an incomplete
+/// valid prefix is still data. Each byte is examined once, including in strings.
+struct JSONPrefixScanner {
+    enum Result {
+        case incomplete, invalid, depthLimit
+        case complete(byteCount: Int)
+    }
+
+    private enum Expectation {
+        case value, arrayValueOrEnd, keyOrEnd, key, colon
+        case arraySeparator, objectSeparator, end
+    }
+
+    private enum Token {
+        case none
+        case string(key: Bool)
+        case escape(key: Bool)
+        case unicode(remaining: Int, key: Bool)
+        case literal(remaining: ArraySlice<UInt8>)
+        case number(NumberState)
+    }
+
+    private enum NumberState {
+        case sign, zero, integer, point, fraction, exponent, exponentSign, exponentDigits
+
+        var canEnd: Bool {
+            switch self {
+            case .zero, .integer, .fraction, .exponentDigits: true
+            default: false
+            }
+        }
+
+        func next(_ byte: UInt8) -> Self? {
+            switch (self, byte) {
+            case (.sign, 48): .zero
+            case (.sign, 49 ... 57), (.integer, 48 ... 57): .integer
+            case (.zero, 46), (.integer, 46): .point
+            case (.point, 48 ... 57), (.fraction, 48 ... 57): .fraction
+            case (.zero, 69), (.zero, 101), (.integer, 69), (.integer, 101),
+                (.fraction, 69), (.fraction, 101):
+                .exponent
+            case (.exponent, 43), (.exponent, 45): .exponentSign
+            case (.exponent, 48 ... 57), (.exponentSign, 48 ... 57),
+                (.exponentDigits, 48 ... 57):
+                .exponentDigits
+            default: nil
+            }
+        }
+    }
+
+    private var expectation: Expectation = .value
+    private var parents: [Expectation] = []
+    private var token: Token = .none
+    private var consumed = 0
+
+    mutating func scan(_ text: String) -> Result {
+        let bytes = text.utf8
+        var index = bytes.index(bytes.startIndex, offsetBy: consumed)
+        while index < bytes.endIndex {
+            let byte = bytes[index]
+            switch token {
+            case .string(let key):
+                switch byte {
+                case 34:
+                    token = .none
+                    if key { expectation = .colon } else { completeValue() }
+                case 92: token = .escape(key: key)
+                case 0 ..< 32: return .invalid
+                default: break
+                }
+            case .escape(let key):
+                switch byte {
+                case 34, 47, 92, 98, 102, 110, 114, 116: token = .string(key: key)
+                case 117: token = .unicode(remaining: 4, key: key)
+                default: return .invalid
+                }
+            case .unicode(let remaining, let key):
+                guard
+                    (48 ... 57).contains(byte) || (65 ... 70).contains(byte)
+                        || (97 ... 102).contains(byte)
+                else { return .invalid }
+                token =
+                    remaining == 1
+                    ? .string(key: key) : .unicode(remaining: remaining - 1, key: key)
+            case .literal(let remaining):
+                guard byte == remaining.first else { return .invalid }
+                if remaining.count == 1 {
+                    token = .none
+                    completeValue()
+                } else {
+                    token = .literal(remaining: remaining.dropFirst())
+                }
+            case .number(let state):
+                if let next = state.next(byte) {
+                    token = .number(next)
+                } else {
+                    guard state.canEnd else { return .invalid }
+                    token = .none
+                    completeValue()
+                    // The delimiter belongs to the surrounding container.
+                    continue
+                }
+            case .none:
+                if expectation == .end { return .complete(byteCount: consumed) }
+                if [9, 10, 13, 32].contains(byte) {
+                    break
+                }
+                switch expectation {
+                case .value, .arrayValueOrEnd:
+                    if expectation == .arrayValueOrEnd, byte == 93 {
+                        closeContainer()
+                    } else {
+                        switch byte {
+                        case 123, 91:
+                            guard parents.count < 256 else { return .depthLimit }
+                            parents.append(byte == 123 ? .objectSeparator : .arraySeparator)
+                            expectation = byte == 123 ? .keyOrEnd : .arrayValueOrEnd
+                        case 34: token = .string(key: false)
+                        case 116: token = .literal(remaining: [114, 117, 101][...])
+                        case 102: token = .literal(remaining: [97, 108, 115, 101][...])
+                        case 110: token = .literal(remaining: [117, 108, 108][...])
+                        case 45: token = .number(.sign)
+                        case 48: token = .number(.zero)
+                        case 49 ... 57: token = .number(.integer)
+                        default: return .invalid
+                        }
+                    }
+                case .key, .keyOrEnd:
+                    if expectation == .keyOrEnd, byte == 125 {
+                        closeContainer()
+                    } else {
+                        guard byte == 34 else { return .invalid }
+                        token = .string(key: true)
+                    }
+                case .colon:
+                    guard byte == 58 else { return .invalid }
+                    expectation = .value
+                case .arraySeparator:
+                    if byte == 93 {
+                        closeContainer()
+                    } else if byte == 44 {
+                        expectation = .value
+                    } else {
+                        return .invalid
+                    }
+                case .objectSeparator:
+                    if byte == 125 {
+                        closeContainer()
+                    } else if byte == 44 {
+                        expectation = .key
+                    } else {
+                        return .invalid
+                    }
+                case .end: break
+                }
+            }
+            bytes.formIndex(after: &index)
+            consumed += 1
+            if expectation == .end, case .none = token {
+                return .complete(byteCount: consumed)
+            }
+        }
+        return .incomplete
+    }
+
+    private mutating func completeValue() {
+        // A key's value follows a colon; array values have no key. The
+        // container kind is represented by the continuation on the stack.
+        expectation = parents.last ?? .end
+    }
+
+    private mutating func closeContainer() {
+        parents.removeLast()
+        completeValue()
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -28,9 +28,16 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
             text = String(text[..<endRange.lowerBound])
         }
 
-        let jsonStr = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return parsePayload(text)
+    }
 
-        return parseToolCall(from: jsonStr) ?? parseRedundantOuterBraces(from: jsonStr)
+    /// Parse an already-extracted JSON payload without searching for protocol
+    /// delimiters again. Framing-aware callers use this after finding the
+    /// structural outer close, so a literal end-tag string inside an argument
+    /// remains JSON data rather than truncating the payload.
+    func parsePayload(_ payload: String) -> ToolCall? {
+        let json = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+        return parseToolCall(from: json) ?? parseRedundantOuterBraces(from: json)
     }
 
     /// Some Qwen chat templates emit an EOS-delimited JSON call with a

--- a/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/JSONToolCallParser.swift
@@ -7,9 +7,11 @@ import Foundation
 public struct JSONToolCallParser: ToolCallParser, Sendable {
     public let startTag: String?
     public let endTag: String?
+    public let supportsBareJSON: Bool
     private let jsonObjectScanner = JSONLeadingObjectScanner(startCharacter: "{")
 
-    public init(startTag: String, endTag: String) {
+    public init(startTag: String, endTag: String, supportsBareJSON: Bool = false) {
+        self.supportsBareJSON = supportsBareJSON
         self.startTag = startTag
         self.endTag = endTag
     }
@@ -17,15 +19,15 @@ public struct JSONToolCallParser: ToolCallParser, Sendable {
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
         guard let start = startTag, let end = endTag else { return nil }
 
-        // Find the JSON content between tags
-        var text = content
-
-        // Strip tags if present
-        if let startRange = text.range(of: start) {
-            text = String(text[startRange.upperBound...])
+        var text = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        // A bare JSON payload may contain literal protocol markers in its
+        // strings. Only wrapper tags outside that payload are delimiters.
+        if !text.hasPrefix("{"), let startRange = text.range(of: start) {
+            text = String(text[startRange.upperBound...]).trimmingCharacters(
+                in: .whitespacesAndNewlines)
         }
-        if let endRange = text.range(of: end) {
-            text = String(text[..<endRange.lowerBound])
+        if text.hasSuffix(end) {
+            text.removeLast(end.count)
         }
 
         return parsePayload(text)

--- a/Libraries/MLXLMCommon/Tool/Parsers/Llama3ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Llama3ToolCallParser.swift
@@ -8,6 +8,7 @@ import Foundation
 public struct Llama3ToolCallParser: ToolCallParser, Sendable {
     public let startTag: String? = nil
     public let endTag: String? = nil
+    public let supportsBareJSON = true
 
     public init() {}
 

--- a/Libraries/MLXLMCommon/Tool/Parsers/MiniMaxM2ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MiniMaxM2ToolCallParser.swift
@@ -70,8 +70,10 @@ public struct MiniMaxM2ToolCallParser: ToolCallParser, Sendable {
 
             // Get types from schema for this parameter
             let paramSchema = paramConfig[paramName] as? [String: any Sendable]
-            let paramTypes = extractTypesFromSchema(paramSchema)
-            arguments[paramName] = convertValueWithTypes(paramValue, types: paramTypes)
+            arguments[paramName] =
+                ToolArgumentNormalization.normalize(
+                    .string(paramValue), schema: paramSchema
+                ).sendableValue
 
             searchRange = paramEnd.upperBound ..< paramSection.endIndex
         }

--- a/Libraries/MLXLMCommon/Tool/Parsers/OnyxStreamAdapter.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/OnyxStreamAdapter.swift
@@ -225,6 +225,21 @@ private struct OnyxProtocolDecoder {
                 else {
                     return .protocolError("Rejected Onyx tool frame for recipient \(recipient)")
                 }
+                // The ATEM parser already enforces required parameters and
+                // typed values; check the full schema before the call leaves.
+                if case .invalid(let violations) = ToolSchemaValidator.validate(
+                    arguments: call.function.arguments,
+                    forToolNamed: call.function.name,
+                    in: tools)
+                {
+                    return .rejectedToolCall(
+                        RejectedToolCall(
+                            reason: .invalidArguments,
+                            format: .atem,
+                            toolName: call.function.name,
+                            rawText: text,
+                            detail: ToolSchemaValidator.describe(violations)))
+                }
                 return .toolCall(
                     ToolCall(
                         function: call.function,
@@ -244,6 +259,7 @@ private struct OnyxProtocolDecoder {
 struct OnyxStreamAdapter: TokenStreamDecoder {
     private var protocolDecoder: OnyxProtocolDecoder
     private var stopStringFilter: StopStringFilter
+    private(set) var rejectedToolCallCount = 0
     let additionalStopTokenIDs: Set<Int>
     let receivesStopTokens = true
 
@@ -295,6 +311,7 @@ struct OnyxStreamAdapter: TokenStreamDecoder {
             }
             return emit(.toolCall(call))
         case .rejectedToolCall(let rejection):
+            rejectedToolCallCount += 1
             if let response = stopStringFilter.finish(), !emit(.response(response)) {
                 return false
             }

--- a/Libraries/MLXLMCommon/Tool/Parsers/OnyxStreamAdapter.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/OnyxStreamAdapter.swift
@@ -166,15 +166,20 @@ private struct OnyxProtocolDecoder {
     private let tokenizer: any Tokenizer
     private let toolParser = ATEMToolCallParser()
     private let tools: [[String: any Sendable]]?
+    private let validationPolicy: ToolCallValidationPolicy
     private var reasoningDetokenizer: NaiveStreamingDetokenizer
     private var responseDetokenizer: NaiveStreamingDetokenizer
     private(set) var isInsideReasoning = false
 
-    init?(tokenizer: any Tokenizer, tools: [[String: any Sendable]]?) {
+    init?(
+        tokenizer: any Tokenizer, tools: [[String: any Sendable]]?,
+        toolCallPolicy: ToolCallPolicy = .init()
+    ) {
         guard let parser = OnyxFrameParser(tokenizer: tokenizer) else { return nil }
         self.parser = parser
         self.tokenizer = tokenizer
         self.tools = tools
+        self.validationPolicy = toolCallPolicy.validation
         self.reasoningDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         self.responseDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
     }
@@ -220,17 +225,19 @@ private struct OnyxProtocolDecoder {
                 responseDetokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
             case .tool(let recipient):
                 let text = tokenizer.decode(tokenIds: payload, skipSpecialTokens: false)
-                guard let call = toolParser.parse(content: text, tools: tools),
+                guard var call = toolParser.parse(content: text, tools: tools),
                     call.function.name == recipient
                 else {
                     return .protocolError("Rejected Onyx tool frame for recipient \(recipient)")
                 }
                 // The ATEM parser already enforces required parameters and
                 // typed values; check the full schema before the call leaves.
-                if case .invalid(let violations) = ToolSchemaValidator.validate(
-                    arguments: call.function.arguments,
-                    forToolNamed: call.function.name,
-                    in: tools)
+                call = ToolArgumentNormalization.normalize(call, tools: tools)
+                if validationPolicy == .strict,
+                    case .invalid(let violations) = ToolSchemaValidator.validate(
+                        arguments: call.function.arguments,
+                        forToolNamed: call.function.name,
+                        in: tools)
                 {
                     return .rejectedToolCall(
                         RejectedToolCall(
@@ -268,9 +275,13 @@ struct OnyxStreamAdapter: TokenStreamDecoder {
     init?(
         tokenizer: any Tokenizer,
         tools: [[String: any Sendable]]?,
-        stopStrings: Set<String>
+        stopStrings: Set<String>,
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
-        guard let decoder = OnyxProtocolDecoder(tokenizer: tokenizer, tools: tools) else {
+        guard
+            let decoder = OnyxProtocolDecoder(
+                tokenizer: tokenizer, tools: tools, toolCallPolicy: toolCallPolicy)
+        else {
             return nil
         }
         self.protocolDecoder = decoder

--- a/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
@@ -225,7 +225,8 @@ func convertParameterValue(
 ) -> any Sendable {
     guard let paramType = getParameterType(funcName: funcName, paramName: paramName, tools: tools)
     else {
-        return value
+        return convertParameterValueUsingDeclaredTypes(
+            value, paramName: paramName, funcName: funcName, tools: tools)
     }
 
     let type = paramType.lowercased()
@@ -266,6 +267,35 @@ func convertParameterValue(
     }
 
     return value
+}
+
+/// Conservative conversion for parameter schemas whose `type` is not a plain
+/// string: union types (`["integer", "null"]`), combinators (`anyOf` /
+/// `oneOf` / `allOf`), and flat-shaped tool declarations that
+/// `getParameterType` cannot see.
+///
+/// The textual wire value is preserved whenever the declared schema admits a
+/// string — or declares no recognizable type at all — so conversion never
+/// invents a type the schema did not ask for. Only when every declared type
+/// is non-string is the value converted, so that downstream schema
+/// validation judges the call the model intended rather than an artifact of
+/// the textual transport.
+private func convertParameterValueUsingDeclaredTypes(
+    _ value: String, paramName: String, funcName: String, tools: [[String: any Sendable]]?
+) -> any Sendable {
+    guard let tools,
+        let parameters = ToolSchemaValidator.parametersSchema(ofToolNamed: funcName, in: tools),
+        let properties = parameters["properties"] as? [String: any Sendable],
+        let schema = properties[paramName] as? [String: any Sendable]
+    else { return value }
+
+    // `extractTypesFromSchema` falls back to `["string"]` when the schema
+    // carries no recognizable type information, so both "no declared types"
+    // and "string admitted" leave the wire value unchanged.
+    let types = extractTypesFromSchema(schema)
+    let normalized = Set(types.map { $0.lowercased() })
+    guard normalized.isDisjoint(with: ["string", "str", "text"]) else { return value }
+    return convertValueWithTypes(value, types: types)
 }
 
 // MARK: - String Utilities

--- a/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
@@ -163,139 +163,21 @@ func isDeclaredTool(
 /// Convert parameter value based on multiple possible types.
 /// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/minimax_m2.py
 func convertValueWithTypes(_ value: String, types: [String]) -> any Sendable {
-    let lowerValue = value.lowercased()
-
-    // Handle null values
-    if ["null", "none", "nil"].contains(lowerValue) {
-        return NSNull()
-    }
-
-    let normalizedTypes = Set(types.map { $0.lowercased() })
-
-    // Priority: integer > number > boolean > object > array > string
-    let typePriority = [
-        "integer", "int", "number", "float", "boolean", "bool",
-        "object", "array", "string", "str", "text",
-    ]
-
-    for paramType in typePriority {
-        guard normalizedTypes.contains(paramType) else { continue }
-
-        switch paramType {
-        case "string", "str", "text":
-            return value
-
-        case "integer", "int":
-            if let intVal = Int(value) {
-                return intVal
-            }
-
-        case "number", "float":
-            if let floatVal = Double(value) {
-                let intVal = Int(floatVal)
-                return floatVal != Double(intVal) ? floatVal : intVal
-            }
-
-        case "boolean", "bool":
-            let trimmed = lowerValue.trimmingCharacters(in: .whitespaces)
-            if ["true", "1", "yes", "on"].contains(trimmed) {
-                return true
-            } else if ["false", "0", "no", "off"].contains(trimmed) {
-                return false
-            }
-
-        case "object", "array":
-            if let json = tryParseJSON(value) {
-                return json
-            }
-
-        default:
-            continue
-        }
-    }
-
-    // Fallback: try JSON parse, then return as string
-    return tryParseJSON(value) ?? value
+    ToolArgumentNormalization.normalize(.string(value), schema: ["type": types]).sendableValue
 }
 
-/// Convert parameter value based on schema type.
-/// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/qwen3_coder.py
+/// Read a textual parameter using its declared schema; unknown or ambiguous
+/// schemas preserve the original text. Validation is a separate boundary.
 func convertParameterValue(
-    _ value: String, paramName: String, funcName: String, tools: [[String: any Sendable]]?
-) -> any Sendable {
-    guard let paramType = getParameterType(funcName: funcName, paramName: paramName, tools: tools)
-    else {
-        return convertParameterValueUsingDeclaredTypes(
-            value, paramName: paramName, funcName: funcName, tools: tools)
-    }
-
-    let type = paramType.lowercased()
-
-    // String types - return as-is
-    if ["string", "str", "text", "varchar", "char", "enum"].contains(type) {
-        return value
-    }
-
-    // Integer types
-    if type.hasPrefix("int") || type.hasPrefix("uint")
-        || type.hasPrefix("long") || type.hasPrefix("short")
-        || type.hasPrefix("unsigned")
-    {
-        return Int(value) ?? value
-    }
-
-    // Float types
-    if type.hasPrefix("num") || type.hasPrefix("float") {
-        if let floatVal = Double(value) {
-            let intVal = Int(floatVal)
-            return floatVal != Double(intVal) ? floatVal : intVal
-        }
-        return value
-    }
-
-    // Boolean types
-    if ["boolean", "bool", "binary"].contains(type) {
-        return ["true", "1", "yes", "on"].contains(
-            value.lowercased().trimmingCharacters(in: .whitespaces))
-    }
-
-    // Object/Array types - JSON decode
-    if ["object", "array"].contains(type) || type.hasPrefix("dict") || type.hasPrefix("list") {
-        if let json = tryParseJSON(value) {
-            return json
-        }
-    }
-
-    return value
-}
-
-/// Conservative conversion for parameter schemas whose `type` is not a plain
-/// string: union types (`["integer", "null"]`), combinators (`anyOf` /
-/// `oneOf` / `allOf`), and flat-shaped tool declarations that
-/// `getParameterType` cannot see.
-///
-/// The textual wire value is preserved whenever the declared schema admits a
-/// string — or declares no recognizable type at all — so conversion never
-/// invents a type the schema did not ask for. Only when every declared type
-/// is non-string is the value converted, so that downstream schema
-/// validation judges the call the model intended rather than an artifact of
-/// the textual transport.
-private func convertParameterValueUsingDeclaredTypes(
     _ value: String, paramName: String, funcName: String, tools: [[String: any Sendable]]?
 ) -> any Sendable {
     guard let tools,
         let parameters = ToolSchemaValidator.parametersSchema(ofToolNamed: funcName, in: tools),
-        let properties = parameters["properties"] as? [String: any Sendable],
-        let schema = properties[paramName] as? [String: any Sendable]
+        let properties = parameters["properties"] as? [String: any Sendable]
     else { return value }
-
-    // `extractTypesFromSchema` falls back to `["string"]` when the schema
-    // carries no recognizable type information, so both "no declared types"
-    // and "string admitted" leave the wire value unchanged.
-    let types = extractTypesFromSchema(schema)
-    let normalized = Set(types.map { $0.lowercased() })
-    guard normalized.isDisjoint(with: ["string", "str", "text"]) else { return value }
-    return convertValueWithTypes(value, types: types)
+    return ToolArgumentNormalization.normalize(
+        .string(value), schema: properties[paramName] as? [String: any Sendable]
+    ).sendableValue
 }
 
 // MARK: - String Utilities

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonLiteralParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonLiteralParser.swift
@@ -11,6 +11,7 @@ import Foundation
 struct PythonLiteralParser {
     private let source: Substring
     private var index: String.Index
+    private var depth = 0
 
     private init(_ source: Substring) {
         self.source = source
@@ -21,6 +22,17 @@ struct PythonLiteralParser {
         var parser = Self(source)
         guard let value = parser.parseValue() else { return nil }
         parser.skipWhitespace()
+        if parser.consume(",") {
+            var values = [value]
+            repeat {
+                parser.skipWhitespace()
+                if parser.current == nil { return values }
+                guard let next = parser.parseValue() else { return nil }
+                values.append(next)
+                parser.skipWhitespace()
+            } while parser.consume(",")
+            return parser.current == nil ? values : nil
+        }
         return parser.index == source.endIndex ? value : nil
     }
 
@@ -29,12 +41,15 @@ struct PythonLiteralParser {
     }
 
     private mutating func parseValue() -> (any Sendable)? {
+        guard depth < 32 else { return nil }
+        depth += 1
+        defer { depth -= 1 }
         skipWhitespace()
 
         switch current {
         case "'", "\"":
             return parseString()
-        case "[":
+        case "[", "(":
             return parseArray()
         case "{":
             return parseObject()
@@ -46,21 +61,25 @@ struct PythonLiteralParser {
     }
 
     private mutating func parseArray() -> (any Sendable)? {
-        guard consume("[") else { return nil }
+        let tuple = current == "("
+        guard consume(tuple ? "(" : "[") else { return nil }
+        let close: Character = tuple ? ")" : "]"
+        var hasComma = false
         skipWhitespace()
 
         var values: [any Sendable] = []
-        if consume("]") { return values }
+        if consume(close) { return values }
 
         while true {
             guard let value = parseValue() else { return nil }
             values.append(value)
             skipWhitespace()
 
-            if consume("]") { return values }
+            if consume(close) { return tuple && !hasComma ? value : values }
             guard consume(",") else { return nil }
+            hasComma = true
             skipWhitespace()
-            if consume("]") { return values }
+            if consume(close) { return values }
         }
     }
 
@@ -146,7 +165,7 @@ struct PythonLiteralParser {
         let start = index
         while let character = current,
             !character.isWhitespace,
-            ![",", "]", "}"].contains(character)
+            ![",", "]", "}", ")"].contains(character)
         {
             advance()
         }

--- a/Libraries/MLXLMCommon/Tool/Parsers/Qwen35ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Qwen35ToolCallParser.swift
@@ -42,24 +42,8 @@ public struct Qwen35ToolCallParser: ToolCallParser, Sendable {
     /// Returns the body used only to select a parser. The concrete parser remains
     /// responsible for validating the entire payload.
     private func payloadBody(in content: String) -> String? {
-        var payload = content.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        if let startTag, payload.hasPrefix(startTag) {
-            payload.removeFirst(startTag.count)
-            payload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        if let endTag {
-            if payload.hasSuffix(endTag) {
-                payload.removeLast(endTag.count)
-                payload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
-            } else if payload.contains(endTag) {
-                // The streaming processor normally separates trailing content.
-                // Direct parser callers must not have it silently discarded.
-                return nil
-            }
-        }
-
-        return payload
+        QwenXMLPayloadScanner.framedPayload(
+            in: content, startTag: startTag, endTag: endTag)
     }
 
     /// Validate and extract a canonical XML payload with the shared structural
@@ -71,19 +55,6 @@ public struct Qwen35ToolCallParser: ToolCallParser, Sendable {
         _ payload: String,
         tools: [[String: any Sendable]]?
     ) -> ToolCall? {
-        guard case .complete(let parsed) = QwenXMLPayloadScanner.scan(payload[...]),
-            payload[parsed.end...].allSatisfy(\.isWhitespace)
-        else { return nil }
-
-        var arguments: [String: any Sendable] = [:]
-        for parameter in parsed.parameters {
-            var value = String(parameter.value)
-            // Trim a single leading/trailing newline (matching XMLFunctionParser).
-            if value.hasPrefix("\n") { value = String(value.dropFirst()) }
-            if value.hasSuffix("\n") { value = String(value.dropLast()) }
-            arguments[parameter.name] = convertParameterValue(
-                value, paramName: parameter.name, funcName: parsed.name, tools: tools)
-        }
-        return ToolCall(function: .init(name: parsed.name, arguments: arguments))
+        QwenXMLPayloadScanner.parseCanonical(payload[...], tools: tools)
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/Qwen35ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Qwen35ToolCallParser.swift
@@ -13,13 +13,11 @@ public struct Qwen35ToolCallParser: ToolCallParser, Sendable {
     public let startTag: String?
     public let endTag: String?
 
-    private let xmlParser: XMLFunctionParser
     private let jsonParser: JSONToolCallParser
 
     public init(startTag: String, endTag: String) {
         self.startTag = startTag
         self.endTag = endTag
-        self.xmlParser = XMLFunctionParser(startTag: startTag, endTag: endTag)
         self.jsonParser = JSONToolCallParser(startTag: startTag, endTag: endTag)
     }
 
@@ -28,10 +26,9 @@ public struct Qwen35ToolCallParser: ToolCallParser, Sendable {
 
         let call: ToolCall?
         if payload.hasPrefix("<function=") {
-            guard isCanonicalXMLPayload(payload) else { return nil }
-            call = xmlParser.parse(content: payload, tools: tools)
+            call = parseCanonicalXML(payload, tools: tools)
         } else if payload.hasPrefix("{") {
-            call = jsonParser.parse(content: payload, tools: tools)
+            call = jsonParser.parsePayload(payload)
         } else {
             return nil
         }
@@ -65,37 +62,28 @@ public struct Qwen35ToolCallParser: ToolCallParser, Sendable {
         return payload
     }
 
-    /// Validate the whole XML body before delegating value conversion to the
-    /// existing parser. This prevents a recognizable prefix plus unrelated or
-    /// mixed-dialect text from becoming an executable call.
-    private func isCanonicalXMLPayload(_ payload: String) -> Bool {
-        var remainder = payload[...]
-        guard consumeNamedOpeningTag("<function=", from: &remainder) else { return false }
+    /// Validate and extract a canonical XML payload with the shared structural
+    /// scanner. Validation and value extraction use the same grammar, so a
+    /// parameter value containing a literal `</function>` cannot truncate the
+    /// parse into silently incomplete arguments, and a recognizable prefix plus
+    /// unrelated or mixed-dialect text never becomes an executable call.
+    private func parseCanonicalXML(
+        _ payload: String,
+        tools: [[String: any Sendable]]?
+    ) -> ToolCall? {
+        guard case .complete(let parsed) = QwenXMLPayloadScanner.scan(payload[...]),
+            payload[parsed.end...].allSatisfy(\.isWhitespace)
+        else { return nil }
 
-        while true {
-            remainder = remainder.drop(while: { $0.isWhitespace })
-            if remainder.hasPrefix("</function>") {
-                remainder = remainder.dropFirst("</function>".count)
-                return remainder.allSatisfy(\.isWhitespace)
-            }
-
-            guard consumeNamedOpeningTag("<parameter=", from: &remainder),
-                let parameterEnd = remainder.range(of: "</parameter>")
-            else { return false }
-            remainder = remainder[parameterEnd.upperBound...]
+        var arguments: [String: any Sendable] = [:]
+        for parameter in parsed.parameters {
+            var value = String(parameter.value)
+            // Trim a single leading/trailing newline (matching XMLFunctionParser).
+            if value.hasPrefix("\n") { value = String(value.dropFirst()) }
+            if value.hasSuffix("\n") { value = String(value.dropLast()) }
+            arguments[parameter.name] = convertParameterValue(
+                value, paramName: parameter.name, funcName: parsed.name, tools: tools)
         }
-    }
-
-    private func consumeNamedOpeningTag(
-        _ prefix: String, from text: inout Substring
-    ) -> Bool {
-        guard text.hasPrefix(prefix) else { return false }
-        text = text.dropFirst(prefix.count)
-        guard let closingAngle = text.firstIndex(of: ">") else { return false }
-
-        let name = text[..<closingAngle]
-        guard !name.isEmpty, !name.contains(where: \.isWhitespace) else { return false }
-        text = text[text.index(after: closingAngle)...]
-        return true
+        return ToolCall(function: .init(name: parsed.name, arguments: arguments))
     }
 }

--- a/Libraries/MLXLMCommon/Tool/Parsers/QwenXMLPayloadScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/QwenXMLPayloadScanner.swift
@@ -1,0 +1,225 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Shared structural scanner for the Qwen XML function dialect:
+/// `<function=name><parameter=key>value</parameter>...</function>`.
+///
+/// `Qwen35ToolCallParser` validates native payloads with this scanner and the
+/// cross-dialect recovery scanner uses the same implementation for candidate
+/// extents and argument extraction. There is exactly one definition of a
+/// canonical payload, so a malformed or ambiguous payload cannot be promoted
+/// through a looser secondary path:
+///
+/// - the function close is the structural close, not the first textual
+///   `</function>` (a parameter value may contain that literal),
+/// - every opened `<parameter=` must close with `</parameter>`,
+/// - the payload must be consumed in full, apart from whitespace.
+enum QwenXMLPayloadScanner {
+
+    /// A canonically valid payload.
+    struct Payload {
+        let name: String
+        /// Parameters in source order. Each value is the verbatim text between
+        /// the parameter's `>` and its matching `</parameter>`.
+        let parameters: [(name: String, value: Substring)]
+        /// Index just past the payload (after `</function>`, or after the last
+        /// parameter when a missing close is explicitly allowed).
+        let end: String.Index
+    }
+
+    enum ScanResult {
+        /// The payload is structurally complete and canonical.
+        case complete(Payload)
+        /// The buffer ended before completeness or malformation could be
+        /// decided; more input may still complete it.
+        case needMore
+        /// A structural violation was found. `consumed` marks the extent that
+        /// was examined, suitable for a bounded rejection diagnostic.
+        case malformed(consumed: String.Index)
+    }
+
+    static let functionOpen = "<function="
+    static let functionClose = "</function>"
+    static let parameterOpen = "<parameter="
+    static let parameterClose = "</parameter>"
+
+    /// Scan a payload that must begin with `<function=`.
+    ///
+    /// - Parameter allowMissingFunctionClose: when `true`, a payload that is
+    ///   canonical except for the final `</function>` also reports
+    ///   `.complete`. Used only by permissive end-of-stream repair.
+    static func scan(
+        _ text: Substring,
+        allowMissingFunctionClose: Bool = false
+    ) -> ScanResult {
+        var index = text.startIndex
+
+        switch matchLiteral(functionOpen, in: text, at: index) {
+        case .matched(let after): index = after
+        case .needMore: return .needMore
+        case .noMatch: return .malformed(consumed: index)
+        }
+
+        // Function name: everything up to `>`; non-empty, no whitespace.
+        guard let nameEnd = text[index...].firstIndex(of: ">") else { return .needMore }
+        let name = text[index ..< nameEnd]
+        guard !name.isEmpty, !name.contains(where: \.isWhitespace) else {
+            return .malformed(consumed: text.index(after: nameEnd))
+        }
+        index = text.index(after: nameEnd)
+
+        var parameters: [(name: String, value: Substring)] = []
+
+        while true {
+            while index < text.endIndex, text[index].isWhitespace {
+                index = text.index(after: index)
+            }
+            guard index < text.endIndex else {
+                if allowMissingFunctionClose {
+                    return .complete(
+                        Payload(name: String(name), parameters: parameters, end: index))
+                }
+                return .needMore
+            }
+
+            switch matchLiteral(functionClose, in: text, at: index) {
+            case .matched(let after):
+                return .complete(
+                    Payload(name: String(name), parameters: parameters, end: after))
+            case .needMore:
+                return .needMore
+            case .noMatch:
+                break
+            }
+
+            switch matchLiteral(parameterOpen, in: text, at: index) {
+            case .matched(let after):
+                index = after
+            case .needMore:
+                return .needMore
+            case .noMatch:
+                return .malformed(consumed: index)
+            }
+
+            guard let parameterNameEnd = text[index...].firstIndex(of: ">") else {
+                return .needMore
+            }
+            let parameterName = text[index ..< parameterNameEnd]
+            guard !parameterName.isEmpty, !parameterName.contains(where: \.isWhitespace) else {
+                return .malformed(consumed: text.index(after: parameterNameEnd))
+            }
+            let valueStart = text.index(after: parameterNameEnd)
+
+            // The parameter value is opaque text up to the first
+            // `</parameter>`. An unterminated value may simply need more input;
+            // the bounded buffer upstream decides when to give up.
+            guard
+                let valueEnd = text.range(
+                    of: parameterClose, range: valueStart ..< text.endIndex)
+            else { return .needMore }
+            parameters.append(
+                (name: String(parameterName), value: text[valueStart ..< valueEnd.lowerBound]))
+            index = valueEnd.upperBound
+        }
+    }
+
+    /// Whether `payload` is canonical in full: structurally valid with nothing
+    /// but whitespace after the closing tag.
+    static func isCanonical(_ payload: Substring) -> Bool {
+        guard case .complete(let parsed) = scan(payload) else { return false }
+        return payload[parsed.end...].allSatisfy(\.isWhitespace)
+    }
+
+    private enum LiteralMatch {
+        case matched(after: String.Index)
+        case needMore
+        case noMatch
+    }
+
+    /// Match `literal` at `index`, distinguishing "not here" from "the buffer
+    /// ended while it could still complete".
+    private static func matchLiteral(
+        _ literal: String,
+        in text: Substring,
+        at index: String.Index
+    ) -> LiteralMatch {
+        var literalIndex = literal.startIndex
+        var textIndex = index
+        while literalIndex < literal.endIndex {
+            guard textIndex < text.endIndex else { return .needMore }
+            guard text[textIndex] == literal[literalIndex] else { return .noMatch }
+            literalIndex = literal.index(after: literalIndex)
+            textIndex = text.index(after: textIndex)
+        }
+        return .matched(after: textIndex)
+    }
+}
+
+/// Structural framing for `<tool_call>...</tool_call>` payloads, shared by the
+/// native tagged streaming path and cross-dialect recovery so both always agree
+/// on where a frame ends.
+///
+/// A frame closes only after a structurally complete payload:
+///
+/// - a JSON payload must balance as one top-level value, honoring string
+///   escapes — a literal `</tool_call>` inside a string argument is data and
+///   cannot close the frame;
+/// - a Qwen XML payload must be canonical per ``QwenXMLPayloadScanner`` — a
+///   literal `</function>` inside a parameter value cannot close it.
+///
+/// Payloads in neither dialect fall back to the first textual close, matching
+/// the historical framing the native parsers already used.
+enum ToolCallFrameScanner {
+    static let startTag = "<tool_call>"
+    static let endTag = "</tool_call>"
+
+    /// The index just past the frame's structural close, or `nil` when the
+    /// buffer does not yet contain a complete frame. `text` must begin with
+    /// `<tool_call>`.
+    static func frameEnd(in text: String) -> String.Index? {
+        guard text.hasPrefix(startTag) else { return nil }
+        var payloadStart = text.index(text.startIndex, offsetBy: startTag.count)
+        while payloadStart < text.endIndex, text[payloadStart].isWhitespace {
+            payloadStart = text.index(after: payloadStart)
+        }
+        guard payloadStart < text.endIndex else { return nil }
+
+        if text[payloadStart] == "{" {
+            let jsonScanner = JSONLeadingObjectScanner(startCharacter: "{")
+            let payloadAndSuffix = String(text[payloadStart...])
+            guard let split = jsonScanner.splitLeadingObject(from: payloadAndSuffix) else {
+                return nil
+            }
+            var afterPayload = text.index(payloadStart, offsetBy: split.object.count)
+            while afterPayload < text.endIndex, text[afterPayload].isWhitespace {
+                afterPayload = text.index(after: afterPayload)
+            }
+            guard afterPayload < text.endIndex,
+                text[afterPayload...].hasPrefix(endTag)
+            else { return nil }
+            return text.index(afterPayload, offsetBy: endTag.count)
+        }
+
+        if text[payloadStart...].hasPrefix(QwenXMLPayloadScanner.functionOpen) {
+            guard
+                case .complete(let payload) = QwenXMLPayloadScanner.scan(text[payloadStart...])
+            else { return nil }
+            var afterPayload = payload.end
+            while afterPayload < text.endIndex, text[afterPayload].isWhitespace {
+                afterPayload = text.index(after: afterPayload)
+            }
+            guard afterPayload < text.endIndex,
+                text[afterPayload...].hasPrefix(endTag)
+            else { return nil }
+            return text.index(afterPayload, offsetBy: endTag.count)
+        }
+
+        // A split `<function=` prefix may still complete; anything else uses
+        // the first textual close.
+        if QwenXMLPayloadScanner.functionOpen.hasPrefix(String(text[payloadStart...])) {
+            return nil
+        }
+        return text.range(of: endTag).map(\.upperBound)
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/QwenXMLPayloadScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/QwenXMLPayloadScanner.swift
@@ -5,11 +5,11 @@ import Foundation
 /// Shared structural scanner for the Qwen XML function dialect:
 /// `<function=name><parameter=key>value</parameter>...</function>`.
 ///
-/// `Qwen35ToolCallParser` validates native payloads with this scanner and the
-/// cross-dialect recovery scanner uses the same implementation for candidate
-/// extents and argument extraction. There is exactly one definition of a
-/// canonical payload, so a malformed or ambiguous payload cannot be promoted
-/// through a looser secondary path:
+/// `XMLFunctionParser` and `Qwen35ToolCallParser` validate native payloads with
+/// this scanner, and the cross-dialect recovery scanner uses the same
+/// implementation for candidate extents and argument extraction. There is
+/// exactly one definition of a canonical payload, so a malformed or ambiguous
+/// payload cannot be promoted through a looser secondary path:
 ///
 /// - the function close is the structural close, not the first textual
 ///   `</function>` (a parameter value may contain that literal),
@@ -131,6 +131,59 @@ enum QwenXMLPayloadScanner {
         return payload[parsed.end...].allSatisfy(\.isWhitespace)
     }
 
+    /// Parse a payload that must be canonical *in full* into a `ToolCall`.
+    ///
+    /// This is the only supported way to turn the Qwen XML dialect into an
+    /// executable call. Validation and value extraction share one grammar, so a
+    /// structurally degraded payload can never be downgraded into a call with
+    /// silently missing arguments.
+    ///
+    /// - Parameter allowMissingFunctionClose: see ``scan(_:allowMissingFunctionClose:)``.
+    ///   Only documented end-of-stream repair may set this.
+    static func parseCanonical(
+        _ payload: Substring,
+        tools: [[String: any Sendable]]?,
+        allowMissingFunctionClose: Bool = false
+    ) -> ToolCall? {
+        guard
+            case .complete(let parsed) = scan(
+                payload, allowMissingFunctionClose: allowMissingFunctionClose),
+            payload[parsed.end...].allSatisfy(\.isWhitespace)
+        else { return nil }
+        return parsed.toolCall(tools: tools)
+    }
+
+    /// Strip the optional framing tags from `content`, returning the payload a
+    /// parser must then validate in full.
+    ///
+    /// Returns `nil` when `endTag` appears anywhere other than the very end: the
+    /// streaming processor separates trailing content before parsing, so a
+    /// direct caller must never have it silently discarded. A close marker
+    /// *inside* a parameter value is unaffected, because the trailing marker is
+    /// removed as a suffix before that check can apply.
+    static func framedPayload(
+        in content: String,
+        startTag: String?,
+        endTag: String?
+    ) -> String? {
+        var payload = content.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let startTag, payload.hasPrefix(startTag) {
+            payload.removeFirst(startTag.count)
+            payload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let endTag {
+            if payload.hasSuffix(endTag) {
+                payload.removeLast(endTag.count)
+                payload = payload.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else if payload.contains(endTag) {
+                return nil
+            }
+        }
+
+        return payload
+    }
+
     private enum LiteralMatch {
         case matched(after: String.Index)
         case needMore
@@ -153,6 +206,28 @@ enum QwenXMLPayloadScanner {
             textIndex = text.index(after: textIndex)
         }
         return .matched(after: textIndex)
+    }
+}
+
+extension QwenXMLPayloadScanner.Payload {
+
+    /// The single definition of how a canonical payload becomes call arguments.
+    ///
+    /// Every caller — the native ``XMLFunctionParser`` and ``Qwen35ToolCallParser``
+    /// paths as well as cross-dialect recovery — funnels through this method, so
+    /// argument extraction cannot drift between them.
+    func toolCall(tools: [[String: any Sendable]]?) -> ToolCall {
+        var arguments: [String: any Sendable] = [:]
+        for parameter in parameters {
+            var value = String(parameter.value)
+            // Trim a single leading/trailing newline (matching the Qwen3 Coder
+            // reference implementation, which formats values on their own line).
+            if value.hasPrefix("\n") { value = String(value.dropFirst()) }
+            if value.hasSuffix("\n") { value = String(value.dropLast()) }
+            arguments[parameter.name] = convertParameterValue(
+                value, paramName: parameter.name, funcName: name, tools: tools)
+        }
+        return ToolCall(function: .init(name: name, arguments: arguments))
     }
 }
 

--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -4,6 +4,20 @@ import Foundation
 
 /// Parser for XML function format: <function=name><parameter=key>value</parameter></function>
 /// Reference: https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/tool_parsers/qwen3_coder.py
+///
+/// Structure is validated with the shared `QwenXMLPayloadScanner`, the same
+/// grammar used by ``Qwen35ToolCallParser`` and by cross-dialect recovery. A
+/// payload becomes a call only when it is canonical in full:
+///
+/// - the function close is the *structural* close rather than the first textual
+///   `</function>`, so a parameter value may contain that literal verbatim;
+/// - every `<parameter=` must close with `</parameter>`;
+/// - nothing but whitespace may follow the payload inside its frame.
+///
+/// A malformed payload yields `nil` instead of a partially populated call. This
+/// matters most at end of stream, where a truncated frame must be rejected
+/// rather than executed with silently missing arguments — structural validity
+/// must never depend on whether the caller's schema declares `required`.
 public struct XMLFunctionParser: ToolCallParser, Sendable {
     public let startTag: String?
     public let endTag: String?
@@ -14,59 +28,12 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
     }
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
-        // Pattern: <function=(content)</function> — [\s\S] matches newlines
         guard
-            let funcMatch = content.range(
-                of: #"<function=([\s\S]*?)</function>"#, options: .regularExpression)
+            let payload = QwenXMLPayloadScanner.framedPayload(
+                in: content, startTag: startTag, endTag: endTag),
+            payload.hasPrefix(QwenXMLPayloadScanner.functionOpen)
         else { return nil }
 
-        let funcContent = String(content[funcMatch])
-
-        // Extract function name (everything between <function= and first >)
-        guard let nameStart = funcContent.range(of: "<function="),
-            let nameEnd = funcContent.range(
-                of: ">", range: nameStart.upperBound ..< funcContent.endIndex)
-        else { return nil }
-
-        let funcName = String(funcContent[nameStart.upperBound ..< nameEnd.lowerBound])
-        let paramSection = String(funcContent[nameEnd.upperBound...])
-
-        var arguments: [String: any Sendable] = [:]
-
-        // Find all parameter tags
-        var searchRange = paramSection.startIndex ..< paramSection.endIndex
-        while let paramStart = paramSection.range(of: "<parameter=", range: searchRange) {
-            // Find the parameter name (between = and >)
-            guard
-                let nameEnd = paramSection.range(
-                    of: ">", range: paramStart.upperBound ..< paramSection.endIndex)
-            else { break }
-
-            let paramName = String(paramSection[paramStart.upperBound ..< nameEnd.lowerBound])
-
-            // Find the closing </parameter> tag
-            guard
-                let paramEnd = paramSection.range(
-                    of: "</parameter>", range: nameEnd.upperBound ..< paramSection.endIndex)
-            else { break }
-
-            var paramValue = String(paramSection[nameEnd.upperBound ..< paramEnd.lowerBound])
-
-            // Trim leading/trailing newlines (matching Python behavior)
-            if paramValue.hasPrefix("\n") {
-                paramValue = String(paramValue.dropFirst())
-            }
-            if paramValue.hasSuffix("\n") {
-                paramValue = String(paramValue.dropLast())
-            }
-
-            // Convert value based on schema type
-            arguments[paramName] = convertParameterValue(
-                paramValue, paramName: paramName, funcName: funcName, tools: tools)
-
-            searchRange = paramEnd.upperBound ..< paramSection.endIndex
-        }
-
-        return ToolCall(function: .init(name: funcName, arguments: arguments))
+        return QwenXMLPayloadScanner.parseCanonical(payload[...], tools: tools)
     }
 }

--- a/Libraries/MLXLMCommon/Tool/RejectedToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/RejectedToolCall.swift
@@ -26,6 +26,10 @@ public struct RejectedToolCall: Hashable, Codable, Sendable {
 
         /// The function arguments could not be represented as a tool input.
         case invalidArguments = "invalid_arguments"
+
+        /// The candidate exceeded the bounded parser budget and was discarded
+        /// without execution.
+        case resourceLimitExceeded = "resource_limit_exceeded"
     }
 
     /// The default maximum number of UTF-8 bytes retained in ``rawTextPreview``.
@@ -126,6 +130,8 @@ extension RejectedToolCall.Reason {
             "The function was not present in the supplied tool definitions."
         case .invalidArguments:
             "The function arguments were not a JSON object."
+        case .resourceLimitExceeded:
+            "The tool-call payload exceeded the parser's safety limit."
         }
     }
 }

--- a/Libraries/MLXLMCommon/Tool/RejectedToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/RejectedToolCall.swift
@@ -24,7 +24,8 @@ public struct RejectedToolCall: Hashable, Codable, Sendable {
         /// The call named a function that was not present in the supplied tools.
         case undeclaredTool = "undeclared_tool"
 
-        /// The function arguments could not be represented as a tool input.
+        /// The function arguments could not be represented as a tool input or
+        /// definitively violated the tool's declared schema.
         case invalidArguments = "invalid_arguments"
 
         /// The candidate exceeded the bounded parser budget and was discarded

--- a/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
@@ -1240,16 +1240,13 @@ struct TextToolCallRecoveryScanner: Sendable {
             call = parseMistralStyle(raw)
         }
 
-        guard let call, allowedToolNames.contains(call.function.name),
-            satisfiesDeclaredRequiredArguments(call)
-        else { return nil }
+        guard let call, allowedToolNames.contains(call.function.name) else { return nil }
         return call
     }
 
     private func recoverDeclaredArgs(_ raw: String, name: String) -> ToolCall? {
         guard raw.hasPrefix(name + "[ARGS]"),
-            let call = parseMistralStyle(raw, expectedName: name),
-            satisfiesDeclaredRequiredArguments(call)
+            let call = parseMistralStyle(raw, expectedName: name)
         else { return nil }
         return call
     }
@@ -1267,23 +1264,6 @@ struct TextToolCallRecoveryScanner: Sendable {
             raw[...],
             tools: tools,
             allowMissingFunctionClose: allowMissingFunctionClose)
-    }
-
-    /// A recovered call must satisfy the declared schema's required arguments
-    /// before promotion; an empty-arguments promotion for a tool that declares
-    /// required parameters is never valid recovery.
-    private func satisfiesDeclaredRequiredArguments(_ call: ToolCall) -> Bool {
-        for tool in tools {
-            guard let function = tool["function"] as? [String: any Sendable],
-                function["name"] as? String == call.function.name
-            else { continue }
-            guard let parameters = function["parameters"] as? [String: any Sendable],
-                let required = parameters["required"] as? [any Sendable]
-            else { return true }
-            let requiredNames = required.compactMap { $0 as? String }
-            return requiredNames.allSatisfy { call.function.arguments[$0] != nil }
-        }
-        return true
     }
 
     private func rejection(

--- a/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
@@ -6,7 +6,8 @@ import Foundation
 ///
 /// The selected `ToolCallParser` remains authoritative. This scanner only owns
 /// dialect markers that the selected parser cannot consume, plus exact
-/// `declaredTool[ARGS]{...}` rehearsals. It deliberately uses fixed-string
+/// `declaredTool[ARGS]{...}` rehearsals under the permissive policy. It
+/// deliberately uses fixed-string
 /// searches and structural JSON scanning instead of regular expressions or
 /// speculative JSON decoding on ordinary response text.
 ///
@@ -217,7 +218,7 @@ struct TextToolCallRecoveryScanner: Sendable {
                 prefixes.insert(String(signal.text.prefix(length)))
             }
         }
-        if policy != .disabled {
+        if policy == .permissive {
             for name in allowedToolNames {
                 let marker = name + "[ARGS]"
                 for length in 1 ..< marker.count {
@@ -646,8 +647,13 @@ struct TextToolCallRecoveryScanner: Sendable {
     /// heals Mistral's observed `[TOOL_CALLS]name{json}` variant.
     mutating func recoverEOSPayloads(_ raw: String) -> [ToolCall] {
         guard policy != .disabled else { return [] }
-        if raw.contains("[TOOL_CALLS]") {
-            return raw.components(separatedBy: "[TOOL_CALLS]").compactMap { segment in
+        if let firstMarker = raw.range(of: "[TOOL_CALLS]") {
+            // Only text that actually followed a `[TOOL_CALLS]` marker may be
+            // re-framed as a Mistral call. Re-prefixing the prose before the
+            // first marker would fabricate a frame the model never emitted
+            // and could promote plain response text shaped like `name{json}`.
+            let framed = raw[firstMarker.lowerBound...]
+            return framed.components(separatedBy: "[TOOL_CALLS]").compactMap { segment in
                 guard !segment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     return nil
                 }
@@ -699,7 +705,11 @@ struct TextToolCallRecoveryScanner: Sendable {
             }
         }
 
-        guard policy != .disabled else { return earliest }
+        // Markerless `name[ARGS]{...}` rehearsals carry no protocol marker,
+        // so prose that merely mentions a declared call is indistinguishable
+        // from an intended call. Promotion of this dialect is opt-in via the
+        // permissive policy; the conservative default leaves it as text.
+        guard policy == .permissive else { return earliest }
 
         var argsSearchStart = text.startIndex
         while argsSearchStart < text.endIndex,

--- a/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
@@ -1263,22 +1263,10 @@ struct TextToolCallRecoveryScanner: Sendable {
         _ raw: String,
         allowMissingFunctionClose: Bool
     ) -> ToolCall? {
-        guard
-            case .complete(let payload) = QwenXMLPayloadScanner.scan(
-                raw[...], allowMissingFunctionClose: allowMissingFunctionClose),
-            raw[payload.end...].allSatisfy(\.isWhitespace)
-        else { return nil }
-
-        var arguments: [String: any Sendable] = [:]
-        for parameter in payload.parameters {
-            var value = String(parameter.value)
-            // Trim a single leading/trailing newline (matching XMLFunctionParser).
-            if value.hasPrefix("\n") { value = String(value.dropFirst()) }
-            if value.hasSuffix("\n") { value = String(value.dropLast()) }
-            arguments[parameter.name] = convertParameterValue(
-                value, paramName: parameter.name, funcName: payload.name, tools: tools)
-        }
-        return ToolCall(function: .init(name: payload.name, arguments: arguments))
+        QwenXMLPayloadScanner.parseCanonical(
+            raw[...],
+            tools: tools,
+            allowMissingFunctionClose: allowMissingFunctionClose)
     }
 
     /// A recovered call must satisfy the declared schema's required arguments

--- a/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
@@ -1,0 +1,1411 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// A bounded, streaming recovery pass for common textual tool-call dialects.
+///
+/// The selected `ToolCallParser` remains authoritative. This scanner only owns
+/// dialect markers that the selected parser cannot consume, plus exact
+/// `declaredTool[ARGS]{...}` rehearsals. It deliberately uses fixed-string
+/// searches and structural JSON scanning instead of regular expressions or
+/// speculative JSON decoding on ordinary response text.
+///
+/// Recovery is a *context lexer*, not just a collection of parsers. Text is
+/// classified before any candidate is considered, and only committed response
+/// text is eligible for promotion:
+///
+/// - **reasoning** (`<think>`, `<thinking>`, `[THINK]` spans): models rehearse
+///   and reject candidate calls while reasoning; a call mentioned there is not
+///   a committed action and is never promoted.
+/// - **code** (Markdown fenced blocks and inline code spans): examples and
+///   documentation of tool syntax are data, not actions.
+/// - **JSON data** (objects, arrays and strings): ordinary structured output
+///   remains response data; protocol-shaped string contents stay inert.
+/// - **native frames** (the selected format's own protocol): opaque to
+///   recovery, and a JSON or Qwen-XML payload frame only closes after a
+///   structurally balanced payload, so a literal close marker inside a string
+///   argument cannot expose fabricated suffixes to recovery.
+///
+/// Explicit protocol attempts (`<tool_call>`, `<|tool_call>`, `<function=`,
+/// `[TOOL_CALLS]`) that are malformed, incomplete at end of stream, or name an
+/// undeclared tool are reported as rejected rather than leaked as response
+/// text. Ambiguous markerless candidates that fail validation remain text.
+struct TextToolCallRecoveryScanner: Sendable {
+    enum Output: Sendable {
+        case text(String)
+        /// Response data that has already been classified as non-executable.
+        /// The downstream processor must emit it directly and must never feed
+        /// it through the selected format's native tool parser.
+        case protectedText(String)
+        case toolCall(ToolCall, rawText: String)
+        /// An explicit protocol attempt that could not become a call.
+        case rejected(rawText: String, reason: RejectedToolCall.Reason, toolName: String?)
+    }
+
+    /// Explicit alternate-dialect protocol markers owned by recovery.
+    private enum ExplicitKind: Sendable {
+        case toolCallFrame
+        case gemma4
+        case qwenFunction
+        case mistral
+    }
+
+    private enum Kind: Sendable, Equatable {
+        case nativeFrame(endMarker: String)
+        case nativeUntilEOS
+        case nativeInlineJSON
+        case opaqueJSONValue
+        case reasoning(close: String)
+        case explicit(ExplicitKind)
+        case declaredArgs(name: String)
+        /// A backtick run: an inline code span, or a fenced block at line start.
+        case codeBacktick
+        /// A tilde run: a fenced block at line start, otherwise ordinary text.
+        case codeTilde
+    }
+
+    private enum Context: Sendable, Equatable {
+        case response
+        case reasoning(close: String)
+        case codeFence(character: Character, count: Int)
+        case codeSpan(count: Int)
+        case jsonValue
+        case nativeFrame(endMarker: String)
+        case nativeUntilEOS
+        /// Once a structured data value exceeds the inspection budget, remain
+        /// fail-closed until EOS. This keeps memory and work bounded without
+        /// ever re-entering executable response context from the middle of a
+        /// JSON string or container.
+        case opaqueUntilEOS
+    }
+
+    private struct Signal: Sendable {
+        let text: String
+        let kind: Kind
+    }
+
+    /// Avoid rescanning an incomplete candidate for every token. A candidate
+    /// is structurally reconsidered only when the new chunk can contain a
+    /// closing boundary (or when the byte limit/EOS forces a decision).
+    private enum PendingCandidate: Sendable {
+        case explicit(ExplicitKind)
+        case declaredArgs(name: String)
+
+        func shouldInspect(_ chunk: String) -> Bool {
+            switch self {
+            case .explicit(.mistral), .declaredArgs:
+                chunk.contains("}")
+            case .explicit(.toolCallFrame), .explicit(.gemma4), .explicit(.qwenFunction):
+                chunk.contains(">")
+            }
+        }
+    }
+
+    private let primaryFormat: ToolCallFormat
+    private let policy: ToolCallRecoveryPolicy
+    private let tools: [[String: any Sendable]]
+    private let allowedToolNames: Set<String>
+    private let allowedToolNamesByLength: [String]
+    private let signals: [Signal]
+    private let potentialSignalPrefixes: Set<String>
+    private let maximumPotentialSignalPrefixLength: Int
+    private let potentialPrefixEndCharacters: Set<Character>
+    private let maximumBufferedByteCount: Int
+    private let jsonScanner = JSONLeadingObjectScanner(startCharacter: "{")
+    private let gemmaScanner = StructuredTextScanner(
+        quotes: ["\""], escapeMarker: "<|\"|>")
+    private let framedParser = Qwen35ToolCallParser(
+        startTag: "<tool_call>", endTag: "</tool_call>")
+    private let gemmaParser = GemmaFunctionParser(
+        startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
+
+    /// Provenance for every call promoted by recovery, in source order.
+    private(set) var events: [ToolCallRecoveryEvent] = []
+
+    private var buffer = ""
+    private var context: Context = .response
+    private var previousSourceCharacter: Character?
+    private var pendingCandidate: PendingCandidate?
+
+    /// Bytes that can begin a signal or context and therefore disqualify a
+    /// chunk from the pass-through fast path.
+    private static let interestingBytes: Set<UInt8> = [
+        0x3C,  // <
+        0x5B,  // [
+        0x7B,  // {
+        0x22,  // "
+        0x60,  // `
+        0x7E,  // ~
+    ]
+
+    init?(
+        primaryFormat: ToolCallFormat,
+        policy: ToolCallRecoveryPolicy,
+        tools: [[String: any Sendable]]?,
+        allowedToolNames: Set<String>?,
+        maximumBufferedByteCount: Int = 65_536
+    ) {
+        guard let tools, let allowedToolNames, !allowedToolNames.isEmpty else { return nil }
+
+        self.primaryFormat = primaryFormat
+        self.policy = policy
+        self.tools = tools
+        self.allowedToolNames = allowedToolNames
+        self.allowedToolNamesByLength = allowedToolNames.sorted { $0.count > $1.count }
+        self.maximumBufferedByteCount = maximumBufferedByteCount
+
+        var signals: [Signal] = []
+        if Self.primaryOwnsToolCallFrame(primaryFormat) {
+            signals.append(
+                Signal(
+                    text: "<tool_call>",
+                    kind: .nativeFrame(endMarker: "</tool_call>")))
+        } else if policy != .disabled {
+            signals.append(Signal(text: "<tool_call>", kind: .explicit(.toolCallFrame)))
+        }
+        if primaryFormat == .gemma4 {
+            signals.append(
+                Signal(
+                    text: "<|tool_call>",
+                    kind: .nativeFrame(endMarker: "<tool_call|>")))
+        } else if policy != .disabled {
+            signals.append(Signal(text: "<|tool_call>", kind: .explicit(.gemma4)))
+        }
+        if policy != .disabled {
+            signals.append(Signal(text: "<function=", kind: .explicit(.qwenFunction)))
+        }
+        // Reasoning spans are never eligible for recovery, regardless of the
+        // selected dialect. Ordered so longer markers win ties.
+        signals.append(Signal(text: "<thinking>", kind: .reasoning(close: "</thinking>")))
+        signals.append(Signal(text: "<think>", kind: .reasoning(close: "</think>")))
+        signals.append(Signal(text: "[THINK]", kind: .reasoning(close: "[/THINK]")))
+        if primaryFormat != .mistral, policy != .disabled {
+            signals.append(Signal(text: "[TOOL_CALLS]", kind: .explicit(.mistral)))
+        }
+        if primaryFormat == .llama3 {
+            signals.append(Signal(text: "<|python_tag|>", kind: .nativeInlineJSON))
+        }
+
+        let primaryParser = primaryFormat.createParser()
+        if let start = primaryParser.startTag,
+            !signals.contains(where: { $0.text == start })
+        {
+            if let end = primaryParser.endTag {
+                signals.append(Signal(text: start, kind: .nativeFrame(endMarker: end)))
+            } else {
+                signals.append(Signal(text: start, kind: .nativeUntilEOS))
+            }
+        }
+
+        // Ordinary JSON values and Markdown code are data: protocol-shaped
+        // text inside them must never be promoted. Single-character signals
+        // are validated structurally when matched, so prose punctuation that
+        // cannot begin a JSON value or code span falls through as text.
+        signals.append(Signal(text: "{", kind: .opaqueJSONValue))
+        signals.append(Signal(text: "[", kind: .opaqueJSONValue))
+        signals.append(Signal(text: "\"", kind: .opaqueJSONValue))
+        signals.append(Signal(text: "`", kind: .codeBacktick))
+        signals.append(Signal(text: "~", kind: .codeTilde))
+
+        self.signals = signals
+
+        // Prefix lookup replaces an O(tool count) suffix search on every text
+        // fragment. Declared names are consulted only after `[ARGS]` is present.
+        var prefixes: Set<String> = []
+        for signal in signals {
+            for length in 1 ..< signal.text.count {
+                prefixes.insert(String(signal.text.prefix(length)))
+            }
+        }
+        if policy != .disabled {
+            for name in allowedToolNames {
+                let marker = name + "[ARGS]"
+                for length in 1 ..< marker.count {
+                    prefixes.insert(String(marker.prefix(length)))
+                }
+            }
+        }
+        self.potentialSignalPrefixes = prefixes
+        self.maximumPotentialSignalPrefixLength = prefixes.map(\.count).max() ?? 0
+        self.potentialPrefixEndCharacters = Set(prefixes.compactMap(\.last))
+    }
+
+    /// Removes and returns the provenance recorded since the last drain.
+    mutating func drainEvents() -> [ToolCallRecoveryEvent] {
+        let drained = events
+        events.removeAll(keepingCapacity: true)
+        return drained
+    }
+
+    /// Consume a streaming fragment and release all text that cannot still be
+    /// the prefix of a recoverable call.
+    mutating func consumeIfPassThrough(_ chunk: String) -> Bool {
+        guard buffer.isEmpty, context == .response,
+            !chunk.utf8.contains(where: { Self.interestingBytes.contains($0) })
+        else { return false }
+        guard longestRetainedSuffix(in: chunk) == 0 else { return false }
+        if let last = chunk.last { previousSourceCharacter = last }
+        return true
+    }
+
+    mutating func process(_ chunk: String) -> [Output] {
+        if let pendingCandidate {
+            buffer += chunk
+            if buffer.utf8.count <= maximumBufferedByteCount,
+                !pendingCandidate.shouldInspect(chunk)
+            {
+                return []
+            }
+            self.pendingCandidate = nil
+        } else {
+            if buffer.isEmpty, context == .response,
+                !chunk.utf8.contains(where: { Self.interestingBytes.contains($0) })
+            {
+                let retained = longestRetainedSuffix(in: chunk)
+                guard retained > 0 else {
+                    if let last = chunk.last { previousSourceCharacter = last }
+                    return chunk.isEmpty ? [] : [.text(chunk)]
+                }
+
+                let split = chunk.index(chunk.endIndex, offsetBy: -retained)
+                buffer = String(chunk[split...])
+                let released = String(chunk[..<split])
+                if let last = released.last { previousSourceCharacter = last }
+                return released.isEmpty ? [] : [.text(released)]
+            }
+
+            buffer += chunk
+        }
+        var output: [Output] = []
+
+        scanLoop: while !buffer.isEmpty {
+            switch context {
+            case .reasoning(let close):
+                if let range = buffer.range(of: close) {
+                    appendProtectedText(String(buffer[..<range.upperBound]), to: &output)
+                    buffer = String(buffer[range.upperBound...])
+                    context = .response
+                    continue
+                }
+                releaseProtectedAllButSuffix(
+                    longestSuffix(in: buffer, matchingPrefixOf: close), &output)
+                break scanLoop
+
+            case .codeFence(let character, let count):
+                if let close = closingFenceEnd(
+                    in: buffer, character: character, minimumCount: count)
+                {
+                    appendProtectedText(String(buffer[..<close]), to: &output)
+                    buffer = String(buffer[close...])
+                    context = .response
+                    continue
+                }
+                releaseProtectedAllButSuffix(
+                    closingFenceRetention(in: buffer, character: character), &output)
+                break scanLoop
+
+            case .codeSpan(let count):
+                if let close = spanCloseEnd(in: buffer, count: count) {
+                    appendProtectedText(String(buffer[..<close]), to: &output)
+                    buffer = String(buffer[close...])
+                    context = .response
+                    continue
+                }
+                releaseProtectedAllButSuffix(
+                    trailingRunLength(in: buffer, character: "`"), &output)
+                break scanLoop
+
+            case .jsonValue:
+                if buffer.utf8.count <= maximumBufferedByteCount,
+                    !chunkMayCompleteJSONValue(chunk, opener: buffer.first)
+                {
+                    break scanLoop
+                }
+                switch jsonValueExtent(in: buffer) {
+                case .complete(let end):
+                    let value = String(buffer[..<end])
+                    if value.utf8.count > maximumBufferedByteCount {
+                        appendProtectedText(value, to: &output)
+                    } else {
+                        appendJSONData(value, to: &output)
+                    }
+                    buffer = String(buffer[end...])
+                    context = .response
+                    continue
+                case .invalid:
+                    // Not a JSON value after all; release the opener as text.
+                    appendText(String(buffer[buffer.startIndex ... buffer.startIndex]), to: &output)
+                    buffer.removeFirst()
+                    context = .response
+                    continue
+                case .needMore:
+                    if buffer.utf8.count > maximumBufferedByteCount {
+                        appendProtectedText(buffer, to: &output)
+                        buffer.removeAll(keepingCapacity: true)
+                        context = .opaqueUntilEOS
+                    }
+                    break scanLoop
+                }
+
+            case .opaqueUntilEOS:
+                appendProtectedText(buffer, to: &output)
+                buffer.removeAll(keepingCapacity: true)
+                break scanLoop
+
+            case .nativeFrame(let endMarker):
+                let frameEnd =
+                    endMarker == ToolCallFrameScanner.endTag
+                    ? ToolCallFrameScanner.frameEnd(in: buffer)
+                    : buffer.range(of: endMarker).map(\.upperBound)
+                if let frameEnd {
+                    let raw = String(buffer[..<frameEnd])
+                    buffer = String(buffer[frameEnd...])
+                    context = .response
+                    if raw.utf8.count > maximumBufferedByteCount {
+                        previousSourceCharacter = raw.last
+                        output.append(
+                            .rejected(
+                                rawText: raw, reason: .resourceLimitExceeded,
+                                toolName: nil))
+                    } else {
+                        appendText(raw, to: &output)
+                    }
+                    continue
+                }
+                if buffer.utf8.count > maximumBufferedByteCount {
+                    let raw = buffer
+                    buffer.removeAll(keepingCapacity: true)
+                    previousSourceCharacter = raw.last
+                    output.append(
+                        .rejected(
+                            rawText: raw, reason: .resourceLimitExceeded,
+                            toolName: nil))
+                    context = .opaqueUntilEOS
+                }
+                break scanLoop
+
+            case .nativeUntilEOS:
+                if buffer.utf8.count > maximumBufferedByteCount {
+                    let raw = buffer
+                    buffer.removeAll(keepingCapacity: true)
+                    previousSourceCharacter = raw.last
+                    output.append(
+                        .rejected(
+                            rawText: raw, reason: .resourceLimitExceeded,
+                            toolName: nil))
+                    context = .opaqueUntilEOS
+                }
+                break scanLoop
+
+            case .response:
+                // A generic one-character construct (`[`, `{`, `"`, or a code
+                // delimiter) must not win while that suffix may still grow
+                // into a longer protocol marker split across token chunks.
+                let retained = longestRetainedSuffix(in: buffer)
+                if retained > 0 {
+                    let retainedStart = buffer.index(buffer.endIndex, offsetBy: -retained)
+                    if let match = earliestConstruct(in: buffer),
+                        match.range.lowerBound >= retainedStart
+                    {
+                        if retainedStart != buffer.startIndex {
+                            appendText(String(buffer[..<retainedStart]), to: &output)
+                            buffer = String(buffer[retainedStart...])
+                        }
+                        break scanLoop
+                    }
+                }
+
+                guard let match = earliestConstruct(in: buffer) else {
+                    releaseAllButSuffix(longestRetainedSuffix(in: buffer), &output)
+                    break scanLoop
+                }
+
+                if match.range.lowerBound != buffer.startIndex {
+                    appendText(String(buffer[..<match.range.lowerBound]), to: &output)
+                    buffer = String(buffer[match.range.lowerBound...])
+                    continue
+                }
+
+                switch match.signal.kind {
+                case .reasoning(let close):
+                    appendProtectedText(match.signal.text, to: &output)
+                    buffer.removeFirst(match.signal.text.count)
+                    context = .reasoning(close: close)
+
+                case .nativeFrame(let endMarker):
+                    // Keep the whole frame buffered; it is emitted verbatim
+                    // once its structural close arrives.
+                    context = .nativeFrame(endMarker: endMarker)
+
+                case .nativeUntilEOS:
+                    context = .nativeUntilEOS
+
+                case .nativeInlineJSON:
+                    guard let end = nativeInlineJSONEnd(in: buffer) else {
+                        if buffer.utf8.count > maximumBufferedByteCount {
+                            let raw = buffer
+                            buffer.removeAll(keepingCapacity: true)
+                            previousSourceCharacter = raw.last
+                            output.append(
+                                .rejected(
+                                    rawText: raw, reason: .resourceLimitExceeded,
+                                    toolName: nil))
+                            context = .opaqueUntilEOS
+                        }
+                        break scanLoop
+                    }
+                    let raw = String(buffer[..<end])
+                    buffer = String(buffer[end...])
+                    if raw.utf8.count > maximumBufferedByteCount {
+                        previousSourceCharacter = raw.last
+                        output.append(
+                            .rejected(
+                                rawText: raw, reason: .resourceLimitExceeded,
+                                toolName: nil))
+                    } else {
+                        appendText(raw, to: &output)
+                    }
+
+                case .opaqueJSONValue:
+                    context = .jsonValue
+
+                case .codeBacktick:
+                    let run = backtickRun(in: buffer)
+                    guard run.terminated else { break scanLoop }
+                    let isFence = run.count >= 3 && isLineStart(buffer.startIndex, in: buffer)
+                    appendProtectedText(String(buffer[..<run.end]), to: &output)
+                    buffer = String(buffer[run.end...])
+                    context =
+                        isFence
+                        ? .codeFence(character: "`", count: run.count)
+                        : .codeSpan(count: run.count)
+
+                case .codeTilde:
+                    let run = tildeRun(in: buffer)
+                    guard run.terminated else { break scanLoop }
+                    if run.count >= 3, isLineStart(buffer.startIndex, in: buffer) {
+                        appendProtectedText(String(buffer[..<run.end]), to: &output)
+                        buffer = String(buffer[run.end...])
+                        context = .codeFence(character: "~", count: run.count)
+                    } else {
+                        appendText(String(buffer[..<run.end]), to: &output)
+                        buffer = String(buffer[run.end...])
+                    }
+
+                case .explicit(let explicitKind):
+                    switch candidateExtent(for: explicitKind, in: buffer) {
+                    case .complete(let end):
+                        let raw = String(buffer[..<end])
+                        buffer = String(buffer[end...])
+                        previousSourceCharacter = raw.last
+                        if raw.utf8.count > maximumBufferedByteCount {
+                            output.append(
+                                .rejected(
+                                    rawText: raw, reason: .resourceLimitExceeded,
+                                    toolName: extractToolName(from: raw, kind: explicitKind)))
+                        } else if let call = recoverExplicit(
+                            raw, as: explicitKind, allowMissingOuterEnd: false)
+                        {
+                            recordEvent(
+                                for: call, kind: match.signal.kind,
+                                repair: .alternateDialect, wasIncompleteAtEOS: false)
+                            output.append(.toolCall(call, rawText: raw))
+                        } else {
+                            output.append(rejection(for: raw, kind: explicitKind, atEOS: false))
+                        }
+                    case .needMore:
+                        if buffer.utf8.count > maximumBufferedByteCount {
+                            let raw = buffer
+                            buffer.removeAll(keepingCapacity: true)
+                            previousSourceCharacter = raw.last
+                            output.append(
+                                .rejected(
+                                    rawText: raw, reason: .resourceLimitExceeded,
+                                    toolName: extractToolName(from: raw, kind: explicitKind)))
+                            context = .opaqueUntilEOS
+                        } else {
+                            pendingCandidate = .explicit(explicitKind)
+                            break scanLoop
+                        }
+                    case .malformed(let consumed):
+                        let raw = String(buffer[..<consumed])
+                        buffer = String(buffer[consumed...])
+                        previousSourceCharacter = raw.last
+                        output.append(rejection(for: raw, kind: explicitKind, atEOS: false))
+                    }
+
+                case .declaredArgs(let name):
+                    switch markerlessCandidateExtent(in: buffer) {
+                    case .complete(let end):
+                        let raw = String(buffer[..<end])
+                        buffer = String(buffer[end...])
+                        previousSourceCharacter = raw.last
+                        if raw.utf8.count > maximumBufferedByteCount {
+                            appendProtectedText(raw, to: &output)
+                        } else if let call = recoverDeclaredArgs(raw, name: name) {
+                            recordEvent(
+                                for: call, kind: match.signal.kind,
+                                repair: .alternateDialect, wasIncompleteAtEOS: false)
+                            output.append(.toolCall(call, rawText: raw))
+                        } else {
+                            // Ambiguous markerless rehearsal: remain response text.
+                            appendText(raw, to: &output)
+                        }
+                    case .needMore:
+                        if buffer.utf8.count > maximumBufferedByteCount {
+                            appendProtectedText(buffer, to: &output)
+                            buffer.removeAll(keepingCapacity: true)
+                            context = .opaqueUntilEOS
+                        } else {
+                            pendingCandidate = .declaredArgs(name: name)
+                        }
+                        break scanLoop
+                    }
+                }
+            }
+        }
+
+        return output
+    }
+
+    /// Finish the recovery stream.
+    ///
+    /// A missing outer end marker may be repaired at EOS under the permissive
+    /// policy when its inner payload is structurally complete. Under the
+    /// conservative policy an explicit but incomplete attempt is rejected.
+    /// Unterminated reasoning, code, and JSON-data spans flush as protected
+    /// response text. Native frames alone remain the native parser's own
+    /// end-of-stream responsibility.
+    mutating func finish() -> [Output] {
+        var output = process("")
+        guard !buffer.isEmpty else {
+            // `ToolCallProcessor` supports reuse after EOS. A native opening
+            // marker delivered immediately before EOS must not leave recovery
+            // shielding every subsequent generation.
+            context = .response
+            return output
+        }
+
+        defer {
+            buffer.removeAll(keepingCapacity: true)
+            context = .response
+            pendingCandidate = nil
+        }
+
+        guard context == .response,
+            let match = earliestConstruct(in: buffer),
+            match.range.lowerBound == buffer.startIndex
+        else {
+            switch context {
+            case .reasoning, .codeFence, .codeSpan, .jsonValue, .opaqueUntilEOS:
+                appendProtectedText(buffer, to: &output)
+            case .response, .nativeFrame, .nativeUntilEOS:
+                appendText(buffer, to: &output)
+            }
+            return output
+        }
+
+        switch match.signal.kind {
+        case .explicit(let explicitKind):
+            let allowMissingOuterEnd = policy == .permissive
+            if let call = recoverExplicit(
+                buffer, as: explicitKind, allowMissingOuterEnd: allowMissingOuterEnd)
+            {
+                recordEvent(
+                    for: call, kind: match.signal.kind,
+                    repair: allowMissingOuterEnd ? .missingOuterClose : .alternateDialect,
+                    wasIncompleteAtEOS: true)
+                output.append(.toolCall(call, rawText: buffer))
+                previousSourceCharacter = buffer.last
+            } else {
+                previousSourceCharacter = buffer.last
+                output.append(rejection(for: buffer, kind: explicitKind, atEOS: true))
+            }
+        case .declaredArgs(let name):
+            if let call = recoverDeclaredArgs(buffer, name: name) {
+                recordEvent(
+                    for: call, kind: match.signal.kind,
+                    repair: .alternateDialect, wasIncompleteAtEOS: true)
+                output.append(.toolCall(call, rawText: buffer))
+                previousSourceCharacter = buffer.last
+            } else {
+                appendText(buffer, to: &output)
+            }
+        default:
+            appendText(buffer, to: &output)
+        }
+        return output
+    }
+
+    /// Retry a complete payload rejected by the selected native parser.
+    mutating func recoverCompletePayload(_ raw: String) -> ToolCall? {
+        recoverCompletePayload(raw, atEOS: false)
+    }
+
+    /// Retry each EOS-delimited native segment independently. This primarily
+    /// heals Mistral's observed `[TOOL_CALLS]name{json}` variant.
+    mutating func recoverEOSPayloads(_ raw: String) -> [ToolCall] {
+        guard policy != .disabled else { return [] }
+        if raw.contains("[TOOL_CALLS]") {
+            return raw.components(separatedBy: "[TOOL_CALLS]").compactMap { segment in
+                guard !segment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    return nil
+                }
+                let recovered = recoverExplicit(
+                    "[TOOL_CALLS]" + segment, as: .mistral,
+                    allowMissingOuterEnd: policy == .permissive)
+                if let recovered {
+                    recordEvent(
+                        for: recovered, kind: .explicit(.mistral),
+                        repair: .alternateDialect, wasIncompleteAtEOS: true)
+                }
+                return recovered
+            }
+        }
+        return recoverCompletePayload(raw, atEOS: true).map { [$0] } ?? []
+    }
+
+    private mutating func recoverCompletePayload(_ raw: String, atEOS: Bool) -> ToolCall? {
+        guard policy != .disabled else { return nil }
+        let allowMissingOuterEnd = policy == .permissive
+        let candidates: [(String, ExplicitKind)] = [
+            ("<tool_call>", .toolCallFrame),
+            ("<|tool_call>", .gemma4),
+            ("<function=", .qwenFunction),
+            ("[TOOL_CALLS]", .mistral),
+        ]
+        for (marker, kind) in candidates where raw.contains(marker) {
+            guard
+                let call = recoverExplicit(
+                    raw, as: kind, allowMissingOuterEnd: allowMissingOuterEnd)
+            else { continue }
+            recordEvent(
+                for: call, kind: .explicit(kind),
+                repair: .alternateDialect, wasIncompleteAtEOS: atEOS)
+            return call
+        }
+        return nil
+    }
+
+    // MARK: - Construct scanning
+
+    private func earliestConstruct(in text: String) -> (signal: Signal, range: Range<String.Index>)?
+    {
+        var earliest: (signal: Signal, range: Range<String.Index>)?
+        for signal in signals {
+            guard let range = text.range(of: signal.text) else { continue }
+            if earliest == nil || range.lowerBound < earliest!.range.lowerBound {
+                earliest = (signal, range)
+            }
+        }
+
+        guard policy != .disabled else { return earliest }
+
+        var argsSearchStart = text.startIndex
+        while argsSearchStart < text.endIndex,
+            let args = text.range(of: "[ARGS]", range: argsSearchStart ..< text.endIndex)
+        {
+            let prefix = text[..<args.lowerBound]
+            if let name = allowedToolNamesByLength.first(where: { prefix.hasSuffix($0) }) {
+                let start = text.index(args.lowerBound, offsetBy: -name.count)
+                if text[..<start].hasSuffix("[TOOL_CALLS]") {
+                    argsSearchStart = args.upperBound
+                    continue
+                }
+                let predecessor =
+                    start == text.startIndex
+                    ? previousSourceCharacter
+                    : text[text.index(before: start)]
+                if predecessor.map(isToolNameContinuation) == true {
+                    argsSearchStart = args.upperBound
+                    continue
+                }
+                let range = start ..< args.upperBound
+                if earliest == nil || range.lowerBound < earliest!.range.lowerBound {
+                    earliest = (
+                        Signal(text: name + "[ARGS]", kind: .declaredArgs(name: name)), range
+                    )
+                }
+                break
+            }
+            argsSearchStart = args.upperBound
+        }
+        return earliest
+    }
+
+    private func isToolNameContinuation(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber
+            || character == "_" || character == "." || character == "-"
+    }
+
+    private mutating func appendText(_ text: String, to output: inout [Output]) {
+        guard !text.isEmpty else { return }
+        output.append(.text(text))
+        previousSourceCharacter = text.last
+    }
+
+    private mutating func appendProtectedText(_ text: String, to output: inout [Output]) {
+        guard !text.isEmpty else { return }
+        output.append(.protectedText(text))
+        previousSourceCharacter = text.last
+    }
+
+    /// Bare top-level JSON remains eligible only when JSON is the selected
+    /// native tool-call format. For every other dialect it is response data and
+    /// must bypass native parsing, including protocol-shaped strings inside it.
+    private mutating func appendJSONData(_ text: String, to output: inout [Output]) {
+        if primaryFormat == .json, text.first == "{" {
+            appendText(text, to: &output)
+        } else {
+            appendProtectedText(text, to: &output)
+        }
+    }
+
+    private func chunkMayCompleteJSONValue(_ chunk: String, opener: Character?) -> Bool {
+        guard !chunk.isEmpty else { return true }
+        if opener == "\"" {
+            return chunk.contains("\"") || chunk.contains("\n") || chunk.contains("\r")
+        }
+        return chunk.contains("}") || chunk.contains("]")
+    }
+
+    /// Release everything except a suffix that may still complete a signal or
+    /// context boundary when the next token arrives.
+    private mutating func releaseAllButSuffix(_ retained: Int, _ output: inout [Output]) {
+        let releaseCount = buffer.count - retained
+        guard releaseCount > 0 else { return }
+        let split = buffer.index(buffer.startIndex, offsetBy: releaseCount)
+        appendText(String(buffer[..<split]), to: &output)
+        buffer = String(buffer[split...])
+    }
+
+    private mutating func releaseProtectedAllButSuffix(
+        _ retained: Int, _ output: inout [Output]
+    ) {
+        let releaseCount = buffer.count - retained
+        guard releaseCount > 0 else { return }
+        let split = buffer.index(buffer.startIndex, offsetBy: releaseCount)
+        appendProtectedText(String(buffer[..<split]), to: &output)
+        buffer = String(buffer[split...])
+    }
+
+    private func longestRetainedSuffix(in text: String) -> Int {
+        max(
+            longestPotentialSignalSuffix(in: text),
+            trailingRunLength(in: text, character: "`"),
+            trailingRunLength(in: text, character: "~"))
+    }
+
+    /// Keep only a suffix that might become a signal when the next token arrives.
+    private func longestPotentialSignalSuffix(in text: String) -> Int {
+        guard let last = text.last, potentialPrefixEndCharacters.contains(last) else { return 0 }
+        let upperBound = min(text.count, maximumPotentialSignalPrefixLength)
+        guard upperBound > 0 else { return 0 }
+        for length in stride(from: upperBound, through: 1, by: -1) {
+            if potentialSignalPrefixes.contains(String(text.suffix(length))) {
+                return length
+            }
+        }
+        return 0
+    }
+
+    private func longestSuffix(in text: String, matchingPrefixOf marker: String) -> Int {
+        let upperBound = min(text.count, marker.count - 1)
+        guard upperBound > 0 else { return 0 }
+        for length in stride(from: upperBound, through: 1, by: -1) {
+            if text.suffix(length) == marker.prefix(length) { return length }
+        }
+        return 0
+    }
+
+    private func trailingRunLength(in text: String, character: Character) -> Int {
+        var count = 0
+        var index = text.endIndex
+        while index > text.startIndex {
+            let previous = text.index(before: index)
+            guard text[previous] == character else { break }
+            count += 1
+            index = previous
+        }
+        return count
+    }
+
+    // MARK: - Code contexts
+
+    private func backtickRun(in text: String) -> (count: Int, end: String.Index, terminated: Bool) {
+        runLength(of: "`", in: text)
+    }
+
+    private func tildeRun(in text: String) -> (count: Int, end: String.Index, terminated: Bool) {
+        runLength(of: "~", in: text)
+    }
+
+    /// Length of the marker run at the start of `text`. A run that reaches the
+    /// end of the buffer is not terminated: the next chunk may extend it, and
+    /// CommonMark open/close semantics depend on the exact run length.
+    private func runLength(
+        of character: Character, in text: String
+    ) -> (count: Int, end: String.Index, terminated: Bool) {
+        var index = text.startIndex
+        while index < text.endIndex, text[index] == character {
+            index = text.index(after: index)
+        }
+        return (text.distance(from: text.startIndex, to: index), index, index < text.endIndex)
+    }
+
+    /// Whether `index` begins a Markdown line: at most three spaces since the
+    /// last newline (or since the start of the stream across chunks).
+    private func isLineStart(_ index: String.Index, in text: String) -> Bool {
+        var spaces = 0
+        var current = index
+        while current > text.startIndex {
+            let previous = text.index(before: current)
+            let character = text[previous]
+            if character == "\n" { return spaces <= 3 }
+            guard character == " " else { return false }
+            spaces += 1
+            current = previous
+        }
+        guard spaces <= 3 else { return false }
+        guard let previous = previousSourceCharacter else { return true }
+        // A preceding newline starts a line; preceding spaces may continue the
+        // indentation of one (over-gating into code is the safe direction).
+        return previous == "\n" || previous == " "
+    }
+
+    /// The end of a closing fence: a line starting with a run of `character`
+    /// at least as long as the opening run.
+    private func closingFenceEnd(
+        in text: String, character: Character, minimumCount: Int
+    ) -> String.Index? {
+        var lineStart = text.startIndex
+        while lineStart < text.endIndex {
+            if isLineStart(lineStart, in: text) {
+                var index = lineStart
+                var spaces = 0
+                while index < text.endIndex, text[index] == " " {
+                    spaces += 1
+                    index = text.index(after: index)
+                }
+                if spaces <= 3, index < text.endIndex, text[index] == character {
+                    var runEnd = index
+                    while runEnd < text.endIndex, text[runEnd] == character {
+                        runEnd = text.index(after: runEnd)
+                    }
+                    let count = text.distance(from: index, to: runEnd)
+                    if count >= minimumCount {
+                        // A run touching the buffer end may still grow; wait.
+                        guard runEnd < text.endIndex else { return nil }
+                        return runEnd
+                    }
+                }
+            }
+            guard let newline = text.range(of: "\n", range: lineStart ..< text.endIndex)
+            else { return nil }
+            lineStart = newline.upperBound
+        }
+        return nil
+    }
+
+    /// Retention for a suffix that may become a closing fence line: optional
+    /// indentation followed by a (possibly still growing) run of the fence
+    /// character at a line start.
+    private func closingFenceRetention(in text: String, character: Character) -> Int {
+        let lineStart: String.Index
+        if let newline = text.range(of: "\n", options: .backwards) {
+            lineStart = newline.upperBound
+        } else {
+            guard isLineStart(text.startIndex, in: text) else { return 0 }
+            lineStart = text.startIndex
+        }
+        var index = lineStart
+        var spaces = 0
+        while index < text.endIndex, text[index] == " " {
+            spaces += 1
+            index = text.index(after: index)
+        }
+        guard spaces <= 3 else { return 0 }
+        while index < text.endIndex, text[index] == character {
+            index = text.index(after: index)
+        }
+        guard index == text.endIndex else { return 0 }
+        return text.distance(from: lineStart, to: text.endIndex)
+    }
+
+    /// The end of the backtick run that closes an inline code span. CommonMark
+    /// requires the closing run to have exactly the opening run's length.
+    private func spanCloseEnd(in text: String, count: Int) -> String.Index? {
+        var index = text.startIndex
+        while index < text.endIndex {
+            guard text[index] == "`" else {
+                index = text.index(after: index)
+                continue
+            }
+            var runEnd = index
+            while runEnd < text.endIndex, text[runEnd] == "`" {
+                runEnd = text.index(after: runEnd)
+            }
+            // A run touching the buffer end may still grow; wait.
+            guard runEnd < text.endIndex else { return nil }
+            let length = text.distance(from: index, to: runEnd)
+            if length == count { return runEnd }
+            index = runEnd
+        }
+        return nil
+    }
+
+    // MARK: - JSON data opacity
+
+    private enum ValueExtent {
+        case complete(end: String.Index)
+        case needMore
+        case invalid
+    }
+
+    /// The extent of the JSON value starting at the beginning of `text`.
+    /// Objects, arrays and strings are opaque data; numbers, booleans and null
+    /// contain no interior text and need no shielding.
+    private func jsonValueExtent(in text: String) -> ValueExtent {
+        switch text[text.startIndex] {
+        case "{", "[":
+            return jsonContainerExtent(in: text)
+        case "\"":
+            return jsonStringExtent(in: text)
+        default:
+            return .invalid
+        }
+    }
+
+    private func jsonContainerExtent(in text: String) -> ValueExtent {
+        let start = text.startIndex
+        var index = text.index(after: start)
+        while index < text.endIndex, text[index].isWhitespace {
+            index = text.index(after: index)
+        }
+        guard index < text.endIndex else { return .needMore }
+
+        // Validate the first meaningful character so prose such as `[TOOL...`
+        // or `{not json` is never treated as structured data.
+        let first = text[index]
+        let plausible: Bool
+        if text[start] == "{" {
+            plausible = first == "\"" || first == "}"
+        } else {
+            plausible =
+                first == "\"" || first == "{" || first == "[" || first == "]"
+                || first == "-" || first.isNumber
+                || first == "t" || first == "f" || first == "n"
+        }
+        guard plausible else { return .invalid }
+
+        var depth = 0
+        var inString = false
+        var isEscaped = false
+        var scan = start
+        while scan < text.endIndex {
+            let character = text[scan]
+            if inString {
+                if isEscaped {
+                    isEscaped = false
+                } else if character == "\\" {
+                    isEscaped = true
+                } else if character == "\"" {
+                    inString = false
+                }
+            } else {
+                switch character {
+                case "\"":
+                    inString = true
+                case "{", "[":
+                    depth += 1
+                case "}", "]":
+                    depth -= 1
+                    if depth == 0 {
+                        return .complete(end: text.index(after: scan))
+                    }
+                default:
+                    break
+                }
+            }
+            scan = text.index(after: scan)
+        }
+        return .needMore
+    }
+
+    private func jsonStringExtent(in text: String) -> ValueExtent {
+        var index = text.index(after: text.startIndex)
+        var isEscaped = false
+        while index < text.endIndex {
+            let character = text[index]
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == "\"" {
+                return .complete(end: text.index(after: index))
+            } else if character == "\n" || character == "\r" {
+                // Valid JSON strings never contain a literal newline, so this
+                // quote was prose punctuation rather than structured data.
+                return .invalid
+            }
+            index = text.index(after: index)
+        }
+        return .needMore
+    }
+
+    // MARK: - Candidate extents
+
+    private enum CandidateExtent {
+        case complete(end: String.Index)
+        case needMore
+        /// The attempt is structurally impossible; `consumed` is the examined
+        /// extent retained for a rejection diagnostic.
+        case malformed(consumed: String.Index)
+    }
+
+    private func candidateExtent(for kind: ExplicitKind, in text: String) -> CandidateExtent {
+        switch kind {
+        case .qwenFunction:
+            switch QwenXMLPayloadScanner.scan(text[...]) {
+            case .complete(let payload):
+                return .complete(end: payload.end)
+            case .needMore:
+                return .needMore
+            case .malformed(let consumed):
+                return .malformed(consumed: consumed)
+            }
+
+        case .toolCallFrame:
+            var payloadStart = text.index(text.startIndex, offsetBy: "<tool_call>".count)
+            while payloadStart < text.endIndex, text[payloadStart].isWhitespace {
+                payloadStart = text.index(after: payloadStart)
+            }
+            guard payloadStart < text.endIndex else { return .needMore }
+
+            if text[payloadStart] == "{" {
+                // The frame closes only after a structurally balanced top-level
+                // JSON payload: a literal `</tool_call>` inside a string
+                // argument cannot end the candidate.
+                let payloadAndSuffix = String(text[payloadStart...])
+                guard let split = jsonScanner.splitLeadingObject(from: payloadAndSuffix) else {
+                    return .needMore
+                }
+                var afterPayload = text.index(payloadStart, offsetBy: split.object.count)
+                while afterPayload < text.endIndex, text[afterPayload].isWhitespace {
+                    afterPayload = text.index(after: afterPayload)
+                }
+                guard afterPayload < text.endIndex else { return .needMore }
+                if text[afterPayload...].hasPrefix("</tool_call>") {
+                    return .complete(
+                        end: text.index(afterPayload, offsetBy: "</tool_call>".count))
+                }
+                if let stray = text.range(
+                    of: "</tool_call>", range: afterPayload ..< text.endIndex)
+                {
+                    return .malformed(consumed: stray.upperBound)
+                }
+                return .needMore
+            }
+
+            if text[payloadStart...].hasPrefix(QwenXMLPayloadScanner.functionOpen) {
+                switch QwenXMLPayloadScanner.scan(text[payloadStart...]) {
+                case .complete(let payload):
+                    var afterPayload = payload.end
+                    while afterPayload < text.endIndex, text[afterPayload].isWhitespace {
+                        afterPayload = text.index(after: afterPayload)
+                    }
+                    guard afterPayload < text.endIndex else { return .needMore }
+                    if text[afterPayload...].hasPrefix("</tool_call>") {
+                        return .complete(
+                            end: text.index(afterPayload, offsetBy: "</tool_call>".count))
+                    }
+                    if let stray = text.range(
+                        of: "</tool_call>", range: afterPayload ..< text.endIndex)
+                    {
+                        return .malformed(consumed: stray.upperBound)
+                    }
+                    return .needMore
+                case .needMore:
+                    return .needMore
+                case .malformed(let consumed):
+                    return .malformed(consumed: consumed)
+                }
+            }
+
+            // The payload may still be a split `<function=` prefix.
+            if QwenXMLPayloadScanner.functionOpen.hasPrefix(String(text[payloadStart...])) {
+                return .needMore
+            }
+            if let close = text.range(
+                of: "</tool_call>", range: payloadStart ..< text.endIndex)
+            {
+                return .malformed(consumed: close.upperBound)
+            }
+            return .needMore
+
+        case .gemma4:
+            guard let brace = gemmaScanner.firstTopLevelIndex(of: "{", in: text[...]) else {
+                if let close = text.range(of: "<tool_call|>") {
+                    return .malformed(consumed: close.upperBound)
+                }
+                return .needMore
+            }
+            guard let braceEnd = gemmaScanner.endOfGroup(in: text[...], openedAt: brace)
+            else {
+                if let close = text.range(of: "<tool_call|>") {
+                    return .malformed(consumed: close.upperBound)
+                }
+                return .needMore
+            }
+            guard
+                let close = text.range(
+                    of: "<tool_call|>", range: braceEnd ..< text.endIndex)
+            else { return .needMore }
+            return .complete(end: close.upperBound)
+
+        case .mistral:
+            guard let brace = text.firstIndex(of: "{") else { return .needMore }
+            let tail = String(text[brace...])
+            guard let split = jsonScanner.splitLeadingObject(from: tail) else { return .needMore }
+            return .complete(end: text.index(brace, offsetBy: split.object.count))
+        }
+    }
+
+    /// Markerless `name[ARGS]{...}` rehearsals only ever produce text or a
+    /// call — never a rejection — so their extent has no malformed case.
+    private enum MarkerlessExtent {
+        case complete(end: String.Index)
+        case needMore
+    }
+
+    private func markerlessCandidateExtent(in text: String) -> MarkerlessExtent {
+        guard let brace = text.firstIndex(of: "{") else { return .needMore }
+        let tail = String(text[brace...])
+        guard let split = jsonScanner.splitLeadingObject(from: tail) else { return .needMore }
+        return .complete(end: text.index(brace, offsetBy: split.object.count))
+    }
+
+    private func nativeInlineJSONEnd(in text: String) -> String.Index? {
+        guard let brace = text.firstIndex(of: "{") else { return nil }
+        let json = String(text[brace...])
+        guard let split = jsonScanner.splitLeadingObject(from: json) else { return nil }
+        return text.index(brace, offsetBy: split.object.count)
+    }
+
+    // MARK: - Parsing
+
+    private mutating func recordEvent(
+        for call: ToolCall,
+        kind: Kind,
+        repair: ToolCallRecoveryEvent.Repair,
+        wasIncompleteAtEOS: Bool
+    ) {
+        let dialect: ToolCallRecoveryEvent.Dialect
+        switch kind {
+        case .explicit(.toolCallFrame): dialect = .toolCallFrame
+        case .explicit(.gemma4): dialect = .gemma4
+        case .explicit(.qwenFunction): dialect = .qwenFunction
+        case .explicit(.mistral): dialect = .mistral
+        case .declaredArgs: dialect = .declaredArgs
+        case .nativeFrame, .nativeUntilEOS, .nativeInlineJSON, .opaqueJSONValue, .reasoning,
+            .codeBacktick, .codeTilde:
+            return
+        }
+        events.append(
+            ToolCallRecoveryEvent(
+                toolName: call.function.name,
+                callID: call.id,
+                selectedFormat: primaryFormat,
+                dialect: dialect,
+                repair: repair,
+                wasIncompleteAtEOS: wasIncompleteAtEOS))
+    }
+
+    private func recoverExplicit(
+        _ raw: String,
+        as kind: ExplicitKind,
+        allowMissingOuterEnd: Bool
+    ) -> ToolCall? {
+        let call: ToolCall?
+        switch kind {
+        case .toolCallFrame:
+            guard allowMissingOuterEnd || raw.contains("</tool_call>") else { return nil }
+            call = framedParser.parse(content: raw, tools: tools)
+        case .gemma4:
+            guard allowMissingOuterEnd || raw.contains("<tool_call|>") else { return nil }
+            call = gemmaParser.parse(content: raw, tools: tools)
+        case .qwenFunction:
+            call = parseStrictQwenFunction(raw, allowMissingFunctionClose: allowMissingOuterEnd)
+        case .mistral:
+            call = parseMistralStyle(raw)
+        }
+
+        guard let call, allowedToolNames.contains(call.function.name),
+            satisfiesDeclaredRequiredArguments(call)
+        else { return nil }
+        return call
+    }
+
+    private func recoverDeclaredArgs(_ raw: String, name: String) -> ToolCall? {
+        guard raw.hasPrefix(name + "[ARGS]"),
+            let call = parseMistralStyle(raw, expectedName: name),
+            satisfiesDeclaredRequiredArguments(call)
+        else { return nil }
+        return call
+    }
+
+    /// Parse a bare `<function=...>` candidate with the shared structural
+    /// scanner. The candidate must be canonical and fully consumed: every
+    /// opened parameter must close, the function close is the structural close
+    /// rather than the first textual one, and no arguments are fabricated for
+    /// incomplete payloads.
+    private func parseStrictQwenFunction(
+        _ raw: String,
+        allowMissingFunctionClose: Bool
+    ) -> ToolCall? {
+        guard
+            case .complete(let payload) = QwenXMLPayloadScanner.scan(
+                raw[...], allowMissingFunctionClose: allowMissingFunctionClose),
+            raw[payload.end...].allSatisfy(\.isWhitespace)
+        else { return nil }
+
+        var arguments: [String: any Sendable] = [:]
+        for parameter in payload.parameters {
+            var value = String(parameter.value)
+            // Trim a single leading/trailing newline (matching XMLFunctionParser).
+            if value.hasPrefix("\n") { value = String(value.dropFirst()) }
+            if value.hasSuffix("\n") { value = String(value.dropLast()) }
+            arguments[parameter.name] = convertParameterValue(
+                value, paramName: parameter.name, funcName: payload.name, tools: tools)
+        }
+        return ToolCall(function: .init(name: payload.name, arguments: arguments))
+    }
+
+    /// A recovered call must satisfy the declared schema's required arguments
+    /// before promotion; an empty-arguments promotion for a tool that declares
+    /// required parameters is never valid recovery.
+    private func satisfiesDeclaredRequiredArguments(_ call: ToolCall) -> Bool {
+        for tool in tools {
+            guard let function = tool["function"] as? [String: any Sendable],
+                function["name"] as? String == call.function.name
+            else { continue }
+            guard let parameters = function["parameters"] as? [String: any Sendable],
+                let required = parameters["required"] as? [any Sendable]
+            else { return true }
+            let requiredNames = required.compactMap { $0 as? String }
+            return requiredNames.allSatisfy { call.function.arguments[$0] != nil }
+        }
+        return true
+    }
+
+    private func rejection(
+        for raw: String,
+        kind: ExplicitKind,
+        atEOS: Bool
+    ) -> Output {
+        let name = extractToolName(from: raw, kind: kind)
+        let reason: RejectedToolCall.Reason
+        if atEOS {
+            reason = .incompleteOutput
+        } else if let name, !allowedToolNames.contains(name) {
+            reason = .undeclaredTool
+        } else {
+            reason = .malformedSyntax
+        }
+        return .rejected(rawText: raw, reason: reason, toolName: name)
+    }
+
+    /// Best-effort function-name extraction for rejection diagnostics.
+    private func extractToolName(from raw: String, kind: ExplicitKind) -> String? {
+        switch kind {
+        case .qwenFunction:
+            return extractXMLFunctionName(from: raw)
+        case .toolCallFrame:
+            let payload = raw.dropFirst("<tool_call>".count)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if payload.hasPrefix("{"),
+                let object = jsonScanner.splitLeadingObject(from: payload)?.object,
+                let dictionary = tryParseJSON(object) as? [String: any Sendable]
+            {
+                return dictionary["name"] as? String
+            }
+            if payload.hasPrefix(QwenXMLPayloadScanner.functionOpen) {
+                return extractXMLFunctionName(from: payload)
+            }
+            return nil
+        case .gemma4:
+            guard let callRange = raw.range(of: "call:") else { return nil }
+            let remainder = raw[callRange.upperBound...]
+            guard let brace = remainder.firstIndex(of: "{") else { return nil }
+            let name = remainder[..<brace].trimmingCharacters(in: .whitespacesAndNewlines)
+            return name.isEmpty ? nil : name
+        case .mistral:
+            var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.hasPrefix("[TOOL_CALLS]") {
+                text.removeFirst("[TOOL_CALLS]".count)
+                text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard
+                let delimiter = text.range(of: "[ARGS]") ?? text.range(of: "{")
+                    ?? text.range(of: "[CALL_ID]")
+            else {
+                return text.isEmpty ? nil : text
+            }
+            let name = text[..<delimiter.lowerBound]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return name.isEmpty ? nil : name
+        }
+    }
+
+    private func extractXMLFunctionName(from text: String) -> String? {
+        guard let openEnd = text.range(of: QwenXMLPayloadScanner.functionOpen)?.upperBound,
+            let nameEnd = text[openEnd...].firstIndex(of: ">")
+        else { return nil }
+        let name = text[openEnd ..< nameEnd]
+        return name.isEmpty || name.contains(where: \.isWhitespace) ? nil : String(name)
+    }
+
+    private func parseMistralStyle(_ raw: String, expectedName: String? = nil) -> ToolCall? {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.hasPrefix("[TOOL_CALLS]") {
+            text.removeFirst("[TOOL_CALLS]".count)
+            text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        guard let brace = text.firstIndex(of: "{") else { return nil }
+        var header = String(text[..<brace]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let argumentsText = String(text[brace...])
+        var callID: String?
+
+        if header.hasSuffix("[ARGS]") {
+            header.removeLast("[ARGS]".count)
+            header = header.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let idMarker = header.range(of: "[CALL_ID]") {
+            let parsedID = header[idMarker.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            callID = parsedID.isEmpty ? nil : String(parsedID)
+            header = String(header[..<idMarker.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        guard !header.isEmpty, expectedName.map({ $0 == header }) ?? true,
+            allowedToolNames.contains(header),
+            let arguments = tryParseJSON(argumentsText) as? [String: any Sendable]
+        else { return nil }
+
+        return ToolCall(
+            function: .init(name: header, arguments: arguments),
+            id: callID)
+    }
+
+    private static func primaryOwnsToolCallFrame(_ format: ToolCallFormat) -> Bool {
+        switch format {
+        case .json, .xmlFunction, .qwen35, .gptOSS:
+            true
+        case .lfm2, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2, .atem, .mistral,
+            .llama3:
+            false
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
+++ b/Libraries/MLXLMCommon/Tool/TextToolCallRecoveryScanner.swift
@@ -102,6 +102,8 @@ struct TextToolCallRecoveryScanner: Sendable {
         }
     }
 
+    private let supportsBareJSON: Bool
+    private var jsonPrefixScanner = JSONPrefixScanner()
     private let primaryFormat: ToolCallFormat
     private let policy: ToolCallRecoveryPolicy
     private let tools: [[String: any Sendable]]
@@ -155,48 +157,31 @@ struct TextToolCallRecoveryScanner: Sendable {
         self.allowedToolNamesByLength = allowedToolNames.sorted { $0.count > $1.count }
         self.maximumBufferedByteCount = maximumBufferedByteCount
 
+        let primaryParser = primaryFormat.createParser()
+        self.supportsBareJSON = primaryParser.supportsBareJSON
         var signals: [Signal] = []
-        if Self.primaryOwnsToolCallFrame(primaryFormat) {
-            signals.append(
-                Signal(
-                    text: "<tool_call>",
-                    kind: .nativeFrame(endMarker: "</tool_call>")))
-        } else if policy != .disabled {
-            signals.append(Signal(text: "<tool_call>", kind: .explicit(.toolCallFrame)))
-        }
-        if primaryFormat == .gemma4 {
-            signals.append(
-                Signal(
-                    text: "<|tool_call>",
-                    kind: .nativeFrame(endMarker: "<tool_call|>")))
-        } else if policy != .disabled {
-            signals.append(Signal(text: "<|tool_call>", kind: .explicit(.gemma4)))
-        }
-        if policy != .disabled {
-            signals.append(Signal(text: "<function=", kind: .explicit(.qwenFunction)))
-        }
-        // Reasoning spans are never eligible for recovery, regardless of the
-        // selected dialect. Ordered so longer markers win ties.
-        signals.append(Signal(text: "<thinking>", kind: .reasoning(close: "</thinking>")))
-        signals.append(Signal(text: "<think>", kind: .reasoning(close: "</think>")))
-        signals.append(Signal(text: "[THINK]", kind: .reasoning(close: "[/THINK]")))
-        if primaryFormat != .mistral, policy != .disabled {
-            signals.append(Signal(text: "[TOOL_CALLS]", kind: .explicit(.mistral)))
+        // Native markers win ties. Alternate dialects may never steal a
+        // frame which the selected parser already owns (for example GLM4).
+        if let start = primaryParser.startTag {
+            let kind: Kind =
+                primaryParser.endTag.map { .nativeFrame(endMarker: $0) }
+                ?? .nativeUntilEOS
+            signals.append(Signal(text: start, kind: kind))
         }
         if primaryFormat == .llama3 {
             signals.append(Signal(text: "<|python_tag|>", kind: .nativeInlineJSON))
         }
-
-        let primaryParser = primaryFormat.createParser()
-        if let start = primaryParser.startTag,
-            !signals.contains(where: { $0.text == start })
-        {
-            if let end = primaryParser.endTag {
-                signals.append(Signal(text: start, kind: .nativeFrame(endMarker: end)))
-            } else {
-                signals.append(Signal(text: start, kind: .nativeUntilEOS))
+        if policy != .disabled {
+            for (marker, kind): (String, ExplicitKind) in [
+                ("<tool_call>", .toolCallFrame), ("<|tool_call>", .gemma4),
+                ("<function=", .qwenFunction), ("[TOOL_CALLS]", .mistral),
+            ] where !signals.contains(where: { $0.text == marker }) {
+                signals.append(Signal(text: marker, kind: .explicit(kind)))
             }
         }
+        signals.append(Signal(text: "<thinking>", kind: .reasoning(close: "</thinking>")))
+        signals.append(Signal(text: "<think>", kind: .reasoning(close: "</think>")))
+        signals.append(Signal(text: "[THINK]", kind: .reasoning(close: "[/THINK]")))
 
         // Ordinary JSON values and Markdown code are data: protocol-shaped
         // text inside them must never be promoted. Single-character signals
@@ -317,13 +302,9 @@ struct TextToolCallRecoveryScanner: Sendable {
                 break scanLoop
 
             case .jsonValue:
-                if buffer.utf8.count <= maximumBufferedByteCount,
-                    !chunkMayCompleteJSONValue(chunk, opener: buffer.first)
-                {
-                    break scanLoop
-                }
-                switch jsonValueExtent(in: buffer) {
-                case .complete(let end):
+                switch jsonPrefixScanner.scan(buffer) {
+                case .complete(let byteCount):
+                    let end = buffer.utf8.index(buffer.utf8.startIndex, offsetBy: byteCount)
                     let value = String(buffer[..<end])
                     if value.utf8.count > maximumBufferedByteCount {
                         appendProtectedText(value, to: &output)
@@ -339,7 +320,12 @@ struct TextToolCallRecoveryScanner: Sendable {
                     buffer.removeFirst()
                     context = .response
                     continue
-                case .needMore:
+                case .depthLimit:
+                    appendProtectedText(buffer, to: &output)
+                    buffer.removeAll(keepingCapacity: true)
+                    context = .opaqueUntilEOS
+                    break scanLoop
+                case .incomplete:
                     if buffer.utf8.count > maximumBufferedByteCount {
                         appendProtectedText(buffer, to: &output)
                         buffer.removeAll(keepingCapacity: true)
@@ -468,7 +454,16 @@ struct TextToolCallRecoveryScanner: Sendable {
                     }
 
                 case .opaqueJSONValue:
-                    context = .jsonValue
+                    // A quote after a word or measurement is punctuation,
+                    // including inch marks and German-style closing quotes.
+                    if buffer.first == "\"", let previousSourceCharacter,
+                        previousSourceCharacter.isLetter || previousSourceCharacter.isNumber
+                    {
+                        appendText(String(buffer.removeFirst()), to: &output)
+                    } else {
+                        jsonPrefixScanner = JSONPrefixScanner()
+                        context = .jsonValue
+                    }
 
                 case .codeBacktick:
                     let run = backtickRun(in: buffer)
@@ -584,12 +579,14 @@ struct TextToolCallRecoveryScanner: Sendable {
             // marker delivered immediately before EOS must not leave recovery
             // shielding every subsequent generation.
             context = .response
+            previousSourceCharacter = nil
             return output
         }
 
         defer {
             buffer.removeAll(keepingCapacity: true)
             context = .response
+            previousSourceCharacter = nil
             pendingCandidate = nil
         }
 
@@ -760,23 +757,15 @@ struct TextToolCallRecoveryScanner: Sendable {
         previousSourceCharacter = text.last
     }
 
-    /// Bare top-level JSON remains eligible only when JSON is the selected
-    /// native tool-call format. For every other dialect it is response data and
+    /// Bare top-level JSON is eligible only when the selected parser declares
+    /// it as native call syntax. For other dialects it is response data and
     /// must bypass native parsing, including protocol-shaped strings inside it.
     private mutating func appendJSONData(_ text: String, to output: inout [Output]) {
-        if primaryFormat == .json, text.first == "{" {
+        if supportsBareJSON, text.first == "{" {
             appendText(text, to: &output)
         } else {
             appendProtectedText(text, to: &output)
         }
-    }
-
-    private func chunkMayCompleteJSONValue(_ chunk: String, opener: Character?) -> Bool {
-        guard !chunk.isEmpty else { return true }
-        if opener == "\"" {
-            return chunk.contains("\"") || chunk.contains("\n") || chunk.contains("\r")
-        }
-        return chunk.contains("}") || chunk.contains("]")
     }
 
     /// Release everything except a suffix that may still complete a signal or
@@ -962,105 +951,6 @@ struct TextToolCallRecoveryScanner: Sendable {
             index = runEnd
         }
         return nil
-    }
-
-    // MARK: - JSON data opacity
-
-    private enum ValueExtent {
-        case complete(end: String.Index)
-        case needMore
-        case invalid
-    }
-
-    /// The extent of the JSON value starting at the beginning of `text`.
-    /// Objects, arrays and strings are opaque data; numbers, booleans and null
-    /// contain no interior text and need no shielding.
-    private func jsonValueExtent(in text: String) -> ValueExtent {
-        switch text[text.startIndex] {
-        case "{", "[":
-            return jsonContainerExtent(in: text)
-        case "\"":
-            return jsonStringExtent(in: text)
-        default:
-            return .invalid
-        }
-    }
-
-    private func jsonContainerExtent(in text: String) -> ValueExtent {
-        let start = text.startIndex
-        var index = text.index(after: start)
-        while index < text.endIndex, text[index].isWhitespace {
-            index = text.index(after: index)
-        }
-        guard index < text.endIndex else { return .needMore }
-
-        // Validate the first meaningful character so prose such as `[TOOL...`
-        // or `{not json` is never treated as structured data.
-        let first = text[index]
-        let plausible: Bool
-        if text[start] == "{" {
-            plausible = first == "\"" || first == "}"
-        } else {
-            plausible =
-                first == "\"" || first == "{" || first == "[" || first == "]"
-                || first == "-" || first.isNumber
-                || first == "t" || first == "f" || first == "n"
-        }
-        guard plausible else { return .invalid }
-
-        var depth = 0
-        var inString = false
-        var isEscaped = false
-        var scan = start
-        while scan < text.endIndex {
-            let character = text[scan]
-            if inString {
-                if isEscaped {
-                    isEscaped = false
-                } else if character == "\\" {
-                    isEscaped = true
-                } else if character == "\"" {
-                    inString = false
-                }
-            } else {
-                switch character {
-                case "\"":
-                    inString = true
-                case "{", "[":
-                    depth += 1
-                case "}", "]":
-                    depth -= 1
-                    if depth == 0 {
-                        return .complete(end: text.index(after: scan))
-                    }
-                default:
-                    break
-                }
-            }
-            scan = text.index(after: scan)
-        }
-        return .needMore
-    }
-
-    private func jsonStringExtent(in text: String) -> ValueExtent {
-        var index = text.index(after: text.startIndex)
-        var isEscaped = false
-        while index < text.endIndex {
-            let character = text[index]
-            if isEscaped {
-                isEscaped = false
-            } else if character == "\\" {
-                isEscaped = true
-            } else if character == "\"" {
-                return .complete(end: text.index(after: index))
-            } else if character == "\n" || character == "\r" {
-                // Valid JSON strings never contain a literal newline, so this
-                // quote was prose punctuation rather than structured data.
-                return .invalid
-            }
-            index = text.index(after: index)
-        }
-        return .needMore
     }
 
     // MARK: - Candidate extents
@@ -1377,13 +1267,4 @@ struct TextToolCallRecoveryScanner: Sendable {
             id: callID)
     }
 
-    private static func primaryOwnsToolCallFrame(_ format: ToolCallFormat) -> Bool {
-        switch format {
-        case .json, .xmlFunction, .qwen35, .gptOSS:
-            true
-        case .lfm2, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2, .atem, .mistral,
-            .llama3:
-            false
-        }
-    }
 }

--- a/Libraries/MLXLMCommon/Tool/TokenStreamDecoder.swift
+++ b/Libraries/MLXLMCommon/Tool/TokenStreamDecoder.swift
@@ -35,6 +35,9 @@ package protocol TokenStreamDecoder {
     /// Decoders whose response protocol never rejects tool calls report zero.
     var rejectedToolCallCount: Int { get }
 
+    /// Calls promoted by bounded cross-dialect recovery during this generation.
+    var recoveredToolCallCount: Int { get }
+
     /// Consumes one generated token. Returns `false` when decoding should stop
     /// because of either a semantic boundary or consumer termination.
     mutating func push(_ token: Int, emit: (TokenStreamEvent) -> Bool) -> Bool
@@ -49,6 +52,7 @@ extension TokenStreamDecoder {
     package var receivesStopTokens: Bool { false }
     package var isInsideReasoning: Bool { false }
     package var rejectedToolCallCount: Int { 0 }
+    package var recoveredToolCallCount: Int { 0 }
 }
 
 /// Decoder for ordinary detokenized tool-call syntaxes.
@@ -61,14 +65,17 @@ struct StandardTokenStreamDecoder: TokenStreamDecoder {
         tokenizer: any Tokenizer,
         format: ToolCallFormat,
         tools: [[String: any Sendable]]?,
-        stopStrings: Set<String>
+        stopStrings: Set<String>,
+        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
     ) {
         self.detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
-        self.toolCallProcessor = ToolCallProcessor(format: format, tools: tools)
+        self.toolCallProcessor = ToolCallProcessor(
+            format: format, tools: tools, recoveryPolicy: recoveryPolicy)
         self.stopStringFilter = StopStringFilter(stopStrings: stopStrings)
     }
 
     var rejectedToolCallCount: Int { toolCallProcessor.rejectedToolCallCount }
+    var recoveredToolCallCount: Int { toolCallProcessor.recoveredToolCallCount }
 
     mutating func push(_ token: Int, emit: (TokenStreamEvent) -> Bool) -> Bool {
         detokenizer.append(token: token)

--- a/Libraries/MLXLMCommon/Tool/TokenStreamDecoder.swift
+++ b/Libraries/MLXLMCommon/Tool/TokenStreamDecoder.swift
@@ -66,11 +66,11 @@ struct StandardTokenStreamDecoder: TokenStreamDecoder {
         format: ToolCallFormat,
         tools: [[String: any Sendable]]?,
         stopStrings: Set<String>,
-        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
         self.detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         self.toolCallProcessor = ToolCallProcessor(
-            format: format, tools: tools, recoveryPolicy: recoveryPolicy)
+            format: format, tools: tools, toolCallPolicy: toolCallPolicy)
         self.stopStringFilter = StopStringFilter(stopStrings: stopStrings)
     }
 

--- a/Libraries/MLXLMCommon/Tool/ToolArgumentNormalization.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolArgumentNormalization.swift
@@ -1,0 +1,195 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Schema-guided reading of textual arguments, shared by all call dialects.
+/// This is intentionally separate from validation: unconvertible or ambiguous
+/// values keep their original spelling so the caller can reject or inspect them.
+enum ToolArgumentNormalization {
+    static func normalize(_ call: ToolCall, tools: [[String: any Sendable]]?) -> ToolCall {
+        guard !call.function.arguments.isEmpty, let tools,
+            let schema = ToolSchemaValidator.parametersSchema(
+                ofToolNamed: call.function.name, in: tools),
+            let properties = schema["properties"] as? [String: any Sendable]
+        else { return call }
+        var arguments = call.function.arguments
+        var changed = false
+        for (key, value) in call.function.arguments {
+            let converted = normalize(value, schema: properties[key] as? [String: any Sendable])
+            if converted != value {
+                arguments[key] = converted
+                changed = true
+            }
+        }
+        guard changed else { return call }
+        return ToolCall(
+            function: .init(name: call.function.name, arguments: arguments), id: call.id)
+    }
+
+    static func normalize(
+        _ value: JSONValue, schema: [String: any Sendable]?, depth: Int = 0
+    ) -> JSONValue {
+        switch value {
+        case .string, .array, .object: break
+        default: return value
+        }
+        if schema?["type"] as? String == "string" { return value }
+        guard depth < 32, let schema, let types = declaredTypes(schema, depth: depth) else {
+            return value
+        }
+        var nonNull = types.subtracting(["null"])
+        if nonNull.contains("number") { nonNull.remove("integer") }
+        // An admitted string or multiple interpretations is not an invitation
+        // to guess which union branch the model meant (for example "001").
+        guard !types.contains("string"), nonNull.count <= 1 else { return value }
+        var result = value
+        if case .string(let text) = value {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if types.contains("null"), ["null", "none", "nil"].contains(trimmed.lowercased()) {
+                return .null
+            }
+            switch nonNull.first {
+            case "integer", "number":
+                result = number(trimmed, integer: nonNull.first == "integer") ?? value
+            case "boolean":
+                switch trimmed.lowercased() {
+                case "true", "1", "yes", "on": result = .bool(true)
+                case "false", "0", "no", "off": result = .bool(false)
+                default: break
+                }
+            case "object", "array":
+                let parsed: (any Sendable)? =
+                    tryParseJSON(trimmed) ?? tryParsePythonLiteral(trimmed)
+                if let parsed {
+                    let json = JSONValue.from(parsed)
+                    switch (nonNull.first, json) {
+                    case ("object", .object), ("array", .array): result = json
+                    default: break
+                    }
+                }
+            default: break
+            }
+        }
+        switch result {
+        case .object(let object):
+            let properties = schema["properties"] as? [String: any Sendable] ?? [:]
+            let extra = schema["additionalProperties"] as? [String: any Sendable]
+            guard !properties.isEmpty || extra != nil else { return result }
+            var normalized = object
+            for (key, value) in object {
+                let converted = normalize(
+                    value, schema: properties[key] as? [String: any Sendable] ?? extra,
+                    depth: depth + 1)
+                if converted != value { normalized[key] = converted }
+            }
+            return .object(normalized)
+        case .array(let array):
+            guard let items = schema["items"] as? [String: any Sendable] else { return result }
+            var normalized = array
+            for index in array.indices {
+                let converted = normalize(array[index], schema: items, depth: depth + 1)
+                if converted != array[index] { normalized[index] = converted }
+            }
+            return .array(normalized)
+        default: return result
+        }
+    }
+
+    /// Returns only interpretations every branch describes. Unknown branches
+    /// (notably references) prevent coercion rather than being silently ignored.
+    private static func declaredTypes(_ schema: [String: any Sendable], depth: Int) -> Set<String>?
+    {
+        guard depth < 32,
+            ["$ref", "$dynamicRef", "not", "if", "then", "else"].allSatisfy({ schema[$0] == nil })
+        else { return nil }
+        var result: Set<String>?
+        if let raw = schema["type"] {
+            let names = (raw as? String).map { [$0] } ?? (raw as? [String]) ?? []
+            let mapped = names.compactMap(canonicalType)
+            guard !names.isEmpty, mapped.count == names.count else { return nil }
+            result = Set(mapped)
+            // Integer is a subtype of number, so intersections such as
+            // allOf(number, integer) still describe an integer.
+            if result?.contains("number") == true { result?.insert("integer") }
+        }
+        for key in ["anyOf", "oneOf", "allOf"] where schema[key] != nil {
+            guard let branches = schema[key] as? [[String: any Sendable]], !branches.isEmpty else {
+                return nil
+            }
+            let types = branches.compactMap { declaredTypes($0, depth: depth + 1) }
+            guard types.count == branches.count else { return nil }
+            let combined = types.dropFirst().reduce(types[0]) {
+                key == "allOf" ? $0.intersection($1) : $0.union($1)
+            }
+            result = result.map { $0.intersection(combined) } ?? combined
+        }
+        return result
+    }
+
+    private static func canonicalType(_ name: String) -> String? {
+        let type = name.lowercased()
+        switch type {
+        case "string", "str", "text", "varchar", "char", "enum": return "string"
+        case "integer", "int", "uint", "long", "short", "unsigned": return "integer"
+        case "number", "float": return "number"
+        case "boolean", "bool", "binary": return "boolean"
+        case "object", "dict": return "object"
+        case "array", "arr", "list": return "array"
+        case "null": return "null"
+        default:
+            // Preserve the aliases already accepted by the textual parsers.
+            if ["int", "uint", "long", "short", "unsigned"].contains(where: type.hasPrefix) {
+                return "integer"
+            }
+            if type.hasPrefix("num") || type.hasPrefix("float") { return "number" }
+            if type.hasPrefix("dict") { return "object" }
+            if type.hasPrefix("list") { return "array" }
+            return nil
+        }
+    }
+
+    private static func number(_ text: String, integer: Bool) -> JSONValue? {
+        if let value = Int(text) { return .int(value) }
+        guard let value = Double(text), value.isFinite else { return nil }
+        return decimalInteger(text).map(JSONValue.int) ?? (integer ? nil : .double(value))
+    }
+
+    /// Recognize integral decimal/exponent spellings without floating-point
+    /// rounding. No fixed-width conversion occurs until all digits are known.
+    private static func decimalInteger(_ text: String) -> Int? {
+        var body = text[...]
+        let negative = body.first == "-"
+        if body.first == "-" || body.first == "+" { body.removeFirst() }
+        let parts = body.split(
+            omittingEmptySubsequences: false, whereSeparator: { $0 == "e" || $0 == "E" })
+        guard parts.count <= 2 else { return nil }
+        let exponent: Int
+        if parts.count == 2 {
+            guard let parsed = Int(parts[1]) else { return nil }
+            exponent = parsed
+        } else {
+            exponent = 0
+        }
+        let mantissa = parts[0].split(separator: ".", omittingEmptySubsequences: false)
+        guard mantissa.count <= 2 else { return nil }
+        let fractionalCount = mantissa.count == 2 ? mantissa[1].count : 0
+        var digits = mantissa.joined()
+        guard !digits.isEmpty, digits.utf8.allSatisfy({ (48 ... 57).contains($0) }) else {
+            return nil
+        }
+        digits = String(digits.drop(while: { $0 == "0" }))
+        if digits.isEmpty { return 0 }
+        let (scale, overflow) = exponent.subtractingReportingOverflow(fractionalCount)
+        guard !overflow else { return nil }
+        if scale >= 0 {
+            guard scale <= 19, digits.count <= 19 - scale else { return nil }
+            digits += String(repeating: "0", count: scale)
+        } else {
+            guard scale > -digits.count, digits.suffix(-scale).allSatisfy({ $0 == "0" }) else {
+                return nil
+            }
+            digits.removeLast(-scale)
+        }
+        return Int((negative ? "-" : "") + digits)
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -169,7 +169,8 @@ public enum ToolCallFormat: String, Hashable, Sendable, Codable, CaseIterable {
     package func makeTokenStreamDecoder(
         tokenizer: any Tokenizer,
         tools: [[String: any Sendable]]?,
-        stopStrings: Set<String>
+        stopStrings: Set<String>,
+        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
     ) -> any TokenStreamDecoder {
         if let decoder = makeProtocolTokenStreamDecoder(
             tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
@@ -177,7 +178,8 @@ public enum ToolCallFormat: String, Hashable, Sendable, Codable, CaseIterable {
             return decoder
         }
         return StandardTokenStreamDecoder(
-            tokenizer: tokenizer, format: self, tools: tools, stopStrings: stopStrings)
+            tokenizer: tokenizer, format: self, tools: tools, stopStrings: stopStrings,
+            recoveryPolicy: recoveryPolicy)
     }
 
     /// Builds a decoder only for formats which own a framed token protocol.

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -19,6 +19,9 @@ public protocol ToolCallParser: Sendable {
     /// Returns `nil` for inline formats that don't use wrapper tags.
     var endTag: String? { get }
 
+    /// Whether an unframed JSON object is native call syntax for this parser.
+    var supportsBareJSON: Bool { get }
+
     /// Parse the content into a `ToolCall`.
     /// - Parameters:
     ///   - content: The text content to parse (may include tags)
@@ -35,6 +38,8 @@ public protocol ToolCallParser: Sendable {
 }
 
 extension ToolCallParser {
+    public var supportsBareJSON: Bool { false }
+
     public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
         if let startTag {
             return
@@ -129,7 +134,8 @@ public enum ToolCallFormat: String, Hashable, Sendable, Codable, CaseIterable {
     public func createParser() -> any ToolCallParser {
         switch self {
         case .json:
-            return JSONToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+            return JSONToolCallParser(
+                startTag: "<tool_call>", endTag: "</tool_call>", supportsBareJSON: true)
         case .lfm2:
             return PythonicToolCallParser(
                 startTag: "<|tool_call_start|>", endTag: "<|tool_call_end|>")
@@ -170,16 +176,17 @@ public enum ToolCallFormat: String, Hashable, Sendable, Codable, CaseIterable {
         tokenizer: any Tokenizer,
         tools: [[String: any Sendable]]?,
         stopStrings: Set<String>,
-        recoveryPolicy: ToolCallRecoveryPolicy = .conservative
+        toolCallPolicy: ToolCallPolicy = .init()
     ) -> any TokenStreamDecoder {
         if let decoder = makeProtocolTokenStreamDecoder(
-            tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
+            tokenizer: tokenizer, tools: tools, stopStrings: stopStrings,
+            toolCallPolicy: toolCallPolicy)
         {
             return decoder
         }
         return StandardTokenStreamDecoder(
             tokenizer: tokenizer, format: self, tools: tools, stopStrings: stopStrings,
-            recoveryPolicy: recoveryPolicy)
+            toolCallPolicy: toolCallPolicy)
     }
 
     /// Builds a decoder only for formats which own a framed token protocol.
@@ -189,16 +196,19 @@ public enum ToolCallFormat: String, Hashable, Sendable, Codable, CaseIterable {
     package func makeProtocolTokenStreamDecoder(
         tokenizer: any Tokenizer,
         tools: [[String: any Sendable]]?,
-        stopStrings: Set<String>
+        stopStrings: Set<String>,
+        toolCallPolicy: ToolCallPolicy = .init()
     ) -> (any TokenStreamDecoder)? {
         switch self {
         case .gptOSS:
             return HarmonyStreamAdapter(
-                tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
+                tokenizer: tokenizer, tools: tools, stopStrings: stopStrings,
+                toolCallPolicy: toolCallPolicy)
 
         case .atem:
             return OnyxStreamAdapter(
-                tokenizer: tokenizer, tools: tools, stopStrings: stopStrings)
+                tokenizer: tokenizer, tools: tools, stopStrings: stopStrings,
+                toolCallPolicy: toolCallPolicy)
 
         case .json, .lfm2, .xmlFunction, .qwen35, .glm4, .gemma, .gemma4, .kimiK2, .minimaxM2,
             .mistral, .llama3:

--- a/Libraries/MLXLMCommon/Tool/ToolCallPolicy.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallPolicy.swift
@@ -1,0 +1,32 @@
+// Copyright © 2026 Apple Inc.
+
+/// Rules for recovering and validating generated tool calls.
+/// Native parser requirements and declared-tool authorization always apply.
+public struct ToolCallPolicy: Hashable, Sendable {
+    /// Bounded recovery of calls emitted in a different dialect.
+    /// Applies to text formats; framed token protocols use their native parser.
+    public var recovery: ToolCallRecoveryPolicy
+
+    /// Schema enforcement after unambiguous argument normalization.
+    public var validation: ToolCallValidationPolicy
+
+    public init(
+        recovery: ToolCallRecoveryPolicy = .conservative,
+        validation: ToolCallValidationPolicy = .strict
+    ) {
+        self.recovery = recovery
+        self.validation = validation
+    }
+}
+
+/// Controls schema enforcement independently of syntax recovery and tool-name
+/// authorization. Both modes normalize unambiguous, schema-declared values.
+public enum ToolCallValidationPolicy: String, Hashable, Sendable, CaseIterable {
+    /// Reject proven schema violations. Unsupported schema assertions remain
+    /// unknown. This is the default, including for automatic tool dispatch.
+    case strict
+    /// Forward parsed arguments after normalization, even if they violate the
+    /// schema, for applications that validate or repair arguments themselves.
+    /// Native parser requirements and declared-tool authorization still apply.
+    case permissive
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallPolicy.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallPolicy.swift
@@ -12,7 +12,7 @@ public struct ToolCallPolicy: Hashable, Sendable {
 
     public init(
         recovery: ToolCallRecoveryPolicy = .conservative,
-        validation: ToolCallValidationPolicy = .strict
+        validation: ToolCallValidationPolicy = .permissive
     ) {
         self.recovery = recovery
         self.validation = validation
@@ -23,10 +23,10 @@ public struct ToolCallPolicy: Hashable, Sendable {
 /// authorization. Both modes normalize unambiguous, schema-declared values.
 public enum ToolCallValidationPolicy: String, Hashable, Sendable, CaseIterable {
     /// Reject proven schema violations. Unsupported schema assertions remain
-    /// unknown. This is the default, including for automatic tool dispatch.
+    /// unknown. Enable this to check arguments before automatic tool dispatch.
     case strict
     /// Forward parsed arguments after normalization, even if they violate the
-    /// schema, for applications that validate or repair arguments themselves.
+    /// schema. This is the default; applications validate arguments themselves.
     /// Native parser requirements and declared-tool authorization still apply.
     case permissive
 }

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -730,36 +730,12 @@ public class ToolCallProcessor {
             fallthrough
 
         case .potentialToolCall:
-            if partialMatch(buffer: toolCallBuffer, tag: startTag) {
-                if toolCallBuffer.starts(with: startTag) {
-                    state = .collectingToolCall
-                    recordResponse(leadingToken ?? "")
-                    leadingTokenWasRecorded = true
-                    fallthrough
-                } else {
-                    recordResponse(leadingToken ?? "")
-                    leadingTokenWasRecorded = true
-                    return nil
-                }
-            } else {
-                // Otherwise, return the collected text and reset the state.
-                state = .normal
-                let buffer = toolCallBuffer
-                toolCallBuffer = ""
-                if let attempt = protocolMarkerAttempt(in: buffer, startTag: startTag) {
-                    recordResponse(leadingToken ?? "")
-                    appendRejectedToolCall(
-                        reason: .malformedSyntax,
-                        rawText: attempt,
-                        detail: RejectedToolCall.Reason.malformedSyntax.diagnosticDetail)
-                    let remainder = buffer.replacingOccurrences(of: attempt, with: "")
-                    recordResponse(sanitizingProtocol: remainder)
-                    return combine(leadingToken, stripProtocolSpans(from: remainder))
-                }
-                let response = (leadingToken ?? "") + buffer
-                recordResponse(sanitizingProtocol: response)
-                return response
-            }
+            leadingToken = scanTaggedStart(
+                startTag: startTag, startChar: startChar, leadingToken: leadingToken)
+            leadingTokenWasRecorded = true
+            guard toolCallBuffer.hasPrefix(startTag) else { return leadingToken }
+            state = .collectingToolCall
+            fallthrough
 
         case .collectingToolCall:
             if toolCallBuffer.utf8.count > maximumToolCallBufferByteCount {
@@ -769,7 +745,7 @@ public class ToolCallProcessor {
             }
 
             guard let endTag = parser.endTag else {
-                return nil
+                return leadingToken
             }
 
             // `<tool_call>` frames close only after a structurally complete
@@ -843,7 +819,7 @@ public class ToolCallProcessor {
                 return combine(leadingToken, trailingToken.isEmpty ? nil : trailingToken)
             }
 
-            return nil
+            return leadingToken
 
         case .collectingJSONToolCall:
             return processCollectingJSONToolCall(
@@ -855,6 +831,54 @@ public class ToolCallProcessor {
         case .quarantiningOversizedToolCall:
             return nil
         }
+    }
+
+    private func scanTaggedStart(
+        startTag: String, startChar: Character, leadingToken: String?
+    ) -> String? {
+        let buffer = toolCallBuffer
+        var candidate = buffer.startIndex
+        var responseStart = candidate
+        var response = leadingToken ?? ""
+        var rejectedMarker = false
+        recordResponse(response)
+
+        func emitText(until end: String.Index) {
+            let text = String(buffer[responseStart ..< end])
+            recordResponse(sanitizingProtocol: text)
+            response += rejectedMarker ? stripProtocolSpans(from: text) : text
+        }
+
+        // A disproven opener only rules out that candidate, not the remaining chunk.
+        while candidate < buffer.endIndex {
+            let suffix = buffer[candidate...]
+            if suffix.hasPrefix(startTag) || startTag.hasPrefix(suffix) {
+                emitText(until: candidate)
+                toolCallBuffer = String(suffix)
+                return response.isEmpty ? nil : response
+            }
+
+            let next =
+                buffer[buffer.index(after: candidate)...].firstIndex(of: startChar)
+                ?? buffer.endIndex
+            if let attempt = protocolMarkerAttempt(
+                in: String(buffer[candidate ..< next]), startTag: startTag)
+            {
+                emitText(until: candidate)
+                appendRejectedToolCall(
+                    reason: .malformedSyntax,
+                    rawText: attempt,
+                    detail: RejectedToolCall.Reason.malformedSyntax.diagnosticDetail)
+                rejectedMarker = true
+                responseStart = buffer.index(candidate, offsetBy: attempt.count)
+            }
+            candidate = next
+        }
+
+        emitText(until: buffer.endIndex)
+        toolCallBuffer = ""
+        state = .normal
+        return response.isEmpty ? nil : response
     }
 
     private func processCollectingJSONToolCall(

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -38,7 +38,9 @@ public class ToolCallProcessor {
     private let tools: [[String: any Sendable]]?
     private let allowedToolNames: Set<String>?
     private let supportsBareJSONFallback: Bool
+    private var recoveryScanner: TextToolCallRecoveryScanner?
     private let maxJSONFallbackBufferLength = 32_768
+    private let maximumToolCallBufferByteCount = 65_536
     private let jsonObjectScanner = JSONLeadingObjectScanner(startCharacter: "{")
     private var state = State.normal
     private var toolCallBuffer = ""
@@ -57,6 +59,14 @@ public class ToolCallProcessor {
     /// Total rejected calls observed by this processor, including drained calls.
     public private(set) var rejectedToolCallCount = 0
 
+    /// Provenance for every call produced by cross-dialect recovery, in source
+    /// order. Calls produced by the selected native parser are not included.
+    public private(set) var recoveryEvents: [ToolCallRecoveryEvent] = []
+
+    /// Total calls promoted by cross-dialect recovery, including events that
+    /// have already been drained by a diagnostic consumer.
+    public private(set) var recoveredToolCallCount = 0
+
     // MARK: - State Enum
 
     private enum State {
@@ -64,6 +74,9 @@ public class ToolCallProcessor {
         case potentialToolCall
         case collectingToolCall
         case collectingJSONToolCall
+        /// An oversized explicit attempt is ignored until EOS. Resuming in the
+        /// middle of its syntax could turn argument data into a new call.
+        case quarantiningOversizedToolCall
     }
 
     private enum TaggedStartMode {
@@ -80,7 +93,18 @@ public class ToolCallProcessor {
     ///   - tools: Optional tool schemas for type-aware parsing and authorization.
     ///     `nil` accepts any parsed function name; a supplied array, including
     ///     an empty one, authorizes only the names it declares.
-    public init(format: ToolCallFormat = .json, tools: [[String: any Sendable]]? = nil) {
+    ///     A nonempty declaration also enables bounded cross-dialect recovery;
+    ///     only an exactly declared function name can be promoted by recovery.
+    ///   - recoveryPolicy: Governs cross-dialect recovery. `nil` selects
+    ///     ``ToolCallRecoveryPolicy/conservative``. Recovery only ever runs
+    ///     when a nonempty tool declaration is supplied, and never promotes
+    ///     text inside reasoning spans, Markdown code, ordinary JSON data, or
+    ///     the selected format's own protocol frames.
+    public init(
+        format: ToolCallFormat = .json,
+        tools: [[String: any Sendable]]? = nil,
+        recoveryPolicy: ToolCallRecoveryPolicy? = nil
+    ) {
         self.format = format
         self.parser = format.createParser()
         self.tools = tools
@@ -91,6 +115,11 @@ public class ToolCallProcessor {
                 })
         }
         self.supportsBareJSONFallback = format == .json
+        self.recoveryScanner = TextToolCallRecoveryScanner(
+            primaryFormat: format,
+            policy: recoveryPolicy ?? .conservative,
+            tools: tools,
+            allowedToolNames: self.allowedToolNames)
     }
 
     // MARK: - Computed Properties
@@ -105,12 +134,38 @@ public class ToolCallProcessor {
         parser.startTag?.first
     }
 
+    /// Whether the selected format frames calls with `<tool_call>` tags and
+    /// therefore closes frames only after a structurally complete payload.
+    private var usesStructuralToolCallFrame: Bool {
+        parser.startTag == ToolCallFrameScanner.startTag
+            && parser.endTag == ToolCallFrameScanner.endTag
+    }
+
     // MARK: - Public Methods
 
     /// Process a generated text chunk and extract any tool call content.
     /// - Parameter chunk: The text chunk to process
     /// - Returns: Regular text that should be displayed (non-tool call content), or `nil` if buffering
     public func processChunk(_ chunk: String) -> String? {
+        guard recoveryScanner != nil else {
+            return processNativeChunk(chunk)
+        }
+        if recoveryScanner!.consumeIfPassThrough(chunk) {
+            if state == .normal,
+                isInlineFormat || startTagFirstChar == "<" || startTagFirstChar == "["
+            {
+                recordResponse(chunk)
+                return chunk
+            }
+            return processNativeChunk(chunk)
+        }
+
+        let recovered = recoveryScanner!.process(chunk)
+        return processRecoveryOutputs(recovered)
+    }
+
+    /// Sends text not claimed by recovery through the selected native parser.
+    private func processNativeChunk(_ chunk: String) -> String? {
         if isInlineFormat {
             return processInlineChunk(chunk)
         }
@@ -153,6 +208,15 @@ public class ToolCallProcessor {
         return drained
     }
 
+    /// Removes and returns every cross-dialect recovery event in source order.
+    /// A second call returns an empty array until more calls are recovered.
+    public func drainRecoveryEvents() -> [ToolCallRecoveryEvent] {
+        guard !recoveryEvents.isEmpty else { return [] }
+        let drained = recoveryEvents
+        recoveryEvents.removeAll(keepingCapacity: true)
+        return drained
+    }
+
     /// Process end-of-sequence, parsing any buffered content as tool call(s).
     ///
     /// Call this when generation ends (e.g., on EOS token) to handle formats
@@ -177,6 +241,19 @@ public class ToolCallProcessor {
     ///   `returnBufferedText` is `false`).
     @discardableResult
     public func processEOS(returnBufferedText: Bool = true) -> String? {
+        let recoveredText = finishRecoveryStream()
+        return combine(
+            recoveredText,
+            processNativeEOS(returnBufferedText: returnBufferedText))
+    }
+
+    private func processNativeEOS(returnBufferedText: Bool) -> String? {
+        if state == .quarantiningOversizedToolCall {
+            state = .normal
+            toolCallBuffer = ""
+            hasExplicitInlineMarker = false
+            return nil
+        }
         guard
             state == .collectingToolCall || state == .potentialToolCall
                 || state == .collectingJSONToolCall
@@ -189,7 +266,11 @@ public class ToolCallProcessor {
 
         let buffered = toolCallBuffer
         let terminalState = state
-        let parsedCalls = parser.parseEOS(buffered, tools: tools)
+        var parsedCalls = parser.parseEOS(buffered, tools: tools)
+        if parsedCalls.isEmpty {
+            parsedCalls = recoveryScanner?.recoverEOSPayloads(buffered) ?? []
+            collectRecoveryEvents()
+        }
         appendToolCalls(parsedCalls, rawText: buffered)
 
         let didReject: Bool
@@ -219,6 +300,7 @@ public class ToolCallProcessor {
     /// this API with the legacy processing and draining APIs.
     public func processEOSOutputs() -> [Output] {
         orderedOutputEnabled = true
+        _ = finishRecoveryStream()
         if format == .mistral, let outputs = processMistralEOSOutputs() {
             orderedOutputQueue.removeAll(keepingCapacity: true)
             return outputs
@@ -229,13 +311,54 @@ public class ToolCallProcessor {
         }
 
         let outputCount = orderedOutputQueue.count
-        let visible = processEOS(returnBufferedText: true)
+        let visible = processNativeEOS(returnBufferedText: true)
         if orderedOutputQueue.count == outputCount, let visible {
             recordEOSResidual(visible)
         }
         _ = drainToolCalls()
         _ = drainRejectedToolCalls()
         return drainOrderedOutputs()
+    }
+
+    private func processRecoveryOutputs(_ outputs: [TextToolCallRecoveryScanner.Output])
+        -> String?
+    {
+        var visible: String?
+        for output in outputs {
+            switch output {
+            case .text(let text):
+                visible = combine(visible, processNativeChunk(text))
+            case .protectedText(let text):
+                // The recovery lexer has already classified this as inert
+                // response data. Routing it through the native parser would
+                // reopen the trust boundary and allow calls hidden in
+                // reasoning, code, or JSON strings to execute.
+                recordResponse(text)
+                visible = combine(visible, text)
+            case .toolCall(let call, let rawText):
+                appendToolCall(call, rawText: rawText)
+            case .rejected(let rawText, let reason, let toolName):
+                appendRejectedToolCall(
+                    reason: reason,
+                    rawText: rawText,
+                    toolName: toolName,
+                    detail: reason.diagnosticDetail)
+            }
+        }
+        collectRecoveryEvents()
+        return visible
+    }
+
+    /// Moves provenance recorded by the recovery scanner into the public log.
+    private func collectRecoveryEvents() {
+        guard let drained = recoveryScanner?.drainEvents(), !drained.isEmpty else { return }
+        recoveredToolCallCount += drained.count
+        recoveryEvents.append(contentsOf: drained)
+    }
+
+    private func finishRecoveryStream() -> String? {
+        guard recoveryScanner != nil else { return nil }
+        return processRecoveryOutputs(recoveryScanner!.finish())
     }
 
     // MARK: - Private Methods
@@ -296,6 +419,11 @@ public class ToolCallProcessor {
         case .potentialToolCall, .collectingToolCall, .collectingJSONToolCall:
             toolCallBuffer += chunk
 
+            if toolCallBuffer.utf8.count > maximumToolCallBufferByteCount {
+                rejectOversizedNativeBuffer()
+                return nil
+            }
+
             if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
                 appendToolCall(toolCall, rawText: toolCallBuffer)
                 toolCallBuffer = ""
@@ -318,6 +446,9 @@ public class ToolCallProcessor {
             }
 
             // Still collecting
+            return nil
+
+        case .quarantiningOversizedToolCall:
             return nil
         }
     }
@@ -413,11 +544,10 @@ public class ToolCallProcessor {
         else { return nil }
 
         let startTag = "[TOOL_CALLS]"
-        let argsTag = "[ARGS]"
         var remaining = toolCallBuffer
 
         while remaining.hasPrefix(startTag) {
-            guard let argsRange = remaining.range(of: argsTag) else {
+            guard let brace = remaining.firstIndex(of: "{") else {
                 appendRejectedToolCall(
                     reason: .incompleteOutput,
                     rawText: remaining,
@@ -425,7 +555,7 @@ public class ToolCallProcessor {
                 remaining = ""
                 break
             }
-            let arguments = String(remaining[argsRange.upperBound...])
+            let arguments = String(remaining[brace...])
             guard let split = jsonObjectScanner.splitLeadingObject(from: arguments) else {
                 appendRejectedToolCall(
                     reason: .incompleteOutput,
@@ -435,8 +565,12 @@ public class ToolCallProcessor {
                 break
             }
 
-            let callText = String(remaining[..<argsRange.upperBound]) + split.object
-            if let call = parser.parse(content: callText, tools: tools) {
+            let callEnd = remaining.index(brace, offsetBy: split.object.count)
+            let callText = String(remaining[..<callEnd])
+            if let call = parser.parse(content: callText, tools: tools)
+                ?? recoveryScanner?.recoverCompletePayload(callText)
+            {
+                collectRecoveryEvents()
                 appendToolCall(call, rawText: callText)
             } else {
                 let reason = classifyCompletePayload(callText)
@@ -618,16 +752,28 @@ public class ToolCallProcessor {
             }
 
         case .collectingToolCall:
+            if toolCallBuffer.utf8.count > maximumToolCallBufferByteCount {
+                if !leadingTokenWasRecorded { recordResponse(leadingToken ?? "") }
+                rejectOversizedNativeBuffer()
+                return leadingToken
+            }
+
             guard let endTag = parser.endTag else {
                 return nil
             }
 
-            if toolCallBuffer.contains(endTag) {
-                // Separate the trailing token.
-                let trailingToken = separateToken(
-                    from: &toolCallBuffer, separator: endTag, returnLeading: false)
+            // `<tool_call>` frames close only after a structurally complete
+            // payload, so a literal close marker inside a JSON string argument
+            // cannot truncate the frame and expose its suffix as new input.
+            // Other dialects keep the first textual close their parsers use.
+            let frameEnd =
+                usesStructuralToolCallFrame
+                ? ToolCallFrameScanner.frameEnd(in: toolCallBuffer)
+                : toolCallBuffer.range(of: endTag).map(\.upperBound)
 
-                let bufferedToolCall = toolCallBuffer
+            if let frameEnd {
+                let bufferedToolCall = String(toolCallBuffer[..<frameEnd])
+                let trailingToken = String(toolCallBuffer[frameEnd...])
 
                 // Parse the tool call using the parser.
                 if let toolCall = parser.parse(content: bufferedToolCall, tools: tools) {
@@ -639,16 +785,33 @@ public class ToolCallProcessor {
                     toolCallBuffer = ""
 
                     // If trailing content may contain another tool call, recurse.
-                    if let trailingToken,
-                        tokenCouldContainToolStart(trailingToken, startChar: startChar)
-                    {
+                    if tokenCouldContainToolStart(trailingToken, startChar: startChar) {
                         return combine(leadingToken, processChunk(trailingToken))
                     }
 
                     // Otherwise, return trailing text if non-empty.
-                    let trailingText = trailingToken?.isEmpty ?? true ? nil : trailingToken
+                    let trailingText = trailingToken.isEmpty ? nil : trailingToken
                     if let trailingText { recordResponse(trailingText) }
                     return combine(leadingToken, trailingText)
+                }
+
+                // The native parser owns its advertised syntax. Only after it
+                // declines a complete payload do we try the cross-dialect
+                // healer, preserving the native path and its performance.
+                if let toolCall = recoveryScanner?.recoverCompletePayload(bufferedToolCall) {
+                    if !leadingTokenWasRecorded {
+                        recordResponse(leadingToken ?? "")
+                    }
+                    collectRecoveryEvents()
+                    appendToolCall(toolCall, rawText: bufferedToolCall)
+                    state = .normal
+                    toolCallBuffer = ""
+
+                    if tokenCouldContainToolStart(trailingToken, startChar: startChar) {
+                        return combine(leadingToken, processChunk(trailingToken))
+                    }
+                    if !trailingToken.isEmpty { recordResponse(trailingToken) }
+                    return combine(leadingToken, trailingToken.isEmpty ? nil : trailingToken)
                 }
 
                 // A complete tagged payload is unambiguously intended as a tool
@@ -663,13 +826,11 @@ public class ToolCallProcessor {
                     reason: reason,
                     rawText: bufferedToolCall,
                     detail: reason.diagnosticDetail)
-                if let trailingToken,
-                    tokenCouldContainToolStart(trailingToken, startChar: startChar)
-                {
+                if tokenCouldContainToolStart(trailingToken, startChar: startChar) {
                     return combine(leadingToken, processChunk(trailingToken))
                 }
-                if let trailingToken { recordResponse(trailingToken) }
-                return combine(leadingToken, trailingToken)
+                if !trailingToken.isEmpty { recordResponse(trailingToken) }
+                return combine(leadingToken, trailingToken.isEmpty ? nil : trailingToken)
             }
 
             return nil
@@ -680,6 +841,9 @@ public class ToolCallProcessor {
                 startChar: startChar,
                 leadingToken: leadingToken
             )
+
+        case .quarantiningOversizedToolCall:
+            return nil
         }
     }
 
@@ -819,11 +983,36 @@ public class ToolCallProcessor {
             return
         }
 
+        guard satisfiesDeclaredRequiredArguments(call) else {
+            appendRejectedToolCall(
+                reason: .invalidArguments,
+                rawText: rawText,
+                toolName: call.function.name,
+                callID: call.id,
+                detail: "The tool-call payload omitted one or more required arguments.")
+            return
+        }
+
         let normalized = normalizedToolCall(call)
         toolCalls.append(normalized)
         if orderedOutputEnabled {
             orderedOutputQueue.append(.toolCall(normalized))
         }
+    }
+
+    private func satisfiesDeclaredRequiredArguments(_ call: ToolCall) -> Bool {
+        guard let tools else { return true }
+        for tool in tools {
+            guard let function = tool["function"] as? [String: any Sendable],
+                function["name"] as? String == call.function.name
+            else { continue }
+            guard let parameters = function["parameters"] as? [String: any Sendable],
+                let required = parameters["required"] as? [any Sendable]
+            else { return true }
+            return required.compactMap { $0 as? String }
+                .allSatisfy { call.function.arguments[$0] != nil }
+        }
+        return true
     }
 
     private func appendRejectedToolCall(
@@ -881,7 +1070,20 @@ public class ToolCallProcessor {
                 return .incompleteOutput
             }
             return classifyCompletePayload(text)
+        case .quarantiningOversizedToolCall:
+            return .resourceLimitExceeded
         }
+    }
+
+    private func rejectOversizedNativeBuffer() {
+        let raw = toolCallBuffer
+        toolCallBuffer = ""
+        state = .quarantiningOversizedToolCall
+        hasExplicitInlineMarker = false
+        appendRejectedToolCall(
+            reason: .resourceLimitExceeded,
+            rawText: raw,
+            detail: RejectedToolCall.Reason.resourceLimitExceeded.diagnosticDetail)
     }
 
     private func rejectInlinePayloadIfNeeded(

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -267,11 +267,14 @@ public class ToolCallProcessor {
         let buffered = toolCallBuffer
         let terminalState = state
         var parsedCalls = parser.parseEOS(buffered, tools: tools)
+        let usedRecovery = parsedCalls.isEmpty
         if parsedCalls.isEmpty {
             parsedCalls = recoveryScanner?.recoverEOSPayloads(buffered) ?? []
-            collectRecoveryEvents()
         }
-        appendToolCalls(parsedCalls, rawText: buffered)
+        let acceptedCalls = appendToolCalls(parsedCalls, rawText: buffered)
+        if usedRecovery {
+            collectRecoveryEvents(acceptedCandidates: acceptedCalls)
+        }
 
         let didReject: Bool
         if parsedCalls.isEmpty,
@@ -324,6 +327,7 @@ public class ToolCallProcessor {
         -> String?
     {
         var visible: String?
+        var acceptedCandidates: [Bool] = []
         for output in outputs {
             switch output {
             case .text(let text):
@@ -336,7 +340,7 @@ public class ToolCallProcessor {
                 recordResponse(text)
                 visible = combine(visible, text)
             case .toolCall(let call, let rawText):
-                appendToolCall(call, rawText: rawText)
+                acceptedCandidates.append(appendToolCall(call, rawText: rawText))
             case .rejected(let rawText, let reason, let toolName):
                 appendRejectedToolCall(
                     reason: reason,
@@ -345,15 +349,21 @@ public class ToolCallProcessor {
                     detail: reason.diagnosticDetail)
             }
         }
-        collectRecoveryEvents()
+        collectRecoveryEvents(acceptedCandidates: acceptedCandidates)
         return visible
     }
 
-    /// Moves provenance recorded by the recovery scanner into the public log.
-    private func collectRecoveryEvents() {
+    /// Moves provenance for executable promotions into the public log.
+    /// Candidates rejected by the common authorization/schema boundary are
+    /// rejection telemetry, not successful recoveries.
+    private func collectRecoveryEvents(acceptedCandidates: [Bool]) {
         guard let drained = recoveryScanner?.drainEvents(), !drained.isEmpty else { return }
-        recoveredToolCallCount += drained.count
-        recoveryEvents.append(contentsOf: drained)
+        assert(drained.count == acceptedCandidates.count)
+        let acceptedEvents = zip(drained, acceptedCandidates).compactMap { event, accepted in
+            accepted ? event : nil
+        }
+        recoveredToolCallCount += acceptedEvents.count
+        recoveryEvents.append(contentsOf: acceptedEvents)
     }
 
     private func finishRecoveryStream() -> String? {
@@ -570,8 +580,8 @@ public class ToolCallProcessor {
             if let call = parser.parse(content: callText, tools: tools)
                 ?? recoveryScanner?.recoverCompletePayload(callText)
             {
-                collectRecoveryEvents()
-                appendToolCall(call, rawText: callText)
+                let accepted = appendToolCall(call, rawText: callText)
+                collectRecoveryEvents(acceptedCandidates: [accepted])
             } else {
                 let reason = classifyCompletePayload(callText)
                 appendRejectedToolCall(
@@ -802,8 +812,8 @@ public class ToolCallProcessor {
                     if !leadingTokenWasRecorded {
                         recordResponse(leadingToken ?? "")
                     }
-                    collectRecoveryEvents()
-                    appendToolCall(toolCall, rawText: bufferedToolCall)
+                    let accepted = appendToolCall(toolCall, rawText: bufferedToolCall)
+                    collectRecoveryEvents(acceptedCandidates: [accepted])
                     state = .normal
                     toolCallBuffer = ""
 
@@ -966,13 +976,12 @@ public class ToolCallProcessor {
         return merged.isEmpty ? nil : merged
     }
 
-    private func appendToolCalls(_ calls: [ToolCall], rawText: String) {
-        for call in calls {
-            appendToolCall(call, rawText: rawText)
-        }
+    private func appendToolCalls(_ calls: [ToolCall], rawText: String) -> [Bool] {
+        calls.map { appendToolCall($0, rawText: rawText) }
     }
 
-    private func appendToolCall(_ call: ToolCall, rawText: String) {
+    @discardableResult
+    private func appendToolCall(_ call: ToolCall, rawText: String) -> Bool {
         guard allowedToolNames?.contains(call.function.name) ?? true else {
             appendRejectedToolCall(
                 reason: .undeclaredTool,
@@ -980,37 +989,27 @@ public class ToolCallProcessor {
                 toolName: call.function.name,
                 callID: call.id,
                 detail: RejectedToolCall.Reason.undeclaredTool.diagnosticDetail)
-            return
+            return false
         }
 
-        guard satisfiesDeclaredRequiredArguments(call) else {
+        if case .invalid(let violations) = ToolSchemaValidator.validate(
+            arguments: call.function.arguments,
+            forToolNamed: call.function.name,
+            in: tools)
+        {
             appendRejectedToolCall(
                 reason: .invalidArguments,
                 rawText: rawText,
                 toolName: call.function.name,
                 callID: call.id,
-                detail: "The tool-call payload omitted one or more required arguments.")
-            return
+                detail: ToolSchemaValidator.describe(violations))
+            return false
         }
 
         let normalized = normalizedToolCall(call)
         toolCalls.append(normalized)
         if orderedOutputEnabled {
             orderedOutputQueue.append(.toolCall(normalized))
-        }
-    }
-
-    private func satisfiesDeclaredRequiredArguments(_ call: ToolCall) -> Bool {
-        guard let tools else { return true }
-        for tool in tools {
-            guard let function = tool["function"] as? [String: any Sendable],
-                function["name"] as? String == call.function.name
-            else { continue }
-            guard let parameters = function["parameters"] as? [String: any Sendable],
-                let required = parameters["required"] as? [any Sendable]
-            else { return true }
-            return required.compactMap { $0 as? String }
-                .allSatisfy { call.function.arguments[$0] != nil }
         }
         return true
     }

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -33,6 +33,7 @@ public class ToolCallProcessor {
 
     // MARK: - Properties
 
+    private let validationPolicy: ToolCallValidationPolicy
     private let format: ToolCallFormat
     private let parser: any ToolCallParser
     private let tools: [[String: any Sendable]]?
@@ -95,16 +96,14 @@ public class ToolCallProcessor {
     ///     an empty one, authorizes only the names it declares.
     ///     A nonempty declaration also enables bounded cross-dialect recovery;
     ///     only an exactly declared function name can be promoted by recovery.
-    ///   - recoveryPolicy: Governs cross-dialect recovery. `nil` selects
-    ///     ``ToolCallRecoveryPolicy/conservative``. Recovery only ever runs
-    ///     when a nonempty tool declaration is supplied, and never promotes
-    ///     text inside reasoning spans, Markdown code, ordinary JSON data, or
-    ///     the selected format's own protocol frames.
+    ///   - toolCallPolicy: Recovery and validation rules. Defaults to conservative
+    ///     recovery and strict schema validation; tool-name authorization always applies.
     public init(
         format: ToolCallFormat = .json,
         tools: [[String: any Sendable]]? = nil,
-        recoveryPolicy: ToolCallRecoveryPolicy? = nil
+        toolCallPolicy: ToolCallPolicy = .init()
     ) {
+        self.validationPolicy = toolCallPolicy.validation
         self.format = format
         self.parser = format.createParser()
         self.tools = tools
@@ -114,10 +113,10 @@ public class ToolCallProcessor {
                     (tool["function"] as? [String: any Sendable])?["name"] as? String
                 })
         }
-        self.supportsBareJSONFallback = format == .json
+        self.supportsBareJSONFallback = parser.supportsBareJSON
         self.recoveryScanner = TextToolCallRecoveryScanner(
             primaryFormat: format,
-            policy: recoveryPolicy ?? .conservative,
+            policy: toolCallPolicy.recovery,
             tools: tools,
             allowedToolNames: self.allowedToolNames)
     }
@@ -411,7 +410,7 @@ public class ToolCallProcessor {
                     toolCallBuffer = ""
                     hasExplicitInlineMarker = false
                     let response = rejected ? visibleLeading : visibleLeading + buffered
-                    if !rejected { recordResponse(sanitizingProtocol: buffered) }
+                    if !rejected { recordResponse(buffered) }
                     return response
                 }
 
@@ -451,7 +450,7 @@ public class ToolCallProcessor {
                 toolCallBuffer = ""
                 hasExplicitInlineMarker = false
                 guard !rejected else { return nil }
-                recordResponse(sanitizingProtocol: buffered)
+                recordResponse(buffered)
                 return buffered
             }
 
@@ -955,7 +954,7 @@ public class ToolCallProcessor {
                 combine(rejected ? nil : jsonCandidate, processChunk(trailingToken)))
         }
         let response = (rejected ? "" : jsonCandidate) + trailingToken
-        recordResponse(sanitizingProtocol: response)
+        recordResponse(response)
         return combine(leadingToken, response)
     }
 
@@ -1016,10 +1015,12 @@ public class ToolCallProcessor {
             return false
         }
 
-        if case .invalid(let violations) = ToolSchemaValidator.validate(
-            arguments: call.function.arguments,
-            forToolNamed: call.function.name,
-            in: tools)
+        let call = ToolArgumentNormalization.normalize(call, tools: tools)
+        if validationPolicy == .strict,
+            case .invalid(let violations) = ToolSchemaValidator.validate(
+                arguments: call.function.arguments,
+                forToolNamed: call.function.name,
+                in: tools)
         {
             appendRejectedToolCall(
                 reason: .invalidArguments,

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -97,7 +97,7 @@ public class ToolCallProcessor {
     ///     A nonempty declaration also enables bounded cross-dialect recovery;
     ///     only an exactly declared function name can be promoted by recovery.
     ///   - toolCallPolicy: Recovery and validation rules. Defaults to conservative
-    ///     recovery and strict schema validation; tool-name authorization always applies.
+    ///     recovery and permissive schema validation; tool-name authorization always applies.
     public init(
         format: ToolCallFormat = .json,
         tools: [[String: any Sendable]]? = nil,

--- a/Libraries/MLXLMCommon/Tool/ToolCallRecoveryPolicy.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallRecoveryPolicy.swift
@@ -1,0 +1,99 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Policy governing bounded cross-dialect tool-call recovery.
+///
+/// The selected `ToolCallFormat` parser is always authoritative. Recovery is a
+/// secondary pass that may promote a call written in a *different* common
+/// dialect when the model drifts from the selected one. Because recovery turns
+/// response text into executable actions, it is deliberately conservative:
+/// a missed recovery is preferable to a false execution.
+public enum ToolCallRecoveryPolicy: String, Hashable, Sendable, CaseIterable {
+    /// Only the selected parser may produce calls. No alternate-dialect
+    /// recovery is attempted.
+    case disabled
+
+    /// Recover only structurally complete alternate-dialect calls that appear
+    /// in committed response text — never inside reasoning spans
+    /// (`<think>`/`<thinking>`/`[THINK]`), Markdown code spans or fences, or
+    /// ordinary JSON data — and only when the call names an exactly declared
+    /// tool and satisfies its declared required arguments.
+    ///
+    /// Explicit protocol attempts that are malformed, incomplete at end of
+    /// stream, or undeclared are surfaced as ``RejectedToolCall`` rather than
+    /// leaked as response text. Ambiguous markerless candidates
+    /// (`name[ARGS]{...}`) that fail validation remain response text.
+    case conservative
+
+    /// Everything ``conservative`` does, plus documented end-of-stream repair
+    /// of calls whose outer closing marker is missing while their payload is
+    /// structurally complete. Every repair is recorded in
+    /// ``ToolCallProcessor/recoveryEvents`` with its provenance.
+    case permissive
+}
+
+/// Provenance for a tool call produced by cross-dialect recovery.
+///
+/// Recovery events feed diagnostics and telemetry without changing the
+/// ordinary ``ToolCall`` execution interface.
+public struct ToolCallRecoveryEvent: Hashable, Sendable {
+    /// The textual dialect the model actually emitted.
+    public enum Dialect: String, Hashable, Sendable {
+        /// `<tool_call>{...}</tool_call>` or `<tool_call><function=...>...</tool_call>`.
+        case toolCallFrame = "tool_call_frame"
+        /// `<|tool_call>call:name{...}<tool_call|>`.
+        case gemma4
+        /// `<function=name><parameter=k>v</parameter></function>`.
+        case qwenFunction = "qwen_function"
+        /// `[TOOL_CALLS]name[ARGS]{...}`.
+        case mistral
+        /// Markerless `name[ARGS]{...}` rehearsal syntax.
+        case declaredArgs = "declared_args"
+    }
+
+    /// The repair applied to make the call executable.
+    public enum Repair: String, Hashable, Sendable {
+        /// The payload was structurally complete as emitted; only the dialect
+        /// differed from the selected format.
+        case alternateDialect = "alternate_dialect"
+        /// The outer closing marker was missing at end of stream and the
+        /// structurally complete payload was committed (permissive policy).
+        case missingOuterClose = "missing_outer_close"
+    }
+
+    /// The recovered function name.
+    public let toolName: String
+
+    /// The recovered call identifier, when the dialect carried one.
+    public let callID: String?
+
+    /// The format selected for this generation (the authoritative parser).
+    public let selectedFormat: ToolCallFormat
+
+    /// The dialect the call was actually emitted in.
+    public let dialect: Dialect
+
+    /// The repair that was applied.
+    public let repair: Repair
+
+    /// Whether the call was committed at end of stream rather than from a
+    /// complete in-stream frame.
+    public let wasIncompleteAtEOS: Bool
+
+    public init(
+        toolName: String,
+        callID: String?,
+        selectedFormat: ToolCallFormat,
+        dialect: Dialect,
+        repair: Repair,
+        wasIncompleteAtEOS: Bool
+    ) {
+        self.toolName = toolName
+        self.callID = callID
+        self.selectedFormat = selectedFormat
+        self.dialect = dialect
+        self.repair = repair
+        self.wasIncompleteAtEOS = wasIncompleteAtEOS
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallRecoveryPolicy.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallRecoveryPolicy.swift
@@ -14,22 +14,29 @@ public enum ToolCallRecoveryPolicy: String, Hashable, Sendable, CaseIterable {
     /// recovery is attempted.
     case disabled
 
-    /// Recover only structurally complete alternate-dialect calls that appear
-    /// in committed response text — never inside reasoning spans
-    /// (`<think>`/`<thinking>`/`[THINK]`), Markdown code spans or fences, or
-    /// ordinary JSON data — and only when the call names an exactly declared
-    /// tool and satisfies its declared required arguments.
+    /// Recover only structurally complete alternate-dialect calls that carry
+    /// an explicit protocol marker (`<tool_call>`, `<|tool_call>`,
+    /// `<function=`, `[TOOL_CALLS]`) and appear in committed response text —
+    /// never inside reasoning spans (`<think>`/`<thinking>`/`[THINK]`),
+    /// Markdown code spans or fences, or ordinary JSON data — and only when
+    /// the call names an exactly declared tool and satisfies its declared
+    /// required arguments.
     ///
     /// Explicit protocol attempts that are malformed, incomplete at end of
     /// stream, or undeclared are surfaced as ``RejectedToolCall`` rather than
-    /// leaked as response text. Ambiguous markerless candidates
-    /// (`name[ARGS]{...}`) that fail validation remain response text.
+    /// leaked as response text. Markerless `name[ARGS]{...}` rehearsals are
+    /// never promoted by this policy: without a protocol marker, prose that
+    /// merely mentions a declared call is indistinguishable from an intended
+    /// one.
     case conservative
 
-    /// Everything ``conservative`` does, plus documented end-of-stream repair
-    /// of calls whose outer closing marker is missing while their payload is
-    /// structurally complete. Every repair is recorded in
-    /// ``ToolCallProcessor/recoveryEvents`` with its provenance.
+    /// Everything ``conservative`` does, plus promotion of exact markerless
+    /// `declaredTool[ARGS]{...}` rehearsals in committed response text, and
+    /// documented end-of-stream repair of calls whose outer closing marker is
+    /// missing while their payload is structurally complete. Every promotion
+    /// and repair is recorded in ``ToolCallProcessor/recoveryEvents`` with
+    /// its provenance. Markerless candidates that fail validation remain
+    /// response text.
     case permissive
 }
 
@@ -48,7 +55,8 @@ public struct ToolCallRecoveryEvent: Hashable, Sendable {
         case qwenFunction = "qwen_function"
         /// `[TOOL_CALLS]name[ARGS]{...}`.
         case mistral
-        /// Markerless `name[ARGS]{...}` rehearsal syntax.
+        /// Markerless `name[ARGS]{...}` rehearsal syntax (promoted only under
+        /// ``ToolCallRecoveryPolicy/permissive``).
         case declaredArgs = "declared_args"
     }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallRecoveryPolicy.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallRecoveryPolicy.swift
@@ -19,8 +19,9 @@ public enum ToolCallRecoveryPolicy: String, Hashable, Sendable, CaseIterable {
     /// `<function=`, `[TOOL_CALLS]`) and appear in committed response text —
     /// never inside reasoning spans (`<think>`/`<thinking>`/`[THINK]`),
     /// Markdown code spans or fences, or ordinary JSON data — and only when
-    /// the call names an exactly declared tool and satisfies its declared
-    /// required arguments.
+    /// the call names an exactly declared tool. Argument normalization and
+    /// schema enforcement are governed independently by
+    /// ``ToolCallValidationPolicy``.
     ///
     /// Explicit protocol attempts that are malformed, incomplete at end of
     /// stream, or undeclared are surfaced as ``RejectedToolCall`` rather than

--- a/Libraries/MLXLMCommon/Tool/ToolSchemaValidator.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolSchemaValidator.swift
@@ -1,0 +1,810 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Conservatively checks tool-call arguments against a declared JSON Schema.
+///
+/// Tool schemas may contain vocabularies this package does not implement. An
+/// unsupported assertion must never turn a valid call into a rejection, so an
+/// evaluation has three outcomes:
+///
+/// - ``Result/valid``: every applicable assertion is understood and satisfied;
+/// - ``Result/invalid(_:)``: at least one understood assertion is definitively
+///   violated;
+/// - ``Result/unknown``: no understood assertion is violated, but unsupported
+///   or malformed schema content prevents a proof of validity.
+///
+/// Callers may reject only ``Result/invalid(_:)``. `unknown` deliberately
+/// fails open: schema declarations are trusted configuration, but a partial
+/// validator is not an authority on semantics it does not implement.
+package enum ToolSchemaValidator {
+
+    /// The result of evaluating one value against a schema.
+    package enum Result: Equatable, Sendable {
+        case valid
+        case invalid([Violation])
+        case unknown
+    }
+
+    /// One understood schema assertion that a value did not satisfy.
+    package struct Violation: Hashable, Sendable, CustomStringConvertible {
+        /// The location of the value, for example `arguments.filters.limit`.
+        package let path: String
+
+        /// What the schema requires, for example "must be an integer".
+        package let requirement: String
+
+        package init(path: String, requirement: String) {
+            self.path = path
+            self.requirement = requirement
+        }
+
+        package var description: String { "\(path) \(requirement)" }
+    }
+
+    /// Checks arguments against the `parameters` schema of a tool.
+    ///
+    /// A missing schema declares no constraints and is therefore valid. An
+    /// unsupported assertion returns `unknown`, which executable-call routing
+    /// must accept rather than guess at its meaning.
+    package static func validate(
+        arguments: [String: JSONValue],
+        against parameters: [String: any Sendable]?
+    ) -> Result {
+        guard let parameters else { return .valid }
+        return check(.object(arguments), against: parameters, at: "arguments")
+    }
+
+    /// Finds and evaluates the schema for one declared tool call.
+    package static func validate(
+        arguments: [String: JSONValue],
+        forToolNamed name: String,
+        in tools: [[String: any Sendable]]?
+    ) -> Result {
+        guard let tools else { return .valid }
+        guard let parameters = rawParametersSchema(ofToolNamed: name, in: tools) else {
+            return .valid
+        }
+        return check(.object(arguments), against: parameters, at: "arguments")
+    }
+
+    /// Checks one value against a schema.
+    ///
+    /// Boolean schemas are supported. Any other schema must be a keyword
+    /// object; a different shape is unknown rather than an argument failure.
+    package static func validate(
+        _ value: JSONValue, against schema: Any, at path: String = "$"
+    ) -> Result {
+        check(value, against: schema, at: path)
+    }
+
+    /// Finds the `parameters` schema of a declared tool, if it has one.
+    ///
+    /// Both declaration shapes are supported: the OpenAI envelope
+    /// (`{"function": {"name": ..., "parameters": ...}}`) and the flat
+    /// shape (`{"name": ..., "parameters": ...}`).
+    package static func parametersSchema(
+        ofToolNamed name: String, in tools: [[String: any Sendable]]
+    ) -> [String: any Sendable]? {
+        rawParametersSchema(ofToolNamed: name, in: tools) as? [String: any Sendable]
+    }
+
+    /// Finds the raw declaration so a malformed schema remains distinguishable
+    /// from an absent one at the proof boundary.
+    private static func rawParametersSchema(
+        ofToolNamed name: String, in tools: [[String: any Sendable]]
+    ) -> (any Sendable)? {
+        for tool in tools {
+            if let function = tool["function"] as? [String: any Sendable] {
+                if function["name"] as? String == name {
+                    return function["parameters"]
+                }
+            } else if tool["name"] as? String == name {
+                return tool["parameters"]
+            }
+        }
+        return nil
+    }
+
+    /// Makes a bounded, stable, non-sensitive diagnostic summary.
+    package static func describe(_ violations: [Violation], limit: Int = 3) -> String {
+        guard !violations.isEmpty else { return "" }
+        let limit = max(0, limit)
+        guard limit > 0 else { return "\(violations.count) schema violations" }
+
+        let shown = violations.prefix(limit).map(\.description).joined(separator: "; ")
+        let hidden = violations.count - min(violations.count, limit)
+        let description = hidden > 0 ? "\(shown); and \(hidden) more" : shown
+        guard description.unicodeScalars.count > maximumDescriptionScalarCount else {
+            return description
+        }
+        return String(description.unicodeScalars.prefix(maximumDescriptionScalarCount - 1)) + "…"
+    }
+
+    // MARK: - Core evaluation
+
+    private struct Assessment {
+        var violations: [Violation] = []
+        var containsUnknown = false
+
+        mutating func merge(_ result: Result) {
+            switch result {
+            case .valid:
+                break
+            case .invalid(let incoming):
+                violations.append(contentsOf: incoming)
+            case .unknown:
+                containsUnknown = true
+            }
+        }
+
+        mutating func reject(at path: String, _ requirement: String) {
+            violations.append(Violation(path: path, requirement: requirement))
+        }
+
+        var result: Result {
+            if !violations.isEmpty { return .invalid(violations) }
+            return containsUnknown ? .unknown : .valid
+        }
+    }
+
+    private enum Keyword<Value> {
+        case absent
+        case value(Value)
+        case malformed
+    }
+
+    private static let maximumSchemaDepth = 64
+    private static let maximumDescriptionScalarCount = 512
+
+    private static func check(
+        _ value: JSONValue,
+        against rawSchema: Any,
+        at path: String,
+        depth: Int = 0
+    ) -> Result {
+        guard depth <= maximumSchemaDepth else { return .unknown }
+        if let permitted = strictBoolean(rawSchema) {
+            return permitted
+                ? .valid
+                : .invalid([Violation(path: path, requirement: "is not permitted")])
+        }
+        guard let schema = rawSchema as? [String: any Sendable] else { return .unknown }
+
+        // Before draft 2019-09, `$ref` replaced the schema object and its
+        // siblings were ignored. Without resolving the reference and dialect,
+        // no sibling assertion is a portable proof of rejection.
+        if schema["$ref"] != nil || schema["$dynamicRef"] != nil
+            || schema["$recursiveRef"] != nil
+        {
+            return .unknown
+        }
+
+        var assessment = Assessment()
+        if schema.keys.contains(where: isUnsupportedAssertion) {
+            assessment.containsUnknown = true
+        }
+
+        switch declaredTypes(schema["type"]) {
+        case .absent:
+            break
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(let types):
+            guard types.contains(where: { matchesType(value, $0) }) else {
+                return .invalid([
+                    Violation(path: path, requirement: typeRequirement(types))
+                ])
+            }
+        }
+
+        assessment.merge(checkConst(value, schema["const"], at: path))
+        assessment.merge(checkEnum(value, schema["enum"], at: path))
+
+        switch value {
+        case .object(let object):
+            assessment.merge(checkObject(object, schema, at: path, depth: depth))
+        case .array(let elements):
+            assessment.merge(checkArray(elements, schema, at: path, depth: depth))
+        case .string(let string):
+            assessment.merge(checkString(string, schema, at: path))
+        case .int, .double:
+            assessment.merge(checkNumber(value, schema, at: path))
+        case .null, .bool:
+            break
+        }
+
+        assessment.merge(checkCombinators(value, schema, at: path, depth: depth))
+        return assessment.result
+    }
+
+    // MARK: - Object assertions
+
+    private static func checkObject(
+        _ object: [String: JSONValue],
+        _ schema: [String: any Sendable],
+        at path: String,
+        depth: Int
+    ) -> Result {
+        var assessment = Assessment()
+
+        switch stringArray(schema["required"]) {
+        case .absent:
+            break
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(let required):
+            for key in required.sorted() where object[key] == nil {
+                assessment.reject(at: childPath(path, key), "is required")
+            }
+        }
+
+        let properties: [String: any Sendable]?
+        let propertiesAreMalformed: Bool
+        if let rawProperties = schema["properties"] {
+            properties = rawProperties as? [String: any Sendable]
+            propertiesAreMalformed = properties == nil
+            if propertiesAreMalformed { assessment.containsUnknown = true }
+        } else {
+            properties = nil
+            propertiesAreMalformed = false
+        }
+
+        if let properties {
+            if properties.values.contains(where: { !isSchema($0) }) {
+                assessment.containsUnknown = true
+            }
+            for key in properties.keys.sorted() {
+                guard let member = object[key], let memberSchema = properties[key] else { continue }
+                assessment.merge(
+                    check(
+                        member, against: memberSchema, at: childPath(path, key),
+                        depth: depth + 1))
+            }
+        }
+
+        guard let additional = schema["additionalProperties"] else {
+            return assessment.result
+        }
+        guard !propertiesAreMalformed else { return assessment.result }
+        guard isSchema(additional) else {
+            assessment.containsUnknown = true
+            return assessment.result
+        }
+        // `patternProperties` participates in the definition of an additional
+        // property. Until it is implemented, no key classification is proven.
+        guard schema["patternProperties"] == nil else { return assessment.result }
+
+        let declaredNames = Set(properties?.keys.map { $0 } ?? [])
+        for key in object.keys.sorted() where !declaredNames.contains(key) {
+            let memberPath = childPath(path, key)
+            if let permitted = strictBoolean(additional) {
+                if !permitted {
+                    assessment.reject(at: memberPath, "is not a declared property")
+                }
+            } else {
+                assessment.merge(
+                    check(
+                        object[key]!, against: additional, at: memberPath,
+                        depth: depth + 1))
+            }
+        }
+        return assessment.result
+    }
+
+    // MARK: - Array assertions
+
+    private static func checkArray(
+        _ elements: [JSONValue],
+        _ schema: [String: any Sendable],
+        at path: String,
+        depth: Int
+    ) -> Result {
+        var assessment = Assessment()
+
+        applyCountKeyword(
+            schema["minItems"], actual: elements.count, at: path, unit: "items",
+            bound: .minimum, assessment: &assessment)
+        applyCountKeyword(
+            schema["maxItems"], actual: elements.count, at: path, unit: "items",
+            bound: .maximum, assessment: &assessment)
+
+        switch booleanKeyword(schema["uniqueItems"]) {
+        case .absent, .value(false):
+            break
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(true):
+            var comparableElements: Set<ComparableJSON> = []
+            comparableElements.reserveCapacity(elements.count)
+            for element in elements {
+                guard let comparable = comparable(element) else {
+                    assessment.containsUnknown = true
+                    comparableElements.removeAll(keepingCapacity: true)
+                    break
+                }
+                if !comparableElements.insert(comparable).inserted {
+                    assessment.reject(at: path, "must not contain duplicate items")
+                    break
+                }
+            }
+        }
+
+        if let items = schema["items"] {
+            if schema["prefixItems"] != nil {
+                // In draft 2020-12, `items` applies only after `prefixItems`.
+                // Applying it to every element could manufacture a violation.
+                assessment.containsUnknown = true
+            } else if items is [Any] {
+                // The pre-2020 tuple form has positional semantics that the
+                // single-schema implementation cannot safely approximate.
+                assessment.containsUnknown = true
+            } else if !isSchema(items) {
+                assessment.containsUnknown = true
+            } else {
+                for (index, element) in elements.enumerated() {
+                    assessment.merge(
+                        check(
+                            element, against: items, at: "\(path)[\(index)]",
+                            depth: depth + 1))
+                }
+            }
+        }
+        return assessment.result
+    }
+
+    private enum CountBound {
+        case minimum
+        case maximum
+    }
+
+    private static func applyCountKeyword(
+        _ rawLimit: Any?,
+        actual: Int,
+        at path: String,
+        unit: String,
+        bound: CountBound,
+        assessment: inout Assessment
+    ) {
+        switch nonNegativeInteger(rawLimit) {
+        case .absent:
+            return
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(let limit):
+            let violated =
+                switch bound {
+                case .minimum: actual < limit
+                case .maximum: actual > limit
+                }
+            guard violated else { return }
+            let word =
+                switch bound {
+                case .minimum: "least"
+                case .maximum: "most"
+                }
+            assessment.reject(
+                at: path,
+                countRequirement(unit, limit, word))
+        }
+    }
+
+    // MARK: - String assertions
+
+    private static func checkString(
+        _ string: String, _ schema: [String: any Sendable], at path: String
+    ) -> Result {
+        var assessment = Assessment()
+        // JSON Schema defines string length in Unicode code points. Swift's
+        // `String.count` counts extended grapheme clusters instead.
+        let length = string.unicodeScalars.count
+        applyCountKeyword(
+            schema["minLength"], actual: length, at: path, unit: "characters",
+            bound: .minimum, assessment: &assessment)
+        applyCountKeyword(
+            schema["maxLength"], actual: length, at: path, unit: "characters",
+            bound: .maximum, assessment: &assessment)
+        return assessment.result
+    }
+
+    // MARK: - Numeric assertions
+
+    private static func checkNumber(
+        _ value: JSONValue, _ schema: [String: any Sendable], at path: String
+    ) -> Result {
+        guard let number = comparableNumber(value) else { return .unknown }
+        var assessment = Assessment()
+
+        let minimum = numericKeyword(schema["minimum"])
+        let maximum = numericKeyword(schema["maximum"])
+        let exclusiveMinimum = exclusiveBound(schema["exclusiveMinimum"])
+        let exclusiveMaximum = exclusiveBound(schema["exclusiveMaximum"])
+
+        if case .malformed = minimum { assessment.containsUnknown = true }
+        if case .malformed = maximum { assessment.containsUnknown = true }
+        if case .malformed = exclusiveMinimum { assessment.containsUnknown = true }
+        if case .malformed = exclusiveMaximum { assessment.containsUnknown = true }
+
+        let draft4LowerExclusive = exclusiveMinimum == .boolean(true)
+        let draft4UpperExclusive = exclusiveMaximum == .boolean(true)
+
+        if case .value(let lower) = minimum {
+            let violated = number < lower || (draft4LowerExclusive && number == lower)
+            if violated {
+                assessment.reject(
+                    at: path,
+                    draft4LowerExclusive
+                        ? "must be greater than \(format(lower))"
+                        : "must be at least \(format(lower))")
+            }
+        } else if draft4LowerExclusive {
+            assessment.containsUnknown = true
+        }
+
+        if case .number(let lower) = exclusiveMinimum, number <= lower {
+            assessment.reject(at: path, "must be greater than \(format(lower))")
+        }
+
+        if case .value(let upper) = maximum {
+            let violated = number > upper || (draft4UpperExclusive && number == upper)
+            if violated {
+                assessment.reject(
+                    at: path,
+                    draft4UpperExclusive
+                        ? "must be less than \(format(upper))"
+                        : "must be at most \(format(upper))")
+            }
+        } else if draft4UpperExclusive {
+            assessment.containsUnknown = true
+        }
+
+        if case .number(let upper) = exclusiveMaximum, number >= upper {
+            assessment.reject(at: path, "must be less than \(format(upper))")
+        }
+
+        return assessment.result
+    }
+
+    private enum ExclusiveBound: Equatable {
+        case absent
+        case boolean(Bool)
+        case number(Decimal)
+        case malformed
+    }
+
+    private static func exclusiveBound(_ value: Any?) -> ExclusiveBound {
+        guard let value else { return .absent }
+        if let boolean = strictBoolean(value) { return .boolean(boolean) }
+        guard let number = comparableNumber(value) else { return .malformed }
+        return .number(number)
+    }
+
+    // MARK: - Equality assertions
+
+    private static func checkConst(_ value: JSONValue, _ rawConstant: Any?, at path: String)
+        -> Result
+    {
+        guard let rawConstant else { return .valid }
+        guard let value = comparable(value), let constant = comparable(rawConstant) else {
+            return .unknown
+        }
+        return value == constant
+            ? .valid
+            : .invalid([
+                Violation(path: path, requirement: "must equal the declared constant")
+            ])
+    }
+
+    private static func checkEnum(_ value: JSONValue, _ rawAllowed: Any?, at path: String)
+        -> Result
+    {
+        guard let rawAllowed else { return .valid }
+        guard let allowed = rawAllowed as? [Any], !allowed.isEmpty,
+            let comparableValue = comparable(value)
+        else { return .unknown }
+
+        var comparableAllowed: [ComparableJSON] = []
+        comparableAllowed.reserveCapacity(allowed.count)
+        for candidate in allowed {
+            guard let comparableCandidate = comparable(candidate) else { return .unknown }
+            // Duplicate enum members make the schema malformed.
+            guard !comparableAllowed.contains(comparableCandidate) else { return .unknown }
+            comparableAllowed.append(comparableCandidate)
+        }
+        if comparableAllowed.contains(comparableValue) { return .valid }
+        return .invalid([
+            Violation(path: path, requirement: "must be one of the allowed values")
+        ])
+    }
+
+    private indirect enum ComparableJSON: Hashable {
+        case null
+        case bool(Bool)
+        case number(Decimal)
+        case string(String)
+        case array([ComparableJSON])
+        case object([String: ComparableJSON])
+    }
+
+    private static func comparable(_ value: JSONValue) -> ComparableJSON? {
+        switch value {
+        case .null: .null
+        case .bool(let value): .bool(value)
+        case .int, .double:
+            comparableNumber(value).map(ComparableJSON.number)
+        case .string(let value): .string(value)
+        case .array(let values):
+            sequence(values.map(comparable)).map(ComparableJSON.array)
+        case .object(let values):
+            sequence(values.mapValues(comparable)).map(ComparableJSON.object)
+        }
+    }
+
+    private static func comparable(_ value: Any) -> ComparableJSON? {
+        if value is NSNull { return .null }
+        if let value = strictBoolean(value) { return .bool(value) }
+        if let value = value as? String { return .string(value) }
+        if let values = value as? [Any] {
+            return sequence(values.map(comparable)).map(ComparableJSON.array)
+        }
+        if let values = value as? [String: Any] {
+            return sequence(values.mapValues(comparable)).map(ComparableJSON.object)
+        }
+        return comparableNumber(value).map(ComparableJSON.number)
+    }
+
+    private static func sequence<T>(_ values: [T?]) -> [T]? {
+        var result: [T] = []
+        result.reserveCapacity(values.count)
+        for value in values {
+            guard let value else { return nil }
+            result.append(value)
+        }
+        return result
+    }
+
+    private static func sequence<T>(_ values: [String: T?]) -> [String: T]? {
+        var result: [String: T] = [:]
+        result.reserveCapacity(values.count)
+        for (key, value) in values {
+            guard let value else { return nil }
+            result[key] = value
+        }
+        return result
+    }
+
+    // MARK: - Combinators
+
+    private static func checkCombinators(
+        _ value: JSONValue,
+        _ schema: [String: any Sendable],
+        at path: String,
+        depth: Int
+    ) -> Result {
+        var assessment = Assessment()
+
+        switch schemaArray(schema["allOf"]) {
+        case .absent:
+            break
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(let schemas):
+            for subschema in schemas {
+                assessment.merge(
+                    check(value, against: subschema, at: path, depth: depth + 1))
+            }
+        }
+
+        switch schemaArray(schema["anyOf"]) {
+        case .absent:
+            break
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(let schemas):
+            let results = schemas.map {
+                check(value, against: $0, at: path, depth: depth + 1)
+            }
+            if results.contains(.valid) {
+                break
+            } else if results.contains(.unknown) {
+                assessment.containsUnknown = true
+            } else {
+                assessment.reject(at: path, "must satisfy at least one of the allowed schemas")
+            }
+        }
+
+        switch schemaArray(schema["oneOf"]) {
+        case .absent:
+            break
+        case .malformed:
+            assessment.containsUnknown = true
+        case .value(let schemas):
+            let results = schemas.map {
+                check(value, against: $0, at: path, depth: depth + 1)
+            }
+            let validCount = results.count { $0 == .valid }
+            let containsUnknown = results.contains(.unknown)
+
+            if validCount > 1 || (validCount == 0 && !containsUnknown) {
+                assessment.reject(at: path, "must satisfy exactly one of the allowed schemas")
+            } else if containsUnknown {
+                assessment.containsUnknown = true
+            }
+        }
+
+        return assessment.result
+    }
+
+    // MARK: - Schema extraction
+
+    private static let supportedTypes: Set<String> = [
+        "null", "boolean", "string", "object", "array", "number", "integer",
+    ]
+
+    private static let supportedKeywords: Set<String> = [
+        "type", "properties", "required", "additionalProperties", "items",
+        "minItems", "maxItems", "uniqueItems", "minLength", "maxLength",
+        "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "enum",
+        "const", "anyOf", "oneOf", "allOf",
+    ]
+
+    /// Keywords that carry annotations or reusable schema definitions but do
+    /// not assert anything about the current instance by themselves.
+    private static let annotationKeywords: Set<String> = [
+        "$schema", "$id", "$anchor", "$dynamicAnchor", "$comment", "$defs",
+        "definitions", "title", "description", "default", "examples", "deprecated",
+        "readOnly", "writeOnly", "contentEncoding", "contentMediaType", "contentSchema",
+    ]
+
+    private static func isUnsupportedAssertion(_ key: String) -> Bool {
+        !supportedKeywords.contains(key)
+            && !annotationKeywords.contains(key)
+            && !key.hasPrefix("x-")
+    }
+
+    private static func declaredTypes(_ value: Any?) -> Keyword<[String]> {
+        guard let value else { return .absent }
+        let types: [String]
+        if let single = value as? String {
+            types = [single]
+        } else if let list = value as? [Any], !list.isEmpty,
+            list.allSatisfy({ $0 is String })
+        {
+            types = list.map { $0 as! String }
+        } else {
+            return .malformed
+        }
+        guard types.allSatisfy(supportedTypes.contains), Set(types).count == types.count else {
+            return .malformed
+        }
+        return .value(types)
+    }
+
+    private static func stringArray(_ value: Any?) -> Keyword<[String]> {
+        guard let value else { return .absent }
+        guard let list = value as? [Any], list.allSatisfy({ $0 is String }) else {
+            return .malformed
+        }
+        let strings = list.map { $0 as! String }
+        guard Set(strings).count == strings.count else { return .malformed }
+        return .value(strings)
+    }
+
+    private static func schemaArray(_ value: Any?) -> Keyword<[Any]> {
+        guard let value else { return .absent }
+        guard let schemas = value as? [Any], !schemas.isEmpty else { return .malformed }
+        return .value(schemas)
+    }
+
+    private static func booleanKeyword(_ value: Any?) -> Keyword<Bool> {
+        guard let value else { return .absent }
+        return strictBoolean(value).map(Keyword.value) ?? .malformed
+    }
+
+    private static func isSchema(_ value: Any) -> Bool {
+        strictBoolean(value) != nil || value is [String: any Sendable]
+    }
+
+    private static func numericKeyword(_ value: Any?) -> Keyword<Decimal> {
+        guard let value else { return .absent }
+        return comparableNumber(value).map(Keyword.value) ?? .malformed
+    }
+
+    private static func nonNegativeInteger(_ value: Any?) -> Keyword<Int> {
+        guard let value else { return .absent }
+        guard strictBoolean(value) == nil else { return .malformed }
+        if let value = value as? Int {
+            return value >= 0 ? .value(value) : .malformed
+        }
+        guard let boxed = value as? NSNumber else { return .malformed }
+        if let value = boxed as? Int {
+            return value >= 0 ? .value(value) : .malformed
+        }
+        let doubleValue = boxed.doubleValue
+        guard doubleValue.isFinite, doubleValue >= 0,
+            doubleValue.rounded() == doubleValue,
+            doubleValue < Double(Int.max)
+        else { return .malformed }
+        return .value(Int(doubleValue))
+    }
+
+    /// A Boolean only when the value really is a Boolean. A boxed `0` or `1`
+    /// from `JSONSerialization` must not pass as one.
+    private static func strictBoolean(_ value: Any) -> Bool? {
+        if let boxed = value as? NSNumber {
+            return CFGetTypeID(boxed) == CFBooleanGetTypeID() ? boxed.boolValue : nil
+        }
+        return value as? Bool
+    }
+
+    private static func comparableNumber(_ value: JSONValue) -> Decimal? {
+        switch value {
+        case .int(let value):
+            return Decimal(value)
+        case .double(let value):
+            guard value.isFinite else { return nil }
+            var decimal = Decimal(value)
+            return NSDecimalIsNotANumber(&decimal) ? nil : decimal
+        default:
+            return nil
+        }
+    }
+
+    private static func comparableNumber(_ value: Any) -> Decimal? {
+        guard strictBoolean(value) == nil else { return nil }
+        if let value = value as? Decimal { return value }
+        guard let boxed = value as? NSNumber else { return nil }
+        var decimal = boxed.decimalValue
+        return NSDecimalIsNotANumber(&decimal) ? nil : decimal
+    }
+
+    // MARK: - Messages and paths
+
+    private static func matchesType(_ value: JSONValue, _ type: String) -> Bool {
+        switch (value, type) {
+        case (.null, "null"), (.bool, "boolean"), (.string, "string"),
+            (.object, "object"), (.array, "array"),
+            (.int, "number"), (.double, "number"), (.int, "integer"):
+            true
+        case (.double(let value), "integer"):
+            value.isFinite && value.rounded() == value
+        default:
+            false
+        }
+    }
+
+    private static func typeRequirement(_ types: [String]) -> String {
+        guard types.count > 1 else {
+            let type = types[0]
+            if type == "null" { return "must be null" }
+            let vowels: Set<Character> = ["a", "e", "i", "o", "u"]
+            let article = type.first.map(vowels.contains) == true ? "an" : "a"
+            return "must be \(article) \(type)"
+        }
+        return "must be one of these types: \(types.joined(separator: ", "))"
+    }
+
+    private static func countRequirement(_ unit: String, _ limit: Int, _ bound: String)
+        -> String
+    {
+        "must have at \(bound) \(limit) \(limit == 1 ? String(unit.dropLast()) : unit)"
+    }
+
+    private static func format(_ number: Decimal) -> String {
+        NSDecimalNumber(decimal: number).stringValue
+    }
+
+    private static func childPath(_ path: String, _ key: String) -> String {
+        let identifierStart = CharacterSet.letters.union(CharacterSet(charactersIn: "_"))
+        let identifierBody = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+        guard let first = key.unicodeScalars.first, identifierStart.contains(first),
+            key.unicodeScalars.dropFirst().allSatisfy(identifierBody.contains)
+        else {
+            guard let data = try? JSONEncoder().encode(key),
+                let quoted = String(data: data, encoding: .utf8)
+            else { return "\(path)[<unrepresentable key>]" }
+            return "\(path)[\(quoted)]"
+        }
+        return "\(path).\(key)"
+    }
+}

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -961,6 +961,26 @@ public class ChatSessionTests: XCTestCase {
         XCTAssertTrue(chunks.isEmpty)
     }
 
+    func testStreamDetailsReportsRecoveredToolCallCount() async throws {
+        let tools: [ToolSpec] = [
+            ["function": ["name": "weather"] as [String: any Sendable]]
+        ]
+        let session = rejectionSession(
+            output: "<function=weather><parameter=city>Paris</parameter></function>",
+            tools: tools)
+        var call: ToolCall?
+        var info: GenerateCompletionInfo?
+
+        for try await event in session.streamDetails(to: "trigger") {
+            if let value = event.toolCall { call = value }
+            if let value = event.info { info = value }
+        }
+
+        XCTAssertEqual(call?.function.name, "weather")
+        XCTAssertEqual(info?.recoveredToolCallCount, 1)
+        XCTAssertEqual(info?.rejectedToolCallCount, 0)
+    }
+
     func testTextStreamThrowsRejectedToolCallError() async throws {
         let session = rejectionSession(output: #"<tool_call>{"#)
 
@@ -1018,6 +1038,24 @@ public class ChatSessionTests: XCTestCase {
             XCTFail("Expected RejectedToolCallError")
         } catch let error as RejectedToolCallError {
             XCTAssertEqual(error.rejection.reason, .incompleteOutput)
+        }
+        XCTAssertEqual(dispatchCount.value, 0)
+    }
+
+    func testToolDispatchWithoutSchemasFailsClosed() async throws {
+        let dispatchCount = CallCounter()
+        let session = rejectionSession(
+            output: #"<tool_call>{"name":"undeclared","arguments":{}}</tool_call>"#,
+            toolDispatch: { _ in
+                dispatchCount.increment()
+                return "should not execute"
+            })
+
+        do {
+            for try await _ in session.streamDetails(to: "trigger") {}
+            XCTFail("Expected RejectedToolCallError")
+        } catch let error as RejectedToolCallError {
+            XCTAssertEqual(error.rejection.reason, .undeclaredTool)
         }
         XCTAssertEqual(dispatchCount.value, 0)
     }

--- a/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
+++ b/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
@@ -236,11 +236,11 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
             let context = Self.makeContext(
                 tokenizer: ScriptedToolCallTokenizer(),
                 messageGenerator: DefaultMessageGenerator())
+            var policy = ToolCallPolicy(recovery: .disabled)
+            if validation == .strict { policy.validation = .strict }
             let session = ChatSession(
                 context,
-                generateParameters: .init(
-                    maxTokens: 24,
-                    toolCallPolicy: .init(recovery: .disabled, validation: validation)),
+                generateParameters: .init(maxTokens: 24, toolCallPolicy: policy),
                 tools: [restrictedTool],
                 toolDispatch: { call in
                     dispatched.record(call)

--- a/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
+++ b/Tests/MLXLMTests/ChatSessionToolRoundTripTests.swift
@@ -217,6 +217,48 @@ public class ChatSessionToolRoundTripTests: XCTestCase {
         XCTAssertEqual(function["name"] as? String, "get_weather")
     }
 
+    func testGenerationPolicyControlsValidationBeforeAutomaticDispatch() async throws {
+        let restrictedTool: ToolSpec = [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "city": ["type": "string", "enum": ["Rome"]] as [String: any Sendable]
+                    ],
+                    "required": ["city"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        for validation in ToolCallValidationPolicy.allCases {
+            let dispatched = DispatchLog()
+            let context = Self.makeContext(
+                tokenizer: ScriptedToolCallTokenizer(),
+                messageGenerator: DefaultMessageGenerator())
+            let session = ChatSession(
+                context,
+                generateParameters: .init(
+                    maxTokens: 24,
+                    toolCallPolicy: .init(recovery: .disabled, validation: validation)),
+                tools: [restrictedTool],
+                toolDispatch: { call in
+                    dispatched.record(call)
+                    return "sunny"
+                })
+            do {
+                _ = try await session.respond(to: "Weather in Paris?")
+                XCTAssertEqual(validation, .permissive)
+                XCTAssertEqual(dispatched.all.count, 1)
+                XCTAssertEqual(dispatched.all.first?.function.arguments["city"], .string("Paris"))
+            } catch let error as RejectedToolCallError {
+                XCTAssertEqual(validation, .strict)
+                XCTAssertEqual(error.rejection.reason, .invalidArguments)
+                XCTAssertTrue(dispatched.all.isEmpty)
+            }
+        }
+    }
+
     func testRawCacheToolRestartPreservesLegacyFragmentShape() async throws {
         let log = MessageLog()
         let tokenizer = ScriptedToolCallTokenizer(

--- a/Tests/MLXLMTests/HarmonyOutputRouterTests.swift
+++ b/Tests/MLXLMTests/HarmonyOutputRouterTests.swift
@@ -177,6 +177,61 @@ struct HarmonyOutputRouterTests {
         #expect(events.compactMap(\.response).joined() == "plan stepsdone")
     }
 
+    @Test("arguments that violate the declared schema are rejected")
+    func schemaViolationRejected() throws {
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "get_weather",
+                    "parameters": [
+                        "type": "object",
+                        "properties": ["city": ["type": "string"]],
+                        "required": ["city"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let events = try route(
+            [
+                "<|channel|>", "commentary to=functions.get_weather",
+                "<|message|>", #"{"city":3}"#, "<|call|>",
+            ],
+            tools: tools)
+
+        #expect(events.compactMap(\.toolCall).isEmpty)
+        let rejection = try #require(events.compactMap(\.rejectedToolCall).first)
+        #expect(rejection.reason == .invalidArguments)
+        #expect(rejection.toolName == "get_weather")
+        #expect(rejection.detail == "arguments.city must be a string")
+    }
+
+    @Test("unsupported schema assertions cannot reject a Harmony call")
+    func unsupportedSchemaAssertionFailsOpen() throws {
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "submit",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "code": ["type": "string", "pattern": "^[0-9]+$"]
+                                as [String: any Sendable]
+                        ],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let events = try route(
+            [
+                "<|channel|>", "commentary to=functions.submit",
+                "<|message|>", #"{"code":"not-digits"}"#, "<|call|>",
+            ],
+            tools: tools)
+
+        #expect(events.compactMap(\.toolCall).map(\.function.name) == ["submit"])
+        #expect(events.compactMap(\.rejectedToolCall).isEmpty)
+    }
+
     @Test("stream adapter surfaces and counts Harmony rejections")
     func adapterSurfacesAndCountsRejections() throws {
         let pieces = [
@@ -238,9 +293,19 @@ extension HarmonyOutputRouter.Event {
 }
 
 private func route(_ pieces: [String], allowed: Set<String>) throws -> [HarmonyOutputRouter.Event] {
+    try route(
+        pieces,
+        tools: allowed.map { name in
+            ["function": ["name": name] as [String: any Sendable]]
+        })
+}
+
+private func route(_ pieces: [String], tools: [[String: any Sendable]]) throws
+    -> [HarmonyOutputRouter.Event]
+{
     let tokenizer = RouterDeterministicTokenizer(tokens: pieces + routerControlTokens)
     var parser = try #require(HarmonyFrameParser(tokenizer: tokenizer))
-    var router = HarmonyOutputRouter(tokenizer: tokenizer, allowedToolNames: allowed)
+    var router = HarmonyOutputRouter(tokenizer: tokenizer, tools: tools)
     var events: [HarmonyOutputRouter.Event] = []
     for piece in pieces {
         let id = try #require(tokenizer.convertTokenToId(piece))

--- a/Tests/MLXLMTests/HarmonyOutputRouterTests.swift
+++ b/Tests/MLXLMTests/HarmonyOutputRouterTests.swift
@@ -205,6 +205,31 @@ struct HarmonyOutputRouterTests {
         #expect(rejection.detail == "arguments.city must be a string")
     }
 
+    @Test("Harmony normalizes arguments before independently applying validation")
+    func normalizationAndValidationPolicy() throws {
+        let parameters: [String: any Sendable] = [
+            "type": "object", "properties": ["count": ["type": "integer"]],
+        ]
+        let tools: [[String: any Sendable]] = [
+            ["function": ["name": "search", "parameters": parameters] as [String: any Sendable]]
+        ]
+        for policy in ToolCallValidationPolicy.allCases {
+            for (text, expected): (String, JSONValue?) in [
+                ("6", .int(6)), ("six", policy == .strict ? nil : .string("six")),
+            ] {
+                let events = try route(
+                    [
+                        "<|channel|>", "commentary to=functions.search", "<|message|>",
+                        "{\"count\":\"\(text)\"}", "<|call|>",
+                    ],
+                    tools: tools, toolCallPolicy: .init(validation: policy))
+                #expect(
+                    events.compactMap(\.toolCall).first?.function.arguments["count"] == expected)
+                #expect(events.compactMap(\.rejectedToolCall).count == (expected == nil ? 1 : 0))
+            }
+        }
+    }
+
     @Test("unsupported schema assertions cannot reject a Harmony call")
     func unsupportedSchemaAssertionFailsOpen() throws {
         let tools: [[String: any Sendable]] = [
@@ -300,12 +325,16 @@ private func route(_ pieces: [String], allowed: Set<String>) throws -> [HarmonyO
         })
 }
 
-private func route(_ pieces: [String], tools: [[String: any Sendable]]) throws
+private func route(
+    _ pieces: [String], tools: [[String: any Sendable]],
+    toolCallPolicy: ToolCallPolicy = .init()
+) throws
     -> [HarmonyOutputRouter.Event]
 {
     let tokenizer = RouterDeterministicTokenizer(tokens: pieces + routerControlTokens)
     var parser = try #require(HarmonyFrameParser(tokenizer: tokenizer))
-    var router = HarmonyOutputRouter(tokenizer: tokenizer, tools: tools)
+    var router = HarmonyOutputRouter(
+        tokenizer: tokenizer, tools: tools, toolCallPolicy: toolCallPolicy)
     var events: [HarmonyOutputRouter.Event] = []
     for piece in pieces {
         let id = try #require(tokenizer.convertTokenToId(piece))

--- a/Tests/MLXLMTests/HarmonyOutputRouterTests.swift
+++ b/Tests/MLXLMTests/HarmonyOutputRouterTests.swift
@@ -196,7 +196,7 @@ struct HarmonyOutputRouterTests {
                 "<|channel|>", "commentary to=functions.get_weather",
                 "<|message|>", #"{"city":3}"#, "<|call|>",
             ],
-            tools: tools)
+            tools: tools, toolCallPolicy: .init(validation: .strict))
 
         #expect(events.compactMap(\.toolCall).isEmpty)
         let rejection = try #require(events.compactMap(\.rejectedToolCall).first)
@@ -222,7 +222,8 @@ struct HarmonyOutputRouterTests {
                         "<|channel|>", "commentary to=functions.search", "<|message|>",
                         "{\"count\":\"\(text)\"}", "<|call|>",
                     ],
-                    tools: tools, toolCallPolicy: .init(validation: policy))
+                    tools: tools,
+                    toolCallPolicy: policy == .strict ? .init(validation: .strict) : .init())
                 #expect(
                     events.compactMap(\.toolCall).first?.function.arguments["count"] == expected)
                 #expect(events.compactMap(\.rejectedToolCall).count == (expected == nil ? 1 : 0))
@@ -251,7 +252,7 @@ struct HarmonyOutputRouterTests {
                 "<|channel|>", "commentary to=functions.submit",
                 "<|message|>", #"{"code":"not-digits"}"#, "<|call|>",
             ],
-            tools: tools)
+            tools: tools, toolCallPolicy: .init(validation: .strict))
 
         #expect(events.compactMap(\.toolCall).map(\.function.name) == ["submit"])
         #expect(events.compactMap(\.rejectedToolCall).isEmpty)

--- a/Tests/MLXLMTests/MuseGlimmerTests.swift
+++ b/Tests/MLXLMTests/MuseGlimmerTests.swift
@@ -1217,6 +1217,55 @@ struct MuseGlimmerAgenticProtocolTests {
         #expect(answer == [.response("sunny")])
     }
 
+    @Test("Onyx rejects proven schema violations and counts them")
+    func onyxSchemaViolationIsCounted() throws {
+        let tokenizer = OnyxTestTokenizer()
+        let boundedTools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "weather.get",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "days": ["type": "integer", "maximum": 5]
+                                as [String: any Sendable]
+                        ],
+                        "required": ["days"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        var decoder = try #require(
+            ToolCallFormat.atem.makeProtocolTokenStreamDecoder(
+                tokenizer: tokenizer, tools: boundedTools, stopStrings: []))
+        let payload =
+            "<atem:function_calls><atem:invoke name=\"weather.get\">"
+            + "<atem:parameter name=\"days\">6</atem:parameter>"
+            + "</atem:invoke></atem:function_calls>"
+        let tokens = [
+            tokenizer.id(" to=weather.get"), tokenizer.message,
+            tokenizer.id(payload), tokenizer.eot,
+        ]
+        var events: [TokenStreamEvent] = []
+        for token in tokens {
+            _ = decoder.push(token) {
+                events.append($0)
+                return true
+            }
+        }
+
+        #expect(!events.contains { if case .toolCall = $0 { true } else { false } })
+        let rejection = try #require(
+            events.compactMap { event -> RejectedToolCall? in
+                if case .rejectedToolCall(let rejection) = event { return rejection }
+                return nil
+            }.first)
+        #expect(rejection.reason == .invalidArguments)
+        #expect(rejection.toolName == "weather.get")
+        #expect(rejection.detail == "arguments.days must be at most 5")
+        #expect(decoder.rejectedToolCallCount == 1)
+    }
+
     @Test("Onyx decoder emits distinct IDs for consecutive tool frames")
     func consecutiveToolFrames() throws {
         let tokenizer = OnyxTestTokenizer()

--- a/Tests/MLXLMTests/MuseGlimmerTests.swift
+++ b/Tests/MLXLMTests/MuseGlimmerTests.swift
@@ -1217,8 +1217,10 @@ struct MuseGlimmerAgenticProtocolTests {
         #expect(answer == [.response("sunny")])
     }
 
-    @Test("Onyx rejects proven schema violations and counts them")
-    func onyxSchemaViolationIsCounted() throws {
+    @Test(
+        "Onyx applies the selected validation policy and counts rejections",
+        arguments: ToolCallValidationPolicy.allCases)
+    func onyxSchemaViolationIsCounted(policy: ToolCallValidationPolicy) throws {
         let tokenizer = OnyxTestTokenizer()
         let boundedTools: [[String: any Sendable]] = [
             [
@@ -1237,10 +1239,12 @@ struct MuseGlimmerAgenticProtocolTests {
         ]
         var decoder = try #require(
             ToolCallFormat.atem.makeProtocolTokenStreamDecoder(
-                tokenizer: tokenizer, tools: boundedTools, stopStrings: []))
+                tokenizer: tokenizer, tools: boundedTools, stopStrings: [],
+                toolCallPolicy: .init(validation: policy)
+            ))
         let payload =
             "<atem:function_calls><atem:invoke name=\"weather.get\">"
-            + "<atem:parameter name=\"days\">6</atem:parameter>"
+            + "<atem:parameter name=\"days\">6.0</atem:parameter>"
             + "</atem:invoke></atem:function_calls>"
         let tokens = [
             tokenizer.id(" to=weather.get"), tokenizer.message,
@@ -1254,6 +1258,16 @@ struct MuseGlimmerAgenticProtocolTests {
             }
         }
 
+        if policy == .permissive {
+            let calls = events.compactMap { event -> ToolCall? in
+                if case .toolCall(let call) = event { return call }
+                return nil
+            }
+            #expect(calls.count == 1)
+            #expect(calls.first?.function.arguments["days"] == .int(6))
+            #expect(decoder.rejectedToolCallCount == 0)
+            return
+        }
         #expect(!events.contains { if case .toolCall = $0 { true } else { false } })
         let rejection = try #require(
             events.compactMap { event -> RejectedToolCall? in

--- a/Tests/MLXLMTests/MuseGlimmerTests.swift
+++ b/Tests/MLXLMTests/MuseGlimmerTests.swift
@@ -1240,7 +1240,7 @@ struct MuseGlimmerAgenticProtocolTests {
         var decoder = try #require(
             ToolCallFormat.atem.makeProtocolTokenStreamDecoder(
                 tokenizer: tokenizer, tools: boundedTools, stopStrings: [],
-                toolCallPolicy: .init(validation: policy)
+                toolCallPolicy: policy == .strict ? .init(validation: .strict) : .init()
             ))
         let payload =
             "<atem:function_calls><atem:invoke name=\"weather.get\">"

--- a/Tests/MLXLMTests/ParameterCoercionTests.swift
+++ b/Tests/MLXLMTests/ParameterCoercionTests.swift
@@ -1,0 +1,144 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Schema-driven conversion of textual XML parameter values must agree with
+/// what `ToolSchemaValidator` later judges. A value that the declared schema
+/// can only accept as a non-string type has to be converted before
+/// validation, or a healable call is wrongly rejected.
+@Suite("XML parameter value coercion")
+struct ParameterCoercionTests {
+    private static func envelopeTools(
+        parameterSchema: [String: any Sendable]
+    ) -> [[String: any Sendable]] {
+        [
+            [
+                "function": [
+                    "name": "weather",
+                    "parameters": [
+                        "type": "object",
+                        "properties": ["hour": parameterSchema],
+                        "required": ["hour"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+    }
+
+    private static func flatTools(
+        parameterSchema: [String: any Sendable]
+    ) -> [[String: any Sendable]] {
+        [
+            [
+                "name": "weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["hour": parameterSchema],
+                    "required": ["hour"],
+                ] as [String: any Sendable],
+            ]
+        ]
+    }
+
+    @Test("Union types without string coerce the textual wire value")
+    func unionTypeCoercion() {
+        let tools = Self.envelopeTools(parameterSchema: ["type": ["integer", "null"]])
+
+        let converted = convertParameterValue(
+            "5", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(converted as? Int == 5)
+
+        let null = convertParameterValue(
+            "null", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(null is NSNull)
+
+        // Unconvertible values stay textual so validation reports the model's
+        // actual violation instead of a fabricated value.
+        let unconvertible = convertParameterValue(
+            "Paris", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(unconvertible as? String == "Paris")
+    }
+
+    @Test("Unions that admit a string preserve the wire value")
+    func unionWithStringStaysString() {
+        let tools = Self.envelopeTools(parameterSchema: ["type": ["string", "integer"]])
+
+        let converted = convertParameterValue(
+            "5", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(converted as? String == "5")
+    }
+
+    @Test("anyOf branch types drive conversion")
+    func anyOfCoercion() {
+        let tools = Self.envelopeTools(
+            parameterSchema: [
+                "anyOf": [["type": "integer"], ["type": "null"]] as [[String: any Sendable]]
+            ])
+
+        let converted = convertParameterValue(
+            "7", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(converted as? Int == 7)
+    }
+
+    @Test("Flat tool declarations coerce like the OpenAI envelope")
+    func flatShapeCoercion() {
+        let tools = Self.flatTools(parameterSchema: ["type": "integer"])
+
+        let converted = convertParameterValue(
+            "5", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(converted as? Int == 5)
+    }
+
+    @Test("Schemas without recognizable type information stay textual")
+    func schemalessValueIsUnchanged() {
+        let tools = Self.envelopeTools(parameterSchema: ["description": "an hour"])
+
+        let converted = convertParameterValue(
+            "5", paramName: "hour", funcName: "weather", tools: tools)
+        #expect(converted as? String == "5")
+    }
+
+    @Test("Recovered XML calls with union-typed parameters become executable")
+    func recoveredUnionTypedCallIsExecutable() throws {
+        let tools = Self.envelopeTools(parameterSchema: ["type": ["integer", "null"]])
+        let processor = ToolCallProcessor(format: .json, tools: tools)
+
+        _ = processor.processChunk("<function=weather><parameter=hour>5</parameter></function>")
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.rejectedToolCalls.isEmpty)
+        #expect(call.function.name == "weather")
+        #expect(call.function.arguments["hour"] == .int(5))
+    }
+
+    @Test("Native Qwen XML calls with union-typed parameters become executable")
+    func nativeUnionTypedCallIsExecutable() throws {
+        let tools = Self.envelopeTools(parameterSchema: ["type": ["integer", "null"]])
+        let processor = ToolCallProcessor(format: .qwen35, tools: tools)
+
+        let text =
+            "<tool_call><function=weather><parameter=hour>7</parameter></function></tool_call>"
+        for character in text {
+            _ = processor.processChunk(String(character))
+        }
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.rejectedToolCalls.isEmpty)
+        #expect(call.function.arguments["hour"] == .int(7))
+    }
+
+    @Test("Definite violations still reject after coercion")
+    func definiteViolationsStillReject() {
+        let tools = Self.envelopeTools(parameterSchema: ["type": ["integer", "null"]])
+        let processor = ToolCallProcessor(format: .json, tools: tools)
+
+        _ = processor.processChunk(
+            "<function=weather><parameter=hour>Paris</parameter></function>")
+
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.first?.reason == .invalidArguments)
+    }
+}

--- a/Tests/MLXLMTests/ParameterCoercionTests.swift
+++ b/Tests/MLXLMTests/ParameterCoercionTests.swift
@@ -133,7 +133,8 @@ struct ParameterCoercionTests {
     @Test("Definite violations still reject after coercion")
     func definiteViolationsStillReject() {
         let tools = Self.envelopeTools(parameterSchema: ["type": ["integer", "null"]])
-        let processor = ToolCallProcessor(format: .json, tools: tools)
+        let processor = ToolCallProcessor(
+            format: .json, tools: tools, toolCallPolicy: .init(validation: .strict))
 
         _ = processor.processChunk(
             "<function=weather><parameter=hour>Paris</parameter></function>")

--- a/Tests/MLXLMTests/TextToolCallRecoveryBenchmark.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryBenchmark.swift
@@ -1,0 +1,91 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct TextToolCallRecoveryBenchmark {
+    private func nanoseconds(_ elapsed: Duration) -> Double {
+        let components = elapsed.components
+        return Double(components.seconds) * 1_000_000_000
+            + Double(components.attoseconds) / 1_000_000_000
+    }
+
+    private func nanosecondsPerChunk(_ elapsed: Duration, iterations: Int) -> Double {
+        nanoseconds(elapsed) / Double(iterations)
+    }
+
+    @Test("Ordinary text recovery overhead")
+    func ordinaryTextOverhead() {
+        let schemas: [[String: any Sendable]] = (0 ..< 16).map { index in
+            ["function": ["name": "tool_\(index)"] as [String: any Sendable]]
+        }
+        let disabled = ToolCallProcessor(format: .lfm2)
+        let enabled = ToolCallProcessor(format: .lfm2, tools: schemas)
+        let chunk = "An ordinary response fragment with no protocol markers. "
+        let iterations = 50_000
+        let clock = ContinuousClock()
+        var consumed = 0
+
+        for _ in 0 ..< 1_000 {
+            consumed += disabled.processChunk(chunk)?.utf8.count ?? 0
+            consumed += enabled.processChunk(chunk)?.utf8.count ?? 0
+        }
+
+        var start = clock.now
+        for _ in 0 ..< iterations {
+            consumed += disabled.processChunk(chunk)?.utf8.count ?? 0
+        }
+        let native = nanosecondsPerChunk(clock.now - start, iterations: iterations)
+
+        start = clock.now
+        for _ in 0 ..< iterations {
+            consumed += enabled.processChunk(chunk)?.utf8.count ?? 0
+        }
+        let recovery = nanosecondsPerChunk(clock.now - start, iterations: iterations)
+
+        #expect(consumed > 0)
+        print(
+            String(
+                format:
+                    "[TOOLHEALBENCH] native %.1f ns/chunk | recovery %.1f ns/chunk | %.2fx",
+                native, recovery, recovery / native))
+    }
+
+    @Test("Incomplete candidate processing scales near-linearly")
+    func incompleteCandidateScaling() {
+        let tools: [[String: any Sendable]] = [
+            ["function": ["name": "weather"] as [String: any Sendable]]
+        ]
+        let clock = ContinuousClock()
+
+        func elapsed(for scalarCount: Int) -> Double {
+            let payload =
+                "<function=weather><parameter=city>"
+                + String(repeating: "x", count: scalarCount)
+            let characters = Array(payload)
+            let chunks = stride(from: 0, to: characters.count, by: 16).map { start in
+                String(characters[start ..< min(start + 16, characters.count)])
+            }
+            let processor = ToolCallProcessor(format: .json, tools: tools)
+            let start = clock.now
+            for chunk in chunks {
+                _ = processor.processChunk(chunk)
+            }
+            return nanoseconds(clock.now - start)
+        }
+
+        // Warm the scanner and allocator before measuring the scaling ratio.
+        _ = elapsed(for: 2_000)
+        let small = elapsed(for: 16_000)
+        let large = elapsed(for: 32_000)
+
+        #expect(large < small * 3.5)
+        print(
+            String(
+                format: "[TOOLHEALBENCH] incomplete 16K %.2f ms | 32K %.2f ms | %.2fx",
+                small / 1_000_000, large / 1_000_000, large / small))
+    }
+}

--- a/Tests/MLXLMTests/TextToolCallRecoveryBenchmark.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryBenchmark.swift
@@ -79,13 +79,53 @@ struct TextToolCallRecoveryBenchmark {
 
         // Warm the scanner and allocator before measuring the scaling ratio.
         _ = elapsed(for: 2_000)
-        let small = elapsed(for: 16_000)
-        let large = elapsed(for: 32_000)
+        // Interleave samples so scheduling noise cannot dominate one measurement.
+        var smallSamples: [Double] = []
+        var largeSamples: [Double] = []
+        for _ in 0 ..< 7 {
+            smallSamples.append(elapsed(for: 16_000))
+            largeSamples.append(elapsed(for: 32_000))
+        }
+        let small = smallSamples.sorted()[3]
+        let large = largeSamples.sorted()[3]
 
         #expect(large < small * 3.5)
         print(
             String(
                 format: "[TOOLHEALBENCH] incomplete 16K %.2f ms | 32K %.2f ms | %.2fx",
+                small / 1_000_000, large / 1_000_000, large / small))
+    }
+
+    @Test("JSON context scanning does not rescan earlier objects on each chunk")
+    func structuredJSONScaling() {
+        let tools: [[String: any Sendable]] = [
+            ["function": ["name": "weather"] as [String: any Sendable]]
+        ]
+        let clock = ContinuousClock()
+        func elapsed(objectCount: Int) -> Double {
+            let text =
+                "[" + Array(repeating: #"{"n":0}"#, count: objectCount).joined(separator: ",") + "]"
+            let characters = Array(text)
+            let chunks = stride(from: 0, to: characters.count, by: 16).map {
+                String(characters[$0 ..< min($0 + 16, characters.count)])
+            }
+            let processor = ToolCallProcessor(format: .lfm2, tools: tools)
+            var visibleBytes = 0
+            let start = clock.now
+            for chunk in chunks {
+                visibleBytes += processor.processChunk(chunk)?.utf8.count ?? 0
+            }
+            let elapsed = nanoseconds(clock.now - start)
+            #expect(visibleBytes == text.utf8.count)
+            #expect(processor.toolCalls.isEmpty)
+            return elapsed
+        }
+        _ = elapsed(objectCount: 100)
+        let small = elapsed(objectCount: 1_000)
+        let large = elapsed(objectCount: 2_000)
+        print(
+            String(
+                format: "[TOOLHEALBENCH] JSON 8K %.2f ms | 16K %.2f ms | %.2fx",
                 small / 1_000_000, large / 1_000_000, large / small))
     }
 }

--- a/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
@@ -330,11 +330,16 @@ struct TextToolCallRecoveryTests {
         _ = processor.processChunk("<function=weather></function>")
         #expect(processor.toolCalls.isEmpty)
         #expect(processor.rejectedToolCalls.count == 1)
+        #expect(processor.rejectedToolCalls.first?.reason == .invalidArguments)
+        #expect(processor.rejectedToolCalls.first?.detail == "arguments.city is required")
+        #expect(processor.recoveredToolCallCount == 0)
+        #expect(processor.recoveryEvents.isEmpty)
 
         let native = ToolCallProcessor(format: .json, tools: tools)
         _ = native.processChunk(
             #"<tool_call>{"name":"weather","arguments":{}}</tool_call>"#)
         #expect(native.toolCalls.isEmpty)
         #expect(native.rejectedToolCalls.first?.reason == .invalidArguments)
+        #expect(native.rejectedToolCalls.first?.detail == "arguments.city is required")
     }
 }

--- a/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
@@ -1,0 +1,340 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Text tool-call recovery")
+struct TextToolCallRecoveryTests {
+    private static let tools: [[String: any Sendable]] = [
+        [
+            "function": [
+                "name": "weather"
+            ] as [String: any Sendable]
+        ]
+    ]
+
+    private struct Dialect {
+        let format: ToolCallFormat
+        let text: String
+    }
+
+    private static let alternateDialects = [
+        Dialect(
+            format: .lfm2,
+            text: #"<tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call>"#),
+        Dialect(
+            format: .json,
+            text: #"[TOOL_CALLS]weather{"city":"Paris"}"#),
+        Dialect(
+            format: .json,
+            text: #"weather[ARGS]{"city":"Paris"}"#),
+        Dialect(
+            format: .json,
+            text: "<function=weather><parameter=city>Paris</parameter></function>"),
+        Dialect(
+            format: .json,
+            text: #"<|tool_call>call:weather{city:<|"|>Paris<|"|>}<tool_call|>"#),
+    ]
+
+    private func responseText(_ outputs: [ToolCallProcessor.Output]) -> String {
+        outputs.compactMap { output in
+            if case .response(let text) = output { return text }
+            return nil
+        }.joined()
+    }
+
+    @Test("Every supported alternate dialect promotes a declared call")
+    func promotesAlternateDialects() throws {
+        for dialect in Self.alternateDialects {
+            let processor = ToolCallProcessor(format: dialect.format, tools: Self.tools)
+            _ = processor.processChunk(dialect.text)
+
+            let call = try #require(processor.toolCalls.first, "dialect: \(dialect.text)")
+            #expect(processor.toolCalls.count == 1, "dialect: \(dialect.text)")
+            #expect(call.function.name == "weather")
+            #expect(call.function.arguments["city"] == .string("Paris"))
+            #expect(processor.recoveredToolCallCount == 1)
+            #expect(processor.recoveryEvents.count == 1)
+        }
+    }
+
+    @Test("Recovery is invariant at every streaming boundary")
+    func everyStreamingBoundary() {
+        for dialect in Self.alternateDialects {
+            let characters = Array(dialect.text)
+            for split in 1 ..< characters.count {
+                let processor = ToolCallProcessor(format: dialect.format, tools: Self.tools)
+                _ = processor.processChunk(String(characters[..<split]))
+                _ = processor.processChunk(String(characters[split...]))
+
+                #expect(
+                    processor.toolCalls.count == 1,
+                    "dialect: \(dialect.text), split: \(split)")
+                #expect(processor.toolCalls.first?.function.name == "weather")
+            }
+        }
+    }
+
+    @Test("Mistral heals the no-ARGS variant at EOS")
+    func mistralNoArgsAtEOS() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: Self.tools)
+        #expect(processor.processChunk(#"[TOOL_CALLS]weather{"city":"Paris"}"#) == nil)
+        processor.processEOS()
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(call.function.name == "weather")
+        #expect(call.function.arguments["city"] == .string("Paris"))
+    }
+
+    @Test("Native frames are opaque to alternate markers in argument strings")
+    func nativeFrameIsOpaque() throws {
+        let processor = ToolCallProcessor(format: .qwen35, tools: Self.tools)
+        let text =
+            #"<tool_call>{"name":"weather","arguments":{"city":"literal <function=fake> and weather[ARGS]{}"}}</tool_call>"#
+
+        for character in text {
+            _ = processor.processChunk(String(character))
+        }
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.toolCalls.count == 1)
+        #expect(
+            call.function.arguments["city"]
+                == .string("literal <function=fake> and weather[ARGS]{}"))
+    }
+
+    @Test("Llama's native inline marker remains attached to its JSON payload")
+    func llamaInlineMarkerIsOpaque() {
+        let processor = ToolCallProcessor(format: .llama3, tools: Self.tools)
+        let text =
+            #"<|python_tag|>{"name":"weather","arguments":{"city":"Paris"}}"#
+
+        #expect(processor.processChunk(text) == nil)
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "weather")
+    }
+
+    @Test("Protocol examples inside an ordinary JSON string remain response text")
+    func ordinaryJSONIsOpaque() {
+        let processor = ToolCallProcessor(format: .lfm2, tools: Self.tools)
+        let text =
+            #"{"example":"weather[ARGS]{\"city\":\"Paris\"} and <function=weather><parameter=city>Paris</parameter></function>"}"#
+
+        #expect(processor.processChunk(text) == text)
+        #expect(processor.toolCalls.isEmpty)
+
+        let nativeJSON = ToolCallProcessor(format: .json, tools: Self.tools)
+        let nativeMarkerInData =
+            #"{"example":"<tool_call>{\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}}</tool_call>"}"#
+        #expect(nativeJSON.processChunk(nativeMarkerInData) == nativeMarkerInData)
+        #expect(nativeJSON.toolCalls.isEmpty)
+    }
+
+    @Test("Native tool syntax inside reasoning is inert response text")
+    func reasoningCannotDispatchNativeCall() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        let text =
+            #"<think>consider <tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call> carefully</think>"#
+        let outputs = processor.processChunkOutputs(
+            text)
+
+        #expect(responseText(outputs) == text)
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.isEmpty)
+    }
+
+    @Test("Malformed explicit candidates are rejected and never executable")
+    func malformedCandidatesAreRejected() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        let undeclared = #"other[ARGS]{"city":"Paris"}"#
+        let malformed = "<function=weather>not closed"
+
+        #expect(processor.processChunk(undeclared) == undeclared)
+        let visible =
+            (processor.processChunk(malformed) ?? "")
+            + (processor.processEOS(returnBufferedText: true) ?? "")
+        #expect(visible == "not closed")
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.count == 1)
+        #expect(processor.rejectedToolCalls.first?.reason == .malformedSyntax)
+    }
+
+    @Test("Recovery is disabled without a nonempty declared-tool allowlist")
+    func requiresDeclaredTools() {
+        let text = #"weather[ARGS]{"city":"Paris"}"#
+        let unconstrained = ToolCallProcessor(format: .json)
+        let empty = ToolCallProcessor(format: .json, tools: [])
+
+        #expect(unconstrained.processChunk(text) == text)
+        #expect(empty.processChunk(text) == text)
+        #expect(unconstrained.toolCalls.isEmpty)
+        #expect(empty.toolCalls.isEmpty)
+    }
+
+    @Test("Markerless names require an exact lexical boundary across chunks")
+    func markerlessLexicalBoundary() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        let first = processor.processChunk("not")
+        let second = processor.processChunk(#"weather[ARGS]{"city":"Paris"}"#)
+
+        #expect((first ?? "") + (second ?? "") == #"notweather[ARGS]{"city":"Paris"}"#)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Incomplete recovery buffers are bounded")
+    func boundedBuffer() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        // Combining scalars form very few extended grapheme clusters, so this
+        // verifies the limit is a byte limit rather than `String.count`.
+        let text =
+            "<function=weather><parameter=city>"
+            + String(repeating: "\u{0301}", count: 40_000)
+
+        #expect(processor.processChunk(text) == nil)
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.first?.reason == .resourceLimitExceeded)
+
+        // Do not resume execution from the middle of the oversized attempt.
+        _ = processor.processChunk(#"weather[ARGS]{"city":"Paris"}"#)
+        #expect(processor.toolCalls.isEmpty)
+
+        processor.processEOS()
+        _ = processor.processChunk(#"weather[ARGS]{"city":"Paris"}"#)
+        #expect(processor.toolCalls.count == 1)
+    }
+
+    @Test("Complete oversized calls cannot bypass the byte limit")
+    func completeOversizedCallsAreRejected() {
+        let alternate = ToolCallProcessor(format: .json, tools: Self.tools)
+        let hugeValue = String(repeating: "x", count: 66_000)
+        let alternateText =
+            "<function=weather><parameter=city>" + hugeValue
+            + "</parameter></function>"
+
+        _ = alternate.processChunk(alternateText)
+        #expect(alternate.toolCalls.isEmpty)
+        #expect(alternate.rejectedToolCalls.first?.reason == .resourceLimitExceeded)
+
+        let native = ToolCallProcessor(format: .json, tools: Self.tools)
+        let nativeText =
+            #"<tool_call>{"name":"weather","arguments":{"city":""# + hugeValue
+            + #""}}</tool_call>"#
+        _ = native.processChunk(nativeText)
+        #expect(native.toolCalls.isEmpty)
+        #expect(native.rejectedToolCalls.first?.reason == .resourceLimitExceeded)
+    }
+
+    @Test("EOS clears an unfinished native-frame shield before processor reuse")
+    func eosClearsNativeFrameShield() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        #expect(processor.processChunk("<tool_call>") == nil)
+        processor.processEOS()
+
+        _ = processor.processChunk(
+            "<function=weather><parameter=city>Paris</parameter></function>")
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "weather")
+    }
+
+    @Test("Native tool syntax inside Markdown code is inert")
+    func markdownCodeCannotDispatchNativeCall() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        let text =
+            "```json\n"
+            + #"<tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call>"#
+            + "\n```\n"
+
+        let outputs = processor.processChunkOutputs(text)
+        #expect(responseText(outputs) == text)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Native markers inside JSON arrays and strings are inert")
+    func jsonDataCannotDispatchNativeCall() {
+        let processor = ToolCallProcessor(format: .mistral, tools: Self.tools)
+        let text = #"["[TOOL_CALLS]weather[ARGS]{\"city\":\"Paris\"}"]"#
+
+        #expect(processor.processChunk(text) == text)
+        processor.processEOS()
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("Oversized JSON remains fail-closed until EOS")
+    func oversizedJSONCannotReenterExecutableContext() {
+        let processor = ToolCallProcessor(format: .lfm2, tools: Self.tools)
+        let prefix = "[\"" + String(repeating: "a", count: 65_536)
+
+        #expect(processor.processChunk(prefix) == prefix)
+        let candidate = #"weather[ARGS]{"city":"Paris"}"#
+        #expect(processor.processChunk(candidate) == candidate)
+        #expect(processor.toolCalls.isEmpty)
+
+        processor.processEOS()
+        _ = processor.processChunk(candidate)
+        #expect(processor.toolCalls.count == 1)
+    }
+
+    @Test("Qwen JSON preserves literal outer close markers in arguments")
+    func qwenJSONLiteralCloseMarker() throws {
+        let processor = ToolCallProcessor(format: .qwen35, tools: Self.tools)
+        let text =
+            #"<tool_call>{"name":"weather","arguments":{"city":"literal </tool_call> remains data"}}</tool_call>"#
+
+        for character in text {
+            _ = processor.processChunk(String(character))
+        }
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(call.function.arguments["city"] == .string("literal </tool_call> remains data"))
+        #expect(processor.rejectedToolCalls.isEmpty)
+    }
+
+    @Test("Recovery policy is honored by the public processor path")
+    func disabledPolicyDoesNotRecover() {
+        let processor = ToolCallProcessor(
+            format: .json, tools: Self.tools, recoveryPolicy: .disabled)
+        let text = "<function=weather><parameter=city>Paris</parameter></function>"
+
+        #expect(processor.processChunk(text) == text)
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.recoveredToolCallCount == 0)
+
+        let nativeInReasoning =
+            #"<think><tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call></think>"#
+        #expect(processor.processChunk(nativeInReasoning) == nativeInReasoning)
+        #expect(processor.toolCalls.isEmpty)
+
+        _ = processor.processChunk(
+            #"<tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call>"#)
+        #expect(processor.toolCalls.count == 1)
+    }
+
+    @Test("Recovered calls must satisfy required arguments")
+    func requiredArgumentsAreEnforced() {
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "weather",
+                    "parameters": [
+                        "type": "object",
+                        "properties": ["city": ["type": "string"]],
+                        "required": ["city"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let processor = ToolCallProcessor(format: .json, tools: tools)
+
+        _ = processor.processChunk("<function=weather></function>")
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.count == 1)
+
+        let native = ToolCallProcessor(format: .json, tools: tools)
+        _ = native.processChunk(
+            #"<tool_call>{"name":"weather","arguments":{}}</tool_call>"#)
+        #expect(native.toolCalls.isEmpty)
+        #expect(native.rejectedToolCalls.first?.reason == .invalidArguments)
+    }
+}

--- a/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
@@ -20,6 +20,10 @@ struct TextToolCallRecoveryTests {
         let text: String
     }
 
+    /// Explicitly marked dialects that the conservative default may promote.
+    /// The markerless `name[ARGS]{...}` rehearsal syntax is deliberately not
+    /// in this list: it carries no protocol marker and is promoted only under
+    /// the permissive policy.
     private static let alternateDialects = [
         Dialect(
             format: .lfm2,
@@ -29,14 +33,13 @@ struct TextToolCallRecoveryTests {
             text: #"[TOOL_CALLS]weather{"city":"Paris"}"#),
         Dialect(
             format: .json,
-            text: #"weather[ARGS]{"city":"Paris"}"#),
-        Dialect(
-            format: .json,
             text: "<function=weather><parameter=city>Paris</parameter></function>"),
         Dialect(
             format: .json,
             text: #"<|tool_call>call:weather{city:<|"|>Paris<|"|>}<tool_call|>"#),
     ]
+
+    private static let markerlessText = #"weather[ARGS]{"city":"Paris"}"#
 
     private func responseText(_ outputs: [ToolCallProcessor.Output]) -> String {
         outputs.compactMap { output in
@@ -75,6 +78,73 @@ struct TextToolCallRecoveryTests {
                 #expect(processor.toolCalls.first?.function.name == "weather")
             }
         }
+    }
+
+    @Test("Markerless rehearsals stay response text under the conservative default")
+    func markerlessStaysTextUnderConservative() {
+        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+
+        #expect(processor.processChunk(Self.markerlessText) == Self.markerlessText)
+        processor.processEOS()
+
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.isEmpty)
+        #expect(processor.recoveredToolCallCount == 0)
+        #expect(processor.recoveryEvents.isEmpty)
+    }
+
+    @Test("Markerless rehearsals promote only under the permissive policy")
+    func markerlessPromotesUnderPermissive() throws {
+        let processor = ToolCallProcessor(
+            format: .json, tools: Self.tools, recoveryPolicy: .permissive)
+        _ = processor.processChunk(Self.markerlessText)
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.toolCalls.count == 1)
+        #expect(call.function.name == "weather")
+        #expect(call.function.arguments["city"] == .string("Paris"))
+        #expect(processor.recoveryEvents.first?.dialect == .declaredArgs)
+    }
+
+    @Test("Markerless promotion is invariant at every permissive streaming boundary")
+    func markerlessPermissiveStreamingBoundaries() {
+        let characters = Array(Self.markerlessText)
+        for split in 1 ..< characters.count {
+            let processor = ToolCallProcessor(
+                format: .json, tools: Self.tools, recoveryPolicy: .permissive)
+            _ = processor.processChunk(String(characters[..<split]))
+            _ = processor.processChunk(String(characters[split...]))
+
+            #expect(processor.toolCalls.count == 1, "split: \(split)")
+            #expect(processor.toolCalls.first?.function.name == "weather")
+        }
+    }
+
+    @Test("EOS recovery never fabricates a Mistral frame around leading prose")
+    func eosRecoveryDoesNotFabricateLeadingFrame() throws {
+        var scanner = try #require(
+            TextToolCallRecoveryScanner(
+                primaryFormat: .mistral,
+                policy: .conservative,
+                tools: Self.tools,
+                allowedToolNames: ["weather"]))
+
+        // Prose before the first marker must never be re-framed as a call,
+        // even when it happens to parse as `name{json}`.
+        let recovered = scanner.recoverEOSPayloads(
+            #"weather{"city":"Paris"}[TOOL_CALLS]weather{"city":"Rome"}"#)
+        #expect(recovered.count == 1)
+        #expect(recovered.first?.function.name == "weather")
+        #expect(recovered.first?.function.arguments["city"] == .string("Rome"))
+
+        // A marker with no payload yields nothing; the prose is not promoted.
+        var trailing = try #require(
+            TextToolCallRecoveryScanner(
+                primaryFormat: .mistral,
+                policy: .conservative,
+                tools: Self.tools,
+                allowedToolNames: ["weather"]))
+        #expect(trailing.recoverEOSPayloads(#"weather{"city":"Paris"}[TOOL_CALLS]"#).isEmpty)
     }
 
     @Test("Mistral heals the no-ARGS variant at EOS")
@@ -175,7 +245,8 @@ struct TextToolCallRecoveryTests {
 
     @Test("Markerless names require an exact lexical boundary across chunks")
     func markerlessLexicalBoundary() {
-        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        let processor = ToolCallProcessor(
+            format: .json, tools: Self.tools, recoveryPolicy: .permissive)
         let first = processor.processChunk("not")
         let second = processor.processChunk(#"weather[ARGS]{"city":"Paris"}"#)
 
@@ -185,7 +256,10 @@ struct TextToolCallRecoveryTests {
 
     @Test("Incomplete recovery buffers are bounded")
     func boundedBuffer() {
-        let processor = ToolCallProcessor(format: .json, tools: Self.tools)
+        // Permissive policy so the post-EOS probe exercises markerless
+        // promotion; the byte limit itself is policy-independent.
+        let processor = ToolCallProcessor(
+            format: .json, tools: Self.tools, recoveryPolicy: .permissive)
         // Combining scalars form very few extended grapheme clusters, so this
         // verifies the limit is a byte limit rather than `String.count`.
         let text =
@@ -263,7 +337,8 @@ struct TextToolCallRecoveryTests {
 
     @Test("Oversized JSON remains fail-closed until EOS")
     func oversizedJSONCannotReenterExecutableContext() {
-        let processor = ToolCallProcessor(format: .lfm2, tools: Self.tools)
+        let processor = ToolCallProcessor(
+            format: .lfm2, tools: Self.tools, recoveryPolicy: .permissive)
         let prefix = "[\"" + String(repeating: "a", count: 65_536)
 
         #expect(processor.processChunk(prefix) == prefix)

--- a/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
@@ -400,7 +400,8 @@ struct TextToolCallRecoveryTests {
                 ] as [String: any Sendable]
             ]
         ]
-        let processor = ToolCallProcessor(format: .json, tools: tools)
+        let processor = ToolCallProcessor(
+            format: .json, tools: tools, toolCallPolicy: .init(validation: .strict))
 
         _ = processor.processChunk("<function=weather></function>")
         #expect(processor.toolCalls.isEmpty)
@@ -410,7 +411,8 @@ struct TextToolCallRecoveryTests {
         #expect(processor.recoveredToolCallCount == 0)
         #expect(processor.recoveryEvents.isEmpty)
 
-        let native = ToolCallProcessor(format: .json, tools: tools)
+        let native = ToolCallProcessor(
+            format: .json, tools: tools, toolCallPolicy: .init(validation: .strict))
         _ = native.processChunk(
             #"<tool_call>{"name":"weather","arguments":{}}</tool_call>"#)
         #expect(native.toolCalls.isEmpty)

--- a/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
+++ b/Tests/MLXLMTests/TextToolCallRecoveryTests.swift
@@ -96,7 +96,7 @@ struct TextToolCallRecoveryTests {
     @Test("Markerless rehearsals promote only under the permissive policy")
     func markerlessPromotesUnderPermissive() throws {
         let processor = ToolCallProcessor(
-            format: .json, tools: Self.tools, recoveryPolicy: .permissive)
+            format: .json, tools: Self.tools, toolCallPolicy: .init(recovery: .permissive))
         _ = processor.processChunk(Self.markerlessText)
 
         let call = try #require(processor.toolCalls.first)
@@ -111,7 +111,7 @@ struct TextToolCallRecoveryTests {
         let characters = Array(Self.markerlessText)
         for split in 1 ..< characters.count {
             let processor = ToolCallProcessor(
-                format: .json, tools: Self.tools, recoveryPolicy: .permissive)
+                format: .json, tools: Self.tools, toolCallPolicy: .init(recovery: .permissive))
             _ = processor.processChunk(String(characters[..<split]))
             _ = processor.processChunk(String(characters[split...]))
 
@@ -246,7 +246,7 @@ struct TextToolCallRecoveryTests {
     @Test("Markerless names require an exact lexical boundary across chunks")
     func markerlessLexicalBoundary() {
         let processor = ToolCallProcessor(
-            format: .json, tools: Self.tools, recoveryPolicy: .permissive)
+            format: .json, tools: Self.tools, toolCallPolicy: .init(recovery: .permissive))
         let first = processor.processChunk("not")
         let second = processor.processChunk(#"weather[ARGS]{"city":"Paris"}"#)
 
@@ -259,7 +259,7 @@ struct TextToolCallRecoveryTests {
         // Permissive policy so the post-EOS probe exercises markerless
         // promotion; the byte limit itself is policy-independent.
         let processor = ToolCallProcessor(
-            format: .json, tools: Self.tools, recoveryPolicy: .permissive)
+            format: .json, tools: Self.tools, toolCallPolicy: .init(recovery: .permissive))
         // Combining scalars form very few extended grapheme clusters, so this
         // verifies the limit is a byte limit rather than `String.count`.
         let text =
@@ -338,7 +338,7 @@ struct TextToolCallRecoveryTests {
     @Test("Oversized JSON remains fail-closed until EOS")
     func oversizedJSONCannotReenterExecutableContext() {
         let processor = ToolCallProcessor(
-            format: .lfm2, tools: Self.tools, recoveryPolicy: .permissive)
+            format: .lfm2, tools: Self.tools, toolCallPolicy: .init(recovery: .permissive))
         let prefix = "[\"" + String(repeating: "a", count: 65_536)
 
         #expect(processor.processChunk(prefix) == prefix)
@@ -369,7 +369,7 @@ struct TextToolCallRecoveryTests {
     @Test("Recovery policy is honored by the public processor path")
     func disabledPolicyDoesNotRecover() {
         let processor = ToolCallProcessor(
-            format: .json, tools: Self.tools, recoveryPolicy: .disabled)
+            format: .json, tools: Self.tools, toolCallPolicy: .init(recovery: .disabled))
         let text = "<function=weather><parameter=city>Paris</parameter></function>"
 
         #expect(processor.processChunk(text) == text)

--- a/Tests/MLXLMTests/ToolArgumentNormalizationTests.swift
+++ b/Tests/MLXLMTests/ToolArgumentNormalizationTests.swift
@@ -1,0 +1,170 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+struct ToolArgumentNormalizationTests {
+    private func tools(_ schema: [String: any Sendable]) -> [[String: any Sendable]] {
+        let parameters: [String: any Sendable] = [
+            "type": "object", "properties": ["value": schema], "required": ["value"],
+        ]
+        return [["function": ["name": "read", "parameters": parameters] as [String: any Sendable]]]
+    }
+
+    @Test("JSON, native XML and recovered XML read the same declared values")
+    func dialectParity() throws {
+        let cases: [(String, String, JSONValue)] = [
+            ("integer", "6", .int(6)), ("integer", "1.0", .int(1)),
+            ("int64", "1.0", .int(1)), ("float64", "0.25", .double(0.25)),
+            ("integer", "1.20e2", .int(120)), ("integer", "-0.0", .int(0)),
+            ("integer", "9007199254740993.0", .int(9_007_199_254_740_993)),
+            ("integer", "9223372036854775807.0", .int(Int.max)),
+            ("integer", "-9223372036854775808.0", .int(Int.min)),
+            ("number", "1e100", .double(1e100)), ("number", "0.25", .double(0.25)),
+            ("boolean", "false", .bool(false)), ("boolean", "yes", .bool(true)),
+            ("array", "['SF', 'LA']", .array([.string("SF"), .string("LA")])),
+            ("array", "\"SF\", \"LA\"", .array([.string("SF"), .string("LA")])),
+            ("array", "('SF', 'LA')", .array([.string("SF"), .string("LA")])),
+            ("object", "{'enabled': False}", .object(["enabled": .bool(false)])),
+        ]
+        for (type, text, expected) in cases {
+            let json = String(
+                decoding: try JSONSerialization.data(withJSONObject: [
+                    "name": "read", "arguments": ["value": text],
+                ]), as: UTF8.self)
+            let xml = "<function=read><parameter=value>\(text)</parameter></function>"
+            for (format, payload): (ToolCallFormat, String) in [
+                (.json, "<tool_call>\(json)</tool_call>"),
+                (.xmlFunction, "<tool_call>\(xml)</tool_call>"),
+                (.lfm2, xml),
+            ] {
+                let processor = ToolCallProcessor(format: format, tools: tools(["type": type]))
+                _ = processor.processChunk(payload)
+                processor.processEOS()
+                #expect(
+                    processor.toolCalls.first?.function.arguments["value"] == expected,
+                    "\(type): \(text), \(format)")
+                #expect(processor.rejectedToolCalls.isEmpty)
+            }
+        }
+    }
+
+    @Test("Unconvertible values survive normalization and strict validation rejects them")
+    func invalidValues() {
+        let cases = [
+            ("integer", "1.5"), ("integer", "1.00000000000000000000000000000000000000001"),
+            ("integer", "9223372036854775808"), ("number", "nan"), ("number", "inf"),
+            ("boolean", "maybe"), ("array", "SF, LA"), ("array", "{'a': 1}"),
+            ("object", "[1, 2]"), ("array", "__import__('os').system('x')"),
+        ]
+        for (type, text) in cases {
+            #expect(
+                ToolArgumentNormalization.normalize(.string(text), schema: ["type": type])
+                    == .string(text))
+            for policy in ToolCallValidationPolicy.allCases {
+                let processor = ToolCallProcessor(
+                    format: .lfm2, tools: tools(["type": type]),
+                    toolCallPolicy: .init(validation: policy))
+                _ = processor.processChunk(
+                    "<function=read><parameter=value>\(text)</parameter></function>")
+                processor.processEOS()
+                if policy == .strict {
+                    #expect(processor.toolCalls.isEmpty)
+                    #expect(processor.rejectedToolCalls.first?.reason == .invalidArguments)
+                    #expect(processor.recoveredToolCallCount == 0)
+                } else {
+                    #expect(processor.toolCalls.first?.function.arguments["value"] == .string(text))
+                    #expect(processor.recoveredToolCallCount == 1)
+                }
+            }
+        }
+    }
+
+    @Test("Strings and ambiguous unions retain their spelling")
+    func ambiguity() {
+        let schemas: [[String: any Sendable]] = [
+            ["type": "string"], ["type": ["string", "integer"]],
+            ["type": ["boolean", "integer"]],
+            ["anyOf": [["type": "integer"], ["$ref": "#/$defs/text"]]],
+            ["type": "integer", "$ref": "#/$defs/other"],
+            ["description": "opaque"],
+        ]
+        for schema in schemas {
+            #expect(
+                ToolArgumentNormalization.normalize(.string("001"), schema: schema)
+                    == .string("001"))
+        }
+        #expect(
+            ToolArgumentNormalization.normalize(
+                .string("null"), schema: ["type": ["string", "null"]]) == .string("null"))
+    }
+
+    @Test("Numeric unions and intersections respect integer subtyping")
+    func numericCombinators() {
+        let intersection: [String: any Sendable] = [
+            "allOf": [["type": "number"], ["type": "integer"]]
+        ]
+        #expect(
+            ToolArgumentNormalization.normalize(.string("6.0"), schema: intersection) == .int(6))
+        let union: [String: any Sendable] = ["type": ["integer", "number"]]
+        #expect(ToolArgumentNormalization.normalize(.string("1.5"), schema: union) == .double(1.5))
+    }
+
+    @Test("Normalization descends into declared objects and arrays and preserves IDs")
+    func nestedArguments() {
+        let item: [String: any Sendable] = [
+            "type": "object", "properties": ["count": ["type": "integer"]],
+        ]
+        let schema: [String: any Sendable] = ["type": "array", "items": item]
+        let call = ToolCall(
+            function: .init(name: "read", arguments: ["value": .string("[{'count': '2'}]")]),
+            id: "keep-me")
+        let normalized = ToolArgumentNormalization.normalize(call, tools: tools(schema))
+        #expect(normalized.id == call.id)
+        #expect(normalized.function.arguments["value"] == .array([.object(["count": .int(2)])]))
+        #expect(ToolArgumentNormalization.normalize(normalized, tools: tools(schema)) == normalized)
+    }
+
+    @Test("Permissive schema validation never bypasses name authorization or syntax")
+    func authorization() {
+        for recovery in ToolCallRecoveryPolicy.allCases {
+            let processor = ToolCallProcessor(
+                format: .json, tools: tools(["type": "integer"]),
+                toolCallPolicy: .init(recovery: recovery, validation: .permissive))
+            _ = processor.processChunk(
+                #"<tool_call>{"name":"other","arguments":{"value":"6"}}</tool_call>"#)
+            processor.processEOS()
+            #expect(processor.toolCalls.isEmpty)
+            #expect(processor.rejectedToolCalls.first?.reason == .undeclaredTool)
+        }
+    }
+
+    @Test("Extreme exponents and non-integral decimals cannot overflow or round into integers")
+    func extremeIntegers() {
+        for text in [
+            "1e9223372036854775807", "1e-9223372036854775808",
+            "1.0e-9223372036854775808", "1e-999999999999999999999999",
+            "-9223372036854775809.0", "99999999999999999999.1", "0.00000000000000000001",
+        ] {
+            #expect(
+                ToolArgumentNormalization.normalize(.string(text), schema: ["type": "integer"])
+                    == .string(text))
+        }
+        for (text, value) in [("0e10000", 0), ("1200e-2", 12), (".000e-300", 0)] {
+            #expect(
+                ToolArgumentNormalization.normalize(.string(text), schema: ["type": "integer"])
+                    == .int(value))
+        }
+    }
+
+    @Test("Python container parsing is bounded and rejects incomplete structure")
+    func boundedLiterals() {
+        #expect(
+            tryParsePythonLiteral(
+                String(repeating: "[", count: 64) + "0" + String(repeating: "]", count: 64)) == nil)
+        #expect(tryParsePythonLiteral("['SF',") == nil)
+        #expect(tryParsePythonLiteral("[f()]") == nil)
+    }
+}

--- a/Tests/MLXLMTests/ToolCallPolicyTests.swift
+++ b/Tests/MLXLMTests/ToolCallPolicyTests.swift
@@ -1,0 +1,115 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct ToolCallPolicyTests {
+    @Test("Generation policies have independent value semantics and safe defaults")
+    func defaultsAndCopies() {
+        let defaults = GenerateParameters()
+        #expect(defaults.toolCallPolicy == .init(recovery: .conservative, validation: .strict))
+        var custom = defaults
+        custom.toolCallPolicy.recovery = .disabled
+        custom.toolCallPolicy.validation = .permissive
+        #expect(defaults.toolCallPolicy == ToolCallPolicy())
+        #expect(custom.toolCallPolicy == .init(recovery: .disabled, validation: .permissive))
+        #expect(
+            GenerateParameters(toolCallPolicy: custom.toolCallPolicy).toolCallPolicy
+                == custom.toolCallPolicy)
+    }
+
+    @Test(
+        "Generation and token recording preserve both policies and rejection telemetry",
+        arguments: ToolCallRecoveryPolicy.allCases, ToolCallValidationPolicy.allCases)
+    func generation(recovery: ToolCallRecoveryPolicy, validation: ToolCallValidationPolicy)
+        async throws
+    {
+        let policy = ToolCallPolicy(recovery: recovery, validation: validation)
+        let parameters: [String: any Sendable] = [
+            "type": "object", "properties": ["value": ["type": "integer"]],
+            "required": ["value"],
+        ]
+        let tools: [[String: any Sendable]] = [
+            ["function": ["name": "read", "parameters": parameters] as [String: any Sendable]]
+        ]
+        for native in [true, false] {
+            for value in ["6", "six"] {
+                for recordTokens in [false, true] {
+                    let text =
+                        native
+                        ? "<tool_call>{\"name\":\"read\",\"arguments\":{\"value\":\"\(value)\"}}</tool_call>"
+                        : "<function=read><parameter=value>\(value)</parameter></function>"
+                    let tokenizer = PolicyTokenizer()
+                    let tokens = tokenizer.encode(text: text)
+                    let iterator = PolicyIterator(tokens: tokens)
+                    let configuration = ModelConfiguration(id: "policy-test", toolCallFormat: .json)
+                    var events: [Generation] = []
+                    if recordTokens {
+                        let (stream, task) = generateTaskRecordingTokens(
+                            promptTokenCount: 0, modelConfiguration: configuration,
+                            tokenizer: tokenizer, iterator: iterator, tools: tools,
+                            toolCallPolicy: policy)
+                        for await event in stream { events.append(event) }
+                        #expect(await task.value == tokens)
+                    } else {
+                        let (stream, task) = generateTask(
+                            promptTokenCount: 0, modelConfiguration: configuration,
+                            tokenizer: tokenizer, iterator: iterator, tools: tools,
+                            toolCallPolicy: policy)
+                        for await event in stream { events.append(event) }
+                        await task.value
+                    }
+                    let parsed = native || recovery != .disabled
+                    let accepted = parsed && (value == "6" || validation == .permissive)
+                    let calls = events.compactMap(\.toolCall)
+                    let rejected = events.compactMap(\.rejectedToolCall)
+                    #expect(calls.count == (accepted ? 1 : 0))
+                    if accepted {
+                        #expect(
+                            calls.first?.function.arguments["value"]
+                                == (value == "6" ? .int(6) : .string(value)))
+                    }
+                    #expect(rejected.count == (parsed && !accepted ? 1 : 0))
+                    #expect(rejected.allSatisfy { $0.reason == .invalidArguments })
+                    let info = try #require(events.compactMap(\.info).last)
+                    #expect(info.rejectedToolCallCount == rejected.count)
+                    #expect(info.recoveredToolCallCount == (!native && accepted ? 1 : 0))
+                }
+            }
+        }
+    }
+}
+
+/// One Unicode scalar per token makes every syntax boundary a streaming boundary.
+private struct PolicyTokenizer: Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        text.unicodeScalars.map { Int($0.value) }
+    }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        String(String.UnicodeScalarView(tokenIds.compactMap(Unicode.Scalar.init)))
+    }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { Unicode.Scalar(id).map(String.init) }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]], tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+private struct PolicyIterator: TokenIteratorProtocol {
+    let tokens: [Int]
+    var tokenCount = 0
+    var maxTokens: Int? { nil }
+    var promptPrefillTime: TimeInterval { 0 }
+    mutating func next() -> Int? {
+        guard tokenCount < tokens.count else { return nil }
+        defer { tokenCount += 1 }
+        return tokens[tokenCount]
+    }
+}

--- a/Tests/MLXLMTests/ToolCallPolicyTests.swift
+++ b/Tests/MLXLMTests/ToolCallPolicyTests.swift
@@ -7,18 +7,51 @@ import Testing
 
 @Suite(.serialized)
 struct ToolCallPolicyTests {
-    @Test("Generation policies have independent value semantics and safe defaults")
+    @Test(
+        "Generation policies have independent value semantics and permissive validation by default")
     func defaultsAndCopies() {
         let defaults = GenerateParameters()
-        #expect(defaults.toolCallPolicy == .init(recovery: .conservative, validation: .strict))
+        #expect(defaults.toolCallPolicy == .init(recovery: .conservative, validation: .permissive))
         var custom = defaults
         custom.toolCallPolicy.recovery = .disabled
-        custom.toolCallPolicy.validation = .permissive
+        custom.toolCallPolicy.validation = .strict
         #expect(defaults.toolCallPolicy == ToolCallPolicy())
-        #expect(custom.toolCallPolicy == .init(recovery: .disabled, validation: .permissive))
+        #expect(custom.toolCallPolicy == .init(recovery: .disabled, validation: .strict))
         #expect(
             GenerateParameters(toolCallPolicy: custom.toolCallPolicy).toolCallPolicy
                 == custom.toolCallPolicy)
+    }
+
+    @Test("Default processing forwards schema violations but still rejects undeclared tools")
+    func defaultProcessing() {
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "read",
+                    "parameters": [
+                        "type": "object", "properties": ["value": ["type": "integer"]],
+                        "required": ["value"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        for arguments: [String: JSONValue] in [["value": .string("six")], [:]] {
+            let call = ToolCall(function: .init(name: "read", arguments: arguments))
+            let json = arguments.isEmpty ? "{}" : #"{"value":"six"}"#
+            for format: ToolCallFormat in [.json, .lfm2] {
+                let processor = ToolCallProcessor(format: format, tools: tools)
+                _ = processor.processChunk(
+                    "<tool_call>{\"name\":\"read\",\"arguments\":\(json)}</tool_call>")
+                processor.processEOS()
+                #expect(processor.toolCalls.first?.function == call.function)
+                #expect(processor.rejectedToolCalls.isEmpty)
+            }
+        }
+        let processor = ToolCallProcessor(format: .json, tools: tools)
+        _ = processor.processChunk(#"<tool_call>{"name":"other","arguments":{}}</tool_call>"#)
+        processor.processEOS()
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.first?.reason == .undeclaredTool)
     }
 
     @Test(

--- a/Tests/MLXLMTests/ToolCallProcessorStreamingTests.swift
+++ b/Tests/MLXLMTests/ToolCallProcessorStreamingTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+struct ToolCallProcessorStreamingTests {
+    private static let tools: [[String: any Sendable]] = [
+        ["function": ["name": "weather"] as [String: any Sendable]]
+    ]
+    private static let function = ToolCall.Function(
+        name: "weather", arguments: ["city": JSONValue.string("Paris")])
+    private static let xml =
+        "<tool_call><function=weather><parameter=city>Paris</parameter></function></tool_call>"
+    private static let json =
+        #"<tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call>"#
+
+    private enum Event: Equatable {
+        case response(String)
+        case call(ToolCall.Function)
+        case rejected(RejectedToolCall.Reason)
+    }
+
+    private struct Result: Equatable {
+        var text = ""
+        var calls: [ToolCall.Function] = []
+        var rejections: [RejectedToolCall.Reason] = []
+        var events: [Event] = []
+    }
+
+    // Use nil tools to exercise the native scanner without recovery preprocessing.
+    private func process(
+        _ chunks: [String], format: ToolCallFormat = .xmlFunction,
+        tools: [[String: any Sendable]]? = nil, ordered: Bool
+    ) -> Result {
+        let processor = ToolCallProcessor(format: format, tools: tools)
+        var result = Result()
+        if ordered {
+            var outputs = chunks.flatMap { processor.processChunkOutputs($0) }
+            outputs += processor.processEOSOutputs()
+            for output in outputs {
+                switch output {
+                case .response(let text):
+                    result.text += text
+                    if case .response(let previous) = result.events.last {
+                        result.events[result.events.count - 1] = .response(previous + text)
+                    } else {
+                        result.events.append(.response(text))
+                    }
+                case .toolCall(let call):
+                    result.calls.append(call.function)
+                    result.events.append(.call(call.function))
+                case .rejectedToolCall(let rejection):
+                    result.rejections.append(rejection.reason)
+                    result.events.append(.rejected(rejection.reason))
+                }
+            }
+        } else {
+            for chunk in chunks {
+                result.text += processor.processChunk(chunk) ?? ""
+            }
+            result.text += processor.processEOS(returnBufferedText: true) ?? ""
+            result.calls = processor.drainToolCalls().map(\.function)
+            result.rejections = processor.drainRejectedToolCalls().map(\.reason)
+        }
+        return result
+    }
+
+    private func chunkings(_ text: String) -> [[String]] {
+        [[text], text.map(String.init)]
+            + text.indices.map { [String(text[..<$0]), String(text[$0...])] }
+            + [[text, ""]]
+    }
+
+    @Test("A non-tool marker must not hide a later native call", arguments: [false, true])
+    func ordinaryMarkerBeforeCall(ordered: Bool) {
+        let result = process(["</think>\n" + Self.xml + "done"], ordered: ordered)
+        #expect(result.text == "</think>\ndone")
+        #expect(result.calls == [Self.function])
+        #expect(result.rejections.isEmpty)
+        if ordered {
+            #expect(
+                result.events == [.response("</think>\n"), .call(Self.function), .response("done")])
+        }
+    }
+
+    @Test("False openers preserve text and calls at every split", arguments: [false, true])
+    func falseOpenersAtEverySplit(ordered: Bool) {
+        let dialects: [(ToolCallFormat, String)] = [
+            (.xmlFunction, Self.xml), (.json, Self.json), (.qwen35, Self.xml),
+        ]
+        for (format, call) in dialects {
+            for tools in [nil, Self.tools] {
+                for prefix in [
+                    "</think>\n", "a < b < c\n", "<note>hi</note>", "<", "<t", "🧪 e\u{301} < b\n",
+                ] {
+                    let text = prefix + call + "after"
+                    for chunks in chunkings(text) {
+                        let result = process(chunks, format: format, tools: tools, ordered: ordered)
+                        #expect(result.text == prefix + "after", "\(format): \(chunks)")
+                        #expect(result.calls == [Self.function], "\(format): \(chunks)")
+                        #expect(result.rejections.isEmpty, "\(format): \(chunks)")
+                        if ordered {
+                            #expect(
+                                result.events == [
+                                    .response(prefix), .call(Self.function), .response("after"),
+                                ])
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("Text before a partial marker is emitted immediately", arguments: [false, true])
+    func partialMarkerRetainsOnlyTheCandidate(ordered: Bool) {
+        let processor = ToolCallProcessor(format: .xmlFunction)
+        let prefix = "before < b "
+        if ordered {
+            let leading = processor.processChunkOutputs(prefix + "<tool_")
+            #expect(leading.allSatisfy { if case .response = $0 { true } else { false } })
+            #expect(
+                leading.compactMap { if case .response(let text) = $0 { text } else { nil } }
+                    .joined() == prefix)
+            let outputs = processor.processChunkOutputs(String(Self.xml.dropFirst(6)))
+            #expect(outputs.count == 1)
+            if case .toolCall(let call) = outputs.first {
+                #expect(call.function == Self.function)
+            } else {
+                Issue.record("Expected the completed call")
+            }
+            #expect(processor.processEOSOutputs().isEmpty)
+        } else {
+            #expect(processor.processChunk(prefix + "<tool_") == prefix)
+            #expect(processor.processChunk(String(Self.xml.dropFirst(6))) == nil)
+            #expect(processor.toolCalls.map(\.function) == [Self.function])
+            #expect(processor.processEOS(returnBufferedText: true) == nil)
+        }
+    }
+
+    @Test("False openers preserve ordinary text and EOS rejection rules", arguments: [false, true])
+    func residualTextAndRejections(ordered: Bool) {
+        for suffix in ["", "<", "<t", "<tool_call>"] {
+            let prefix = "a < b "
+            for chunks in chunkings(prefix + suffix) {
+                let result = process(chunks, ordered: ordered)
+                #expect(result.calls.isEmpty)
+                if suffix == "<tool_call>" {
+                    #expect(result.text == prefix)
+                    #expect(result.rejections == [.incompleteOutput])
+                } else {
+                    #expect(result.text == prefix + suffix)
+                    #expect(result.rejections.isEmpty)
+                }
+            }
+        }
+    }
+
+    @Test(
+        "Malformed markers and undeclared names still reject before later calls",
+        arguments: [false, true])
+    func rejectionsBeforeLaterCalls(ordered: Bool) {
+        let malformed = process(["<tool_calx>after</tool_call>"], ordered: ordered)
+        #expect(malformed.text == "after")
+        #expect(malformed.calls.isEmpty)
+        #expect(malformed.rejections == [.malformedSyntax])
+
+        for tools in [nil, Self.tools] {
+            let result = process(
+                ["a < b <tool_calx>between" + Self.xml + "after"], tools: tools, ordered: ordered)
+            #expect(result.text == "a < b betweenafter")
+            #expect(result.calls == [Self.function])
+            #expect(result.rejections == [.malformedSyntax])
+            if ordered {
+                #expect(
+                    result.events == [
+                        .response("a < b "), .rejected(.malformedSyntax), .response("between"),
+                        .call(Self.function), .response("after"),
+                    ])
+            }
+        }
+        for tools in [Self.tools, []] {
+            let unknown = Self.xml.replacingOccurrences(of: "weather", with: "unknown")
+            for chunks in chunkings("<" + unknown + "between < b " + Self.xml) {
+                let result = process(chunks, tools: tools, ordered: ordered)
+                #expect(result.text == "<between < b ")
+                #expect(result.calls == (tools.isEmpty ? [] : [Self.function]))
+                #expect(
+                    result.rejections
+                        == (tools.isEmpty ? [.undeclaredTool, .undeclaredTool] : [.undeclaredTool]))
+            }
+        }
+    }
+
+    @Test("Many false candidates do not require recursive parsing")
+    func manyFalseCandidates() {
+        let prefix = String(repeating: "<x ", count: 10_000)
+        let result = process([prefix + Self.xml], ordered: true)
+        #expect(result.text == prefix)
+        #expect(result.calls == [Self.function])
+        #expect(result.rejections.isEmpty)
+    }
+}

--- a/Tests/MLXLMTests/ToolCallRecoveryRegressionTests.swift
+++ b/Tests/MLXLMTests/ToolCallRecoveryRegressionTests.swift
@@ -1,0 +1,120 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+struct ToolCallRecoveryRegressionTests {
+    private let tools: [[String: any Sendable]] = [
+        ["function": ["name": "weather"] as [String: any Sendable]]
+    ]
+    private let call = #"<tool_call>{"name":"weather","arguments":{"city":"Paris"}}</tool_call>"#
+
+    @Test("Native syntax survives recovery under every policy and chunk boundary")
+    func nativeSyntax() {
+        let cases: [(ToolCallFormat, String, String)] = [
+            (
+                .glm4,
+                "<tool_call>weather<arg_key>city</arg_key><arg_value>Paris</arg_value></tool_call>",
+                ""
+            ),
+            (.llama3, #"{"name":"weather","parameters":{"city":"Paris"}}"#, ""),
+            (.json, "The 12\" model. " + call, "The 12\" model. "),
+            (.json, "„Ready\". " + call, "„Ready\". "),
+            (.json, "[for example, see below. " + call, "[for example, see below. "),
+            (.json, "[not an array. " + call, "[not an array. "),
+        ]
+        for (format, text, prefix) in cases {
+            let characters = Array(text)
+            for policy in ToolCallRecoveryPolicy.allCases {
+                for split in 0 ... characters.count {
+                    let chunks = [String(characters[..<split]), String(characters[split...])]
+                    let processor = ToolCallProcessor(
+                        format: format, tools: tools, toolCallPolicy: .init(recovery: policy))
+                    let visible =
+                        chunks.compactMap { processor.processChunk($0) }.joined()
+                        + (processor.processEOS(returnBufferedText: true) ?? "")
+                    #expect(visible == prefix, "\(format), \(policy), split \(split)")
+                    #expect(processor.toolCalls.count == 1)
+                    #expect(
+                        processor.toolCalls.first?.function.arguments["city"] == .string("Paris"))
+                    #expect(processor.rejectedToolCalls.isEmpty)
+                    #expect(processor.recoveredToolCallCount == 0)
+
+                    let ordered = ToolCallProcessor(
+                        format: format, tools: tools, toolCallPolicy: .init(recovery: policy))
+                    let outputs =
+                        chunks.flatMap { ordered.processChunkOutputs($0) }
+                        + ordered.processEOSOutputs()
+                    #expect(
+                        outputs.compactMap {
+                            if case .response(let text) = $0 { text } else { nil }
+                        }.joined() == prefix)
+                    #expect(
+                        outputs.filter { if case .toolCall = $0 { true } else { false } }.count == 1
+                    )
+                    #expect(
+                        outputs.last.map { if case .toolCall = $0 { true } else { false } } == true)
+                }
+            }
+        }
+    }
+
+    @Test("Structured data remains inert, with an executable call only after the value")
+    func structuredData() throws {
+        let payloads: [Any] = [
+            call, ["example": call], [true, false, NSNull(), 1.25e-8, call],
+            ["nested": [["quote": "\\\"🦋", "example": call]]],
+        ]
+        for payload in payloads {
+            let data = try JSONSerialization.data(
+                withJSONObject: payload, options: [.fragmentsAllowed, .sortedKeys])
+            let text = String(decoding: data, as: UTF8.self)
+            for format: ToolCallFormat in [.json, .llama3, .lfm2] {
+                let processor = ToolCallProcessor(format: format, tools: tools)
+                var outputs: [ToolCallProcessor.Output] = []
+                for character in text + " " + call {
+                    outputs += processor.processChunkOutputs(String(character))
+                }
+                outputs += processor.processEOSOutputs()
+                #expect(
+                    outputs.compactMap { if case .response(let text) = $0 { text } else { nil } }
+                        .joined() == text + " ")
+                #expect(
+                    outputs.filter { if case .toolCall = $0 { true } else { false } }.count == 1)
+            }
+        }
+    }
+
+    @Test("JSON syntax tracking rejects impossible prefixes and bounds nesting")
+    func jsonPrefixes() {
+        for text in ["[for", "[nullx", "[01", "[1e+z", "{\"a\" 1", "[true,]", "{\"a\":1]", "\"\\q"]
+        {
+            var scanner = JSONPrefixScanner()
+            if case .invalid = scanner.scan(text) {
+            } else {
+                Issue.record("Accepted impossible prefix: \(text)")
+            }
+        }
+        var scanner = JSONPrefixScanner()
+        if case .depthLimit = scanner.scan(String(repeating: "[", count: 257)) {
+        } else {
+            Issue.record("Missing nesting bound")
+        }
+    }
+
+    @Test("EOS clears prose context before a new generation")
+    func reuseAfterEOS() throws {
+        let processor = ToolCallProcessor(format: .lfm2, tools: tools)
+        _ = processor.processChunk("word")
+        processor.processEOS()
+        let data = try JSONSerialization.data(withJSONObject: call, options: .fragmentsAllowed)
+        let quoted = String(decoding: data, as: UTF8.self)
+        let visible =
+            (processor.processChunk(quoted) ?? "")
+            + (processor.processEOS(returnBufferedText: true) ?? "")
+        #expect(visible == quoted)
+        #expect(processor.toolCalls.isEmpty)
+    }
+}

--- a/Tests/MLXLMTests/ToolSchemaValidatorTests.swift
+++ b/Tests/MLXLMTests/ToolSchemaValidatorTests.swift
@@ -1,0 +1,573 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+/// A partial schema evaluator is safe only when it distinguishes a proven
+/// result from one that depends on unsupported semantics. These tests pin all
+/// three outcomes and the executable-call boundary that consumes them.
+struct ToolSchemaValidatorTests {
+
+    private func tool(
+        _ name: String, parameters: [String: any Sendable]? = nil
+    ) -> [String: any Sendable] {
+        var function: [String: any Sendable] = ["name": name]
+        if let parameters { function["parameters"] = parameters }
+        return ["type": "function", "function": function]
+    }
+
+    private var weatherSchema: [String: any Sendable] {
+        [
+            "type": "object",
+            "properties": [
+                "city": ["type": "string", "minLength": 1] as [String: any Sendable],
+                "limit": ["type": "integer", "minimum": 1, "maximum": 50]
+                    as [String: any Sendable],
+                "units": ["type": "string", "enum": ["celsius", "fahrenheit"]]
+                    as [String: any Sendable],
+            ],
+            "required": ["city"],
+        ]
+    }
+
+    private func descriptions(_ result: ToolSchemaValidator.Result) -> [String] {
+        guard case .invalid(let violations) = result else { return [] }
+        return violations.map(\.description)
+    }
+
+    // MARK: - Types and objects
+
+    @Test("Arguments that satisfy every understood assertion are valid")
+    func validArgumentsPass() {
+        #expect(
+            ToolSchemaValidator.validate(
+                arguments: [
+                    "city": .string("Paris"), "limit": .int(5),
+                    "units": .string("celsius"),
+                ],
+                against: weatherSchema) == .valid)
+    }
+
+    @Test("A wrong type is a proven violation at the argument path")
+    func wrongTypeIsReported() {
+        let result = ToolSchemaValidator.validate(
+            arguments: ["city": .string("Paris"), "limit": .string("five")],
+            against: weatherSchema)
+        #expect(descriptions(result) == ["arguments.limit must be an integer"])
+    }
+
+    @Test("An integral double satisfies integer while a fractional value does not")
+    func integerAcceptsIntegralDoubles() {
+        let schema: [String: any Sendable] = ["type": "integer"]
+        #expect(ToolSchemaValidator.validate(.int(3), against: schema) == .valid)
+        #expect(ToolSchemaValidator.validate(.double(3.0), against: schema) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.double(3.5), against: schema))
+                == ["$ must be an integer"])
+    }
+
+    @Test("A type list accepts any declared type")
+    func typeList() {
+        let schema: [String: any Sendable] = ["type": ["string", "null"]]
+        #expect(ToolSchemaValidator.validate(.string("x"), against: schema) == .valid)
+        #expect(ToolSchemaValidator.validate(.null, against: schema) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(1), against: schema))
+                == ["$ must be one of these types: string, null"])
+    }
+
+    @Test("A missing required argument is reported by name")
+    func missingRequiredIsReported() {
+        let result = ToolSchemaValidator.validate(
+            arguments: ["limit": .int(3)], against: weatherSchema)
+        #expect(descriptions(result) == ["arguments.city is required"])
+    }
+
+    @Test("Nested objects report a stable full path")
+    func nestedPathIsReported() {
+        let schema: [String: any Sendable] = [
+            "type": "object",
+            "properties": [
+                "filters": [
+                    "type": "object",
+                    "properties": ["limit": ["type": "integer"]],
+                    "required": ["limit"],
+                ] as [String: any Sendable]
+            ],
+        ]
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(
+                    arguments: ["filters": .object([:])], against: schema))
+                == ["arguments.filters.limit is required"])
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(
+                    arguments: ["filters": .object(["limit": .string("x")])],
+                    against: schema))
+                == ["arguments.filters.limit must be an integer"])
+    }
+
+    @Test("Diagnostic paths quote property names that are not identifiers")
+    func nonIdentifierPath() {
+        let schema: [String: any Sendable] = [
+            "properties": ["postal-code": ["type": "integer"]]
+        ]
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(
+                    arguments: ["postal-code": .string("x")], against: schema))
+                == [#"arguments["postal-code"] must be an integer"#])
+    }
+
+    @Test("Diagnostic paths JSON-escape control and punctuation characters")
+    func pathEscaping() {
+        let key = "line\n\"\\"
+        let schema: [String: any Sendable] = [
+            "properties": [key: ["type": "integer"]]
+        ]
+        let description = descriptions(
+            ToolSchemaValidator.validate(
+                arguments: [key: .string("x")], against: schema)
+        ).first
+        #expect(description == #"arguments["line\n\"\\"] must be an integer"#)
+        #expect(description?.contains("\n") == false)
+    }
+
+    @Test("additionalProperties false applies without a properties keyword")
+    func additionalPropertiesWithoutProperties() {
+        let schema: [String: any Sendable] = [
+            "type": "object", "additionalProperties": false,
+        ]
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(arguments: ["extra": .int(1)], against: schema))
+                == ["arguments.extra is not a declared property"])
+    }
+
+    @Test("additionalProperties checks undeclared values against its schema")
+    func additionalPropertiesSchema() {
+        let schema: [String: any Sendable] = [
+            "properties": ["city": ["type": "string"]],
+            "additionalProperties": ["type": "integer"],
+        ]
+        #expect(
+            ToolSchemaValidator.validate(arguments: ["count": .int(2)], against: schema)
+                == .valid)
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(
+                    arguments: ["count": .string("two")], against: schema))
+                == ["arguments.count must be an integer"])
+    }
+
+    @Test("Malformed properties make additional-property classification unknown")
+    func malformedPropertiesAreUnknown() {
+        let schema: [String: any Sendable] = [
+            "properties": "not an object", "additionalProperties": false,
+        ]
+        #expect(
+            ToolSchemaValidator.validate(arguments: ["x": .int(1)], against: schema)
+                == .unknown)
+    }
+
+    @Test("Malformed nested schema values are unknown even when not traversed")
+    func malformedSubschemasAreUnknown() {
+        let cases: [(JSONValue, [String: any Sendable])] = [
+            (.object([:]), ["properties": ["unused": "not a schema"]]),
+            (.object([:]), ["additionalProperties": "not a schema"]),
+            (.array([]), ["items": "not a schema"]),
+        ]
+        for (value, schema) in cases {
+            #expect(ToolSchemaValidator.validate(value, against: schema) == .unknown)
+        }
+    }
+
+    @Test("patternProperties prevents an unproven additional-property rejection")
+    func patternPropertiesInteractionIsUnknown() {
+        let schema: [String: any Sendable] = [
+            "patternProperties": ["^x-": ["type": "integer"]],
+            "additionalProperties": false,
+        ]
+        #expect(
+            ToolSchemaValidator.validate(arguments: ["x-count": .int(1)], against: schema)
+                == .unknown)
+    }
+
+    // MARK: - Arrays and strings
+
+    @Test("Array items, count limits, and uniqueness are enforced")
+    func arrayRules() {
+        let schema: [String: any Sendable] = [
+            "type": "array", "items": ["type": "string"],
+            "minItems": 1, "maxItems": 3, "uniqueItems": true,
+        ]
+        #expect(ToolSchemaValidator.validate(.array([.string("a")]), against: schema) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.array([]), against: schema))
+                == ["$ must have at least 1 item"])
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(.array([.string("a"), .int(1)]), against: schema))
+                == ["$[1] must be a string"])
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(
+                    .array([.string("a"), .string("a")]), against: schema))
+                == ["$ must not contain duplicate items"])
+    }
+
+    @Test("JSON numeric equality detects 1 and 1.0 as duplicate items")
+    func uniqueItemsUsesJSONNumberEquality() {
+        let schema: [String: any Sendable] = ["uniqueItems": true]
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(.array([.int(1), .double(1.0)]), against: schema))
+                == ["$ must not contain duplicate items"])
+
+        let first: JSONValue = .object([
+            "a": .int(1), "b": .array([.bool(true), .null]),
+        ])
+        let reordered: JSONValue = .object([
+            "b": .array([.bool(true), .null]), "a": .double(1.0),
+        ])
+        #expect(
+            descriptions(
+                ToolSchemaValidator.validate(
+                    .array([first, reordered]), against: schema))
+                == ["$ must not contain duplicate items"])
+    }
+
+    @Test("uniqueItems handles a large distinct array without quadratic scanning")
+    func uniqueItemsScalesWithDistinctValues() {
+        let values = (0 ..< 4_096).map(JSONValue.int)
+        #expect(
+            ToolSchemaValidator.validate(
+                .array(values), against: ["uniqueItems": true]) == .valid)
+    }
+
+    @Test("Tuple-form items are unknown rather than approximated")
+    func tupleItemsAreUnknown() {
+        let schema: [String: any Sendable] = [
+            "items": [["type": "string"], ["type": "integer"]]
+        ]
+        #expect(
+            ToolSchemaValidator.validate(.array([.string("x"), .int(1)]), against: schema)
+                == .unknown)
+    }
+
+    @Test("prefixItems prevents items from being applied to prefix elements")
+    func prefixItemsInteractionIsUnknown() {
+        let schema: [String: any Sendable] = [
+            "prefixItems": [["type": "string"]], "items": ["type": "integer"],
+        ]
+        #expect(
+            ToolSchemaValidator.validate(
+                .array([.string("prefix"), .int(1)]), against: schema) == .unknown)
+    }
+
+    @Test("String bounds count Unicode code points rather than grapheme clusters")
+    func stringLengthUsesUnicodeCodePoints() {
+        let exactlyTwo: [String: any Sendable] = [
+            "type": "string", "minLength": 2, "maxLength": 2,
+        ]
+        let decomposed = "e\u{301}"
+        #expect(decomposed.count == 1)
+        #expect(decomposed.unicodeScalars.count == 2)
+        #expect(ToolSchemaValidator.validate(.string(decomposed), against: exactlyTwo) == .valid)
+    }
+
+    @Test("Malformed count limits are unknown and never trap")
+    func malformedCountLimitsAreUnknown() {
+        let cases: [(JSONValue, [String: any Sendable])] = [
+            (.array([]), ["minItems": -1]),
+            (.array([]), ["maxItems": Double.infinity]),
+            (.string(""), ["minLength": "two"]),
+        ]
+        for (value, schema) in cases {
+            #expect(ToolSchemaValidator.validate(value, against: schema) == .unknown)
+        }
+    }
+
+    // MARK: - Numbers and constants
+
+    @Test("Inclusive and exclusive bounds support modern and draft-4 forms")
+    func numberBounds() {
+        let inclusive: [String: any Sendable] = ["minimum": 1, "maximum": 10]
+        #expect(ToolSchemaValidator.validate(.int(1), against: inclusive) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(0), against: inclusive))
+                == ["$ must be at least 1"])
+
+        let modern: [String: any Sendable] = [
+            "exclusiveMinimum": 0, "exclusiveMaximum": 1,
+        ]
+        #expect(ToolSchemaValidator.validate(.double(0.5), against: modern) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(0), against: modern))
+                == ["$ must be greater than 0"])
+
+        let draft4: [String: any Sendable] = ["minimum": 0, "exclusiveMinimum": true]
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(0), against: draft4))
+                == ["$ must be greater than 0"])
+        #expect(ToolSchemaValidator.validate(.int(1), against: draft4) == .valid)
+    }
+
+    @Test("A modern exclusive bound does not replace its inclusive sibling")
+    func simultaneousBoundsBothApply() {
+        let schema: [String: any Sendable] = ["minimum": 10, "exclusiveMinimum": 0]
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(5), against: schema))
+                == ["$ must be at least 10"])
+    }
+
+    @Test("Large integer comparisons do not lose precision through Double")
+    func largeIntegerBoundsRemainExact() {
+        let maximum = 9_007_199_254_740_992
+        let schema: [String: any Sendable] = ["maximum": maximum]
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(maximum + 1), against: schema))
+                == ["$ must be at most \(maximum)"])
+    }
+
+    @Test("Finite numbers outside Decimal's range are unknown")
+    func numbersOutsideDecimalRangeAreUnknown() {
+        let value = JSONValue.double(Double.greatestFiniteMagnitude)
+        #expect(
+            ToolSchemaValidator.validate(value, against: ["maximum": 1]) == .unknown)
+        #expect(
+            ToolSchemaValidator.validate(
+                value, against: ["const": Double.greatestFiniteMagnitude]) == .unknown)
+        #expect(
+            ToolSchemaValidator.validate(
+                .array([value, value]), against: ["uniqueItems": true]) == .unknown)
+    }
+
+    @Test("enum keeps Boolean and numeric identity distinct")
+    func enumDoesNotConfuseBoolAndInt() {
+        let schema: [String: any Sendable] = ["enum": [true]]
+        #expect(ToolSchemaValidator.validate(.bool(true), against: schema) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(1), against: schema))
+                == ["$ must be one of the allowed values"])
+    }
+
+    @Test("A malformed enum member prevents a proof even when another member matches")
+    func malformedEnumIsUnknown() {
+        let members: [any Sendable] = ["match", Date()]
+        let schema: [String: any Sendable] = ["enum": members]
+        #expect(ToolSchemaValidator.validate(.string("match"), against: schema) == .unknown)
+    }
+
+    @Test("enum and const compare JSON numbers by mathematical value")
+    func numericEquality() {
+        #expect(
+            ToolSchemaValidator.validate(.double(1.0), against: ["const": 1]) == .valid)
+        #expect(
+            ToolSchemaValidator.validate(.int(1), against: ["enum": [1.0]]) == .valid)
+    }
+
+    // MARK: - Proof and uncertainty
+
+    @Test("Unsupported assertions produce unknown")
+    func unsupportedAssertionsAreUnknown() {
+        let schemas: [[String: any Sendable]] = [
+            ["type": "string", "pattern": "[0-9]+"],
+            ["$ref": "#/$defs/Address"],
+            ["not": ["type": "null"] as [String: any Sendable]],
+        ]
+        for schema in schemas {
+            #expect(ToolSchemaValidator.validate(.string("anything"), against: schema) == .unknown)
+        }
+    }
+
+    @Test("A reference makes sibling assertions unknown across schema dialects")
+    func referenceSiblingIsUnknown() {
+        let schema: [String: any Sendable] = [
+            "$ref": "#/$defs/value", "type": "integer",
+            "$defs": ["value": ["type": "string"]],
+        ]
+        #expect(ToolSchemaValidator.validate(.string("x"), against: schema) == .unknown)
+    }
+
+    @Test("Annotations and schema definitions do not create uncertainty")
+    func annotationsAreNonAssertive() {
+        let schema: [String: any Sendable] = [
+            "type": "string", "description": "value", "default": "x",
+            "$defs": ["Unused": ["type": "integer"]], "x-order": ["value"],
+        ]
+        #expect(ToolSchemaValidator.validate(.string("x"), against: schema) == .valid)
+    }
+
+    @Test("A known sibling violation remains invalid beside an unknown assertion")
+    func provenViolationDominatesUnknown() {
+        let schema: [String: any Sendable] = [
+            "type": "integer", "pattern": "unsupported here",
+        ]
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.string("x"), against: schema))
+                == ["$ must be an integer"])
+    }
+
+    @Test("oneOf branches with unsupported distinctions remain unknown")
+    func oneOfDoesNotInventMatches() {
+        let schema: [String: any Sendable] = [
+            "oneOf": [
+                ["type": "string", "pattern": "^a"],
+                ["type": "string", "pattern": "^b"],
+            ]
+        ]
+        #expect(ToolSchemaValidator.validate(.string("apple"), against: schema) == .unknown)
+    }
+
+    @Test("oneOf is invalid when two branches are proven matches")
+    func oneOfProvenMultipleMatches() {
+        let schema: [String: any Sendable] = [
+            "oneOf": [
+                ["type": "integer"], ["type": "number"], ["pattern": "unknown"],
+            ]
+        ]
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(1), against: schema))
+                == ["$ must satisfy exactly one of the allowed schemas"])
+    }
+
+    @Test("anyOf and allOf propagate proof and uncertainty correctly")
+    func combinatorProofRules() {
+        let validAnyOf: [String: any Sendable] = [
+            "anyOf": [["type": "string"], ["pattern": "unknown"]]
+        ]
+        #expect(ToolSchemaValidator.validate(.string("x"), against: validAnyOf) == .valid)
+
+        let unknownAnyOf: [String: any Sendable] = [
+            "anyOf": [["type": "integer"], ["pattern": "unknown"]]
+        ]
+        #expect(ToolSchemaValidator.validate(.string("x"), against: unknownAnyOf) == .unknown)
+
+        let invalidAllOf: [String: any Sendable] = [
+            "allOf": [["type": "integer"], ["pattern": "unknown"]]
+        ]
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.string("x"), against: invalidAllOf))
+                == ["$ must be an integer"])
+    }
+
+    @Test("Boolean and malformed schemas preserve the proof boundary")
+    func schemaShapes() {
+        #expect(ToolSchemaValidator.validate(.int(1), against: true) == .valid)
+        #expect(
+            descriptions(ToolSchemaValidator.validate(.int(1), against: false))
+                == ["$ is not permitted"])
+        #expect(ToolSchemaValidator.validate(.int(1), against: "not a schema") == .unknown)
+        #expect(
+            ToolSchemaValidator.validate(.int(1), against: ["type": "unsupported"])
+                == .unknown)
+    }
+
+    @Test("Excessive schema nesting becomes unknown rather than recursing without bound")
+    func schemaDepthIsBounded() {
+        var schema: [String: any Sendable] = ["type": "integer"]
+        for _ in 0 ... 64 {
+            schema = ["allOf": [schema]]
+        }
+        #expect(ToolSchemaValidator.validate(.int(1), against: schema) == .unknown)
+    }
+
+    // MARK: - Lookup, diagnostics, and executable boundary
+
+    @Test("Both tool declaration shapes expose their parameters schema")
+    func parametersSchemaLookup() {
+        let openAI = tool("f", parameters: ["type": "object"])
+        let flat: [String: any Sendable] = ["name": "g", "parameters": ["type": "object"]]
+        #expect(ToolSchemaValidator.parametersSchema(ofToolNamed: "f", in: [openAI]) != nil)
+        #expect(ToolSchemaValidator.parametersSchema(ofToolNamed: "g", in: [flat]) != nil)
+        #expect(ToolSchemaValidator.parametersSchema(ofToolNamed: "h", in: [openAI]) == nil)
+    }
+
+    @Test("A malformed declared parameters schema is unknown, not absent")
+    func malformedParametersSchemaIsUnknown() {
+        let malformed: [String: any Sendable] = [
+            "function": ["name": "f", "parameters": "not a schema"]
+                as [String: any Sendable]
+        ]
+        #expect(
+            ToolSchemaValidator.validate(
+                arguments: [:], forToolNamed: "f", in: [malformed]) == .unknown)
+    }
+
+    @Test("describe is bounded and never includes argument values")
+    func describeBounds() {
+        let result = ToolSchemaValidator.validate(
+            arguments: [
+                "city": .int(1), "limit": .string("secret-value"),
+                "units": .string("kelvin"),
+            ],
+            against: weatherSchema)
+        guard case .invalid(let violations) = result else {
+            Issue.record("Expected schema violations, got \(result)")
+            return
+        }
+        let summary = ToolSchemaValidator.describe(violations, limit: 2)
+        #expect(summary.hasSuffix("; and \(violations.count - 2) more"))
+        #expect(!summary.contains("secret-value"))
+        #expect(!summary.contains("kelvin"))
+        #expect(ToolSchemaValidator.describe(violations, limit: -1) == "3 schema violations")
+    }
+
+    @Test("describe bounds a single adversarially long path")
+    func describeBoundsLongPaths() {
+        let key = String(repeating: "x", count: 2_048)
+        let result = ToolSchemaValidator.validate(
+            arguments: [key: .int(1)],
+            against: ["additionalProperties": false])
+        guard case .invalid(let violations) = result else {
+            Issue.record("Expected a schema violation, got \(result)")
+            return
+        }
+        let summary = ToolSchemaValidator.describe(violations)
+        #expect(summary.unicodeScalars.count == 512)
+        #expect(summary.hasSuffix("…"))
+    }
+
+    @Test("The processor rejects only a proven schema violation")
+    func processorProofBoundary() {
+        let invalid = ToolCallProcessor(
+            format: .json, tools: [tool("weather", parameters: weatherSchema)])
+        _ = invalid.processChunk(
+            #"<tool_call>{"name":"weather","arguments":{"city":"Paris","limit":"five"}}</tool_call>"#
+        )
+        #expect(invalid.toolCalls.isEmpty)
+        #expect(invalid.rejectedToolCalls.first?.reason == .invalidArguments)
+        #expect(invalid.rejectedToolCallCount == 1)
+
+        let uncertainSchema: [String: any Sendable] = [
+            "type": "object",
+            "properties": ["code": ["type": "string", "pattern": "^[0-9]+$"]],
+        ]
+        let uncertain = ToolCallProcessor(
+            format: .json, tools: [tool("submit", parameters: uncertainSchema)])
+        _ = uncertain.processChunk(
+            #"<tool_call>{"name":"submit","arguments":{"code":"abc"}}</tool_call>"#)
+        #expect(uncertain.toolCalls.map(\.function.name) == ["submit"])
+        #expect(uncertain.rejectedToolCalls.isEmpty)
+    }
+
+    @Test("A missing schema or tool declaration preserves existing fail-open behavior")
+    func absentSchemaPasses() {
+        #expect(
+            ToolSchemaValidator.validate(arguments: ["x": .int(1)], against: nil) == .valid)
+
+        let withoutParameters = ToolCallProcessor(
+            format: .json, tools: [tool("free_form")])
+        _ = withoutParameters.processChunk(
+            #"<tool_call>{"name":"free_form","arguments":{"anything":true}}</tool_call>"#)
+        #expect(withoutParameters.toolCalls.count == 1)
+
+        let withoutTools = ToolCallProcessor(format: .json)
+        _ = withoutTools.processChunk(
+            #"<tool_call>{"name":"any","arguments":{"x":"y"}}</tool_call>"#)
+        #expect(withoutTools.toolCalls.count == 1)
+    }
+}

--- a/Tests/MLXLMTests/ToolSchemaValidatorTests.swift
+++ b/Tests/MLXLMTests/ToolSchemaValidatorTests.swift
@@ -534,7 +534,8 @@ struct ToolSchemaValidatorTests {
     @Test("The processor rejects only a proven schema violation")
     func processorProofBoundary() {
         let invalid = ToolCallProcessor(
-            format: .json, tools: [tool("weather", parameters: weatherSchema)])
+            format: .json, tools: [tool("weather", parameters: weatherSchema)],
+            toolCallPolicy: .init(validation: .strict))
         _ = invalid.processChunk(
             #"<tool_call>{"name":"weather","arguments":{"city":"Paris","limit":"five"}}</tool_call>"#
         )
@@ -547,7 +548,8 @@ struct ToolSchemaValidatorTests {
             "properties": ["code": ["type": "string", "pattern": "^[0-9]+$"]],
         ]
         let uncertain = ToolCallProcessor(
-            format: .json, tools: [tool("submit", parameters: uncertainSchema)])
+            format: .json, tools: [tool("submit", parameters: uncertainSchema)],
+            toolCallPolicy: .init(validation: .strict))
         _ = uncertain.processChunk(
             #"<tool_call>{"name":"submit","arguments":{"code":"abc"}}</tool_call>"#)
         #expect(uncertain.toolCalls.map(\.function.name) == ["submit"])

--- a/Tests/MLXLMTests/XMLFunctionParserStrictnessTests.swift
+++ b/Tests/MLXLMTests/XMLFunctionParserStrictnessTests.swift
@@ -1,0 +1,396 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+/// Structural strictness of the native `.xmlFunction` protocol.
+///
+/// `XMLFunctionParser` previously accepted a structurally degraded payload and
+/// returned a call with silently missing arguments. The only thing preventing
+/// execution was schema-level required-argument validation, so a tool whose
+/// schema omitted `required` could be invoked with no arguments at all from a
+/// truncated frame. These tests pin the parser to the shared
+/// `QwenXMLPayloadScanner` grammar and deliberately declare **no** `required`
+/// list, so structural validity alone must carry the rejection.
+struct XMLFunctionParserStrictnessTests {
+
+    private let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+
+    /// Schemas without a `required` list: required-argument validation cannot
+    /// mask a structural parser flaw here.
+    private func toolSchemas(_ names: String...) -> [[String: any Sendable]] {
+        names.map { name in
+            ["function": ["name": name] as [String: any Sendable]]
+        }
+    }
+
+    // MARK: - Structural rejection
+
+    @Test("An unclosed <parameter> never becomes a call")
+    func unclosedParameterIsRejected() {
+        let payloads = [
+            "<function=weather><parameter=city>Paris</function>",
+            "<tool_call><function=weather><parameter=city>Paris</function></tool_call>",
+            """
+            <tool_call>
+            <function=weather>
+            <parameter=city>Paris
+            </function>
+            </tool_call>
+            """,
+            // First parameter closes, second does not: partial success is still
+            // a structurally invalid payload.
+            "<function=weather><parameter=city>Paris</parameter><parameter=unit>c</function>",
+        ]
+
+        for payload in payloads {
+            #expect(
+                parser.parse(content: payload, tools: nil) == nil,
+                "expected structural rejection of: \(payload)")
+        }
+    }
+
+    @Test("A missing </function> never becomes a call")
+    func missingFunctionCloseIsRejected() {
+        let payloads = [
+            "<function=weather>",
+            "<function=weather><parameter=city>Paris</parameter>",
+            "<tool_call><function=weather><parameter=city>Paris</parameter></tool_call>",
+        ]
+
+        for payload in payloads {
+            #expect(
+                parser.parse(content: payload, tools: nil) == nil,
+                "expected structural rejection of: \(payload)")
+        }
+    }
+
+    @Test("Malformed function and parameter names never become a call")
+    func malformedNamesAreRejected() {
+        let payloads = [
+            "<function=><parameter=city>Paris</parameter></function>",
+            "<function=get weather><parameter=city>Paris</parameter></function>",
+            "<function=weather><parameter=>Paris</parameter></function>",
+        ]
+
+        for payload in payloads {
+            #expect(
+                parser.parse(content: payload, tools: nil) == nil,
+                "expected structural rejection of: \(payload)")
+        }
+    }
+
+    @Test("Content beyond the payload is never silently discarded")
+    func trailingContentIsRejected() {
+        let payloads = [
+            // A second call in one frame must not silently collapse to the first.
+            "<function=a><parameter=x>1</parameter></function><function=b></function>",
+            "<function=weather></function>trailing text",
+            // A complete frame followed by text: the streaming processor splits
+            // this, so a direct parse must not quietly drop the remainder.
+            "<tool_call><function=weather></function></tool_call>trailing",
+        ]
+
+        for payload in payloads {
+            #expect(
+                parser.parse(content: payload, tools: nil) == nil,
+                "expected rejection of payload with trailing content: \(payload)")
+        }
+    }
+
+    // MARK: - Literal markers inside values are data
+
+    @Test("A literal </function> inside a parameter value is preserved")
+    func literalFunctionCloseIsPreserved() throws {
+        let content = """
+            <tool_call>
+            <function=weather>
+            <parameter=city>
+            literal </function> text
+            </parameter>
+            </function>
+            </tool_call>
+            """
+
+        let call = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(call.function.name == "weather")
+        #expect(call.function.arguments["city"] == .string("literal </function> text"))
+    }
+
+    @Test("A literal </tool_call> inside a parameter value is preserved")
+    func literalFrameCloseIsPreserved() throws {
+        let content =
+            "<tool_call><function=weather><parameter=city>a</tool_call>b</parameter>"
+            + "</function></tool_call>"
+
+        let call = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(call.function.arguments["city"] == .string("a</tool_call>b"))
+    }
+
+    // MARK: - Canonical payloads keep working
+
+    @Test("Canonical payloads still parse unchanged")
+    func canonicalPayloadsStillParse() throws {
+        let unframed = try #require(
+            parser.parse(
+                content:
+                    "<function=get_weather><parameter=location>Tokyo</parameter>"
+                    + "<parameter=unit>celsius</parameter></function>",
+                tools: nil))
+        #expect(unframed.function.name == "get_weather")
+        #expect(unframed.function.arguments["location"] == .string("Tokyo"))
+        #expect(unframed.function.arguments["unit"] == .string("celsius"))
+
+        let framedMultiline = try #require(
+            parser.parse(
+                content: """
+                    <tool_call>
+                    <function=get_current_datetime>
+                    </function>
+                    </tool_call>
+                    """,
+                tools: nil))
+        #expect(framedMultiline.function.name == "get_current_datetime")
+        #expect(framedMultiline.function.arguments.isEmpty)
+
+        let multilineValue = try #require(
+            parser.parse(
+                content: """
+                    <function=get_weather>
+                    <parameter=location>
+                    Tokyo
+                    </parameter>
+                    </function>
+                    """,
+                tools: nil))
+        #expect(multilineValue.function.arguments["location"] == .string("Tokyo"))
+    }
+
+    @Test("Schema-driven type conversion is unchanged")
+    func typeConversionIsUnchanged() throws {
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "search",
+                    "parameters": [
+                        "properties": [
+                            "page": ["type": "integer"],
+                            "filters": ["type": "object"],
+                        ]
+                    ],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content =
+            "<tool_call><function=search><parameter=page>1</parameter>"
+            + #"<parameter=filters>{"archived": false, "limit": 1}</parameter></function></tool_call>"#
+
+        let call = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(call.function.arguments["page"] == .int(1))
+        #expect(
+            call.function.arguments["filters"]
+                == .object(["archived": .bool(false), "limit": .int(1)]))
+    }
+
+    // MARK: - End-to-end through ToolCallProcessor
+
+    @Test("Native XML rejects an unclosed parameter at EOS")
+    func nativeXMLRejectsUnclosedParameterAtEOS() {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction,
+            tools: toolSchemas("weather"))
+
+        _ = processor.processChunk(
+            "<tool_call><function=weather><parameter=city>Paris</function></tool_call>")
+        processor.processEOS()
+
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.rejectedToolCalls.count == 1)
+    }
+
+    @Test("A truncated frame is rejected at every chunk boundary")
+    func truncatedFrameRejectedAtEveryChunkBoundary() {
+        let payload = """
+            <tool_call>
+            <function=weather>
+            <parameter=city>Paris
+            </function>
+            </tool_call>
+            """
+
+        for splitOffset in 0 ... payload.count {
+            let split = payload.index(payload.startIndex, offsetBy: splitOffset)
+            let processor = ToolCallProcessor(
+                format: .xmlFunction,
+                tools: toolSchemas("weather"))
+
+            _ = processor.processChunk(String(payload[..<split]))
+            _ = processor.processChunk(String(payload[split...]))
+            processor.processEOS()
+
+            #expect(
+                processor.toolCalls.isEmpty,
+                "executed a truncated frame when split at \(splitOffset)")
+            #expect(
+                processor.rejectedToolCalls.count == 1,
+                "expected exactly one rejection when split at \(splitOffset)")
+        }
+    }
+
+    @Test("A canonical call still executes at every chunk boundary")
+    func canonicalCallExecutesAtEveryChunkBoundary() throws {
+        let payload = """
+            <tool_call>
+            <function=weather>
+            <parameter=city>
+            Paris
+            </parameter>
+            </function>
+            </tool_call>
+            """
+
+        for splitOffset in 0 ... payload.count {
+            let split = payload.index(payload.startIndex, offsetBy: splitOffset)
+            let processor = ToolCallProcessor(
+                format: .xmlFunction,
+                tools: toolSchemas("weather"))
+
+            _ = processor.processChunk(String(payload[..<split]))
+            _ = processor.processChunk(String(payload[split...]))
+            processor.processEOS()
+
+            #expect(
+                processor.rejectedToolCalls.isEmpty,
+                "rejected a canonical call when split at \(splitOffset)")
+            #expect(
+                processor.toolCalls.count == 1,
+                "lost a canonical call when split at \(splitOffset)")
+            let call = try #require(processor.toolCalls.first)
+            #expect(call.function.name == "weather")
+            #expect(
+                call.function.arguments["city"] == .string("Paris"),
+                "dropped arguments when split at \(splitOffset)")
+        }
+    }
+
+    @Test("A literal </function> argument survives streaming at every chunk boundary")
+    func literalFunctionCloseSurvivesStreaming() throws {
+        let payload = """
+            <tool_call>
+            <function=weather>
+            <parameter=city>
+            literal </function> text
+            </parameter>
+            </function>
+            </tool_call>
+            """
+
+        for splitOffset in 0 ... payload.count {
+            let split = payload.index(payload.startIndex, offsetBy: splitOffset)
+            let processor = ToolCallProcessor(
+                format: .xmlFunction,
+                tools: toolSchemas("weather"))
+
+            _ = processor.processChunk(String(payload[..<split]))
+            _ = processor.processChunk(String(payload[split...]))
+            processor.processEOS()
+
+            #expect(
+                processor.toolCalls.count == 1,
+                "lost the call when split at \(splitOffset)")
+            let call = try #require(processor.toolCalls.first)
+            #expect(
+                call.function.arguments["city"] == .string("literal </function> text"),
+                "corrupted the argument when split at \(splitOffset)")
+        }
+    }
+
+    @Test("Text following a canonical call is still emitted")
+    func trailingTextAfterCallIsPreserved() {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction,
+            tools: toolSchemas("weather"))
+
+        var response = ""
+        response +=
+            processor.processChunk(
+                "<tool_call><function=weather><parameter=city>Paris</parameter>"
+                    + "</function></tool_call>done") ?? ""
+        response += processor.processEOS(returnBufferedText: true) ?? ""
+
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.rejectedToolCalls.isEmpty)
+        #expect(response.contains("done"))
+    }
+
+    @Test("Consecutive canonical calls are all executed")
+    func consecutiveCallsAreExecuted() {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction,
+            tools: toolSchemas("weather", "clock"))
+
+        _ = processor.processChunk(
+            "<tool_call><function=weather><parameter=city>Paris</parameter></function></tool_call>"
+                + "<tool_call><function=clock></function></tool_call>")
+        processor.processEOS()
+
+        #expect(processor.rejectedToolCalls.isEmpty)
+        #expect(processor.toolCalls.map(\.function.name) == ["weather", "clock"])
+    }
+
+    // MARK: - Cross-parser parity
+
+    @Test("Both Qwen XML dialect parsers agree on structural validity")
+    func dialectParsersAgree() {
+        let qwen35 = Qwen35ToolCallParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let tools = toolSchemas("weather")
+
+        let malformed = [
+            "<tool_call><function=weather><parameter=city>Paris</function></tool_call>",
+            "<tool_call><function=weather><parameter=city>Paris</parameter></tool_call>",
+            "<tool_call><function=></function></tool_call>",
+        ]
+        for payload in malformed {
+            #expect(parser.parse(content: payload, tools: tools) == nil, "xmlFunction: \(payload)")
+            #expect(qwen35.parse(content: payload, tools: tools) == nil, "qwen35: \(payload)")
+        }
+
+        let canonical =
+            "<tool_call><function=weather><parameter=city>Paris</parameter></function></tool_call>"
+        #expect(parser.parse(content: canonical, tools: tools) != nil)
+        #expect(qwen35.parse(content: canonical, tools: tools) != nil)
+    }
+
+    /// Before this fix the schema's `required` list was the only defense: the
+    /// same truncated frame was executed as `weather()` without one and
+    /// rejected with one. Both must now be rejected structurally.
+    @Test("Rejection no longer depends on a declared required list")
+    func rejectionIsIndependentOfRequiredList() {
+        let withoutRequired: [[String: any Sendable]] = toolSchemas("weather")
+        let withRequired: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "weather",
+                    "parameters": [
+                        "type": "object",
+                        "required": ["city"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+
+        for tools in [withoutRequired, withRequired] {
+            let processor = ToolCallProcessor(format: .xmlFunction, tools: tools)
+            _ = processor.processChunk(
+                "<tool_call><function=weather><parameter=city>Paris</function></tool_call>")
+            processor.processEOS()
+
+            #expect(processor.toolCalls.isEmpty)
+            #expect(processor.rejectedToolCalls.count == 1)
+        }
+    }
+}

--- a/skills/mlx-swift-lm/references/tool-calling.md
+++ b/skills/mlx-swift-lm/references/tool-calling.md
@@ -185,6 +185,28 @@ let processor = ToolCallProcessor(
 )
 ```
 
+### Schema Validation
+
+When you supply tool schemas, the processor does two checks before a call
+becomes executable:
+
+1. The function name must be in the declared tools.
+2. The arguments must not definitively violate the tool's `parameters` schema.
+
+A call that fails a check is not dispatched. It is reported as a
+`RejectedToolCall` with the reason `undeclaredTool` or `invalidArguments`.
+The `detail` of a schema violation says where the problem is and what the
+schema requires, for example `arguments.limit must be an integer`.
+
+The package validates the JSON Schema keywords that tool declarations commonly use:
+`type`, `properties`, `required`, `additionalProperties`, `items`,
+`minItems`, `maxItems`, `uniqueItems`, `minLength`, `maxLength`, `minimum`,
+`maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `enum`, `const`, `anyOf`,
+`oneOf`, and `allOf`. Validation is conservative: an unsupported assertion such
+as `pattern` or `$ref` makes the result uncertain and cannot reject a call on
+its own. A tool without a `parameters` schema accepts all arguments. Without
+tool declarations, all parsed calls pass.
+
 ## Format Resolution
 
 When a model is loaded, the factories resolve the format in this order:

--- a/skills/mlx-swift-lm/references/tool-calling.md
+++ b/skills/mlx-swift-lm/references/tool-calling.md
@@ -187,11 +187,12 @@ let processor = ToolCallProcessor(
 
 ### Schema Validation
 
-When you supply tool schemas, the processor does two checks before a call
-becomes executable:
+When you supply tool schemas, the processor checks calls before dispatch:
 
 1. The function name must be in the declared tools.
-2. The arguments must not definitively violate the tool's `parameters` schema.
+2. With `toolCallPolicy: .init(validation: .strict)`, arguments must not
+   definitively violate the tool's `parameters` schema. The default is
+   `.permissive`, which leaves schema validation to the application.
 
 A call that fails a check is not dispatched. It is reported as a
 `RejectedToolCall` with the reason `undeclaredTool` or `invalidArguments`.


### PR DESCRIPTION
## Proposed changes

This PR follows #531 and adds bounded, streaming recovery for textual tool calls that the selected native parser does not recognize. Fixes #259 

Some checkpoints can emit valid tool calls using a common alternate textual dialect. Previously, these calls could pass through as ordinary response text even when the function was explicitly declared by the caller.

The recovery layer supports:

- framed `<tool_call>…</tool_call>` JSON or XML calls
- `[TOOL_CALLS]name{...}` and `name[ARGS]{...}`
- Qwen-style `<function=name>…</function>` calls
- Gemma `<|tool_call>…<tool_call|>` calls

The native parser remains authoritative. Recovery only promotes a structurally complete call whose function name exactly matches a declared tool. It is disabled when no nonempty tool declaration is provided.

Before a native or recovered call becomes executable, its arguments are checked against the declared tool schema. Validation is deliberately conservative: supported constraints reject only definite violations, while unsupported, malformed, or ambiguous schema features produce an unknown result and remain fail-open.

This prevents clearly invalid arguments such as missing required properties, incorrect types, unexpected properties, invalid enum values, or out-of-range values from reaching application tools without claiming complete JSON Schema support. Rejections use the existing `invalidArguments` reason with bounded, path-specific diagnostics that do not include argument values.

Schema validation is applied consistently across standard tool formats, Harmony, Onyx, and recovered cross-dialect calls.

The implementation also:

- preserves thinking and response text in its original order while extracting embedded calls
- treats native protocol frames and ordinary JSON responses as opaque
- bounds incomplete recovery input to 64 KiB of UTF-8 data
- resets recovery state at EOS
- uses a delimiter-gated ordinary-text fast path with fixed-string structural scanning, avoiding regular expressions and speculative JSON decoding
- keeps schema validation package-scoped with explicit `valid`, `invalid`, and `unknown` outcomes
- prevents rejected candidates from being dispatched or counted as successfully recovered calls
- bounds validation depth and diagnostic output
- preserves existing public rejection semantics and parser entry points

Together, these changes make tool use more reliable and safer: alternate valid tool-call formats can be recovered, while calls that definitively violate their declared contract are stopped before execution.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)