### PR TITLE
Fix mixed-precision QLoRA output promotion

### DIFF
--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRA+Layers.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRA+Layers.swift
@@ -110,7 +110,13 @@ public class LoRALinear: Linear, LoRALayer {
         let y = super.callAsFunction(x.asType(weight.dtype))
         if !loraEnabled { return y }
         let z = matmul(matmul(dropout(x), self.loraA), self.loraB)
-        return y + scale * z
+        // Adapter checkpoints and base weights can use different 16-bit
+        // formats (commonly fp16 LoRA over a bf16 model). MLX promotes
+        // bf16 + fp16 to fp32, so adding `z` directly silently changes the
+        // projection's public dtype and every downstream kernel
+        // specialization. Keep the replacement layer's output contract
+        // identical to the base layer, matching mlx-lm's LoRA path.
+        return y + (scale * z).asType(y.dtype)
     }
 }
 
@@ -211,6 +217,6 @@ public class QLoRALinear: QuantizedLinear, LoRALayer {
         let y = super.callAsFunction(x.asType(scales.dtype))
         if !loraEnabled { return y }
         let z = matmul(matmul(dropout(x), self.loraA), self.loraB)
-        return y + scale * z
+        return y + (scale * z).asType(y.dtype)
     }
 }

--- a/Tests/MLXLMTests/LoRADropoutTests.swift
+++ b/Tests/MLXLMTests/LoRADropoutTests.swift
@@ -182,6 +182,37 @@ final class LoRADropoutTests: XCTestCase {
         try assertDropoutMode(on: layer)
     }
 
+    /// Adapter files are commonly fp16 even when the base model is bf16. The
+    /// wrapper must retain the base projection's dtype: allowing MLX to promote
+    /// bf16 + fp16 to fp32 changes every downstream kernel specialization and,
+    /// for Qwen3.5 linear attention, sends the recurrent Metal kernel down its
+    /// much heavier fp32 path.
+    func testLoRALinearPreservesBaseOutputDTypeWithFP16Adapter() throws {
+        let base = Linear(weight: MLXArray.eye(32).asType(.bfloat16))
+        let layer = try XCTUnwrap(
+            LoRALinear.from(linear: base, rank: 4, scale: 1.0) as? LoRALinear)
+        try installFP16Adapter(on: layer)
+
+        let output = layer(MLXArray.ones([1, 32], dtype: .bfloat16))
+
+        XCTAssertEqual(output.dtype, .bfloat16)
+        eval(output)
+    }
+
+    func testQLoRALinearPreservesBaseOutputDTypeWithFP16Adapter() throws {
+        let base = Linear(weight: MLXArray.eye(32).asType(.bfloat16))
+        let quantized = try XCTUnwrap(
+            base.toQuantized(groupSize: 32, bits: 4, mode: .affine) as? QuantizedLinear)
+        let layer = try XCTUnwrap(
+            LoRALinear.from(linear: quantized, rank: 4, scale: 1.0) as? QLoRALinear)
+        try installFP16Adapter(on: layer)
+
+        let output = layer(MLXArray.ones([1, 32], dtype: .bfloat16))
+
+        XCTAssertEqual(output.dtype, .bfloat16)
+        eval(output)
+    }
+
     func testDoRALinearAppliesDropoutOnlyDuringTraining() throws {
         let base = Linear(weight: MLXArray.eye(32))
         let layer = try XCTUnwrap(
@@ -376,6 +407,15 @@ final class LoRADropoutTests: XCTestCase {
                 .item(Bool.self))
         XCTAssertFalse(
             allClose(firstEvaluationOutput, trainingOutput, rtol: 0, atol: 0).item(Bool.self))
+    }
+
+    private func installFP16Adapter(on layer: Linear) throws {
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                "lora_a": MLXArray.ones([32, 4], dtype: .float16),
+                "lora_b": MLXArray.ones([4, 32], dtype: .float16),
+            ]),
+            verify: [])
     }
 }
 

