### PR TITLE
Fix compiled decoding with fixed-capacity KV cache

### DIFF
--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -150,7 +150,9 @@ public class LlamaModelInner: Module {
 }
 
 /// Model for Llama and Mistral model types.
-public class LlamaModel: Module, LLMModel, KVCacheDimensionProvider {
+public class LlamaModel: Module, LLMModel, KVCacheDimensionProvider,
+    FixedCapacityKVCacheProviding
+{
 
     public let vocabularySize: Int
     public let kvHeads: [Int]

--- a/Libraries/MLXLLM/Models/Qwen2.swift
+++ b/Libraries/MLXLLM/Models/Qwen2.swift
@@ -164,7 +164,9 @@ public class Qwen2ModelInner: Module {
     }
 }
 
-public class Qwen2Model: Module, LLMModel, KVCacheDimensionProvider {
+public class Qwen2Model: Module, LLMModel, KVCacheDimensionProvider,
+    FixedCapacityKVCacheProviding
+{
     public let vocabularySize: Int
     public let kvHeads: [Int]
 

--- a/Libraries/MLXLMCommon/CompiledDecodeSession.swift
+++ b/Libraries/MLXLMCommon/CompiledDecodeSession.swift
@@ -1,0 +1,121 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// Errors raised before a compiled decode step can issue an invalid cache write.
+public enum CompiledDecodeSessionError: Error, LocalizedError, Equatable {
+    case invalidCapacity(Int)
+    case invalidPromptShape([Int])
+    case emptyPrompt
+    case promptExceedsCapacity(promptTokens: Int, capacity: Int)
+    case invalidTokenShape([Int], expectedBatchSize: Int)
+    case capacityExceeded(capacity: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidCapacity(let capacity):
+            "Compiled decode capacity must be positive and fit in Int32; got \(capacity)."
+        case .invalidPromptShape(let shape):
+            "Compiled decode requires prompt tokens shaped [batch, sequence]; got \(shape)."
+        case .emptyPrompt:
+            "Compiled decode requires at least one prompt token."
+        case .promptExceedsCapacity(let promptTokens, let capacity):
+            "Prompt length \(promptTokens) exceeds compiled decode capacity \(capacity)."
+        case .invalidTokenShape(let shape, let expectedBatchSize):
+            "Compiled decode requires one token per row with shape [\(expectedBatchSize), 1]; got \(shape)."
+        case .capacityExceeded(let capacity):
+            "Compiled decode capacity \(capacity) is exhausted."
+        }
+    }
+}
+
+/// Owns a fixed-capacity cache and a compiled, capacity-safe decode step.
+///
+/// Construction performs prefill eagerly, evaluates the allocated cache state,
+/// and only then creates the compiled closure. ``step(_:)`` accepts exactly one
+/// token per batch row and checks capacity on the host before dispatching the
+/// graph. This prevents out-of-range `putAlong` writes without synchronizing the
+/// graph-valued cache position on every decode step.
+///
+/// This session supports text-only, same-length batches. Keep it within the same
+/// serialized model access that owns `model`; it is intentionally not `Sendable`.
+public final class CompiledDecodeSession {
+    public let capacity: Int
+    public let batchSize: Int
+    public let prefillLogits: MLXArray
+
+    /// Number of prompt and decode-input tokens consumed by the model.
+    public private(set) var processedTokenCount: Int
+
+    /// Number of additional single-token decode calls that are safe.
+    public var remainingCapacity: Int {
+        capacity - processedTokenCount
+    }
+
+    /// Per-layer positions for diagnostics. Reading this synchronizes the
+    /// graph-valued positions to the host; do not poll it in a decode loop.
+    public var cacheOffsets: [Int] {
+        caches.map(\.offset)
+    }
+
+    private let caches: [FixedCapacityKVCache]
+    private let decode: (MLXArray) -> MLXArray
+
+    /// Prefill `model` and prepare a compiled single-token decode step.
+    ///
+    /// - Parameters:
+    ///   - model: A model audited for graph-valued cache positions.
+    ///   - prompt: Token IDs shaped `[batch, sequence]`. All rows share one
+    ///     sequence length and cache timeline.
+    ///   - capacity: Total sequence capacity, including the prompt and every
+    ///     token subsequently passed to ``step(_:)``.
+    public init(
+        model: any FixedCapacityKVCacheProviding,
+        prompt: MLXArray,
+        capacity: Int
+    ) throws {
+        guard capacity > 0, capacity <= Int(Int32.max) else {
+            throw CompiledDecodeSessionError.invalidCapacity(capacity)
+        }
+        guard prompt.ndim == 2 else {
+            throw CompiledDecodeSessionError.invalidPromptShape(prompt.shape)
+        }
+        let promptTokenCount = prompt.dim(1)
+        guard prompt.dim(0) > 0, promptTokenCount > 0 else {
+            throw CompiledDecodeSessionError.emptyPrompt
+        }
+        guard promptTokenCount <= capacity else {
+            throw CompiledDecodeSessionError.promptExceedsCapacity(
+                promptTokens: promptTokenCount, capacity: capacity)
+        }
+
+        let caches = try model.newFixedCapacityCache(maxTokens: capacity)
+        let prefillLogits = model(prompt, cache: caches)
+        eval(prefillLogits, caches)
+
+        self.capacity = capacity
+        self.batchSize = prompt.dim(0)
+        self.caches = caches
+        self.prefillLogits = prefillLogits
+        self.processedTokenCount = promptTokenCount
+        self.decode = compile(inputs: caches, outputs: caches) { token in
+            model(token, cache: caches)
+        }
+    }
+
+    /// Run one compiled decode step after validating shape and capacity.
+    public func step(_ token: MLXArray) throws -> MLXArray {
+        guard token.ndim == 2, token.dim(0) == batchSize, token.dim(1) == 1 else {
+            throw CompiledDecodeSessionError.invalidTokenShape(
+                token.shape, expectedBatchSize: batchSize)
+        }
+        guard processedTokenCount < capacity else {
+            throw CompiledDecodeSessionError.capacityExceeded(capacity: capacity)
+        }
+
+        let logits = decode(token)
+        processedTokenCount += 1
+        return logits
+    }
+}

--- a/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
@@ -8,6 +8,7 @@ Common language model code.
 - <doc:upgrade>
 - <doc:wired-memory>
 - <doc:kv-cache-quantization>
+- <doc:compiled-kv-cache>
 
 ## Other MLX Libraries Packages
 

--- a/Libraries/MLXLMCommon/Documentation.docc/compiled-kv-cache.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/compiled-kv-cache.md
@@ -1,0 +1,66 @@
+# Compiled KV-cache decoding
+
+Use ``CompiledDecodeSession`` when repeatedly invoking a compatible text model
+from an `MLX.compile` decode closure.
+
+## Why this is a separate cache
+
+``KVCacheSimple`` is optimized for eager generation. It grows storage in chunks
+and returns only the written prefix, so attention work tracks the actual context
+length. Its write position is a Swift `Int`, however, and dynamic slices derived
+from that value become constants when MLX traces a compiled function.
+
+``FixedCapacityKVCache`` has the opposite tradeoff. It allocates its final shape
+before compilation, carries position as an `MLXArray`, scatters new rows using
+tensor indices, and masks unwritten capacity. This makes the graph reusable and
+correct across decode steps, but attention spans the configured capacity even
+when only part of it has been written. Keeping the implementations separate
+preserves the efficient default for eager generation.
+
+## Supported models
+
+Only models conforming to ``FixedCapacityKVCacheProviding`` may use this cache.
+The capability means the model has been audited and parity-tested so every
+position-dependent forward operation remains in the MLX graph.
+
+The initial supported implementations are:
+
+- `Qwen2Model`, including Qwen 2 and Qwen 2.5 text checkpoints.
+- `LlamaModel`, including Llama and the Mistral text checkpoints backed by that
+  implementation.
+
+Do not substitute this cache into vision-language, sliding-window, recurrent,
+hybrid, or model-specific cache layouts. In particular, a similarly named model
+is not implicitly compatible: `Mistral3TextModel` is distinct from `LlamaModel`.
+Unsupported models continue using their standard eager cache.
+
+## Usage
+
+Size capacity for the prompt and the complete generation. The session performs
+prefill before creating the compiled closure and rejects decode after capacity:
+
+```swift
+guard let cacheProvider = model as? any FixedCapacityKVCacheProviding else {
+    // Fall back to the normal eager generation path.
+    return
+}
+
+let maxNewTokens = 256
+let capacity = promptTokens.dim(1) + maxNewTokens
+let session = try CompiledDecodeSession(
+    model: cacheProvider, prompt: promptTokens, capacity: capacity)
+
+var token = nextToken(from: session.prefillLogits)
+emit(token)
+for _ in 1 ..< maxNewTokens {
+    let logits = try session.step(token.reshaped(1, 1))
+    token = nextToken(from: logits)
+    emit(token)
+}
+```
+
+``CompiledDecodeSession`` is the safe public execution path. It owns the host
+token count because a compiled graph cannot raise a Swift error from a
+tensor-valued position without synchronizing it to the CPU. Advanced callers
+can construct ``FixedCapacityKVCache`` directly, but then they own prefill order
+and capacity admission.

--- a/Libraries/MLXLMCommon/FixedCapacityKVCache.swift
+++ b/Libraries/MLXLMCommon/FixedCapacityKVCache.swift
@@ -1,0 +1,278 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// A fixed-capacity key/value cache for models that conform to
+/// ``FixedCapacityKVCacheProviding``.
+///
+/// ## Why this cache exists
+///
+/// ``KVCacheSimple`` tracks its write position with a Swift `Int` and uses it as
+/// the bounds of array slices inside `update(keys:values:)`. When a model step is
+/// traced for `MLX.compile(inputs:outputs:shapeless:_:)`,
+/// those integers are embedded in the graph as *constants*: the compiled step keeps
+/// writing into the slot and attending over the window captured at trace time, so
+/// decode falls into repeating token loops (issue #406).
+///
+/// For compatible models, ``FixedCapacityKVCache`` removes every position-dependent
+/// Swift integer from the traced step:
+///
+/// - buffers are allocated once at full capacity, so shapes never change across
+///   decode steps and the compiled graph is reused;
+/// - the write position is an `MLXArray` carried through ``innerState()`` and
+///   therefore threaded through compile as an input *and* an output;
+/// - the KV write, RoPE offset and attention mask are all graph operations
+///   derived from that position array.
+///
+/// ## Usage
+///
+/// ```swift
+/// let session = try CompiledDecodeSession(
+///     model: cacheProvider,
+///     prompt: promptTokens,
+///     capacity: promptTokens.dim(1) + maxNewTokens)
+/// var token = nextToken(from: session.prefillLogits)
+/// while session.remainingCapacity > 0 {
+///     let logits = try session.step(token.reshaped(1, 1))
+///     token = nextToken(from: logits)
+/// }
+/// ```
+///
+/// ## Contracts
+///
+/// - Prefer ``CompiledDecodeSession`` over constructing the cache directly. It
+///   performs eager prefill before tracing and enforces capacity on the host.
+/// - Low-level callers must prefill before the first compiled call and must not
+///   invoke the model once the cache reaches capacity.
+/// - One write position is tracked, so every row of a batch shares it:
+///   batch 1, or same-length rows.
+/// - The attention read spans the full capacity with unwritten slots masked out,
+///   which trades a little attention compute for static shapes.
+///
+/// Use this cache only for models conforming to ``FixedCapacityKVCacheProviding``.
+/// Those models have been audited to keep position-dependent work in MLX graph
+/// values and to use a standard full-attention cache for every layer. The cache
+/// is also correct when used eagerly, but ``KVCacheSimple`` is faster there
+/// because it attends only over written slots.
+public final class FixedCapacityKVCache: KVCache, Updatable {
+
+    /// The capacity, in tokens, of the key/value buffers.
+    public let maxTokens: Int
+
+    private var keys: MLXArray?
+    private var values: MLXArray?
+
+    /// The write position as a `[1]` int32 array.
+    ///
+    /// This is the piece of state ``KVCacheSimple`` keeps as a Swift `Int`; as an
+    /// array it is part of ``innerState()`` and advances through compiled calls
+    /// instead of being baked into the graph as a constant.
+    private var position: MLXArray?
+
+    public init(maxTokens: Int) {
+        precondition(maxTokens > 0, "FixedCapacityKVCache.maxTokens must be positive")
+        precondition(
+            maxTokens <= Int(Int32.max),
+            "FixedCapacityKVCache.maxTokens must fit in an Int32")
+        self.maxTokens = maxTokens
+    }
+
+    // MARK: - KVCache
+
+    public var offset: Int {
+        guard let position else { return 0 }
+        return Int(position.item(Int32.self))
+    }
+
+    /// Array-valued offset so rotary position embeddings participate in the
+    /// compiled graph instead of being read as a Swift `Int` constant.
+    ///
+    /// The `+ 0` snapshots the position before ``update(keys:values:)`` advances
+    /// it, mirroring ``BatchPositionedKVCache``.
+    public var ropeOffset: RoPEOffset {
+        .batch((position ?? MLXArray([Int32(0)])) + 0)
+    }
+
+    public var maxSize: Int? { maxTokens }
+
+    public var isTrimmable: Bool { true }
+
+    /// Full-capacity buffers return unwritten slots as well as written ones, so
+    /// every call -- single-token decode included -- must be masked; the shared
+    /// mask helpers delegate to ``makeMask(n:windowSize:returnArray:)`` when
+    /// this is `true`.
+    public var requiresAttentionMask: Bool { true }
+
+    @discardableResult
+    public func update(keys newKeys: MLXArray, values newValues: MLXArray)
+        -> (MLXArray, MLXArray)
+    {
+        let n = newKeys.dim(2)
+        precondition(n > 0, "FixedCapacityKVCache.update requires a non-empty sequence")
+        precondition(
+            n <= maxTokens,
+            "FixedCapacityKVCache capacity \(maxTokens) cannot hold a chunk of \(n) tokens")
+
+        if keys == nil {
+            allocate(with: newKeys, values: newValues)
+        }
+        let writePosition = position!
+
+        // Compile-safe scatter: the write indices are graph values derived from
+        // the threaded position. Unlike a dynamic Swift slice, putAlong remains
+        // dynamic when the compiled graph is reused, and it updates only the new
+        // rows rather than expanding them across the full capacity.
+        let writeIndices =
+            (writePosition + MLXArray(Int32(0) ..< Int32(n)))
+            .reshaped(1, 1, n, 1)
+        keys = putAlong(keys!, writeIndices, values: newKeys, axis: 2)
+        values = putAlong(values!, writeIndices, values: newValues, axis: 2)
+
+        position = writePosition + n
+
+        return (keys!, values!)
+    }
+
+    public func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        // Unwritten slots must never be attended, so the answer is always a
+        // material mask built from the position array -- never a symbolic mode,
+        // regardless of `returnArray`.
+        let currentPosition = position ?? MLXArray([Int32(0)])
+        let keySlots = MLXArray(Int32(0) ..< Int32(maxTokens)).reshaped(1, 1, 1, maxTokens)
+        let queryPositions =
+            currentPosition
+            + MLXArray(Int32(0) ..< Int32(n)).reshaped(
+                1, 1, n, 1)
+
+        var mask = keySlots .<= queryPositions
+        if let windowSize {
+            mask = mask & (keySlots .> (queryPositions - windowSize))
+        }
+        return .array(mask)
+    }
+
+    @discardableResult
+    public func trim(_ n: Int) -> Int {
+        guard n > 0, position != nil else { return 0 }
+        let current = offset
+        let trimmed = min(current, n)
+        position = MLXArray([Int32(current - trimmed)])
+        return trimmed
+    }
+
+    public func copy() -> any KVCache {
+        let new = FixedCapacityKVCache(maxTokens: maxTokens)
+        new.keys = keys?[.ellipsis]
+        new.values = values?[.ellipsis]
+        new.position = position.map { $0[.ellipsis] }
+        return new
+    }
+
+    public var state: [MLXArray] {
+        get {
+            guard let keys, let values else { return [] }
+            let used = offset
+            if used == maxTokens {
+                return [keys, values]
+            }
+            return [
+                keys[.ellipsis, ..<used, 0...],
+                values[.ellipsis, ..<used, 0...],
+            ]
+        }
+        set {
+            guard newValue.count == 2 else {
+                fatalError("FixedCapacityKVCache state must have exactly 2 arrays (keys, values)")
+            }
+            var newKeys = newValue[0]
+            var newValues = newValue[1]
+            let used = newKeys.dim(2)
+            precondition(
+                newKeys.dim(0) == newValues.dim(0) && newKeys.dim(1) == newValues.dim(1)
+                    && used == newValues.dim(2),
+                "FixedCapacityKVCache key/value state must have matching batch, head, and sequence dimensions"
+            )
+            precondition(
+                used <= maxTokens,
+                "FixedCapacityKVCache capacity \(maxTokens) cannot hold state of \(used) tokens")
+
+            // Restore the fixed-capacity shape so the cache stays usable inside
+            // compiled traces after a round-trip through serialization.
+            if used < maxTokens {
+                var keyPadShape = newKeys.shape
+                keyPadShape[2] = maxTokens - used
+                var valuePadShape = newValues.shape
+                valuePadShape[2] = maxTokens - used
+                newKeys = concatenated(
+                    [newKeys, MLXArray.zeros(keyPadShape, dtype: newKeys.dtype)], axis: 2)
+                newValues = concatenated(
+                    [newValues, MLXArray.zeros(valuePadShape, dtype: newValues.dtype)], axis: 2)
+            }
+            keys = newKeys
+            values = newValues
+            position = MLXArray([Int32(used)])
+        }
+    }
+
+    public var metaState: [String] {
+        get { ["\(maxTokens)"] }
+        set {
+            guard newValue.count == 1, Int(newValue[0]) == maxTokens else {
+                fatalError(
+                    "FixedCapacityKVCache meta_state must be [\"\\(maxTokens)\"] for this cache")
+            }
+        }
+    }
+
+    /// The position array rides in ``innerState()`` with the buffers, which is
+    /// what lets `MLX.compile(inputs:outputs:shapeless:_:)`
+    /// thread it through the graph. Also satisfies `Evaluatable`.
+    public func innerState() -> [MLXArray] {
+        guard let keys, let values, let position else { return [] }
+        return [keys, values, position]
+    }
+
+    // MARK: - Private
+
+    private func allocate(with newKeys: MLXArray, values newValues: MLXArray) {
+        let batch = newKeys.dim(0)
+        let kvHeads = newKeys.dim(1)
+        let kHeadDim = newKeys.dim(3)
+        let vHeadDim = newValues.dim(3)
+
+        keys = MLXArray.zeros(
+            [batch, kvHeads, maxTokens, kHeadDim], dtype: newKeys.dtype)
+        values = MLXArray.zeros(
+            [batch, kvHeads, maxTokens, vHeadDim], dtype: newValues.dtype)
+        position = MLXArray([Int32(0)])
+    }
+}
+
+/// A model that can construct a fixed-capacity cache for its forward pass.
+///
+/// This is a behavioral capability rather than a marker for a particular
+/// execution mechanism. A conforming model promises that every
+/// position-dependent operation can consume graph-valued cache positions and
+/// that this factory returns the correct cache topology. Sliding-window,
+/// recurrent, hybrid, and model-specific layouts must provide their own
+/// implementation or omit the conformance.
+public protocol FixedCapacityKVCacheProviding: LanguageModel {
+    /// Create a fixed-capacity cache suitable for graph-reused decoding.
+    func newFixedCapacityCache(maxTokens: Int) throws -> [FixedCapacityKVCache]
+}
+
+extension FixedCapacityKVCacheProviding where Self: KVCacheDimensionProvider {
+    /// Create one fixed-capacity compiled cache per attention layer.
+    ///
+    /// `maxTokens` is the total sequence capacity, including the prompt and all
+    /// generated tokens, rather than a rotating resident-window size.
+    public func newFixedCapacityCache(maxTokens: Int) throws -> [FixedCapacityKVCache] {
+        guard maxTokens > 0, maxTokens <= Int(Int32.max) else {
+            throw KVCacheConfigurationError.invalidCapacity(maxTokens)
+        }
+        return kvHeads.map { _ in FixedCapacityKVCache(maxTokens: maxTokens) }
+    }
+}

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -53,6 +53,14 @@ public protocol KVCache: Evaluatable {
     /// get the maximum size (if any)
     var maxSize: Int? { get }
 
+    /// Whether attention against this cache must always be masked, including
+    /// single-token decode.
+    ///
+    /// Fixed-capacity caches return unwritten slots alongside written keys and
+    /// values. Those caches use this requirement to make the shared mask helpers
+    /// delegate every call to ``makeMask(n:windowSize:returnArray:)``.
+    var requiresAttentionMask: Bool { get }
+
     /// update the cache with new keys and values and return all keys/values
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray)
 
@@ -106,6 +114,19 @@ public protocol KVCache: Evaluatable {
 extension KVCache {
     public var ropeOffset: RoPEOffset {
         .scalar(offset)
+    }
+
+    /// Whether attention against this cache must always be masked, including
+    /// single-token decode.
+    ///
+    /// `true` for caches whose ``KVCache/update(keys:values:)`` returns buffers
+    /// that contain unwritten slots -- e.g. the fixed-capacity
+    /// ``FixedCapacityKVCache`` -- so the shared mask helpers delegate mask
+    /// construction to the cache itself instead of assuming a tight buffer.
+    /// Caches that only ever return written keys/values leave this `false` and
+    /// keep the historic behavior.
+    public var requiresAttentionMask: Bool {
+        false
     }
 
     public func isTrimmable(after positions: Int) -> Bool {
@@ -306,6 +327,15 @@ public func makeAttentionMask(
 @_disfavoredOverload
 public func createAttentionMask(h: MLXArray, cache: [KVCache]?) -> MLXArray? {
     let t = h.dim(1)
+    if let c = cache?.first, c.requiresAttentionMask {
+        // Full-capacity caches must mask every call, decode steps included:
+        // a nil mask would attend to unwritten slots.
+        guard case .array(let mask) = c.makeMask(n: t, windowSize: nil, returnArray: true)
+        else {
+            return nil
+        }
+        return mask
+    }
     if t > 1 {
         var offset = 0
         if let c = cache?.first {
@@ -324,6 +354,11 @@ public func createAttentionMask(h: MLXArray, cache: [KVCache]?, returnArray: Boo
     -> MLXFast.ScaledDotProductAttentionMaskMode
 {
     let t = h.dim(1)
+    if let c = cache?.first, c.requiresAttentionMask {
+        // Full-capacity caches own mask construction at every length; see
+        // ``KVCache/requiresAttentionMask``.
+        return c.makeMask(n: t, windowSize: nil, returnArray: returnArray)
+    }
     if t > 1 {
         var returnArray = returnArray
         var offset = 0
@@ -1745,6 +1780,7 @@ private func cacheClassName(_ cache: KVCache) -> String {
     case is QuantizedKVCache: return "QuantizedKVCache"
     case is TurboQuantKVCache: return "TurboQuantKVCache"
     case is KVCacheSimple: return "KVCache"
+    case is FixedCapacityKVCache: return "FixedCapacityKVCache"
     case is CacheList: return "CacheList"
     default: return "KVCache"
     }
@@ -2127,6 +2163,36 @@ private func restoreCacheFromMetaState(
             bits: bits, keyBits: keyBits, valueBits: valueBits, seed: seed)
         cache.state = state
         cache.metaState = metaState
+        return cache
+
+    case "FixedCapacityKVCache":
+        try validatePromptCache(
+            className: className, state: state, stateCounts: [0, 2],
+            metadata: metaState, metadataCounts: [1])
+        guard metaState.count == 1, let maxTokens = Int(metaState[0]), maxTokens > 0,
+            maxTokens <= Int(Int32.max)
+        else {
+            throw KVCacheError(
+                message:
+                    "Corrupt prompt cache: FixedCapacityKVCache metadata must contain a positive Int32-sized capacity."
+            )
+        }
+        if state.count == 2 {
+            let keys = state[0]
+            let values = state[1]
+            guard keys.dim(0) == values.dim(0), keys.dim(1) == values.dim(1),
+                keys.dim(2) == values.dim(2), keys.dim(2) <= maxTokens
+            else {
+                throw KVCacheError(
+                    message:
+                        "Corrupt prompt cache: FixedCapacityKVCache key/value state must have matching batch, head, and sequence dimensions within capacity."
+                )
+            }
+        }
+        let cache = FixedCapacityKVCache(maxTokens: maxTokens)
+        if !state.isEmpty {
+            cache.state = state
+        }
         return cache
 
     case "CacheList":

--- a/Tests/MLXLMTests/FixedCapacityKVCacheTests.swift
+++ b/Tests/MLXLMTests/FixedCapacityKVCacheTests.swift
@@ -1,0 +1,504 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MLXLLM
+
+/// Regression tests for issue #406.
+///
+/// When a decode step is traced with ``MLX/compile(inputs:outputs:shapeless:_:)``,
+/// every value the trace reads must be threaded through the compile inputs/outputs.
+/// ``KVCacheSimple`` keeps its write position as a Swift `Int`, which bakes into
+/// the graph as a constant: the compiled step keeps writing the same slot and
+/// attending over the same window, so decode falls into repeating token loops.
+///
+/// ``FixedCapacityKVCache`` tracks the position as an `MLXArray` that rides through
+/// compile, so compiled and uncompiled decode stay token-for-token identical.
+final class FixedCapacityKVCacheTests: XCTestCase {
+
+    private let hiddenLayers = 2
+
+    /// A tiny deterministic Qwen2 -- enough layers/heads for the mask, RoPE and
+    /// GQA paths to matter, cheap enough to run on CI.
+    private func makeModel() throws -> Qwen2Model {
+        MLXRandom.seed(7)
+        let configuration = try JSONDecoder().decode(
+            Qwen2Configuration.self,
+            from: Data(
+                """
+                {
+                    "hidden_size": 16, "num_hidden_layers": \(hiddenLayers),
+                    "intermediate_size": 32, "num_attention_heads": 2,
+                    "num_key_value_heads": 1, "rms_norm_eps": 1e-6,
+                    "vocab_size": 64, "tie_word_embeddings": true
+                }
+                """.utf8))
+        return Qwen2Model(configuration)
+    }
+
+    private func makeLlamaModel() -> LlamaModel {
+        MLXRandom.seed(11)
+        return LlamaModel(
+            LlamaConfiguration(
+                hiddenSize: 16, hiddenLayers: hiddenLayers, intermediateSize: 32,
+                attentionHeads: 2, rmsNormEps: 1e-6, vocabularySize: 64, kvHeads: 1))
+    }
+
+    private func simpleCaches() -> [KVCache] {
+        (0 ..< hiddenLayers).map { _ in KVCacheSimple() }
+    }
+
+    private func compiledCaches(maxTokens: Int = 32) -> [FixedCapacityKVCache] {
+        (0 ..< hiddenLayers).map { _ in FixedCapacityKVCache(maxTokens: maxTokens) }
+    }
+
+    /// Greedy sample from the last position's logits.
+    private func greedy(_ logits: MLXArray) -> Int {
+        Int(argMax(logits[0..., -1, 0...]).item(Int32.self))
+    }
+
+    /// A single-token model input `[1, 1]`.
+    private func tokenInput(_ token: Int) -> MLXArray {
+        MLXArray([Int32(token)]).reshaped(1, 1)
+    }
+
+    private func assertAllClose(
+        _ a: MLXArray, _ b: MLXArray, _ message: String, file: StaticString, line: UInt
+    ) {
+        XCTAssertTrue(
+            allClose(a, b, rtol: 1e-4, atol: 1e-4).item(Bool.self),
+            message, file: file, line: line)
+    }
+
+    // MARK: - The issue: compiled decode must not freeze
+
+    /// Compiled decode must match the uncompiled reference token-for-token and
+    /// keep advancing the write position across steps instead of staying frozen
+    /// at the value captured when the graph was traced.
+    func testCompiledDecodeMatchesUncompiledTokenForToken() throws {
+        let model = try makeModel()
+        let prompt = MLXArray([3, 55, 17, 42, 5, 29, 11, 51]).reshaped(1, -1)
+
+        let referenceCaches = simpleCaches()
+        let caches = compiledCaches()
+
+        // Eager prefill first: allocates the fixed-capacity buffers before the
+        // first compiled call, exactly as the documented usage requires.
+        let referencePrefill = model(prompt, cache: referenceCaches)
+        let compiledPrefill = model(prompt, cache: caches)
+        eval(referencePrefill, compiledPrefill)
+        assertAllClose(
+            referencePrefill, compiledPrefill, "prefill logits diverged",
+            file: #filePath, line: #line)
+
+        let updatables: [any Updatable] = caches
+        let compiledDecode = compile(inputs: updatables, outputs: updatables) { token in
+            model(token, cache: caches)
+        }
+
+        var referenceToken = greedy(referencePrefill)
+        var compiledToken = greedy(compiledPrefill)
+        XCTAssertEqual(referenceToken, compiledToken, "prefill sample diverged")
+
+        let decodeSteps = 12
+        for step in 0 ..< decodeSteps {
+            let referenceLogits = model(tokenInput(referenceToken), cache: referenceCaches)
+            let compiledLogits = compiledDecode(tokenInput(compiledToken))
+            eval(referenceLogits, compiledLogits)
+
+            assertAllClose(
+                referenceLogits, compiledLogits, "logits diverged at step \(step)",
+                file: #filePath, line: #line)
+
+            referenceToken = greedy(referenceLogits)
+            compiledToken = greedy(compiledLogits)
+            XCTAssertEqual(
+                referenceToken, compiledToken,
+                "sampled token diverged at decode step \(step) — the compiled cache "
+                    + "write position is not tracking the decode position")
+        }
+
+        // The position array must have been threaded through compile: 8 prompt
+        // tokens plus one step per decode call. With a frozen Swift-Int offset
+        // this stays at the trace-time constant.
+        XCTAssertEqual(caches[0].offset, 8 + decodeSteps)
+
+        // And the accumulated cache contents must match the reference exactly.
+        for layer in 0 ..< hiddenLayers {
+            let referenceState = referenceCaches[layer].state
+            let compiledState = caches[layer].state
+            XCTAssertEqual(referenceState.count, compiledState.count)
+            for index in 0 ..< referenceState.count {
+                XCTAssertEqual(
+                    referenceState[index].shape, compiledState[index].shape,
+                    "layer \(layer) state \(index) shape mismatch")
+                assertAllClose(
+                    referenceState[index], compiledState[index],
+                    "layer \(layer) state \(index) contents diverged",
+                    file: #filePath, line: #line)
+            }
+        }
+    }
+
+    /// The second explicitly supported model family gets its own compiled parity
+    /// test so protocol conformance remains a checked correctness promise.
+    func testLlamaCompiledDecodeMatchesUncompiled() throws {
+        let model = makeLlamaModel()
+        let prompt = MLXArray([7, 9, 13, 21, 4]).reshaped(1, -1)
+        let referenceCaches = simpleCaches()
+        let caches = try model.newFixedCapacityCache(maxTokens: 24)
+
+        let referencePrefill = model(prompt, cache: referenceCaches)
+        let compiledPrefill = model(prompt, cache: caches)
+        eval(referencePrefill, compiledPrefill)
+        assertAllClose(
+            referencePrefill, compiledPrefill, "Llama prefill logits diverged",
+            file: #filePath, line: #line)
+
+        let compiledDecode = compile(inputs: caches, outputs: caches) { token in
+            model(token, cache: caches)
+        }
+        var token = greedy(referencePrefill)
+        for step in 0 ..< 8 {
+            let reference = model(tokenInput(token), cache: referenceCaches)
+            let compiled = compiledDecode(tokenInput(token))
+            eval(reference, compiled)
+            assertAllClose(
+                reference, compiled, "Llama logits diverged at step \(step)",
+                file: #filePath, line: #line)
+            token = greedy(reference)
+        }
+        XCTAssertEqual(caches.map(\.offset), [13, 13])
+    }
+
+    func testFixedCapacityCacheProviderValidatesCapacity() throws {
+        let qwen: any FixedCapacityKVCacheProviding = try makeModel()
+        let qwenCaches = try qwen.newFixedCapacityCache(maxTokens: 17)
+        XCTAssertEqual(qwenCaches.count, hiddenLayers)
+        XCTAssertTrue(qwenCaches.allSatisfy { $0.maxTokens == 17 })
+
+        let llama: any FixedCapacityKVCacheProviding = makeLlamaModel()
+        XCTAssertEqual(try llama.newFixedCapacityCache(maxTokens: 9).count, hiddenLayers)
+
+        XCTAssertThrowsError(try qwen.newFixedCapacityCache(maxTokens: 0)) { error in
+            XCTAssertEqual(error as? KVCacheConfigurationError, .invalidCapacity(0))
+        }
+    }
+
+    func testCompiledDecodeSessionOwnsPrefillAndEnforcesCapacity() throws {
+        let model = try makeModel()
+        let prompt = MLXArray([3, 55, 17]).reshaped(1, -1)
+        let referenceCaches = simpleCaches()
+        let referencePrefill = model(prompt, cache: referenceCaches)
+
+        let session = try CompiledDecodeSession(model: model, prompt: prompt, capacity: 5)
+        eval(referencePrefill, session.prefillLogits)
+        assertAllClose(
+            referencePrefill, session.prefillLogits, "session prefill logits diverged",
+            file: #filePath, line: #line)
+        XCTAssertEqual(session.processedTokenCount, 3)
+        XCTAssertEqual(session.remainingCapacity, 2)
+
+        var token = greedy(referencePrefill)
+        for step in 0 ..< 2 {
+            let reference = model(tokenInput(token), cache: referenceCaches)
+            let compiled = try session.step(tokenInput(token))
+            eval(reference, compiled)
+            assertAllClose(
+                reference, compiled, "session logits diverged at step \(step)",
+                file: #filePath, line: #line)
+            token = greedy(reference)
+        }
+
+        XCTAssertEqual(session.processedTokenCount, 5)
+        XCTAssertEqual(session.remainingCapacity, 0)
+        XCTAssertEqual(session.cacheOffsets, [5, 5])
+        XCTAssertThrowsError(try session.step(tokenInput(token))) { error in
+            XCTAssertEqual(
+                error as? CompiledDecodeSessionError,
+                .capacityExceeded(capacity: 5))
+        }
+        XCTAssertEqual(session.cacheOffsets, [5, 5], "rejected step must not mutate cache")
+    }
+
+    func testCompiledDecodeSessionValidatesShapes() throws {
+        let model = try makeModel()
+
+        XCTAssertThrowsError(
+            try CompiledDecodeSession(
+                model: model, prompt: MLXArray([1, 2]).reshaped(1, 2), capacity: 0)
+        ) { error in
+            XCTAssertEqual(error as? CompiledDecodeSessionError, .invalidCapacity(0))
+        }
+
+        XCTAssertThrowsError(
+            try CompiledDecodeSession(model: model, prompt: MLXArray([1, 2]), capacity: 4)
+        ) { error in
+            XCTAssertEqual(
+                error as? CompiledDecodeSessionError,
+                .invalidPromptShape([2]))
+        }
+
+        let prompt = MLXArray([1, 2]).reshaped(1, 2)
+        let session = try CompiledDecodeSession(model: model, prompt: prompt, capacity: 4)
+        XCTAssertThrowsError(try session.step(MLXArray([3, 4]).reshaped(1, 2))) { error in
+            XCTAssertEqual(
+                error as? CompiledDecodeSessionError,
+                .invalidTokenShape([1, 2], expectedBatchSize: 1))
+        }
+        XCTAssertEqual(session.processedTokenCount, 2)
+    }
+
+    /// Opt-in regression against the checkpoint from issue #406. Set
+    /// `MLX_QWEN25_7B_PATH` to a local Qwen2.5-7B-Instruct-4bit directory.
+    func testQwen25SevenBCompiledDecodeParity() throws {
+        guard let path = ProcessInfo.processInfo.environment["MLX_QWEN25_7B_PATH"] else {
+            throw XCTSkip("set MLX_QWEN25_7B_PATH to run the Qwen2.5-7B regression")
+        }
+
+        let directory = URL(fileURLWithPath: path, isDirectory: true)
+        let configurationData = try Data(
+            contentsOf: directory.appendingPathComponent("config.json"))
+        let configuration = try JSONDecoder.json5().decode(
+            Qwen2Configuration.self, from: configurationData)
+        let baseConfiguration = try JSONDecoder.json5().decode(
+            BaseConfiguration.self, from: configurationData)
+        let model = Qwen2Model(configuration)
+        try loadWeights(
+            modelDirectory: directory, model: model,
+            perLayerQuantization: baseConfiguration.perLayerQuantization)
+
+        let prompt = MLXArray([151644, 8948, 198, 2610, 525, 498, 30]).reshaped(1, -1)
+        let referenceCaches = try model.newCache(parameters: nil)
+        let referencePrefill = model(prompt, cache: referenceCaches)
+        let session = try CompiledDecodeSession(
+            model: model, prompt: prompt, capacity: 4_096)
+        eval(referencePrefill, session.prefillLogits)
+        assertAllClose(
+            referencePrefill, session.prefillLogits, "Qwen2.5-7B prefill logits diverged",
+            file: #filePath, line: #line)
+
+        var token = greedy(referencePrefill)
+        var eagerSeconds = 0.0
+        var compiledSeconds = 0.0
+        var firstCompiledSeconds = 0.0
+        for step in 0 ..< 16 {
+            let eagerStart = Date()
+            let reference = model(tokenInput(token), cache: referenceCaches)
+            eval(reference)
+            eagerSeconds += Date().timeIntervalSince(eagerStart)
+
+            let compiledStart = Date()
+            let compiled = try session.step(tokenInput(token))
+            eval(compiled)
+            let compiledStepSeconds = Date().timeIntervalSince(compiledStart)
+            compiledSeconds += compiledStepSeconds
+            if step == 0 {
+                firstCompiledSeconds = compiledStepSeconds
+            }
+            assertAllClose(
+                reference, compiled, "Qwen2.5-7B logits diverged at step \(step)",
+                file: #filePath, line: #line)
+            let referenceToken = greedy(reference)
+            XCTAssertEqual(
+                referenceToken, greedy(compiled),
+                "Qwen2.5-7B sampled token diverged at step \(step)")
+            token = referenceToken
+        }
+        XCTAssertEqual(session.processedTokenCount, prompt.dim(1) + 16)
+        let steadyCompiledSeconds = compiledSeconds - firstCompiledSeconds
+        print(
+            String(
+                format:
+                    "[QWEN2.5-7B] eager %.1f tok/s; compiled steady %.1f tok/s; first compiled step %.1f ms",
+                16 / eagerSeconds, 15 / steadyCompiledSeconds, firstCompiledSeconds * 1_000))
+    }
+
+    /// Prefill on the fixed-capacity cache matches ``KVCacheSimple``: the mask
+    /// keeps unwritten slots out of attention.
+    func testPrefillMatchesSimpleCache() throws {
+        let model = try makeModel()
+        let prompt = MLXArray([3, 55, 17, 42, 5, 29, 11, 51]).reshaped(1, -1)
+
+        let reference = simpleCaches()
+        let caches = compiledCaches()
+
+        let referenceLogits = model(prompt, cache: reference)
+        let logits = model(prompt, cache: caches)
+        eval(referenceLogits, logits)
+
+        assertAllClose(
+            referenceLogits, logits, "prefill logits diverged",
+            file: #filePath, line: #line)
+        XCTAssertEqual(caches.map(\.offset), [8, 8])
+    }
+
+    /// A continuation chunk after the first prompt exercises the causal mask
+    /// inside the chunk with a nonzero write position.
+    func testContinuedPrefillMatchesSimpleCache() throws {
+        let model = try makeModel()
+        let prompt = MLXArray([3, 55, 17, 42, 5]).reshaped(1, -1)
+        let continuation = MLXArray([29, 11, 51]).reshaped(1, -1)
+
+        let reference = simpleCaches()
+        let caches = compiledCaches()
+
+        eval(model(prompt, cache: reference), model(prompt, cache: caches))
+
+        let referenceLogits = model(continuation, cache: reference)
+        let logits = model(continuation, cache: caches)
+        eval(referenceLogits, logits)
+
+        assertAllClose(
+            referenceLogits, logits, "continuation logits diverged",
+            file: #filePath, line: #line)
+        XCTAssertEqual(caches.map(\.offset), [8, 8])
+    }
+
+    // MARK: - Mask construction
+
+    func assertMaskValues(
+        _ cache: FixedCapacityKVCache, n: Int, windowSize: Int?, queryPosition: Int,
+        expected: (Int, Int) -> Bool, file: StaticString = #filePath, line: UInt = #line
+    ) {
+        guard
+            case .array(let mask) = cache.makeMask(
+                n: n, windowSize: windowSize, returnArray: false)
+        else {
+            XCTFail("expected an array mask", file: file, line: line)
+            return
+        }
+        eval(mask)
+        XCTAssertEqual(mask.shape, [1, 1, n, cache.maxTokens], file: file, line: line)
+
+        for query in 0 ..< n {
+            for slot in 0 ..< cache.maxTokens {
+                XCTAssertEqual(
+                    mask[0, 0, query, slot].item(Bool.self),
+                    expected(queryPosition + query, slot),
+                    "query \(query) (position \(queryPosition + query)) slot \(slot)",
+                    file: file, line: line)
+            }
+        }
+    }
+
+    /// Single-token decode mask: slots up to and including the slot the update
+    /// writes into are attendable; the rest of the capacity is not.
+    func testDecodeMaskCoversOnlyWrittenSlots() throws {
+        let cache = FixedCapacityKVCache(maxTokens: 8)
+        let chunk = MLXArray.zeros([1, 1, 3, 4])
+        cache.update(keys: chunk, values: chunk)
+        XCTAssertEqual(cache.offset, 3)
+
+        // Decode query at position 3; slots 0...3 are written.
+        assertMaskValues(cache, n: 1, windowSize: nil, queryPosition: 3) { position, slot in
+            slot <= position
+        }
+    }
+
+    /// The legacy array-based helper receives caches as protocol existentials;
+    /// this pins witness-table dispatch for requiresAttentionMask.
+    func testRequiredMaskDispatchesThroughKVCacheExistential() throws {
+        let concrete = FixedCapacityKVCache(maxTokens: 8)
+        let chunk = MLXArray.zeros([1, 1, 3, 4])
+        concrete.update(keys: chunk, values: chunk)
+        let caches: [KVCache] = [concrete]
+
+        XCTAssertTrue(caches[0].requiresAttentionMask)
+        let hidden = MLXArray.zeros([1, 1, 4])
+        let optionalMask: MLXArray? = createAttentionMask(h: hidden, cache: caches)
+        let mask = try XCTUnwrap(optionalMask)
+        eval(mask)
+        XCTAssertEqual(mask.shape, [1, 1, 1, 8])
+        XCTAssertEqual(
+            mask.asArray(Bool.self),
+            [true, true, true, true, false, false, false, false])
+    }
+
+    /// Multi-token chunk mask: causal within the chunk against the full capacity.
+    func testChunkMaskIsCausalAgainstCapacity() throws {
+        let cache = FixedCapacityKVCache(maxTokens: 8)
+        let chunk = MLXArray.zeros([1, 1, 3, 4])
+        cache.update(keys: chunk, values: chunk)
+
+        assertMaskValues(cache, n: 2, windowSize: nil, queryPosition: 3) { position, slot in
+            slot <= position
+        }
+    }
+
+    /// A fresh cache masks from position zero.
+    func testEmptyCacheMaskIsCausalFromZero() throws {
+        let cache = FixedCapacityKVCache(maxTokens: 8)
+        assertMaskValues(cache, n: 3, windowSize: nil, queryPosition: 0) { position, slot in
+            slot <= position
+        }
+    }
+
+    /// windowSize bounds the mask to a trailing window of attendable slots.
+    func testMaskHonorsWindowSize() throws {
+        let cache = FixedCapacityKVCache(maxTokens: 8)
+        let chunk = MLXArray.zeros([1, 1, 5, 4])
+        cache.update(keys: chunk, values: chunk)
+
+        assertMaskValues(cache, n: 1, windowSize: 2, queryPosition: 5) { position, slot in
+            slot <= position && slot > position - 2
+        }
+    }
+
+    // MARK: - Cache bookkeeping
+
+    func testOffsetTrimCopyAndState() throws {
+        let cache = FixedCapacityKVCache(maxTokens: 8)
+        XCTAssertEqual(cache.offset, 0)
+        XCTAssertEqual(cache.maxSize, 8)
+        XCTAssertTrue(cache.isTrimmable)
+        XCTAssertTrue(cache.innerState().isEmpty)
+        XCTAssertEqual(cache.state.count, 0)
+
+        func chunk(_ n: Int) -> MLXArray { MLXArray.zeros([1, 1, n, 4]) }
+
+        cache.update(keys: chunk(3), values: chunk(3))
+        XCTAssertEqual(cache.offset, 3)
+        XCTAssertEqual(cache.state[0].shape, [1, 1, 3, 4])
+        XCTAssertEqual(cache.innerState().map(\.shape).last, [1], "position rides in innerState")
+
+        cache.update(keys: chunk(2), values: chunk(2))
+        XCTAssertEqual(cache.offset, 5)
+
+        let copy = cache.copy()
+        cache.update(keys: chunk(1), values: chunk(1))
+        XCTAssertEqual(cache.offset, 6)
+        XCTAssertEqual(copy.offset, 5, "copy must be independent")
+
+        XCTAssertEqual(cache.trim(4), 4)
+        XCTAssertEqual(cache.offset, 2)
+        XCTAssertEqual(cache.trim(10), 2)
+        XCTAssertEqual(cache.offset, 0)
+
+        // Restoring trimmed state must pad back to full capacity so the cache
+        // stays usable inside compiled traces.
+        let restored = FixedCapacityKVCache(maxTokens: 8)
+        restored.state = copy.state
+        XCTAssertEqual(restored.offset, 5)
+        XCTAssertEqual(restored.state[0].shape, [1, 1, 5, 4])
+        XCTAssertEqual(restored.innerState()[0].shape, [1, 1, 8, 4])
+        XCTAssertEqual(restored.metaState, ["8"])
+    }
+
+    func testStateRestorePreservesAsymmetricKeyValueDimensions() throws {
+        let keys = MLXArray.ones([1, 2, 3, 6])
+        let values = MLXArray.ones([1, 2, 3, 4]) * 2
+        let cache = FixedCapacityKVCache(maxTokens: 8)
+
+        cache.state = [keys, values]
+        let inner = cache.innerState()
+        XCTAssertEqual(inner[0].shape, [1, 2, 8, 6])
+        XCTAssertEqual(inner[1].shape, [1, 2, 8, 4])
+        XCTAssertEqual(cache.state[0].shape, keys.shape)
+        XCTAssertEqual(cache.state[1].shape, values.shape)
+        assertAllClose(cache.state[0], keys, "restored keys diverged", file: #filePath, line: #line)
+        assertAllClose(
+            cache.state[1], values, "restored values diverged", file: #filePath, line: #line)
+    }
+}

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 private let cacheCreators: [@Sendable () -> any KVCache] = [
     { KVCacheSimple() },
+    { FixedCapacityKVCache(maxTokens: 64) },
     { RotatingKVCache(maxSize: 32) },
     { QuantizedKVCache() },
     { ChunkedKVCache(chunkSize: 16) },
@@ -215,6 +216,25 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
         #expect(lhs.metaState == rhs.metaState)
         assertArraysClose(lhs.state, rhs.state)
     }
+}
+
+@Test func testFixedCapacityKVCacheAsymmetricStateRoundTrip() throws {
+    let cache = FixedCapacityKVCache(maxTokens: 8)
+    cache.state = [
+        MLXArray.ones([1, 2, 3, 6], dtype: .float16),
+        MLXArray.ones([1, 2, 3, 4], dtype: .float16) * 2,
+    ]
+    let url = tempURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    try savePromptCache(url: url, cache: [cache])
+    let (loaded, _) = try loadPromptCache(url: url)
+    let restored = try #require(loaded.first as? FixedCapacityKVCache)
+
+    #expect(restored.maxTokens == 8)
+    #expect(restored.innerState()[0].shape == [1, 2, 8, 6])
+    #expect(restored.innerState()[1].shape == [1, 2, 8, 4])
+    assertArraysClose(restored.state, cache.state)
 }
 
 @Test func testPromptCacheStateRoundTrip() throws {
@@ -576,6 +596,10 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
             className: "QuantizedKVCache", arrayCount: 0,
             metadata: ["256", "invalid", "64", "4"]),
         .init(className: "ChunkedKVCache", arrayCount: 0, metadata: ["invalid", "0"]),
+        .init(className: "FixedCapacityKVCache", arrayCount: 0, metadata: ["0"]),
+        .init(
+            className: "FixedCapacityKVCache", arrayCount: 2, metadata: ["1"],
+            arrayShape: [1, 1, 2, 4]),
     ])
 }
 


### PR DESCRIPTION
## Proposed changes

Fixes #406.

This PR fixes incorrect token generation when autoregressive decoding is wrapped in `MLX.compile`. The failure could cause generated text to enter repeating-token loops even though the same model decoded correctly without compilation.

### Root cause

During generation, a model keeps a KV cache containing information from tokens it has already processed. Each new token must be written into the next position in that cache.

The existing `KVCacheSimple` stores this write position as a Swift `Int`. When MLX compiles the decode function, it traces the function once and reuses the resulting computation graph. The Swift integer and the array slices derived from it are captured as constants during that trace.

As a result, later decode calls can continue using the position observed during compilation instead of the current position. In simpler terms, the compiled decoder keeps writing to and reading from the wrong place in its memory. This is the root cause of the repeating generation reported in #406.

### How this PR fixes it

This PR introduces `FixedCapacityKVCache`, a cache designed for reusable compiled graphs:

- It allocates the complete cache shape before compilation, keeping tensor shapes stable between tokens.
- It stores the current write position as an `MLXArray` instead of a Swift integer.
- The position is passed through the compiled graph as both input and output, so it advances on every call.
- New keys and values are written using tensor-based indices rather than Swift array slices.
- Unused cache positions are masked so the model cannot attend to memory that has not been written yet.

A `CompiledDecodeSession` owns the cache and provides the safe high-level interface. It:

- Performs prompt processing eagerly before compiling the single-token decode step.
- Verifies prompt and token shapes.
- Tracks capacity on the Swift side.
- Prevents an out-of-range cache write before it reaches the compiled graph.

### Why this is a separate cache

`KVCacheSimple` remains the better default for normal, non-compiled generation. It grows as needed and only performs attention over tokens that have actually been written.

A compiled graph benefits from the opposite behavior: fixed shapes and tensor-managed state. `FixedCapacityKVCache` therefore allocates the requested capacity up front and performs attention over that capacity, masking unused positions. This uses more attention work when the cache is only partially filled, but it makes compiled decoding correct and allows the graph to be reused.

Keeping these implementations separate avoids making ordinary eager generation slower to solve a compilation-specific problem.

### Supported models

Support is capability-based through `FixedCapacityKVCacheProviding`. A model should conform only after its position handling and cache topology have been audited for compiled execution.

This PR initially enables:

- Qwen 2 and Qwen 2.5 text models through `Qwen2Model`.
- Llama and the Mistral checkpoints implemented by `LlamaModel`.

Models with sliding-window, recurrent, hybrid, vision-language, or custom cache layouts are not assumed to be compatible.

### Testing

The new tests cover:

- Compiled versus eager logit and token parity.
- Qwen2 and Llama model paths.
- Cache position advancement through repeated compiled calls.
- Prompt prefill and multi-token continuation.
- Causal and unused-capacity masking.
- Cache copying, trimming, and serialization.
- Invalid shapes and capacity exhaustion.
- An opt-in regression test using the Qwen2.5-7B checkpoint from #406.

The Qwen2.5-7B regression was also run locally for 16 decode steps. Compiled and eager decoding produced matching logits and selected tokens at every step.

### Longer-term direction

This issue exposes a broader distinction between ordinary Swift state and state that must change inside a reusable MLX computation graph.

Long term, compiled generation should probably move toward:

- Representing all decode-time state that affects computation as tensors carried through the graph.
- Making compiled-decoding support an explicit model capability rather than assuming every cache and model architecture is compatible.
- Keeping compilation lifecycle, prompt prefill, cache ownership, and capacity validation behind a session-style API.
- Adding compiled-versus-eager parity tests whenever a new model family adopts this capability.
- Exploring more efficient fixed-shape or paged cache strategies later, without weakening the correctness guarantees introduced here.


## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)