### PR TITLE
Report the progress of reading the weights while loading a model

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/PlatformAvailability/ColdHubClientFetchTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/PlatformAvailability/ColdHubClientFetchTests.swift
@@ -78,7 +78,7 @@ struct ColdHubClientFetchTests {
                 try await loadModelContainer(
                     from: #hubDownloader(HuggingFace.HubClient(cache: cache)),
                     using: #huggingFaceTokenizerLoader(),
-                    configuration: configuration, progressHandler: progress)
+                    configuration: configuration, progress: progress)
             })
 
         // Drop any in-memory entry so `loadContainer()` runs the load closure

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
@@ -89,19 +89,19 @@ func makeReasoningTestModel(
         resolver: resolver)
 }
 
-/// A `ContainerLoader` backed by the production Hugging Face wiring: the same
+/// A `ProgressContainerLoader` backed by the production Hugging Face wiring: the same
 /// `#hubDownloader()` (a `HuggingFace.HubClient` bridge) and
 /// `#huggingFaceTokenizerLoader()` the `#huggingFaceLanguageModel` macro
 /// synthesizes. Paired with `testWeightsLocation(modelID:)`, so downloading
 /// and on-disk availability resolve against the same HubClient cache — exactly
 /// as they do in shipping code.
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
-func testLoad() -> MLXLanguageModel.ContainerLoader {
+func testLoad() -> MLXLanguageModel.ProgressContainerLoader {
     { configuration, progress in
         try await loadModelContainer(
             from: #hubDownloader(),
             using: #huggingFaceTokenizerLoader(),
-            configuration: configuration, progressHandler: progress)
+            configuration: configuration, progress: progress)
     }
 }
 

--- a/Libraries/BenchmarkHelpers/BenchmarkHelpers.swift
+++ b/Libraries/BenchmarkHelpers/BenchmarkHelpers.swift
@@ -358,7 +358,7 @@ public func benchmarkLLMLoading(
 
     _ = try await LLMModelFactory.shared.load(
         from: downloader, using: tokenizerLoader, configuration: config
-    ) { _ in }
+    )
     Memory.clearCache()
 
     var times: [Double] = []
@@ -366,7 +366,7 @@ public func benchmarkLLMLoading(
         let start = CFAbsoluteTimeGetCurrent()
         _ = try await LLMModelFactory.shared.load(
             from: downloader, using: tokenizerLoader, configuration: config
-        ) { _ in }
+        )
         let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
         times.append(elapsed)
         print("LLM load run \(i): \(String(format: "%.1f", elapsed))ms")
@@ -387,7 +387,7 @@ public func benchmarkVLMLoading(
 
     _ = try await VLMModelFactory.shared.load(
         from: downloader, using: tokenizerLoader, configuration: config
-    ) { _ in }
+    )
     Memory.clearCache()
 
     var times: [Double] = []
@@ -395,7 +395,7 @@ public func benchmarkVLMLoading(
         let start = CFAbsoluteTimeGetCurrent()
         _ = try await VLMModelFactory.shared.load(
             from: downloader, using: tokenizerLoader, configuration: config
-        ) { _ in }
+        )
         let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
         times.append(elapsed)
         print("VLM load run \(i): \(String(format: "%.1f", elapsed))ms")
@@ -415,7 +415,7 @@ public func benchmarkEmbeddingLoading(
 ) async throws -> BenchmarkStats {
     _ = try await EmbedderModelFactory.shared.loadContainer(
         from: downloader, using: tokenizerLoader, configuration: configuration
-    ) { _ in }
+    )
     Memory.clearCache()
 
     var times: [Double] = []
@@ -423,7 +423,7 @@ public func benchmarkEmbeddingLoading(
         let start = CFAbsoluteTimeGetCurrent()
         _ = try await EmbedderModelFactory.shared.loadContainer(
             from: downloader, using: tokenizerLoader, configuration: configuration
-        ) { _ in }
+        )
         let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
         times.append(elapsed)
         print("Embedding load run \(i): \(String(format: "%.1f", elapsed))ms")