--- a/Tests/MLXLMTests/Qwen35QLoRATests.swift
+++ b/Tests/MLXLMTests/Qwen35QLoRATests.swift
@@ -1,0 +1,106 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+
+final class Qwen35QLoRATests: XCTestCase {
+
+    private func configuration() throws -> Qwen35TextConfiguration {
+        let json = """
+            {
+                "model_type": "qwen3_5",
+                "hidden_size": 64,
+                "num_hidden_layers": 2,
+                "intermediate_size": 128,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 32,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 32,
+                "linear_conv_kernel_dim": 4,
+                "vocab_size": 32,
+                "full_attention_interval": 2,
+                "num_experts": 0,
+                "num_experts_per_tok": 0
+            }
+            """
+        return try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Regression for #561. Real Qwen3.5 MLX checkpoints use bf16 base
+    /// tensors while converted PEFT adapters commonly use fp16. Wrapping the
+    /// three linear-attention projections used to promote their results to
+    /// fp32, changing the custom gated-delta kernel specialization and making
+    /// the first generation command buffer hit macOS's GPU watchdog.
+    func testFP16QLoRAKeepsQwen35LinearAttentionOnBaseDType() throws {
+        let model = Qwen35TextModel(try configuration())
+        model.update(parameters: model.parameters().mapValues { $0.asType(.bfloat16) })
+
+        let targetPaths: Set<String> = [
+            "model.layers.0.linear_attn.in_proj_qkv",
+            "model.layers.0.linear_attn.in_proj_z",
+            "model.layers.0.linear_attn.out_proj",
+        ]
+        quantize(model: model, groupSize: 32, bits: 4) { path, _ in
+            targetPaths.contains(path)
+        }
+
+        let rank = 4
+        let adapter = LoRAContainer(
+            configuration: .init(
+                numLayers: 2,
+                loraParameters: .init(
+                    rank: rank, scale: 1.0,
+                    keys: [
+                        "linear_attn.in_proj_qkv",
+                        "linear_attn.in_proj_z",
+                        "linear_attn.out_proj",
+                    ])),
+            parameters: ModuleParameters.unflattened([
+                "model.layers.0.linear_attn.in_proj_qkv.lora_a": fp16Adapter([64, rank]),
+                "model.layers.0.linear_attn.in_proj_qkv.lora_b": fp16Adapter([rank, 256]),
+                "model.layers.0.linear_attn.in_proj_z.lora_a": fp16Adapter([64, rank]),
+                "model.layers.0.linear_attn.in_proj_z.lora_b": fp16Adapter([rank, 128]),
+                "model.layers.0.linear_attn.out_proj.lora_a": fp16Adapter([128, rank]),
+                "model.layers.0.linear_attn.out_proj.lora_b": fp16Adapter([rank, 64]),
+            ]))
+        try adapter.load(into: model)
+
+        let gdn = try XCTUnwrap(
+            model.modules().compactMap { $0 as? Qwen35GatedDeltaNet }.first)
+        XCTAssertTrue(gdn.inProjQKV is QLoRALinear)
+        XCTAssertTrue(gdn.inProjZ is QLoRALinear)
+        XCTAssertTrue(gdn.outProj is QLoRALinear)
+
+        let hidden = MLXArray.ones([1, 15, 64], dtype: .bfloat16)
+        XCTAssertEqual(gdn.inProjQKV(hidden).dtype, .bfloat16)
+        XCTAssertEqual(gdn.inProjZ(hidden).dtype, .bfloat16)
+        XCTAssertEqual(
+            gdn.outProj(MLXArray.ones([1, 15, 128], dtype: .bfloat16)).dtype,
+            .bfloat16)
+
+        let cache = try model.newCache(parameters: nil)
+        let prefill = model(
+            MLXArray(Array(Int32(1) ... Int32(15))).reshaped(1, 15), cache: cache)
+        eval(prefill, cache)
+        XCTAssertEqual(prefill.dtype, .bfloat16)
+        XCTAssertEqual(prefill.shape, [1, 15, 32])
+
+        let decode = model(MLXArray([Int32(16)]).reshaped(1, 1), cache: cache)
+        eval(decode, cache)
+        XCTAssertEqual(decode.dtype, .bfloat16)
+        XCTAssertEqual(decode.shape, [1, 1, 32])
+    }
+
+    private func fp16Adapter(_ shape: [Int]) -> MLXArray {
+        MLXArray.full(shape, values: MLXArray(0.001), dtype: .float16)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fixes #561.

QLoRA could unexpectedly switch parts of a bfloat16 model to slower float32 calculations when loading a float16 adapter. For Qwen3.5 linear-attention layers, this extra work could cause the first generation to exceed the GPU time limit and crash.

This change keeps LoRA outputs in the same data type as the original layer. It also adds tests covering regular LoRA, QLoRA, and the affected Qwen3.5 prefill and decode paths.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed for this behavior-only fix)