### PR TITLE
Fix Qwen3VL prompt cache reuse for text-only inputs

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -117,8 +117,7 @@ public struct Qwen3VLProcessor: UserInputProcessor {
 
         if input.images.isEmpty, input.videos.isEmpty {
             let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
-            let mask = ones(like: promptArray).asType(.int8)
-            return LMInput(text: .init(tokens: promptArray, mask: mask))
+            return LMInput(tokens: promptArray)
         }
 
         var processedImage: LMInput.ProcessedImage?

--- a/Tests/MLXLMTests/Qwen3VLProcessorTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLProcessorTests.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Apple Inc.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MLXVLM
+
+final class Qwen3VLProcessorTests: XCTestCase {
+
+    private struct ProcessorTokenizer: Tokenizer {
+        let promptTokens: [Int]
+
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var unknownToken: String? = nil
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+            if text.contains("<|vision_start|>") {
+                return [90, 91, 92]
+            }
+            return [1, 2, 3]
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            promptTokens
+        }
+    }
+
+    private func makeProcessor(promptTokens: [Int]) throws -> Qwen3VLProcessor {
+        let json = """
+            {
+              "image_mean": [0.5, 0.5, 0.5],
+              "image_std": [0.5, 0.5, 0.5],
+              "min_pixels": 1024,
+              "max_pixels": 1024,
+              "merge_size": 2,
+              "patch_size": 16,
+              "temporal_patch_size": 2,
+              "image_processor_type": "Qwen2VLImageProcessor"
+            }
+            """
+        let config = try JSONDecoder().decode(
+            Qwen3VLProcessorConfiguration.self, from: Data(json.utf8))
+        return Qwen3VLProcessor(
+            config, tokenizer: ProcessorTokenizer(promptTokens: promptTokens))
+    }
+
+    func testTextOnlyInputDoesNotCarryRedundantAttentionMask() async throws {
+        let processor = try makeProcessor(promptTokens: [1, 2, 3])
+
+        let prepared = try await processor.prepare(input: UserInput(prompt: "hello"))
+
+        XCTAssertEqual(prepared.text.tokens.shape, [1, 3])
+        XCTAssertNil(prepared.text.mask)
+        XCTAssertNil(prepared.image)
+        XCTAssertNil(prepared.video)
+    }
+
+    func testImageInputKeepsAttentionMaskAndMediaPayload() async throws {
+        let processor = try makeProcessor(promptTokens: [90, 91, 92])
+        let image = CIImage(color: .black).cropped(
+            to: CGRect(x: 0, y: 0, width: 32, height: 32))
+        var input = UserInput(prompt: "describe", images: [.ciImage(image)])
+        input.processing = .init(minPixels: 1024, maxPixels: 1024)
+
+        let prepared = try await processor.prepare(input: input)
+
+        let mask = try XCTUnwrap(prepared.text.mask)
+        XCTAssertEqual(mask.shape, prepared.text.tokens.shape)
+        XCTAssertNotNil(prepared.image)
+        XCTAssertNil(prepared.video)
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Stop attaching a redundant all-ones attention mask to text-only `Qwen3VLProcessor` inputs.
- Return `LMInput(tokens:)` when no images or videos are present.
- Preserve the existing attention mask and media payload behavior for multimodal inputs.
- Add regression tests for both text-only and image inputs.

## Why

For a single unpadded text sequence, the all-ones mask does not change attention or position semantics. However, `ChatSession` interprets any explicit attention mask as unsafe for prompt-cache suffix reuse, causing the complete prompt to be prefetched again on every continuation.

Removing the redundant mask allows text-only conversations using the VLM loading path to reuse their cached prompt prefix.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