@@ -544,7 +544,7 @@ public func benchmarkLLMGeneration(
     let configuration = MLXLMCommon.ModelConfiguration(id: modelId)
     let container = try await LLMModelFactory.shared.loadContainer(
         from: downloader, using: tokenizerLoader, configuration: configuration
-    ) { _ in }
+    )
 
     let benchmarkPrompt: String
     if let prompt = prompt {

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -281,7 +281,7 @@ public actor IntegrationTestModels {
                 try await LLMModelFactory.shared.loadContainer(
                     from: downloader, using: tokenizerLoader,
                     configuration: configuration,
-                    progressHandler: logProgress(key)
+                    progress: .download(logProgress(key))
                 )
             }
             print("Loaded LLM: \(key)")
@@ -316,7 +316,7 @@ public actor IntegrationTestModels {
             let container = try await VLMModelFactory.shared.loadContainer(
                 from: downloader, using: tokenizerLoader,
                 configuration: configuration,
-                progressHandler: logProgress(key)
+                progress: .download(logProgress(key))
             )
             print("Loaded VLM: \(key)")
             return container
@@ -337,7 +337,7 @@ public actor IntegrationTestModels {
             let container = try await EmbedderModelFactory.shared.loadContainer(
                 from: downloader, using: tokenizerLoader,
                 configuration: EmbedderRegistry.nomic_text_v1_5,
-                progressHandler: logProgress(id)
+                progress: .download(logProgress(id))
             )
             print("Loaded embedding model: \(id)")
             return container
@@ -643,7 +643,7 @@ public enum EmbedderTests {
         let modelContainer = try await EmbedderModelFactory.shared.loadContainer(
             from: downloader, using: tokenizerLoader,
             configuration: ModelConfiguration(id: modelId),
-            progressHandler: logProgress(modelId)
+            progress: .download(logProgress(modelId))
         )
         print("Loaded Gemma 3 embedding model: \(modelId)")
 

--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -154,7 +154,7 @@ public struct EmbedderModelContext {
 /// let modelId = "mlx-community/gemma-3-1b-it-qat-4bit"
 /// let modelContainer = try await EmbedderModelFactory.shared.loadContainer(
 ///     from: downloader, using: tokenizerLoader, configuration: .init(id: modelId),
-///     progressHandler: logProgress(modelId)
+///     progress: .download(logProgress(modelId))
 /// )
 /// ```
 public final class EmbedderModelFactory: GenericModelFactory {

--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -324,12 +324,12 @@ private actor ModelCache {
 ///         }
 ///         return cache.repoDirectory(repo: repo, kind: .model)
 ///     },
-///     load: { configuration, progressHandler in
+///     load: { configuration, progress in
 ///         try await loadModelContainer(
 ///             from: #hubDownloader(),
 ///             using: #huggingFaceTokenizerLoader(),
 ///             configuration: configuration,
-///             progressHandler: progressHandler)
+///             progress: progress)
 ///     })
 /// let session = LanguageModelSession(model: model, tools: [], instructions: nil)
 /// let response = try await session.respond(to: "Hello!")
@@ -362,13 +362,24 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
     /// Loads the model container for a configuration, forwarding download
     /// progress. Injected so this module carries no HuggingFace or
     /// swift-transformers dependency; the HuggingFace wiring lives in callers.
+    @available(
+        *, deprecated, message: "Use ProgressContainerLoader with the progress-aware initializer"
+    )
     public typealias ContainerLoader =
         @Sendable (
             _ configuration: ModelConfiguration,
             _ progressHandler: @Sendable @escaping (Progress) -> Void
         ) async throws -> ModelContainer
 
-    private let load: ContainerLoader
+    /// A container loader that receives phase-specific download and weight progress.
+    public typealias ProgressContainerLoader =
+        @Sendable (
+            _ configuration: ModelConfiguration,
+            _ progress: LoadProgressHandlers
+        ) async throws -> ModelContainer
+
+    private let load: ProgressContainerLoader
+    private let progress: LoadProgressHandlers
 
     /// Stable identity for the model cache, executor configuration, tokenizer
     /// caches, availability, and progress reporting. Derived from the
@@ -406,13 +417,18 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
     private func makeContainerLoader() -> @Sendable () async throws -> ModelContainer {
         let configuration = self.configuration
         let load = self.load
+        let configuredProgress = self.progress
         return {
             // Configure the buffer pool once per process rather than on every
             // load, so a consumer's own `Memory.cacheLimit` survives our loads.
             _ = Self.configureGPUCacheOnce
-            let container = try await load(configuration) { progress in
-                MLXDownloadProgress.report(progress: progress, modelID: configuration.name)
-            }
+            let progress = LoadProgressHandlers(
+                download: { progress in
+                    MLXDownloadProgress.report(progress: progress, modelID: configuration.name)
+                    configuredProgress.download?(progress)
+                },
+                weights: configuredProgress.weights)
+            let container = try await load(configuration, progress)
             MLXDownloadProgress.reportCompleted()
             return container
         }
@@ -506,7 +522,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
     /// `.allowed` tool routing, guided `.required` developer tool calls,
     /// and reasoning (chain-of-thought) routing.
     ///
-    /// Capabilities are declared explicitly by the caller at ``init(configuration:capabilities:configurationResolver:weightsLocation:load:)``
+    /// Capabilities are declared explicitly by the caller at
+    /// ``init(configuration:capabilities:configurationResolver:weightsLocation:progress:load:)``
     /// and stored verbatim. The caller includes
     /// `.guidedGeneration`/`.toolCalling`/`.reasoning` as appropriate; the
     /// adapter does not consult ``ReasoningHeuristics`` (which remains a
@@ -553,6 +570,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
     ///     URL(fileURLWithPath: "/Volumes/SharedCache/models/\(id)")
     /// }
     /// ```
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Use init(..., progress:load:)")
     public init(
         configuration: ModelConfiguration,
         capabilities: [LanguageModelCapabilities.Capability] = [.guidedGeneration],
@@ -565,7 +584,33 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
         self.capabilities = LanguageModelCapabilities(capabilities: capabilities)
         self.configurationResolver = configurationResolver
         self.weightsLocation = weightsLocation
+        self.load = { configuration, progress in
+            try await load(configuration, progress.download ?? { _ in })
+        }
+        self.progress = .init()
+    }
+
+    /// Creates an `MLXLanguageModel` whose loader receives phase-specific model
+    /// loading progress.
+    ///
+    /// Use this initializer when the loader forwards ``LoadProgressHandlers`` to
+    /// `loadModelContainer`. The deprecated `load:` initializer remains available
+    /// for source compatibility with download-only loaders.
+    public init(
+        configuration: ModelConfiguration,
+        capabilities: [LanguageModelCapabilities.Capability] = [.guidedGeneration],
+        configurationResolver: any ModelConfigurationResolver =
+            DefaultConfigurationResolver(),
+        weightsLocation: @Sendable @escaping (String) -> URL,
+        progress: LoadProgressHandlers = .init(),
+        load: @escaping ProgressContainerLoader
+    ) {
+        self.configuration = configuration
+        self.capabilities = LanguageModelCapabilities(capabilities: capabilities)
+        self.configurationResolver = configurationResolver
+        self.weightsLocation = weightsLocation
         self.load = load
+        self.progress = progress
     }
 
     /// Downloads the model and loads its weights into memory.

--- a/Libraries/MLXFoundationModels/README.md
+++ b/Libraries/MLXFoundationModels/README.md
@@ -57,12 +57,12 @@ if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
             }
             return cache.repoDirectory(repo: repo, kind: .model)
         },
-        load: { configuration, progressHandler in
+        load: { configuration, progress in
             try await loadModelContainer(
                 from: #hubDownloader(),
                 using: #huggingFaceTokenizerLoader(),
                 configuration: configuration,
-                progressHandler: progressHandler)
+                progress: progress)
         })
     let session = LanguageModelSession(model: model)
 }

--- a/Libraries/MLXHuggingFace/FoundationModelsMacros.swift
+++ b/Libraries/MLXHuggingFace/FoundationModelsMacros.swift
@@ -10,9 +10,9 @@ import MLXLMCommon
 /// tokenizer loading, so a configuration is all the caller provides.
 ///
 /// The macro synthesizes the `weightsLocation:` and `load:` arguments; the
-/// caller supplies only `configuration` (plus optional `capabilities` and
-/// `configurationResolver`). A caller needing a custom weights location or
-/// loader should call the `MLXLanguageModel` initializer directly.
+/// caller supplies only `configuration` (plus optional `capabilities`,
+/// `configurationResolver`, and model-load `progress`). A caller needing a custom
+/// weights location or loader should call the `MLXLanguageModel` initializer directly.
 ///
 /// The expansion references symbols the caller must have in scope:
 /// ```swift
@@ -32,14 +32,14 @@ import MLXLMCommon
 @freestanding(expression)
 public macro huggingFaceLanguageModel(
     configuration: ModelConfiguration,
-    // The `capabilities` / `configurationResolver` defaults mirror
-    // `MLXLanguageModel.init(configuration:capabilities:configurationResolver:weightsLocation:load:)`.
+    // The defaults mirror the corresponding `MLXLanguageModel` initializers.
     // The expansion forwards each argument only when the caller supplies it, so
     // an omitted argument falls through to the initializer's own default rather
     // than the value written here — keep the two in sync so this signature does
     // not advertise a default the expansion never applies.
     capabilities: [LanguageModelCapabilities.Capability] = [.guidedGeneration],
-    configurationResolver: any ModelConfigurationResolver = DefaultConfigurationResolver()
+    configurationResolver: any ModelConfigurationResolver = DefaultConfigurationResolver(),
+    progress: LoadProgressHandlers = .init()
 ) -> MLXLanguageModel =
     #externalMacro(module: "MLXHuggingFaceMacros", type: "LanguageModelMacro")
 

--- a/Libraries/MLXHuggingFace/Macros.swift
+++ b/Libraries/MLXHuggingFace/Macros.swift
@@ -82,7 +82,8 @@ public macro huggingFaceLoadModelContainer(
 ) -> ModelContainer =
     #externalMacro(module: "MLXHuggingFaceMacros", type: "LoadContainerMacro")
 
-/// Load a `ModelContainer` using default hub client and tokenizer loader with progress.
+/// Load a `ModelContainer` using default hub client and tokenizer loader with
+/// download progress.
 ///
 /// ```swift
 /// import MLXHuggingFace
@@ -90,13 +91,23 @@ public macro huggingFaceLoadModelContainer(
 /// import Tokenizers
 ///
 /// let model = try await huggingFaceLoadModelContainer(
-///     configuration: modelConfiguration
-/// ) { progres in ... }
+///     configuration: modelConfiguration,
+///     progressHandler: { progress in ... })
 /// ```
 @freestanding(expression)
+@available(*, deprecated, message: "Use progress: .download { progress in ... }")
 public macro huggingFaceLoadModelContainer(
     configuration: ModelConfiguration,
     progressHandler: @Sendable @escaping (Progress) -> Void
+) -> ModelContainer =
+    #externalMacro(module: "MLXHuggingFaceMacros", type: "LoadContainerMacro")
+
+/// Load a `ModelContainer` using default hub services with phase-specific model-load
+/// progress.
+@freestanding(expression)
+public macro huggingFaceLoadModelContainer(
+    configuration: ModelConfiguration,
+    progress: LoadProgressHandlers
 ) -> ModelContainer =
     #externalMacro(module: "MLXHuggingFaceMacros", type: "LoadContainerMacro")
 
@@ -117,7 +128,8 @@ public macro huggingFaceLoadModel(
 ) -> ModelContext =
     #externalMacro(module: "MLXHuggingFaceMacros", type: "LoadContextMacro")
 
-/// Load a `ModelContext` using default hub client and tokenizer loader with progress.
+/// Load a `ModelContext` using default hub client and tokenizer loader with download
+/// progress.
 ///
 /// ```swift
 /// import MLXHuggingFace
@@ -125,13 +137,23 @@ public macro huggingFaceLoadModel(
 /// import Tokenizers
 ///
 /// let modelContext = try await huggingFaceLoadModel(
-///     configuration: modelConfiguration
-/// ) { progres in ... }
+///     configuration: modelConfiguration,
+///     progressHandler: { progress in ... })
 /// ```
 @freestanding(expression)
+@available(*, deprecated, message: "Use progress: .download { progress in ... }")
 public macro huggingFaceLoadModel(
     configuration: ModelConfiguration,
     progressHandler: @Sendable @escaping (Progress) -> Void
+) -> ModelContext =
+    #externalMacro(module: "MLXHuggingFaceMacros", type: "LoadContextMacro")
+
+/// Load a `ModelContext` using default hub services with phase-specific model-load
+/// progress.
+@freestanding(expression)
+public macro huggingFaceLoadModel(
+    configuration: ModelConfiguration,
+    progress: LoadProgressHandlers
 ) -> ModelContext =
     #externalMacro(module: "MLXHuggingFaceMacros", type: "LoadContextMacro")
 

--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -167,12 +167,16 @@ public struct LoadContainerMacro: ExpressionMacro {
         }
 
         let progress =
-            if let expr = node.arguments.first(where: { $0.label?.text == "progressHandler" })?
-                .expression
+            if let handlers = node.arguments.first(where: { $0.label?.text == "progress" })?
+                .expression.description
             {
-                expr.description
+                handlers
+            } else if let legacy = node.arguments.first(where: {
+                $0.label?.text == "progressHandler"
+            })?.expression.description {
+                ".download(\(legacy))"
             } else {
-                "{ _ in }"
+                ".init()"
             }
 
         return
@@ -181,7 +185,7 @@ public struct LoadContainerMacro: ExpressionMacro {
                 from: #hubDownloader(),
                 using: #huggingFaceTokenizerLoader(),
                 configuration: \(configuration),
-                progressHandler: \(raw: progress))
+                progress: \(raw: progress))
             """
     }
 }
@@ -196,12 +200,16 @@ public struct LoadContextMacro: ExpressionMacro {
         }
 
         let progress =
-            if let expr = node.arguments.first(where: { $0.label?.text == "progressHandler" })?
-                .expression
+            if let handlers = node.arguments.first(where: { $0.label?.text == "progress" })?
+                .expression.description
             {
-                expr.description
+                handlers
+            } else if let legacy = node.arguments.first(where: {
+                $0.label?.text == "progressHandler"
+            })?.expression.description {
+                ".download(\(legacy))"
             } else {
-                "{ _ in }"
+                ".init()"
             }
 
         return
@@ -210,7 +218,7 @@ public struct LoadContextMacro: ExpressionMacro {
                 from: #hubDownloader(),
                 using: #huggingFaceTokenizerLoader(),
                 configuration: \(configuration),
-                progressHandler: \(raw: progress))
+                progress: \(raw: progress))
             """
     }
 }
@@ -240,6 +248,7 @@ public struct LanguageModelMacro: ExpressionMacro {
         if let resolver = argument("configurationResolver") {
             arguments.append("configurationResolver: \(resolver)")
         }
+        let progress = argument("progress")
         arguments.append(
             """
             weightsLocation: { id in
@@ -254,14 +263,17 @@ public struct LanguageModelMacro: ExpressionMacro {
                     return cache.repoDirectory(repo: repo, kind: .model)
                 }
             """)
+        if let progress {
+            arguments.append("progress: \(progress)")
+        }
         arguments.append(
             """
-            load: { configuration, progressHandler in
+            load: { configuration, progress in
                     try await loadModelContainer(
                         from: #hubDownloader(),
                         using: #huggingFaceTokenizerLoader(),
                         configuration: configuration,
-                        progressHandler: progressHandler)
+                        progress: progress)
                 }
             """)
 

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -19,7 +19,7 @@ private func create<C: Codable, M>(
 
 /// Registry of model type, e.g 'llama', to functions that can instantiate the model from configuration.
 ///
-/// Typically called via ``LLMModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:progress:)``.
+/// Typically called via ``LLMModelFactory/loadContainer(from:using:configuration:useLatest:progress:)``.
 public enum LLMTypeRegistry {
 
     /// Shared instance with default model types.

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -19,7 +19,7 @@ private func create<C: Codable, M>(
 
 /// Registry of model type, e.g 'llama', to functions that can instantiate the model from configuration.
 ///
-/// Typically called via ``LLMModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:)``.
+/// Typically called via ``LLMModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:progress:)``.
 public enum LLMTypeRegistry {
 
     /// Shared instance with default model types.

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -34,7 +34,7 @@ package func safetensorWeightURLs(in modelDirectory: URL) throws -> [URL] {
 
 /// Load model weights.
 ///
-/// This is typically called via ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:progress:)``.
+/// This is typically called via ``GenericModelFactory/load(from:using:configuration:useLatest:progress:)``.
 /// This function loads model weight `safetensor` files in the given `modelDirectory`,
 /// calls ``BaseLanguageModel/sanitize(weights:metadata:)`` to allow per-model preprocessing,
 /// applies optional quantization, and

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -34,7 +34,7 @@ package func safetensorWeightURLs(in modelDirectory: URL) throws -> [URL] {
 
 /// Load model weights.
 ///
-/// This is typically called via ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:)``.
+/// This is typically called via ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:progress:)``.
 /// This function loads model weight `safetensor` files in the given `modelDirectory`,
 /// calls ``BaseLanguageModel/sanitize(weights:metadata:)`` to allow per-model preprocessing,
 /// applies optional quantization, and

--- a/Libraries/MLXLMCommon/LoadProgress.swift
+++ b/Libraries/MLXLMCommon/LoadProgress.swift
@@ -42,8 +42,8 @@ import MLX
 /// }
 /// ```
 ///
-/// - Note: the existing `progressHandler` parameter of the loading entry points keeps
-///   reporting the download and is unchanged; when both are given, both are called.
+/// - Note: the former `progressHandler` loading overloads are deprecated. Use
+///   ``download`` for download progress.
 public struct LoadProgressHandlers: Sendable {
 
     /// Progress of downloading the model from a provider.
@@ -76,17 +76,6 @@ public struct LoadProgressHandlers: Sendable {
         .init(download: handler)
     }
 
-    /// The download callbacks of `self` chained after `progressHandler`, for entry
-    /// points that take both the legacy `progressHandler` parameter and `self`.
-    func chainedDownloadHandler(
-        with progressHandler: @escaping @Sendable (Progress) -> Void
-    ) -> @Sendable (Progress) -> Void {
-        guard let download else { return progressHandler }
-        return { progress in
-            progressHandler(progress)
-            download(progress)
-        }
-    }
 }
 
 extension GenericModelFactory {
@@ -127,20 +116,13 @@ extension GenericModelFactory {
 /// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:)`` does, so the
 /// result is the number of bytes that loading the model will read.
 func safetensorsByteCount(in modelDirectory: URL) -> Int64 {
-    guard
-        let enumerator = FileManager.default.enumerator(
-            at: modelDirectory, includingPropertiesForKeys: [.fileSizeKey])
-    else {
-        return 0
-    }
+    guard FileManager.default.fileExists(atPath: modelDirectory.path) else { return 0 }
 
-    var total: Int64 = 0
-    for case let url as URL in enumerator {
-        guard url.pathExtension == "safetensors" else { continue }
+    let urls = (try? safetensorWeightURLs(in: modelDirectory)) ?? []
+    return urls.reduce(into: 0) { total, url in
         let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
         total += Int64(size)
     }
-    return total
 }
 
 /// Aggregates the per file byte progress reported by MLX while the weights of a model are

--- a/Libraries/MLXLMCommon/LoadProgress.swift
+++ b/Libraries/MLXLMCommon/LoadProgress.swift
@@ -1,0 +1,203 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// The progress callbacks of loading a model, grouped in one value.
+///
+/// Loading a model is a two phase affair, and each phase has its own progress:
+///
+/// 1. _downloading_ the model, when it comes from a provider rather than a local
+///    directory;
+/// 2. _reading the weights_ from disk, which dominates the load once the files are
+///    local. This phase is byte precise: a model is frequently split into several
+///    `safetensors` shards, read concurrently, and the reported `Progress` sums the
+///    bytes read across all of them.
+///
+/// Pass it to the loading entry points, e.g.:
+///
+/// ```swift
+/// let progress = LoadProgressHandlers.weights { progress in
+///     print("reading weights \(progress.fractionCompleted)")
+/// }
+/// let container = try await LLMModelFactory.shared.loadContainer(
+///     from: directory, using: tokenizerLoader, progress: progress)
+/// ```
+///
+/// The handlers are called from background threads -- the download from the
+/// downloader, the weights from MLX worker threads -- and are on the critical path
+/// of the load, so they should be cheap and must not call back into loading. Hop to
+/// the main actor if the progress drives UI:
+///
+/// ```swift
+/// @MainActor
+/// final class LoadingModel {
+///     var fraction: Double = 0
+///
+///     var handlers: LoadProgressHandlers {
+///         .weights { [weak self] progress in
+///             Task { @MainActor in self?.fraction = progress.fractionCompleted }
+///         }
+///     }
+/// }
+/// ```
+///
+/// - Note: the existing `progressHandler` parameter of the loading entry points keeps
+///   reporting the download and is unchanged; when both are given, both are called.
+public struct LoadProgressHandlers: Sendable {
+
+    /// Progress of downloading the model from a provider.
+    ///
+    /// Not called when loading from a local directory.
+    public var download: (@Sendable (Progress) -> Void)?
+
+    /// Progress of reading the weights from disk, reported in bytes.
+    ///
+    /// Loading is lazy, so this is reported while the model is being evaluated, and
+    /// reaches completion when the load returns. Weights dropped by
+    /// ``BaseLanguageModel/sanitize(weights:metadata:)`` are never read.
+    public var weights: (@Sendable (Progress) -> Void)?
+
+    public init(
+        download: (@Sendable (Progress) -> Void)? = nil,
+        weights: (@Sendable (Progress) -> Void)? = nil
+    ) {
+        self.download = download
+        self.weights = weights
+    }
+
+    /// Only report the progress of reading the weights.
+    public static func weights(_ handler: @escaping @Sendable (Progress) -> Void) -> Self {
+        .init(weights: handler)
+    }
+
+    /// Only report the progress of the download.
+    public static func download(_ handler: @escaping @Sendable (Progress) -> Void) -> Self {
+        .init(download: handler)
+    }
+
+    /// The download callbacks of `self` chained after `progressHandler`, for entry
+    /// points that take both the legacy `progressHandler` parameter and `self`.
+    func chainedDownloadHandler(
+        with progressHandler: @escaping @Sendable (Progress) -> Void
+    ) -> @Sendable (Progress) -> Void {
+        guard let download else { return progressHandler }
+        return { progress in
+            progressHandler(progress)
+            download(progress)
+        }
+    }
+}
+
+extension GenericModelFactory {
+
+    /// ``_load(configuration:tokenizerLoader:)`` reporting the progress of the load --
+    /// the reading of the weights -- to `progress.weights`.
+    ///
+    /// Loading is lazy: the weights are read while the model is evaluated at the end of
+    /// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:)``, so the
+    /// progress is collected around the whole load.
+    func _load(
+        configuration: ResolvedModelConfiguration,
+        tokenizerLoader: any TokenizerLoader,
+        progress: LoadProgressHandlers
+    ) async throws -> sending ContextType {
+        guard let weightsHandler = progress.weights else {
+            return try await _load(configuration: configuration, tokenizerLoader: tokenizerLoader)
+        }
+
+        let reporter = ModelLoadProgressReporter(
+            totalUnitCount: safetensorsByteCount(in: configuration.modelDirectory),
+            handler: weightsHandler)
+
+        let context = try await MLX.withLoadProgressHandler(
+            { reporter.update($0) },
+            {
+                try await _load(configuration: configuration, tokenizerLoader: tokenizerLoader)
+            }
+        )
+        reporter.finish()
+        return context
+    }
+}
+
+/// The number of bytes of `safetensors` weights in `modelDirectory`.
+///
+/// This traverses the directory the same way
+/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:)`` does, so the
+/// result is the number of bytes that loading the model will read.
+func safetensorsByteCount(in modelDirectory: URL) -> Int64 {
+    guard
+        let enumerator = FileManager.default.enumerator(
+            at: modelDirectory, includingPropertiesForKeys: [.fileSizeKey])
+    else {
+        return 0
+    }
+
+    var total: Int64 = 0
+    for case let url as URL in enumerator {
+        guard url.pathExtension == "safetensors" else { continue }
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        total += Int64(size)
+    }
+    return total
+}
+
+/// Aggregates the per file byte progress reported by MLX while the weights of a model are
+/// read into a single `Progress` for the whole model.
+///
+/// A model is frequently split into several `safetensors` shards, and MLX reports progress
+/// per file, from several threads. This sums the most recent progress of each file against
+/// the total size of the weights.
+final class ModelLoadProgressReporter: @unchecked Sendable {
+
+    /// Publish at most this many updates over the course of the load.
+    ///
+    /// MLX reports progress in fairly small chunks -- roughly one per 4MB -- and the handler
+    /// typically hops to the main actor to update a progress bar, so coalesce the updates.
+    private static let updateCount: Int64 = 1000
+
+    private let progress: Progress
+    private let handler: @Sendable (Progress) -> Void
+
+    private let lock = NSLock()
+    private var completedByFile = [URL: Int64]()
+    private var lastPublished: Int64 = 0
+    private var didPublish = false
+
+    init(totalUnitCount: Int64, handler: @escaping @Sendable (Progress) -> Void) {
+        self.progress = Progress.discreteProgress(totalUnitCount: max(totalUnitCount, 0))
+        self.handler = handler
+    }
+
+    /// Record the progress of a single file and publish the aggregate.
+    func update(_ update: MLX.LoadProgress) {
+        lock.withLock {
+            completedByFile[update.url] = update.completedUnitCount
+            let completed = completedByFile.values.reduce(0, +)
+
+            let step = max(progress.totalUnitCount / Self.updateCount, 1)
+            guard !didPublish || completed >= lastPublished + step else { return }
+
+            publish(completed)
+        }
+    }
+
+    /// Publish completion.
+    ///
+    /// Call this once the model has loaded. The weights dropped by
+    /// ``BaseLanguageModel/sanitize(weights:metadata:)`` are never evaluated, and therefore
+    /// never read, so the aggregate legitimately stops short of the size of the files.
+    func finish() {
+        lock.withLock {
+            publish(progress.totalUnitCount)
+        }
+    }
+
+    private func publish(_ completedUnitCount: Int64) {
+        lastPublished = completedUnitCount
+        didPublish = true
+        progress.completedUnitCount = min(completedUnitCount, progress.totalUnitCount)
+        handler(progress)
+    }
+}

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -62,7 +62,7 @@ public protocol ModelConfigurationValidating {
 
 /// Context of types that work together to provide a ``LanguageModel``.
 ///
-/// A ``ModelContext`` is created by ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:progress:)``.
+/// A ``ModelContext`` is created by ``GenericModelFactory/load(from:using:configuration:useLatest:progress:)``.
 /// This contains the following:
 ///
 /// - ``ModelConfiguration``: identifier for the model
@@ -70,7 +70,7 @@ public protocol ModelConfigurationValidating {
 /// - ``UserInputProcessor``: can convert ``UserInput`` into ``LMInput``
 /// - `Tokenizer` -- the tokenizer used by ``UserInputProcessor``
 ///
-/// See also ``GenericModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:progress:)`` and
+/// See also ``GenericModelFactory/loadContainer(from:using:configuration:useLatest:progress:)`` and
 /// ``ModelContainer``.
 public struct ModelContext {
     public var configuration: ModelConfiguration
@@ -99,8 +99,8 @@ public struct ModelContext {
 ///
 /// or, if loading LLM/VLMs, use the free functions:
 ///
-/// - ``loadModel(from:using:configuration:useLatest:progressHandler:progress:)``
-/// - ``loadModelContainer(from:using:configuration:useLatest:progressHandler:progress:)``
+/// - ``loadModel(from:using:configuration:useLatest:progress:)``
+/// - ``loadModelContainer(from:using:configuration:useLatest:progress:)``
 ///
 /// or variants.
 public protocol GenericModelFactory<ContextType, ContainerType>: Sendable {
@@ -153,51 +153,74 @@ extension GenericModelFactory {
     /// This resolves the configuration (downloading remote sources via the downloader)
     /// and then loads the model from local files.
     ///
-    /// `progressHandler` keeps reporting the _download_ and is unchanged; the `progress`
-    /// parameter is the new way to pass the callbacks -- see ``LoadProgressHandlers`` --
-    /// and the only one that can report the reading of the weights. The handlers are
+    /// `progress` reports both the download and weight-reading phases. The handlers are
     /// called from background threads.
     ///
     /// ## See Also
-    /// - ``loadModel(from:using:configuration:useLatest:progressHandler:progress:)``
-    /// - ``loadModelContainer(from:using:configuration:useLatest:progressHandler:progress:)``
+    /// - ``loadModel(from:using:configuration:useLatest:progress:)``
+    /// - ``loadModelContainer(from:using:configuration:useLatest:progress:)``
     public func load(
         from downloader: any Downloader,
         using tokenizerLoader: any TokenizerLoader,
         configuration: ModelConfiguration,
         useLatest: Bool = false,
-        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
         progress: LoadProgressHandlers = .init()
     ) async throws -> sending ContextType {
         let resolved = try await resolve(
             configuration: configuration, from: downloader,
             useLatest: useLatest,
-            progressHandler: progress.chainedDownloadHandler(with: progressHandler))
+            progressHandler: progress.download ?? { _ in })
         return try await _load(
             configuration: resolved, tokenizerLoader: tokenizerLoader, progress: progress)
+    }
+
+    /// Load a model while reporting download progress through the legacy callback.
+    @available(*, deprecated, message: "Use progress: .download { progress in ... }")
+    public func load(
+        from downloader: any Downloader,
+        using tokenizerLoader: any TokenizerLoader,
+        configuration: ModelConfiguration,
+        useLatest: Bool = false,
+        progressHandler: @Sendable @escaping (Progress) -> Void
+    ) async throws -> sending ContextType {
+        try await load(
+            from: downloader, using: tokenizerLoader, configuration: configuration,
+            useLatest: useLatest, progress: .download(progressHandler))
     }
 
     /// Load a model from a ``Downloader`` and ``ModelConfiguration``,
     /// producing a ``ModelContainer``.
     ///
-    /// `progressHandler` keeps reporting the _download_ and `progress` carries the
-    /// callbacks of the load -- see
-    /// ``load(from:using:configuration:useLatest:progressHandler:progress:)``.
+    /// `progress` carries the callbacks of the load -- see
+    /// ``load(from:using:configuration:useLatest:progress:)``.
     public func loadContainer(
         from downloader: any Downloader,
         using tokenizerLoader: any TokenizerLoader,
         configuration: ModelConfiguration,
         useLatest: Bool = false,
-        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
         progress: LoadProgressHandlers = .init()
     ) async throws -> ContainerType {
         let resolved = try await resolve(
             configuration: configuration, from: downloader,
             useLatest: useLatest,
-            progressHandler: progress.chainedDownloadHandler(with: progressHandler))
+            progressHandler: progress.download ?? { _ in })
         let context = try await _load(
             configuration: resolved, tokenizerLoader: tokenizerLoader, progress: progress)
         return _wrap(context)
+    }
+
+    /// Load a model container while reporting download progress through the legacy callback.
+    @available(*, deprecated, message: "Use progress: .download { progress in ... }")
+    public func loadContainer(
+        from downloader: any Downloader,
+        using tokenizerLoader: any TokenizerLoader,
+        configuration: ModelConfiguration,
+        useLatest: Bool = false,
+        progressHandler: @Sendable @escaping (Progress) -> Void
+    ) async throws -> ContainerType {
+        try await loadContainer(
+            from: downloader, using: tokenizerLoader, configuration: configuration,
+            useLatest: useLatest, progress: .download(progressHandler))
     }
 
     /// Load a model from a local directory, producing a ``ModelContext``.
@@ -299,9 +322,7 @@ public func resolve(
 ///   - tokenizerLoader: the ``TokenizerLoader`` to use for loading the tokenizer
 ///   - configuration: a ``ModelConfiguration``
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for the progress of the _download_
-///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
-///     byte progress of reading the weights; the handlers are called from
+///   - progress: callbacks for the download and weight-reading phases; called from
 ///     background threads
 /// - Returns: a ``ModelContext``
 public func loadModel(
@@ -309,15 +330,27 @@ public func loadModel(
     using tokenizerLoader: any TokenizerLoader,
     configuration: ModelConfiguration,
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
     progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContext {
     try await load {
         try await $0.load(
             from: downloader, using: tokenizerLoader, configuration: configuration,
-            useLatest: useLatest, progressHandler: progressHandler,
-            progress: progress)
+            useLatest: useLatest, progress: progress)
     }
+}
+
+/// Load a model while reporting download progress through the legacy callback.
+@available(*, deprecated, message: "Use progress: .download { progress in ... }")
+public func loadModel(
+    from downloader: any Downloader,
+    using tokenizerLoader: any TokenizerLoader,
+    configuration: ModelConfiguration,
+    useLatest: Bool = false,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+) async throws -> sending ModelContext {
+    try await loadModel(
+        from: downloader, using: tokenizerLoader, configuration: configuration,
+        useLatest: useLatest, progress: .download(progressHandler))
 }
 
 /// Load a model given a ``ModelConfiguration``, downloading via a ``Downloader``.
@@ -330,9 +363,7 @@ public func loadModel(
 ///   - tokenizerLoader: the ``TokenizerLoader`` to use for loading the tokenizer
 ///   - configuration: a ``ModelConfiguration``
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for the progress of the _download_
-///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
-///     byte progress of reading the weights; the handlers are called from
+///   - progress: callbacks for the download and weight-reading phases; called from
 ///     background threads
 /// - Returns: a ``ModelContainer``
 public func loadModelContainer(
@@ -340,15 +371,27 @@ public func loadModelContainer(
     using tokenizerLoader: any TokenizerLoader,
     configuration: ModelConfiguration,
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
     progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContainer {
     try await load {
         try await $0.loadContainer(
             from: downloader, using: tokenizerLoader, configuration: configuration,
-            useLatest: useLatest, progressHandler: progressHandler,
-            progress: progress)
+            useLatest: useLatest, progress: progress)
     }
+}
+
+/// Load a model container while reporting download progress through the legacy callback.
+@available(*, deprecated, message: "Use progress: .download { progress in ... }")
+public func loadModelContainer(
+    from downloader: any Downloader,
+    using tokenizerLoader: any TokenizerLoader,
+    configuration: ModelConfiguration,
+    useLatest: Bool = false,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+) async throws -> sending ModelContainer {
+    try await loadModelContainer(
+        from: downloader, using: tokenizerLoader, configuration: configuration,
+        useLatest: useLatest, progress: .download(progressHandler))
 }
 
 /// Load a model given a model identifier, downloading via a ``Downloader``.
@@ -362,9 +405,7 @@ public func loadModelContainer(
 ///   - id: model identifier, e.g "mlx-community/Qwen3-4B-4bit"
 ///   - revision: revision to download (defaults to "main")
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for the progress of the _download_
-///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
-///     byte progress of reading the weights; the handlers are called from
+///   - progress: callbacks for the download and weight-reading phases; called from
 ///     background threads
 /// - Returns: a ``ModelContext``
 public func loadModel(
@@ -373,16 +414,29 @@ public func loadModel(
     id: String,
     revision: String = "main",
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
     progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContext {
     try await load {
         try await $0.load(
             from: downloader, using: tokenizerLoader,
             configuration: .init(id: id, revision: revision),
-            useLatest: useLatest, progressHandler: progressHandler,
-            progress: progress)
+            useLatest: useLatest, progress: progress)
     }
+}
+
+/// Load a model by identifier while reporting download progress through the legacy callback.
+@available(*, deprecated, message: "Use progress: .download { progress in ... }")
+public func loadModel(
+    from downloader: any Downloader,
+    using tokenizerLoader: any TokenizerLoader,
+    id: String,
+    revision: String = "main",
+    useLatest: Bool = false,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+) async throws -> sending ModelContext {
+    try await loadModel(
+        from: downloader, using: tokenizerLoader, id: id, revision: revision,
+        useLatest: useLatest, progress: .download(progressHandler))
 }
 
 /// Load a model given a model identifier, downloading via a ``Downloader``.
@@ -396,9 +450,7 @@ public func loadModel(
 ///   - id: model identifier, e.g "mlx-community/Qwen3-4B-4bit"
 ///   - revision: revision to download (defaults to "main")
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for the progress of the _download_
-///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
-///     byte progress of reading the weights; the handlers are called from
+///   - progress: callbacks for the download and weight-reading phases; called from
 ///     background threads
 /// - Returns: a ``ModelContainer``
 public func loadModelContainer(
@@ -407,16 +459,29 @@ public func loadModelContainer(
     id: String,
     revision: String = "main",
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
     progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContainer {
     try await load {
         try await $0.loadContainer(
             from: downloader, using: tokenizerLoader,
             configuration: .init(id: id, revision: revision),
-            useLatest: useLatest, progressHandler: progressHandler,
-            progress: progress)
+            useLatest: useLatest, progress: progress)
     }
+}
+
+/// Load a model container by identifier while reporting download progress through the legacy callback.
+@available(*, deprecated, message: "Use progress: .download { progress in ... }")
+public func loadModelContainer(
+    from downloader: any Downloader,
+    using tokenizerLoader: any TokenizerLoader,
+    id: String,
+    revision: String = "main",
+    useLatest: Bool = false,
+    progressHandler: @Sendable @escaping (Progress) -> Void
+) async throws -> sending ModelContainer {
+    try await loadModelContainer(
+        from: downloader, using: tokenizerLoader, id: id, revision: revision,
+        useLatest: useLatest, progress: .download(progressHandler))
 }
 
 /// Load a model from a local directory of configuration and weights.
@@ -519,18 +584,18 @@ public protocol ModelFactoryTrampoline {
 
 /// Registry of ``ModelFactory`` trampolines.
 ///
-/// This allows ``loadModel(from:using:id:revision:useLatest:progressHandler:progress:)`` to use any ``ModelFactory`` instances
+/// This allows ``loadModel(from:using:id:revision:useLatest:progress:)`` to use any ``ModelFactory`` instances
 /// available but be defined in the `LLMCommon` layer.  This is not typically used directly -- it is
-/// called via ``loadModel(from:using:id:revision:useLatest:progressHandler:progress:)``:
+/// called via ``loadModel(from:using:id:revision:useLatest:progress:)``:
 ///
 /// ```swift
 /// let model = try await loadModel(from: downloader, using: tokenizerLoader, id: "mlx-community/Qwen3-4B-4bit")
 /// ```
 ///
 /// ## See Also
-/// - ``loadModel(from:using:id:revision:useLatest:progressHandler:progress:)``
+/// - ``loadModel(from:using:id:revision:useLatest:progress:)``
 /// - ``loadModel(from:using:progress:)``
-/// - ``loadModelContainer(from:using:id:revision:useLatest:progressHandler:progress:)``
+/// - ``loadModelContainer(from:using:id:revision:useLatest:progress:)``
 /// - ``loadModelContainer(from:using:progress:)``
 final public class ModelFactoryRegistry: @unchecked Sendable {
     public static let shared = ModelFactoryRegistry()

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -62,7 +62,7 @@ public protocol ModelConfigurationValidating {
 
 /// Context of types that work together to provide a ``LanguageModel``.
 ///
-/// A ``ModelContext`` is created by ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:)``.
+/// A ``ModelContext`` is created by ``GenericModelFactory/load(from:using:configuration:useLatest:progressHandler:progress:)``.
 /// This contains the following:
 ///
 /// - ``ModelConfiguration``: identifier for the model
@@ -70,7 +70,7 @@ public protocol ModelConfigurationValidating {
 /// - ``UserInputProcessor``: can convert ``UserInput`` into ``LMInput``
 /// - `Tokenizer` -- the tokenizer used by ``UserInputProcessor``
 ///
-/// See also ``GenericModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:)`` and
+/// See also ``GenericModelFactory/loadContainer(from:using:configuration:useLatest:progressHandler:progress:)`` and
 /// ``ModelContainer``.
 public struct ModelContext {
     public var configuration: ModelConfiguration
@@ -99,8 +99,8 @@ public struct ModelContext {
 ///
 /// or, if loading LLM/VLMs, use the free functions:
 ///
-/// - ``loadModel(from:using:configuration:useLatest:progressHandler:)``
-/// - ``loadModelContainer(from:using:configuration:useLatest:progressHandler:)``
+/// - ``loadModel(from:using:configuration:useLatest:progressHandler:progress:)``
+/// - ``loadModelContainer(from:using:configuration:useLatest:progressHandler:progress:)``
 ///
 /// or variants.
 public protocol GenericModelFactory<ContextType, ContainerType>: Sendable {
@@ -153,35 +153,50 @@ extension GenericModelFactory {
     /// This resolves the configuration (downloading remote sources via the downloader)
     /// and then loads the model from local files.
     ///
+    /// `progressHandler` keeps reporting the _download_ and is unchanged; the `progress`
+    /// parameter is the new way to pass the callbacks -- see ``LoadProgressHandlers`` --
+    /// and the only one that can report the reading of the weights. The handlers are
+    /// called from background threads.
+    ///
     /// ## See Also
-    /// - ``loadModel(from:using:configuration:useLatest:progressHandler:)``
-    /// - ``loadModelContainer(from:using:configuration:useLatest:progressHandler:)``
+    /// - ``loadModel(from:using:configuration:useLatest:progressHandler:progress:)``
+    /// - ``loadModelContainer(from:using:configuration:useLatest:progressHandler:progress:)``
     public func load(
         from downloader: any Downloader,
         using tokenizerLoader: any TokenizerLoader,
         configuration: ModelConfiguration,
         useLatest: Bool = false,
-        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+        progress: LoadProgressHandlers = .init()
     ) async throws -> sending ContextType {
         let resolved = try await resolve(
             configuration: configuration, from: downloader,
-            useLatest: useLatest, progressHandler: progressHandler)
-        return try await _load(configuration: resolved, tokenizerLoader: tokenizerLoader)
+            useLatest: useLatest,
+            progressHandler: progress.chainedDownloadHandler(with: progressHandler))
+        return try await _load(
+            configuration: resolved, tokenizerLoader: tokenizerLoader, progress: progress)
     }
 
     /// Load a model from a ``Downloader`` and ``ModelConfiguration``,
     /// producing a ``ModelContainer``.
+    ///
+    /// `progressHandler` keeps reporting the _download_ and `progress` carries the
+    /// callbacks of the load -- see
+    /// ``load(from:using:configuration:useLatest:progressHandler:progress:)``.
     public func loadContainer(
         from downloader: any Downloader,
         using tokenizerLoader: any TokenizerLoader,
         configuration: ModelConfiguration,
         useLatest: Bool = false,
-        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+        progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+        progress: LoadProgressHandlers = .init()
     ) async throws -> ContainerType {
         let resolved = try await resolve(
             configuration: configuration, from: downloader,
-            useLatest: useLatest, progressHandler: progressHandler)
-        let context = try await _load(configuration: resolved, tokenizerLoader: tokenizerLoader)
+            useLatest: useLatest,
+            progressHandler: progress.chainedDownloadHandler(with: progressHandler))
+        let context = try await _load(
+            configuration: resolved, tokenizerLoader: tokenizerLoader, progress: progress)
         return _wrap(context)
     }
 
@@ -189,21 +204,31 @@ extension GenericModelFactory {
     ///
     /// No downloader is needed — the model and tokenizer are loaded from
     /// the given directory.
+    ///
+    /// There is nothing to download from a local directory, so of the
+    /// ``LoadProgressHandlers`` only `weights` is called.
     public func load(
         from directory: URL,
-        using tokenizerLoader: any TokenizerLoader
+        using tokenizerLoader: any TokenizerLoader,
+        progress: LoadProgressHandlers = .init()
     ) async throws -> sending ContextType {
         try await _load(
-            configuration: .init(directory: directory), tokenizerLoader: tokenizerLoader)
+            configuration: .init(directory: directory), tokenizerLoader: tokenizerLoader,
+            progress: progress)
     }
 
     /// Load a model from a local directory, producing a ``ModelContainer``.
+    ///
+    /// Of the ``LoadProgressHandlers`` only `weights` is called -- see
+    /// ``load(from:using:progress:)``.
     public func loadContainer(
         from directory: URL,
-        using tokenizerLoader: any TokenizerLoader
+        using tokenizerLoader: any TokenizerLoader,
+        progress: LoadProgressHandlers = .init()
     ) async throws -> ContainerType {
         let context = try await _load(
-            configuration: .init(directory: directory), tokenizerLoader: tokenizerLoader)
+            configuration: .init(directory: directory), tokenizerLoader: tokenizerLoader,
+            progress: progress)
         return _wrap(context)
     }
 
@@ -274,19 +299,24 @@ public func resolve(
 ///   - tokenizerLoader: the ``TokenizerLoader`` to use for loading the tokenizer
 ///   - configuration: a ``ModelConfiguration``
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for progress
+///   - progressHandler: optional callback for the progress of the _download_
+///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
+///     byte progress of reading the weights; the handlers are called from
+///     background threads
 /// - Returns: a ``ModelContext``
 public func loadModel(
     from downloader: any Downloader,
     using tokenizerLoader: any TokenizerLoader,
     configuration: ModelConfiguration,
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+    progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContext {
     try await load {
         try await $0.load(
             from: downloader, using: tokenizerLoader, configuration: configuration,
-            useLatest: useLatest, progressHandler: progressHandler)
+            useLatest: useLatest, progressHandler: progressHandler,
+            progress: progress)
     }
 }
 
@@ -300,19 +330,24 @@ public func loadModel(
 ///   - tokenizerLoader: the ``TokenizerLoader`` to use for loading the tokenizer
 ///   - configuration: a ``ModelConfiguration``
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for progress
+///   - progressHandler: optional callback for the progress of the _download_
+///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
+///     byte progress of reading the weights; the handlers are called from
+///     background threads
 /// - Returns: a ``ModelContainer``
 public func loadModelContainer(
     from downloader: any Downloader,
     using tokenizerLoader: any TokenizerLoader,
     configuration: ModelConfiguration,
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+    progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContainer {
     try await load {
         try await $0.loadContainer(
             from: downloader, using: tokenizerLoader, configuration: configuration,
-            useLatest: useLatest, progressHandler: progressHandler)
+            useLatest: useLatest, progressHandler: progressHandler,
+            progress: progress)
     }
 }
 
@@ -327,7 +362,10 @@ public func loadModelContainer(
 ///   - id: model identifier, e.g "mlx-community/Qwen3-4B-4bit"
 ///   - revision: revision to download (defaults to "main")
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for progress
+///   - progressHandler: optional callback for the progress of the _download_
+///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
+///     byte progress of reading the weights; the handlers are called from
+///     background threads
 /// - Returns: a ``ModelContext``
 public func loadModel(
     from downloader: any Downloader,
@@ -335,13 +373,15 @@ public func loadModel(
     id: String,
     revision: String = "main",
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+    progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContext {
     try await load {
         try await $0.load(
             from: downloader, using: tokenizerLoader,
             configuration: .init(id: id, revision: revision),
-            useLatest: useLatest, progressHandler: progressHandler)
+            useLatest: useLatest, progressHandler: progressHandler,
+            progress: progress)
     }
 }
 
@@ -356,7 +396,10 @@ public func loadModel(
 ///   - id: model identifier, e.g "mlx-community/Qwen3-4B-4bit"
 ///   - revision: revision to download (defaults to "main")
 ///   - useLatest: when true, always checks the provider for the latest version
-///   - progressHandler: optional callback for progress
+///   - progressHandler: optional callback for the progress of the _download_
+///   - progress: the ``LoadProgressHandlers`` of the load -- `weights` reports the
+///     byte progress of reading the weights; the handlers are called from
+///     background threads
 /// - Returns: a ``ModelContainer``
 public func loadModelContainer(
     from downloader: any Downloader,
@@ -364,13 +407,15 @@ public func loadModelContainer(
     id: String,
     revision: String = "main",
     useLatest: Bool = false,
-    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in }
+    progressHandler: @Sendable @escaping (Progress) -> Void = { _ in },
+    progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContainer {
     try await load {
         try await $0.loadContainer(
             from: downloader, using: tokenizerLoader,
             configuration: .init(id: id, revision: revision),
-            useLatest: useLatest, progressHandler: progressHandler)
+            useLatest: useLatest, progressHandler: progressHandler,
+            progress: progress)
     }
 }
 
@@ -382,13 +427,19 @@ public func loadModelContainer(
 /// - Parameters:
 ///   - directory: directory of configuration and weights
 ///   - tokenizerLoader: the ``TokenizerLoader`` to use for loading the tokenizer
+///   - progress: the ``LoadProgressHandlers`` of the load -- there is nothing to
+///     download from a local directory, so only `weights` is called, from
+///     background threads
 /// - Returns: a ``ModelContext``
 public func loadModel(
     from directory: URL,
-    using tokenizerLoader: any TokenizerLoader
+    using tokenizerLoader: any TokenizerLoader,
+    progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContext {
     try await load {
-        try await $0.load(from: directory, using: tokenizerLoader)
+        try await $0.load(
+            from: directory, using: tokenizerLoader,
+            progress: progress)
     }
 }
 
@@ -400,13 +451,19 @@ public func loadModel(
 /// - Parameters:
 ///   - directory: directory of configuration and weights
 ///   - tokenizerLoader: the ``TokenizerLoader`` to use for loading the tokenizer
+///   - progress: the ``LoadProgressHandlers`` of the load -- there is nothing to
+///     download from a local directory, so only `weights` is called, from
+///     background threads
 /// - Returns: a ``ModelContainer``
 public func loadModelContainer(
     from directory: URL,
-    using tokenizerLoader: any TokenizerLoader
+    using tokenizerLoader: any TokenizerLoader,
+    progress: LoadProgressHandlers = .init()
 ) async throws -> sending ModelContainer {
     try await load {
-        try await $0.loadContainer(from: directory, using: tokenizerLoader)
+        try await $0.loadContainer(
+            from: directory, using: tokenizerLoader,
+            progress: progress)
     }
 }
 
@@ -462,19 +519,19 @@ public protocol ModelFactoryTrampoline {
 
 /// Registry of ``ModelFactory`` trampolines.
 ///
-/// This allows ``loadModel(from:using:id:revision:useLatest:progressHandler:)`` to use any ``ModelFactory`` instances
+/// This allows ``loadModel(from:using:id:revision:useLatest:progressHandler:progress:)`` to use any ``ModelFactory`` instances
 /// available but be defined in the `LLMCommon` layer.  This is not typically used directly -- it is
-/// called via ``loadModel(from:using:id:revision:useLatest:progressHandler:)``:
+/// called via ``loadModel(from:using:id:revision:useLatest:progressHandler:progress:)``:
 ///
 /// ```swift
 /// let model = try await loadModel(from: downloader, using: tokenizerLoader, id: "mlx-community/Qwen3-4B-4bit")
 /// ```
 ///
 /// ## See Also
-/// - ``loadModel(from:using:id:revision:useLatest:progressHandler:)``
-/// - ``loadModel(from:using:)``
-/// - ``loadModelContainer(from:using:id:revision:useLatest:progressHandler:)``
-/// - ``loadModelContainer(from:using:)``
+/// - ``loadModel(from:using:id:revision:useLatest:progressHandler:progress:)``
+/// - ``loadModel(from:using:progress:)``
+/// - ``loadModelContainer(from:using:id:revision:useLatest:progressHandler:progress:)``
+/// - ``loadModelContainer(from:using:progress:)``
 final public class ModelFactoryRegistry: @unchecked Sendable {
     public static let shared = ModelFactoryRegistry()
 

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -82,7 +82,7 @@ private func create<C: Decodable, P>(
 
 /// Registry of model type, e.g 'llama', to functions that can instantiate the model from configuration.
 ///
-/// Typically called via ``VLMModelFactory/load(from:using:configuration:useLatest:progressHandler:)``.
+/// Typically called via ``VLMModelFactory/load(from:using:configuration:useLatest:progressHandler:progress:)``.
 public enum VLMTypeRegistry {
 
     /// Shared instance with default model types.

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -82,7 +82,7 @@ private func create<C: Decodable, P>(
 
 /// Registry of model type, e.g 'llama', to functions that can instantiate the model from configuration.
 ///
-/// Typically called via ``VLMModelFactory/load(from:using:configuration:useLatest:progressHandler:progress:)``.
+/// Typically called via ``VLMModelFactory/load(from:using:configuration:useLatest:progress:)``.
 public enum VLMTypeRegistry {
 
     /// Shared instance with default model types.

--- a/Tests/MLXFoundationModelsTests/AvailabilityTests.swift
+++ b/Tests/MLXFoundationModelsTests/AvailabilityTests.swift
@@ -39,7 +39,7 @@ extension FoundationModelsCacheTests {
                     try await loadModelContainer(
                         from: StubAvailabilityDownloader(),
                         using: StubAvailabilityTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             let availability = await model.availability
@@ -84,7 +84,7 @@ extension FoundationModelsCacheTests {
                     try await loadModelContainer(
                         from: BlockingDownloader(gate: gate),
                         using: StubAvailabilityTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             let warmTask = Task { try? await model.warmUp() }
@@ -119,7 +119,7 @@ extension FoundationModelsCacheTests {
                     try await loadModelContainer(
                         from: BlockingDownloader(gate: gate),
                         using: StubAvailabilityTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             // preload() is NOT a warmup, so its in-flight load is not suppressed —
@@ -157,7 +157,7 @@ extension FoundationModelsCacheTests {
                     try await loadModelContainer(
                         from: BlockingDownloader(gate: gate),
                         using: StubAvailabilityTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             let warmTask = Task { try? await model.warmUp() }

--- a/Tests/MLXFoundationModelsTests/MLXLanguageModelCapabilitiesTests.swift
+++ b/Tests/MLXFoundationModelsTests/MLXLanguageModelCapabilitiesTests.swift
@@ -21,10 +21,10 @@ struct MLXLanguageModelCapabilitiesTests {
         capabilities: [LanguageModelCapabilities.Capability],
         resolver: (any ModelConfigurationResolver)? = nil
     ) -> MLXLanguageModel {
-        let load: MLXLanguageModel.ContainerLoader = { configuration, progress in
+        let load: MLXLanguageModel.ProgressContainerLoader = { configuration, progress in
             try await loadModelContainer(
                 from: CapabilitiesStubDownloader(), using: CapabilitiesStubTokenizerLoader(),
-                configuration: configuration, progressHandler: progress)
+                configuration: configuration, progress: progress)
         }
         if let resolver {
             return MLXLanguageModel(

--- a/Tests/MLXFoundationModelsTests/MLXLanguageModelTests.swift
+++ b/Tests/MLXFoundationModelsTests/MLXLanguageModelTests.swift
@@ -27,9 +27,27 @@ struct MLXLanguageModelInitTests {
             load: { configuration, progress in
                 try await loadModelContainer(
                     from: StubDownloader(), using: StubTokenizerLoader(),
-                    configuration: configuration, progressHandler: progress)
+                    configuration: configuration, progress: progress)
             }
         )
+        #expect(model.modelID == "mlx-community/Qwen3-4B-4bit")
+    }
+
+    @Test("progress-aware loader initializer remains constructible")
+    func progressAwareLoader() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let model = MLXLanguageModel(
+            configuration: ModelConfiguration(id: "mlx-community/Qwen3-4B-4bit"),
+            weightsLocation: { _ in URL(fileURLWithPath: "/tmp") },
+            progress: .weights { _ in },
+            load: { configuration, progress in
+                try await loadModelContainer(
+                    from: StubDownloader(), using: StubTokenizerLoader(),
+                    configuration: configuration, progress: progress)
+            }
+        )
+
         #expect(model.modelID == "mlx-community/Qwen3-4B-4bit")
     }
 }

--- a/Tests/MLXFoundationModelsTests/ModelCacheEvictionTests.swift
+++ b/Tests/MLXFoundationModelsTests/ModelCacheEvictionTests.swift
@@ -56,7 +56,7 @@ extension FoundationModelsCacheTests {
                 load: { configuration, progress in
                     try await loadModelContainer(
                         from: BlockingDownloader(gate: gate), using: EvictStubTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             // Drive a load that parks, then fails — populating lastErrors[id].
@@ -90,7 +90,7 @@ extension FoundationModelsCacheTests {
                         try await loadModelContainer(
                             from: BlockingDownloader(gate: gate),
                             using: EvictStubTokenizerLoader(),
-                            configuration: configuration, progressHandler: progress)
+                            configuration: configuration, progress: progress)
                     })
                 let task = Task { try? await model.preload() }
                 await gate.waitUntilStarted()
@@ -133,7 +133,7 @@ extension FoundationModelsCacheTests {
                 load: { configuration, progress in
                     try await loadModelContainer(
                         from: BlockingDownloader(gate: gate), using: EvictStubTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             // Park a genuine (non-warmup) load in flight.

--- a/Tests/MLXFoundationModelsTests/TestHelpers.swift
+++ b/Tests/MLXFoundationModelsTests/TestHelpers.swift
@@ -62,14 +62,14 @@ private struct StubTokenizer: MLXLMCommon.Tokenizer {
 
 // MARK: - Model Construction (no download)
 
-/// A `ContainerLoader` backed by the stub downloader/tokenizer: no network, no
+/// A `ProgressContainerLoader` backed by the stub downloader/tokenizer: no network, no
 /// real weights. For construction / capability / gate tests.
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
-func stubLoad() -> MLXLanguageModel.ContainerLoader {
+func stubLoad() -> MLXLanguageModel.ProgressContainerLoader {
     { configuration, progress in
         try await loadModelContainer(
             from: StubDownloader(), using: StubTokenizerLoader(),
-            configuration: configuration, progressHandler: progress)
+            configuration: configuration, progress: progress)
     }
 }
 

--- a/Tests/MLXFoundationModelsTests/TokenizerBiasCacheTests.swift
+++ b/Tests/MLXFoundationModelsTests/TokenizerBiasCacheTests.swift
@@ -82,7 +82,7 @@ extension FoundationModelsCacheTests {
                 load: { configuration, progress in
                     try await loadModelContainer(
                         from: EvictBiasStubDownloader(), using: EvictBiasStubTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             _ = await MLXLanguageModel.makeTokenizerBias(modelID: idA, tokenizer: tokA)
@@ -124,7 +124,7 @@ extension FoundationModelsCacheTests {
                 load: { configuration, progress in
                     try await loadModelContainer(
                         from: EvictBiasStubDownloader(), using: EvictBiasStubTokenizerLoader(),
-                        configuration: configuration, progressHandler: progress)
+                        configuration: configuration, progress: progress)
                 })
 
             let tokSurvivor = CountingTokenizer(tokens: ["x", "y", "}", "\n"])

--- a/Tests/MLXHuggingFaceMacrosTests/LanguageModelMacroTests.swift
+++ b/Tests/MLXHuggingFaceMacrosTests/LanguageModelMacroTests.swift
@@ -27,12 +27,12 @@ final class LanguageModelMacroTests: XCTestCase {
                         }
                         return cache.repoDirectory(repo: repo, kind: .model)
                     },
-                    load: { configuration, progressHandler in
+                    load: { configuration, progress in
                         try await loadModelContainer(
                             from: #hubDownloader(),
                             using: #huggingFaceTokenizerLoader(),
                             configuration: configuration,
-                            progressHandler: progressHandler)
+                            progress: progress)
                     })
                 """,
             macros: testMacros)
@@ -56,12 +56,12 @@ final class LanguageModelMacroTests: XCTestCase {
                         }
                         return cache.repoDirectory(repo: repo, kind: .model)
                     },
-                    load: { configuration, progressHandler in
+                    load: { configuration, progress in
                         try await loadModelContainer(
                             from: #hubDownloader(),
                             using: #huggingFaceTokenizerLoader(),
                             configuration: configuration,
-                            progressHandler: progressHandler)
+                            progress: progress)
                     })
                 """,
             macros: testMacros)
@@ -85,12 +85,12 @@ final class LanguageModelMacroTests: XCTestCase {
                         }
                         return cache.repoDirectory(repo: repo, kind: .model)
                     },
-                    load: { configuration, progressHandler in
+                    load: { configuration, progress in
                         try await loadModelContainer(
                             from: #hubDownloader(),
                             using: #huggingFaceTokenizerLoader(),
                             configuration: configuration,
-                            progressHandler: progressHandler)
+                            progress: progress)
                     })
                 """,
             macros: testMacros)
@@ -115,12 +115,41 @@ final class LanguageModelMacroTests: XCTestCase {
                         }
                         return cache.repoDirectory(repo: repo, kind: .model)
                     },
-                    load: { configuration, progressHandler in
+                    load: { configuration, progress in
                         try await loadModelContainer(
                             from: #hubDownloader(),
                             using: #huggingFaceTokenizerLoader(),
                             configuration: configuration,
-                            progressHandler: progressHandler)
+                            progress: progress)
+                    })
+                """,
+            macros: testMacros)
+    }
+
+    func testExplicitLoadProgress() {
+        assertMacroExpansion(
+            "let model = #huggingFaceLanguageModel(configuration: config, progress: handlers)",
+            expandedSource: """
+                let model = MLXLanguageModel(
+                    configuration: config,
+                    weightsLocation: { id in
+                        let cache = HuggingFace.HubCache.default
+                        guard let repo = HuggingFace.Repo.ID(rawValue: id) else {
+                            return cache.cacheDirectory
+                        }
+                        if let commit = cache.resolveRevision(repo: repo, kind: .model, ref: "main"),
+                            let snapshot = try? cache.snapshotPath(repo: repo, kind: .model, commitHash: commit) {
+                            return snapshot
+                        }
+                        return cache.repoDirectory(repo: repo, kind: .model)
+                    },
+                    progress: handlers,
+                    load: { configuration, progress in
+                        try await loadModelContainer(
+                            from: #hubDownloader(),
+                            using: #huggingFaceTokenizerLoader(),
+                            configuration: configuration,
+                            progress: progress)
                     })
                 """,
             macros: testMacros)

--- a/Tests/MLXHuggingFaceMacrosTests/LoadProgressMacroTests.swift
+++ b/Tests/MLXHuggingFaceMacrosTests/LoadProgressMacroTests.swift
@@ -1,0 +1,52 @@
+// Copyright © 2026 Apple Inc.
+
+import MLXHuggingFaceMacros
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class LoadProgressMacroTests: XCTestCase {
+    let testMacros: [String: Macro.Type] = [
+        "huggingFaceLoadModelContainer": LoadContainerMacro.self,
+        "huggingFaceLoadModel": LoadContextMacro.self,
+    ]
+
+    func testContainerForwardsWeightProgress() {
+        assertMacroExpansion(
+            "let model = #huggingFaceLoadModelContainer(configuration: config, progress: handlers)",
+            expandedSource: """
+                let model = loadModelContainer(
+                    from: #hubDownloader(),
+                    using: #huggingFaceTokenizerLoader(),
+                    configuration: config,
+                    progress: handlers)
+                """,
+            macros: testMacros)
+    }
+
+    func testContainerWrapsLegacyDownloadProgress() {
+        assertMacroExpansion(
+            "let model = #huggingFaceLoadModelContainer(configuration: config, progressHandler: download)",
+            expandedSource: """
+                let model = loadModelContainer(
+                    from: #hubDownloader(),
+                    using: #huggingFaceTokenizerLoader(),
+                    configuration: config,
+                    progress: .download(download))
+                """,
+            macros: testMacros)
+    }
+
+    func testContextForwardsWeightProgress() {
+        assertMacroExpansion(
+            "let context = #huggingFaceLoadModel(configuration: config, progress: handlers)",
+            expandedSource: """
+                let context = loadModel(
+                    from: #hubDownloader(),
+                    using: #huggingFaceTokenizerLoader(),
+                    configuration: config,
+                    progress: handlers)
+                """,
+            macros: testMacros)
+    }
+}

--- a/Tests/MLXLMTests/ModelLoadProgressTests.swift
+++ b/Tests/MLXLMTests/ModelLoadProgressTests.swift
@@ -1,0 +1,173 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Model load progress")
+struct ModelLoadProgressTests {
+
+    @Test("the handlers group in one value")
+    func handlersGroupBothPhases() {
+        let weights: @Sendable (Progress) -> Void = { _ in }
+        let download: @Sendable (Progress) -> Void = { _ in }
+
+        let both = LoadProgressHandlers(download: download, weights: weights)
+        #expect(both.download != nil)
+        #expect(both.weights != nil)
+
+        // the memberwise init has defaults, so the empty value exists
+        let none = LoadProgressHandlers()
+        #expect(none.download == nil)
+        #expect(none.weights == nil)
+    }
+
+    @Test("the static factories select a single phase")
+    func handlerFactories() {
+        let handler: @Sendable (Progress) -> Void = { _ in }
+
+        #expect(LoadProgressHandlers.weights(handler).weights != nil)
+        #expect(LoadProgressHandlers.weights(handler).download == nil)
+        #expect(LoadProgressHandlers.download(handler).download != nil)
+        #expect(LoadProgressHandlers.download(handler).weights == nil)
+    }
+
+    @Test("the download handler chains after the legacy parameter")
+    func downloadHandlerChains() {
+        let recorder = Recorder()
+        let progress = Progress.discreteProgress(totalUnitCount: 10)
+        progress.completedUnitCount = 4
+
+        let legacy = LoadProgressHandlers()
+        legacy.chainedDownloadHandler(with: { recorder.record($0) })(progress)
+        #expect(recorder.completed == [4])
+
+        let chained = LoadProgressHandlers(download: { recorder.record($0) })
+        chained.chainedDownloadHandler(with: { recorder.record($0) })(progress)
+        #expect(recorder.completed == [4, 4, 4])
+    }
+
+    /// Recorder for the `Progress` published by ``ModelLoadProgressReporter``.
+    final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values = [(completed: Int64, total: Int64)]()
+
+        func record(_ progress: Progress) {
+            lock.withLock {
+                values.append((progress.completedUnitCount, progress.totalUnitCount))
+            }
+        }
+
+        var completed: [Int64] {
+            lock.withLock { values.map(\.completed) }
+        }
+
+        var fractions: [Double] {
+            lock.withLock {
+                values.map { $0.total > 0 ? Double($0.completed) / Double($0.total) : 0 }
+            }
+        }
+    }
+
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func write(_ byteCount: Int, to url: URL) throws {
+        try Data(repeating: 0, count: byteCount).write(to: url)
+    }
+
+    @Test("byte count sums the shards and ignores other files")
+    func safetensorsByteCountSumsShards() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try write(1024, to: directory.appending(path: "model-00001-of-00002.safetensors"))
+        try write(2048, to: directory.appending(path: "model-00002-of-00002.safetensors"))
+
+        // not weights -- must not be counted
+        try write(64, to: directory.appending(path: "config.json"))
+        try write(64, to: directory.appending(path: "tokenizer.json"))
+
+        #expect(safetensorsByteCount(in: directory) == 3072)
+    }
+
+    @Test("byte count of a directory without weights is zero")
+    func safetensorsByteCountWithoutWeights() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try write(64, to: directory.appending(path: "config.json"))
+
+        #expect(safetensorsByteCount(in: directory) == 0)
+        #expect(safetensorsByteCount(in: directory.appending(path: "missing")) == 0)
+    }
+
+    @Test("progress of the individual files is aggregated")
+    func reporterAggregatesAcrossFiles() {
+        let first = URL(filePath: "/tmp/first.safetensors")
+        let second = URL(filePath: "/tmp/second.safetensors")
+
+        let recorder = Recorder()
+        let reporter = ModelLoadProgressReporter(totalUnitCount: 300) { recorder.record($0) }
+
+        reporter.update(.init(url: first, completedUnitCount: 0, totalUnitCount: 100))
+        reporter.update(.init(url: second, completedUnitCount: 0, totalUnitCount: 200))
+        reporter.update(.init(url: first, completedUnitCount: 100, totalUnitCount: 100))
+        reporter.update(.init(url: second, completedUnitCount: 200, totalUnitCount: 200))
+
+        // the last update of each file, summed
+        #expect(recorder.completed.last == 300)
+        #expect(recorder.fractions.last == 1)
+        #expect(recorder.completed == recorder.completed.sorted())
+    }
+
+    @Test("updates are coalesced")
+    func reporterCoalescesUpdates() {
+        let url = URL(filePath: "/tmp/weights.safetensors")
+        let total: Int64 = 1_000_000
+
+        let recorder = Recorder()
+        let reporter = ModelLoadProgressReporter(totalUnitCount: total) { recorder.record($0) }
+
+        // one update per byte would be 1_000_000 callbacks
+        for completed in stride(from: Int64(0), through: total, by: 1) {
+            reporter.update(
+                .init(url: url, completedUnitCount: completed, totalUnitCount: total))
+        }
+
+        #expect(recorder.completed.count <= 1001)
+        #expect(recorder.completed.first == 0)
+    }
+
+    @Test("finish publishes completion")
+    func reporterFinishCompletes() {
+        let url = URL(filePath: "/tmp/weights.safetensors")
+
+        let recorder = Recorder()
+        let reporter = ModelLoadProgressReporter(totalUnitCount: 1000) { recorder.record($0) }
+
+        // a model whose weights are partly dropped by sanitize() never reads every byte
+        reporter.update(.init(url: url, completedUnitCount: 400, totalUnitCount: 1000))
+        #expect(recorder.fractions.last == 0.4)
+
+        reporter.finish()
+        #expect(recorder.fractions.last == 1)
+    }
+
+    @Test("a model without weights still completes")
+    func reporterWithoutWeights() {
+        let recorder = Recorder()
+        let reporter = ModelLoadProgressReporter(totalUnitCount: 0) { recorder.record($0) }
+
+        reporter.finish()
+
+        #expect(recorder.completed.last == 0)
+        #expect(recorder.fractions.last == 0)
+    }
+}

--- a/Tests/MLXLMTests/ModelLoadProgressTests.swift
+++ b/Tests/MLXLMTests/ModelLoadProgressTests.swift
@@ -34,21 +34,6 @@ struct ModelLoadProgressTests {
         #expect(LoadProgressHandlers.download(handler).weights == nil)
     }
 
-    @Test("the download handler chains after the legacy parameter")
-    func downloadHandlerChains() {
-        let recorder = Recorder()
-        let progress = Progress.discreteProgress(totalUnitCount: 10)
-        progress.completedUnitCount = 4
-
-        let legacy = LoadProgressHandlers()
-        legacy.chainedDownloadHandler(with: { recorder.record($0) })(progress)
-        #expect(recorder.completed == [4])
-
-        let chained = LoadProgressHandlers(download: { recorder.record($0) })
-        chained.chainedDownloadHandler(with: { recorder.record($0) })(progress)
-        #expect(recorder.completed == [4, 4, 4])
-    }
-
     /// Recorder for the `Progress` published by ``ModelLoadProgressReporter``.
     final class Recorder: @unchecked Sendable {
         private let lock = NSLock()
@@ -93,6 +78,29 @@ struct ModelLoadProgressTests {
         // not weights -- must not be counted
         try write(64, to: directory.appending(path: "config.json"))
         try write(64, to: directory.appending(path: "tokenizer.json"))
+
+        #expect(safetensorsByteCount(in: directory) == 3072)
+    }
+
+    @Test("byte count follows the safetensors index")
+    func safetensorsByteCountUsesIndex() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try write(1024, to: directory.appending(path: "model-00001-of-00002.safetensors"))
+        try write(2048, to: directory.appending(path: "model-00002-of-00002.safetensors"))
+        try write(4096, to: directory.appending(path: "stale.safetensors"))
+
+        let index = """
+            {
+              "weight_map": {
+                "model.layers.0.weight": "model-00001-of-00002.safetensors",
+                "model.layers.1.weight": "model-00002-of-00002.safetensors"
+              }
+            }
+            """
+        try Data(index.utf8).write(
+            to: directory.appending(path: "model.safetensors.index.json"))
 
         #expect(safetensorsByteCount(in: directory) == 3072)
     }


### PR DESCRIPTION
## Proposed changes

Adds a model weights progress handler.

Close the circle of https://github.com/ml-explore/mlx-swift/pull/427 -> https://github.com/ml-explore/mlx-c/pull/126 -> https://github.com/ml-explore/mlx/pull/3742

Requires the first `mlx-swift` release containing ml-explore/mlx-swift#427, which in turn requires [mlx v0.32.1](https://github.com/ml-explore/mlx/releases/tag/v0.32.1)

## Note

> This PR intentionally leaves the `mlx-swift` dependency at 0.31.6 because there is not yet a tagged `mlx-swift` release containing `MLX.withLoadProgressHandler`.
>
> The implementation has been validated against the head of ml-explore/mlx-swift#427 (`fdb7f7aa`), together with ml-explore/mlx-c#126 and MLX v0.32.1.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
