### PR TITLE
Muse Glimmer: honor the requested KV-cache capacity

### DIFF
--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -544,13 +544,14 @@ private class MuseGlimmerLanguageModel: Module, KVCacheDimensionProvider {
         super.init()
     }
 
-    /// Sliding layers get a rotating cache bounded by the window; full layers
-    /// get an unbounded one.
-    func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        config.layerTypes.map { layerType in
-            layerType == "sliding_attention"
-                ? RotatingKVCache(maxSize: config.slidingWindow, keep: 0)
-                : StandardKVCache()
+    /// Sliding layers get a rotating cache bounded by the architecture window;
+    /// full layers honor the requested capacity and are otherwise unbounded.
+    func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        try config.layerTypes.map { layerType in
+            try makeHybridAttentionKVCache(
+                parameters: parameters,
+                slidingWindow: config.slidingWindow,
+                usesSlidingWindow: layerType == "sliding_attention")
         }
     }
 
@@ -1074,8 +1075,8 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         super.init()
     }
 
-    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
-        languageModel.newCache(parameters: parameters)
+    public func newCache(parameters: GenerateParameters?) throws -> [any KVCache] {
+        try languageModel.newCache(parameters: parameters)
     }
 
     private func encodeImage(_ pixelValues: MLXArray, grid: [THW]) -> MLXArray {

--- a/Tests/MLXLMTests/MuseGlimmerTests.swift
+++ b/Tests/MLXLMTests/MuseGlimmerTests.swift
@@ -833,7 +833,7 @@ struct MuseGlimmerForwardTests {
         let input = LMInput(text: .init(tokens: tokens, mask: ones(like: tokens).asType(.int8)))
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil,
+            input, cache: try model.newCache(parameters: nil), state: nil,
             prefill: PrefillParameters(stepSize: 4))
         guard case .logits(let output) = result else {
             Issue.record("expected logits")
@@ -859,7 +859,7 @@ struct MuseGlimmerForwardTests {
             image: .init(pixels: pixels, frames: frames))
 
         let result = try model.prepare(
-            input, cache: model.newCache(parameters: nil), state: nil,
+            input, cache: try model.newCache(parameters: nil), state: nil,
             prefill: PrefillParameters())
         guard case .logits(let output) = result else {
             Issue.record("expected logits")
@@ -877,7 +877,7 @@ struct MuseGlimmerForwardTests {
                     text: .init(
                         tokens: noPlaceholder, mask: ones(like: noPlaceholder).asType(.int8)),
                     image: .init(pixels: pixels, frames: frames)),
-                cache: model.newCache(parameters: nil), state: nil,
+                cache: try model.newCache(parameters: nil), state: nil,
                 prefill: PrefillParameters())
         }
     }
@@ -885,7 +885,7 @@ struct MuseGlimmerForwardTests {
     @Test("cache mix follows layer types: rotating for sliding, standard for full")
     func cacheMix() throws {
         let model = try Self.model()
-        let caches = model.newCache(parameters: nil)
+        let caches = try model.newCache(parameters: nil)
         // 5 layers, full attention every 4th counting back from the last: 0 and 4.
         #expect(caches.count == 5)
         #expect(caches[0] is StandardKVCache)
@@ -893,6 +893,61 @@ struct MuseGlimmerForwardTests {
         #expect(caches[2] is RotatingKVCache)
         #expect(caches[3] is RotatingKVCache)
         #expect(caches[4] is StandardKVCache)
+    }
+
+    /// `newCache` once dropped `parameters`, so the unbounded full-attention
+    /// caches it returned could not realize a requested capacity and every
+    /// generation entry point rejected the model with `incompatibleCapacity`.
+    @Test("a requested capacity is realized by the full-attention layers")
+    func requestedCapacityIsRealized() throws {
+        let model = try Self.model()
+        let caches = try model.newCache(parameters: GenerateParameters(maxKVSize: 64))
+
+        // Sliding layers keep the architecture window; full layers take the request.
+        #expect(caches.map(\.maxSize) == [64, 8, 8, 8, 64])
+        #expect(throws: Never.self) {
+            try validateKVCacheCompatibility(
+                caches,
+                configuration: KVCacheConfiguration(capacity: try .init(maxTokens: 64)))
+        }
+    }
+
+    /// A capacity below the architecture window must still bound every layer.
+    @Test("a capacity smaller than the sliding window caps the sliding layers too")
+    func capacityBelowSlidingWindow() throws {
+        let model = try Self.model()
+        let caches = try model.newCache(parameters: GenerateParameters(maxKVSize: 4))
+
+        #expect(caches.map(\.maxSize) == [4, 4, 4, 4, 4])
+    }
+
+    /// End-to-end proof that the bounded caches decode correctly: prefill past
+    /// the window, then step tokens through the rotating caches.
+    @Test("generation past the capacity keeps producing finite logits")
+    func decodesPastCapacity() throws {
+        let model = try Self.model()
+        let cache = try model.newCache(parameters: GenerateParameters(maxKVSize: 16))
+        let prompt = MLXArray((0 ..< 24).map { Int32($0 % 60) }).expandedDimensions(axis: 0)
+
+        let prepared = try model.prepare(
+            LMInput(text: .init(tokens: prompt, mask: ones(like: prompt).asType(.int8))),
+            cache: cache, state: nil, prefill: PrefillParameters(stepSize: 8))
+        guard case .logits(let output) = prepared else {
+            Issue.record("expected logits")
+            return
+        }
+
+        var logits = output.logits
+        for step in 0 ..< 12 {
+            let next = MLXArray([Int32(step % 60)]).expandedDimensions(axis: 0)
+            logits = model(next, cache: cache)
+        }
+
+        #expect(logits.dim(-1) == 64)
+        #expect(logits.asType(.float32).sum().item(Float.self).isFinite)
+        // Every attention cache advanced together and none exceeded the bound.
+        #expect(cache.allSatisfy { $0.offset == 36 })
+        #expect(cache.allSatisfy { ($0.maxSize ?? .max) <= 16 })
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Today I was trying the new Muse Glimmer and had some bad surprises: 
`newCache(parameters:)` dropped its `parameters`, so the full-attention layers were always unbounded `StandardKVCache`. Any request carrying a capacity, `GenerateParameters.maxKVSize` or `kvCache`, was then rejected by `validateKVCacheCompatibility` with `incompatibleCapacity`, one count per full-attention layer (13 on the 52-layer checkpoint).

Route both layer kinds through `makeHybridAttentionKVCache` instead, as every other hybrid model does. Behavior is unchanged when no capacity is requested: sliding layers keep the architecture window with `keep: 0` and full layers stay unbounded.

@CharlieTLe FYI

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
