### PR TITLE
Read Gemma's brace-form object and array values

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/BareKeyJSONParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/BareKeyJSONParser.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Reads JSON that a dialect wrote with unquoted object keys.
+///
+/// Gemma writes a nested object as `{city: "Paris"}`. That is JSON in every respect except that its
+/// keys carry no quotes, which `JSONSerialization` rejects, so the value falls back to its own raw
+/// text: a parameter the schema declares an `object` reaches the tool as a string, and the call
+/// fails at the far end with a schema error the model has no way to act on.
+///
+/// Only keys are rewritten. A bare *value* is left alone and the payload refused, because quoting it
+/// would invent meaning — `{ok: true}` is a boolean while `{ok: yes}` is nothing JSON can name — and
+/// a parser that guesses there is worse than one that hands back the literal text.
+struct BareKeyJSONParser: Sendable {
+
+    /// Keys are the only bare spans this parser rewrites, so quoted values stay opaque while the
+    /// structure is walked.
+    private let scanner = StructuredTextScanner(quotes: ["\""])
+
+    /// Characters a bare key may contain. Anything else is a payload this parser refuses.
+    private static let keyCharacters = CharacterSet.alphanumerics
+        .union(CharacterSet(charactersIn: "_-."))
+
+    /// Parses `text` as JSON, retrying once with bare object keys quoted.
+    func parse(_ text: String) -> (any Sendable)? {
+        if let value = tryParseJSON(text) { return value }
+        guard let quoted = quotingBareKeys(text[...]) else { return nil }
+        return tryParseJSON(quoted)
+    }
+
+    /// Rewrites `text` with every bare object key quoted.
+    ///
+    /// Scalars are returned verbatim, so the rewrite reaches keys and nothing else. Returns `nil`
+    /// when a group is unbalanced, a member has no `:`, or a key is not a bare identifier.
+    private func quotingBareKeys(_ text: Substring) -> String? {
+        let literal = text.trimmingWhitespace()
+
+        switch literal.first {
+        case "{":
+            guard let body = groupBody(of: literal) else { return nil }
+            var members: [String] = []
+            for member in scanner.splitTopLevel(body, separator: ",") {
+                guard let colon = scanner.firstTopLevelIndex(of: ":", in: member),
+                    let key = quotedKey(member[..<colon].trimmingWhitespace()),
+                    let value = quotingBareKeys(member[member.index(after: colon)...])
+                else { return nil }
+                members.append("\(key):\(value)")
+            }
+            return "{\(members.joined(separator: ","))}"
+
+        case "[":
+            guard let body = groupBody(of: literal) else { return nil }
+            var elements: [String] = []
+            for element in scanner.splitTopLevel(body, separator: ",") {
+                guard let value = quotingBareKeys(element) else { return nil }
+                elements.append(value)
+            }
+            return "[\(elements.joined(separator: ","))]"
+
+        default:
+            return String(literal)
+        }
+    }
+
+    /// The contents of a group whose closing bracket ends `literal`.
+    private func groupBody(of literal: Substring) -> Substring? {
+        guard let end = scanner.endOfGroup(in: literal, openedAt: literal.startIndex),
+            end == literal.index(before: literal.endIndex)
+        else { return nil }
+        return literal[literal.index(after: literal.startIndex) ..< end]
+    }
+
+    /// A quoted form of `key`, or `nil` when it is neither already quoted nor a bare identifier.
+    private func quotedKey(_ key: Substring) -> String? {
+        if key.count > 1, key.hasPrefix("\""), key.hasSuffix("\"") {
+            return String(key)
+        }
+        guard !key.isEmpty,
+            key.unicodeScalars.allSatisfy(Self.keyCharacters.contains)
+        else { return nil }
+        return "\"\(key)\""
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -13,6 +13,9 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
     /// so both spans have to be opaque while the argument list is split.
     private let scanner: StructuredTextScanner
 
+    /// Nested objects and arrays are written in the dialect's brace form, whose keys are unquoted.
+    private let structuredValues = BareKeyJSONParser()
+
     public init(startTag: String, endTag: String, escapeMarker: String) {
         self.startTag = startTag
         self.endTag = endTag
@@ -69,6 +72,9 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
     /// may contain protocol punctuation, so it is taken verbatim. Everything else
     /// is typed from the schema when the parameter is declared, and otherwise
     /// decoded as JSON, falling back to the literal text.
+    ///
+    /// A parameter the schema declares structured is read as a brace-form literal first: the
+    /// dialect writes those without quoting their keys, which strict JSON refuses.
     private func value(
         of rawValue: Substring,
         key: String,
@@ -87,10 +93,21 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
         }
 
         let literal = String(rawValue)
-        if getParameterType(funcName: funcName, paramName: key, tools: tools) != nil {
-            return convertParameterValue(
-                literal, paramName: key, funcName: funcName, tools: tools)
+        guard let declaredType = getParameterType(funcName: funcName, paramName: key, tools: tools)
+        else {
+            return structuredValues.parse(literal) ?? literal
         }
-        return tryParseJSON(literal) ?? literal
+
+        if Self.isStructured(declaredType), let value = structuredValues.parse(literal) {
+            return value
+        }
+        return convertParameterValue(literal, paramName: key, funcName: funcName, tools: tools)
+    }
+
+    /// Whether a declared schema type is one the dialect writes in brace form.
+    private static func isStructured(_ type: String) -> Bool {
+        let type = type.lowercased()
+        return type == "object" || type == "array" || type.hasPrefix("dict")
+            || type.hasPrefix("list")
     }
 }

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -1364,6 +1364,69 @@ struct ToolTests {
         #expect(toolCall.function.arguments["urgent"] == .string("true"))
     }
 
+    @Test("Gemma reads a nested object whose keys are unquoted")
+    func testGemmaBareKeyObjectValue() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let content = #"<|tool_call>call:search{filters:{city: "Paris", limit: 1}}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        // The dialect writes nested objects without quoting their keys, which strict JSON refuses.
+        #expect(
+            toolCall.function.arguments["filters"]
+                == .object(["city": .string("Paris"), "limit": .int(1)]))
+    }
+
+    @Test("Gemma reads a bare-key object into a parameter the schema declares an object")
+    func testGemmaBareKeyObjectValueWithSchema() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "search",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "filters": ["type": "object"] as [String: any Sendable]
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content = #"<|tool_call>call:search{filters:{city: "Paris"}}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: tools))
+
+        // Without the brace-form read the schema-typed conversion hands back the raw text, and the
+        // tool receives a string where it declared an object.
+        #expect(toolCall.function.arguments["filters"] == .object(["city": .string("Paris")]))
+    }
+
+    @Test("Gemma refuses to quote bare object values")
+    func testGemmaBareValueStaysLiteral() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let content = #"<|tool_call>call:search{filters:{city: Paris}}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        // Quoting a bare value would invent meaning, so the literal text is kept instead.
+        #expect(toolCall.function.arguments["filters"] == .string("{city: Paris}"))
+    }
+
+    @Test("Gemma keeps an escaped value that resembles an object as a string")
+    func testGemmaEscapedObjectShapedValueStaysString() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: #"<|"|>"#)
+        let content = #"<|tool_call>call:notify{note:<|"|>{city: "Paris"}<|"|>}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.arguments["note"] == .string(#"{city: "Paris"}"#))
+    }
+
     @Test("Gemma escaped values may contain protocol punctuation")
     func testGemmaEscapedValuePunctuation() throws {
         let parser = GemmaFunctionParser(


### PR DESCRIPTION
## Proposed changes

> Gemma writes a nested value in the dialect's brace form:
>
> ```
> <|tool_call>call:search{filters:{city: "Paris", limit: 1}}<tool_call|>
> ```
>
> That is JSON in every respect except that the keys carry no quotes, which `JSONSerialization` rejects. `GemmaFunctionParser` falls back to the literal text, so `filters` arrives as `.string("{city: \"Paris\", limit: 1}")`. When the schema declares `filters` an object, `convertParameterValue` takes the same strict path and returns the same string: the tool receives a string where it declared an object, and the call fails at the far end — with an MCP server, `-32602 Invalid params` — with an error the model has no way to act on.
>
> #531 made the argument *list* structural, so a value is no longer truncated at an inner comma. This is the remaining half: the value itself is still read as text.
>
> **Fix.** `BareKeyJSONParser` parses JSON, retrying once with bare object keys quoted. It walks the literal with the `StructuredTextScanner` added in #531, so quoted spans stay opaque and nesting is respected. `GemmaFunctionParser` uses it for parameters the schema declares structured (`object`, `array`, `dict…`, `list…`) and for parameters the schema does not declare at all. Every other path is unchanged.
>
> **Keys only, by design.** A bare *value* is not quoted; the payload is refused and keeps today's literal-text behavior. `{ok: true}` is a boolean while `{ok: yes}` is nothing JSON can name, so quoting there would invent meaning, and a parser that guesses is worse than one that hands back the text.

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
