### PR TITLE
Add extensible VLM processor loading rules

### DIFF
--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -419,6 +419,43 @@ public class VLMProcessorTypeRegistry: @unchecked Sendable {
                 YourModelProcessorConfiguration.self, YourModelProcessor.init),
 ```
 
+### Processor metadata supplied by an external package
+
+Some repositories omit processor metadata, or declare a generic processor that is not the
+right implementation for their model type. An external model package can handle either case
+without changing `VLMModelFactory`:
+
+```swift
+struct YourModelProcessorLoadingResolver: VLMProcessorLoadingResolving {
+    func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration? {
+        guard context.modelType == "your_model" else { return nil }
+
+        let model = try JSONDecoder().decode(
+            YourModelConfiguration.self, from: context.configurationData)
+        let processor = YourModelProcessorConfiguration(model: model)
+        return VLMProcessorConfiguration(
+            data: try JSONEncoder().encode(processor),
+            processorType: "YourModelProcessor")
+    }
+
+    func processorTypeOverride(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String
+    ) throws -> String? {
+        context.modelType == "your_model" ? "YourModelProcessor" : nil
+    }
+}
+
+VLMProcessorLoadingRegistry.shared.register(YourModelProcessorLoadingResolver())
+```
+
+Implement only the hook your model needs. A checkpoint's `preprocessor_config.json` or
+`processor_config.json` always wins over a generated fallback. Type overrides are applied
+afterward. For isolated applications and tests, pass a separate
+`VLMProcessorLoadingRegistry` to `VLMModelFactory` instead of registering globally.
+
 Add a constant for the model in the VLMRegistry (not strictly required but useful
 for callers to refer to it in code):
 

--- a/Libraries/MLXVLM/README.md
+++ b/Libraries/MLXVLM/README.md
@@ -426,8 +426,8 @@ right implementation for their model type. An external model package can handle 
 without changing `VLMModelFactory`:
 
 ```swift
-struct YourModelProcessorLoadingResolver: VLMProcessorLoadingResolving {
-    func processorConfigurationFallback(
+struct YourModelProcessorLoadingResolver: VLMProcessorLoadingResolver {
+    func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration? {
         guard context.modelType == "your_model" else { return nil }
@@ -440,9 +440,9 @@ struct YourModelProcessorLoadingResolver: VLMProcessorLoadingResolving {
             processorType: "YourModelProcessor")
     }
 
-    func processorTypeOverride(
+    func processorType(
         for context: VLMProcessorLoadingContext,
-        declaredProcessorType: String
+        declaredProcessorType: String?
     ) throws -> String? {
         context.modelType == "your_model" ? "YourModelProcessor" : nil
     }
@@ -452,8 +452,9 @@ VLMProcessorLoadingRegistry.shared.register(YourModelProcessorLoadingResolver())
 ```
 
 Implement only the hook your model needs. A checkpoint's `preprocessor_config.json` or
-`processor_config.json` always wins over a generated fallback. Type overrides are applied
-afterward. For isolated applications and tests, pass a separate
+`processor_config.json` always wins over a generated fallback. Processor type resolution is
+applied afterward and can supply a missing `processor_class` or correct an incorrect one.
+For isolated applications and tests, pass a separate
 `VLMProcessorLoadingRegistry` to `VLMModelFactory` instead of registering globally.
 
 Add a constant for the model in the VLMRegistry (not strictly required but useful

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -329,12 +329,14 @@ public final class VLMModelFactory: GenericModelFactory {
     public init(
         typeRegistry: ModelTypeRegistry<LanguageModel>, processorRegistry: ProcessorTypeRegistry,
         modelRegistry: AbstractModelRegistry,
-        conventionsRegistry: ChatConventionsRegistry = .shared
+        conventionsRegistry: ChatConventionsRegistry = .shared,
+        processorLoadingRegistry: VLMProcessorLoadingRegistry = .shared
     ) {
         self.typeRegistry = typeRegistry
         self.processorRegistry = processorRegistry
         self.modelRegistry = modelRegistry
         self.conventionsRegistry = conventionsRegistry
+        self.processorLoadingRegistry = processorLoadingRegistry
     }
 
     /// Shared instance with default behavior.
@@ -354,6 +356,9 @@ public final class VLMModelFactory: GenericModelFactory {
     /// resolvers for chat conventions that are keyed on model id rather than declared
     /// by the model itself, e.g. DeepSeek-R1
     public let conventionsRegistry: ChatConventionsRegistry
+
+    /// resolvers for processor metadata that is absent or incorrect in a checkpoint
+    public let processorLoadingRegistry: VLMProcessorLoadingRegistry
 
     public func _load(
         configuration: ResolvedModelConfiguration,
@@ -428,12 +433,16 @@ public final class VLMModelFactory: GenericModelFactory {
         // Note: loadProcessorConfig does synchronous I/O but is marked async to enable
         // parallel scheduling. This may briefly block a cooperative thread pool thread,
         // but the config file is small and model loading is not a high-concurrency path.
-        let processorFallback = try qwenProcessorFallback(
-            modelType: baseConfig.modelType, model: model)
+        let processorLoadingContext = VLMProcessorLoadingContext(
+            modelId: configuration.name,
+            modelType: baseConfig.modelType,
+            configurationData: configData)
         async let tokenizerTask = tokenizerLoader.load(
             from: configuration.tokenizerDirectory)
-        async let processorConfigTask = loadProcessorConfig(
-            from: modelDirectory, fallback: processorFallback)
+        async let processorConfigTask = resolveProcessorConfiguration(
+            from: modelDirectory,
+            context: processorLoadingContext,
+            registry: processorLoadingRegistry)
 
         try loadWeights(
             modelDirectory: modelDirectory, model: model,
@@ -441,10 +450,9 @@ public final class VLMModelFactory: GenericModelFactory {
             weightFileSelection: configuration.weightFileSelection)
 
         let tokenizer = try await tokenizerTask
-        let processorConfigData: Data
-        let baseProcessorConfig: BaseProcessorConfiguration
+        let processorConfiguration: VLMProcessorConfiguration
         do {
-            (processorConfigData, baseProcessorConfig) = try await processorConfigTask
+            processorConfiguration = try await processorConfigTask
         } catch let error as ProcessorConfigError {
             if let decodingError = error.underlying as? DecodingError {
                 throw ModelFactoryError.configurationDecodingError(
@@ -452,21 +460,14 @@ public final class VLMModelFactory: GenericModelFactory {
             }
             throw ModelFactoryError.configurationFileError(
                 error.filename, configuration.name, error.underlying)
+        } catch let error as DecodingError {
+            throw ModelFactoryError.configurationDecodingError(
+                configurationURL.lastPathComponent, configuration.name, error)
         }
 
-        // Override processor type based on model type for models that need special handling
-        // Mistral3 models ship with "PixtralProcessor" in their config but need Mistral3Processor
-        // to handle spatial merging correctly
-        let processorTypeOverrides: [String: String] = [
-            "mistral3": "Mistral3Processor",
-            "gemma4_unified": "Gemma4UnifiedProcessor",
-        ]
-        let processorType =
-            processorTypeOverrides[baseConfig.modelType] ?? baseProcessorConfig.processorClass
-
         let baseProcessor = try await processorRegistry.createModel(
-            configuration: processorConfigData,
-            processorType: processorType, tokenizer: tokenizer)
+            configuration: processorConfiguration.data,
+            processorType: processorConfiguration.processorType, tokenizer: tokenizer)
         let processor: any UserInputProcessor
         if let messageGenerator = mutableConfiguration.messageGenerator {
             processor = MessageGeneratorUserInputProcessor(
@@ -504,21 +505,20 @@ struct ProcessorConfigError: Error {
     let underlying: Error
 }
 
-func qwenProcessorFallback(
-    modelType: String, model: any LanguageModel
-) throws -> (Data, BaseProcessorConfiguration)? {
-    guard modelType == "qwen3_5" || modelType == "qwen3_5_moe",
-        let model = model as? Qwen35
-    else {
-        return nil
+/// Selects checkpoint processor metadata, then applies any registered type correction.
+func resolveProcessorConfiguration(
+    from modelDirectory: URL,
+    context: VLMProcessorLoadingContext,
+    registry: VLMProcessorLoadingRegistry
+) async throws -> VLMProcessorConfiguration {
+    let configuration = try await loadProcessorConfig(from: modelDirectory) {
+        try registry.processorConfigurationFallback(for: context)
     }
-
-    let configuration = Qwen3VLProcessorConfiguration(
-        qwen35VisionConfiguration: model.config.visionConfiguration)
-    return (
-        try JSONEncoder().encode(configuration),
-        BaseProcessorConfiguration(processorClass: "Qwen3VLProcessor")
-    )
+    let processorType =
+        try registry.processorTypeOverride(
+            for: context, declaredProcessorType: configuration.processorType)
+        ?? configuration.processorType
+    return VLMProcessorConfiguration(data: configuration.data, processorType: processorType)
 }
 
 /// Loads processor configuration, preferring preprocessor_config.json over processor_config.json.
@@ -526,10 +526,8 @@ func qwenProcessorFallback(
 /// Throws ProcessorConfigError wrapping any underlying error with the filename.
 func loadProcessorConfig(
     from modelDirectory: URL,
-    fallback: (Data, BaseProcessorConfiguration)? = nil
-) async throws -> (
-    Data, BaseProcessorConfiguration
-) {
+    fallback: () throws -> VLMProcessorConfiguration? = { nil }
+) async throws -> VLMProcessorConfiguration {
     let processorConfigURL = modelDirectory.appending(component: "processor_config.json")
     let preprocessorConfigURL = modelDirectory.appending(component: "preprocessor_config.json")
 
@@ -539,20 +537,18 @@ func loadProcessorConfig(
     if FileManager.default.fileExists(atPath: processorConfigURL.path) {
         return try readProcessorConfig(from: processorConfigURL)
     }
-    if let fallback {
+    if let fallback = try fallback() {
         return fallback
     }
 
     return try readProcessorConfig(from: processorConfigURL)
 }
 
-private func readProcessorConfig(from url: URL) throws -> (
-    Data, BaseProcessorConfiguration
-) {
+private func readProcessorConfig(from url: URL) throws -> VLMProcessorConfiguration {
     do {
         let data = try Data(contentsOf: url)
         let config = try JSONDecoder.json5().decode(BaseProcessorConfiguration.self, from: data)
-        return (data, config)
+        return VLMProcessorConfiguration(data: data, processorType: config.processorClass)
     } catch {
         throw ProcessorConfigError(filename: url.lastPathComponent, underlying: error)
     }

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -505,20 +505,31 @@ struct ProcessorConfigError: Error {
     let underlying: Error
 }
 
-/// Selects checkpoint processor metadata, then applies any registered type correction.
+/// Selects checkpoint processor metadata, then resolves the processor type.
 func resolveProcessorConfiguration(
     from modelDirectory: URL,
     context: VLMProcessorLoadingContext,
     registry: VLMProcessorLoadingRegistry
 ) async throws -> VLMProcessorConfiguration {
     let configuration = try await loadProcessorConfig(from: modelDirectory) {
-        try registry.processorConfigurationFallback(for: context)
+        try registry.fallbackProcessorConfiguration(for: context)
     }
     let processorType =
-        try registry.processorTypeOverride(
+        try registry.processorType(
             for: context, declaredProcessorType: configuration.processorType)
         ?? configuration.processorType
+    guard let processorType else {
+        throw missingProcessorTypeError(filename: configuration.filename)
+    }
     return VLMProcessorConfiguration(data: configuration.data, processorType: processorType)
+}
+
+/// Processor configuration selected from a checkpoint file or a generated fallback.
+/// The type remains optional until loading resolvers have had a chance to supply one.
+struct LoadedVLMProcessorConfiguration {
+    let data: Data
+    let processorType: String?
+    let filename: String
 }
 
 /// Loads processor configuration, preferring preprocessor_config.json over processor_config.json.
@@ -527,7 +538,7 @@ func resolveProcessorConfiguration(
 func loadProcessorConfig(
     from modelDirectory: URL,
     fallback: () throws -> VLMProcessorConfiguration? = { nil }
-) async throws -> VLMProcessorConfiguration {
+) async throws -> LoadedVLMProcessorConfiguration {
     let processorConfigURL = modelDirectory.appending(component: "processor_config.json")
     let preprocessorConfigURL = modelDirectory.appending(component: "preprocessor_config.json")
 
@@ -538,17 +549,47 @@ func loadProcessorConfig(
         return try readProcessorConfig(from: processorConfigURL)
     }
     if let fallback = try fallback() {
-        return fallback
+        return LoadedVLMProcessorConfiguration(
+            data: fallback.data,
+            processorType: fallback.processorType,
+            filename: "config.json")
     }
 
     return try readProcessorConfig(from: processorConfigURL)
 }
 
-private func readProcessorConfig(from url: URL) throws -> VLMProcessorConfiguration {
+private struct DeclaredProcessorConfiguration: Decodable {
+    let processorClass: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case processorClass = "processor_class"
+    }
+}
+
+private enum ProcessorConfigurationCodingKey: String, CodingKey {
+    case processorClass = "processor_class"
+}
+
+private func missingProcessorTypeError(filename: String) -> ProcessorConfigError {
+    ProcessorConfigError(
+        filename: filename,
+        underlying: DecodingError.keyNotFound(
+            ProcessorConfigurationCodingKey.processorClass,
+            DecodingError.Context(
+                codingPath: [],
+                debugDescription:
+                    "No processor_class was declared and no processor loading resolver supplied one."
+            )))
+}
+
+private func readProcessorConfig(from url: URL) throws -> LoadedVLMProcessorConfiguration {
     do {
         let data = try Data(contentsOf: url)
-        let config = try JSONDecoder.json5().decode(BaseProcessorConfiguration.self, from: data)
-        return VLMProcessorConfiguration(data: data, processorType: config.processorClass)
+        let config = try JSONDecoder.json5().decode(DeclaredProcessorConfiguration.self, from: data)
+        return LoadedVLMProcessorConfiguration(
+            data: data,
+            processorType: config.processorClass,
+            filename: url.lastPathComponent)
     } catch {
         throw ProcessorConfigError(filename: url.lastPathComponent, underlying: error)
     }

--- a/Libraries/MLXVLM/VLMProcessorLoadingRegistry.swift
+++ b/Libraries/MLXVLM/VLMProcessorLoadingRegistry.swift
@@ -1,0 +1,155 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLXLMCommon
+
+/// The model metadata available while resolving how to load a VLM processor.
+///
+/// External model packages can decode ``configurationData`` into their own model
+/// configuration type without introducing a dependency from MLXVLM back to that package.
+public struct VLMProcessorLoadingContext: Sendable {
+    public let modelId: String
+    public let modelType: String
+    public let configurationData: Data
+
+    public init(modelId: String, modelType: String, configurationData: Data) {
+        self.modelId = modelId
+        self.modelType = modelType
+        self.configurationData = configurationData
+    }
+}
+
+/// Fully resolved input for constructing a VLM processor.
+public struct VLMProcessorConfiguration: Sendable {
+    public let data: Data
+    public let processorType: String
+
+    public init(data: Data, processorType: String) {
+        self.data = data
+        self.processorType = processorType
+    }
+}
+
+/// Supplies model-specific processor loading policy that is not present in a checkpoint.
+///
+/// Both hooks are optional. A fallback is consulted only when neither
+/// `preprocessor_config.json` nor `processor_config.json` exists. A type override is
+/// consulted after a configuration has been selected, so it can correct processor metadata
+/// shipped by a checkpoint.
+public protocol VLMProcessorLoadingResolving: Sendable {
+    func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration?
+
+    func processorTypeOverride(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String
+    ) throws -> String?
+}
+
+extension VLMProcessorLoadingResolving {
+    public func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration? { nil }
+
+    public func processorTypeOverride(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String
+    ) throws -> String? { nil }
+}
+
+/// Ordered registry of processor-loading resolvers used by ``VLMModelFactory``.
+///
+/// Most recently registered wins for each hook independently. This lets a downstream
+/// package override one decision while deferring the other to an earlier resolver.
+public final class VLMProcessorLoadingRegistry: @unchecked Sendable {
+
+    /// Shared instance, preloaded with this package's built-in loading rules.
+    public static let shared = VLMProcessorLoadingRegistry(resolvers: [
+        Qwen35ProcessorLoadingResolver(),
+        ModelTypeProcessorOverrideResolver(processorTypes: [
+            "mistral3": "Mistral3Processor",
+            "gemma4_unified": "Gemma4UnifiedProcessor",
+        ]),
+    ])
+
+    private let lock = NSLock()
+    private var resolvers: [any VLMProcessorLoadingResolving]
+
+    public init(resolvers: [any VLMProcessorLoadingResolving] = []) {
+        self.resolvers = resolvers
+    }
+
+    /// Add a resolver. It takes precedence over resolvers registered before it.
+    public func register(_ resolver: any VLMProcessorLoadingResolving) {
+        lock.withLock { resolvers.append(resolver) }
+    }
+
+    func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration? {
+        for resolver in snapshot() {
+            if let configuration = try resolver.processorConfigurationFallback(for: context) {
+                return configuration
+            }
+        }
+        return nil
+    }
+
+    func processorTypeOverride(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String
+    ) throws -> String? {
+        for resolver in snapshot() {
+            if let processorType = try resolver.processorTypeOverride(
+                for: context, declaredProcessorType: declaredProcessorType)
+            {
+                return processorType
+            }
+        }
+        return nil
+    }
+
+    /// Copy under the lock, then execute external code outside it. A resolver may be slow
+    /// or may re-enter this registry, neither of which should block registration.
+    private func snapshot() -> [any VLMProcessorLoadingResolving] {
+        lock.withLock { resolvers.reversed() }
+    }
+}
+
+/// A reusable processor-type rule keyed by `model_type` from `config.json`.
+public struct ModelTypeProcessorOverrideResolver: VLMProcessorLoadingResolving {
+    public let processorTypes: [String: String]
+
+    public init(processorTypes: [String: String]) {
+        self.processorTypes = processorTypes
+    }
+
+    public func processorTypeOverride(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String
+    ) throws -> String? {
+        processorTypes[context.modelType]
+    }
+}
+
+/// Reconstructs processor metadata omitted by Qwen3.5 checkpoints from their vision config.
+public struct Qwen35ProcessorLoadingResolver: VLMProcessorLoadingResolving {
+    public init() {}
+
+    public func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration? {
+        guard context.modelType == "qwen3_5" || context.modelType == "qwen3_5_moe" else {
+            return nil
+        }
+
+        let modelConfiguration = try JSONDecoder.json5().decode(
+            Qwen35Configuration.self, from: context.configurationData)
+        let processorConfiguration = Qwen3VLProcessorConfiguration(
+            qwen35VisionConfiguration: modelConfiguration.visionConfiguration)
+        return VLMProcessorConfiguration(
+            data: try JSONEncoder().encode(processorConfiguration),
+            processorType: "Qwen3VLProcessor")
+    }
+}

--- a/Libraries/MLXVLM/VLMProcessorLoadingRegistry.swift
+++ b/Libraries/MLXVLM/VLMProcessorLoadingRegistry.swift
@@ -33,75 +33,78 @@ public struct VLMProcessorConfiguration: Sendable {
 /// Supplies model-specific processor loading policy that is not present in a checkpoint.
 ///
 /// Both hooks are optional. A fallback is consulted only when neither
-/// `preprocessor_config.json` nor `processor_config.json` exists. A type override is
-/// consulted after a configuration has been selected, so it can correct processor metadata
-/// shipped by a checkpoint.
-public protocol VLMProcessorLoadingResolving: Sendable {
-    func processorConfigurationFallback(
+/// `preprocessor_config.json` nor `processor_config.json` exists. Processor type resolvers are
+/// consulted after a configuration has been selected, so they can supply missing metadata or
+/// correct metadata shipped by a checkpoint.
+public protocol VLMProcessorLoadingResolver: Sendable {
+    func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration?
 
-    func processorTypeOverride(
+    /// The processor type to use for this model, or `nil` to defer to another resolver or
+    /// the checkpoint declaration. `declaredProcessorType` is `nil` when the selected
+    /// processor configuration does not contain `processor_class`.
+    func processorType(
         for context: VLMProcessorLoadingContext,
-        declaredProcessorType: String
+        declaredProcessorType: String?
     ) throws -> String?
 }
 
-extension VLMProcessorLoadingResolving {
-    public func processorConfigurationFallback(
+extension VLMProcessorLoadingResolver {
+    public func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration? { nil }
 
-    public func processorTypeOverride(
+    public func processorType(
         for context: VLMProcessorLoadingContext,
-        declaredProcessorType: String
+        declaredProcessorType: String?
     ) throws -> String? { nil }
 }
 
 /// Ordered registry of processor-loading resolvers used by ``VLMModelFactory``.
 ///
 /// Most recently registered wins for each hook independently. This lets a downstream
-/// package override one decision while deferring the other to an earlier resolver.
+/// package choose one value while deferring the other to an earlier resolver.
 public final class VLMProcessorLoadingRegistry: @unchecked Sendable {
 
     /// Shared instance, preloaded with this package's built-in loading rules.
     public static let shared = VLMProcessorLoadingRegistry(resolvers: [
         Qwen35ProcessorLoadingResolver(),
-        ModelTypeProcessorOverrideResolver(processorTypes: [
+        ModelTypeProcessorResolver(processorTypes: [
             "mistral3": "Mistral3Processor",
             "gemma4_unified": "Gemma4UnifiedProcessor",
         ]),
     ])
 
     private let lock = NSLock()
-    private var resolvers: [any VLMProcessorLoadingResolving]
+    private var resolvers: [any VLMProcessorLoadingResolver]
 
-    public init(resolvers: [any VLMProcessorLoadingResolving] = []) {
+    public init(resolvers: [any VLMProcessorLoadingResolver] = []) {
         self.resolvers = resolvers
     }
 
     /// Add a resolver. It takes precedence over resolvers registered before it.
-    public func register(_ resolver: any VLMProcessorLoadingResolving) {
+    public func register(_ resolver: any VLMProcessorLoadingResolver) {
         lock.withLock { resolvers.append(resolver) }
     }
 
-    func processorConfigurationFallback(
+    func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration? {
         for resolver in snapshot() {
-            if let configuration = try resolver.processorConfigurationFallback(for: context) {
+            if let configuration = try resolver.fallbackProcessorConfiguration(for: context) {
                 return configuration
             }
         }
         return nil
     }
 
-    func processorTypeOverride(
+    func processorType(
         for context: VLMProcessorLoadingContext,
-        declaredProcessorType: String
+        declaredProcessorType: String?
     ) throws -> String? {
         for resolver in snapshot() {
-            if let processorType = try resolver.processorTypeOverride(
+            if let processorType = try resolver.processorType(
                 for: context, declaredProcessorType: declaredProcessorType)
             {
                 return processorType
@@ -112,32 +115,32 @@ public final class VLMProcessorLoadingRegistry: @unchecked Sendable {
 
     /// Copy under the lock, then execute external code outside it. A resolver may be slow
     /// or may re-enter this registry, neither of which should block registration.
-    private func snapshot() -> [any VLMProcessorLoadingResolving] {
+    private func snapshot() -> [any VLMProcessorLoadingResolver] {
         lock.withLock { resolvers.reversed() }
     }
 }
 
 /// A reusable processor-type rule keyed by `model_type` from `config.json`.
-public struct ModelTypeProcessorOverrideResolver: VLMProcessorLoadingResolving {
+public struct ModelTypeProcessorResolver: VLMProcessorLoadingResolver {
     public let processorTypes: [String: String]
 
     public init(processorTypes: [String: String]) {
         self.processorTypes = processorTypes
     }
 
-    public func processorTypeOverride(
+    public func processorType(
         for context: VLMProcessorLoadingContext,
-        declaredProcessorType: String
+        declaredProcessorType: String?
     ) throws -> String? {
         processorTypes[context.modelType]
     }
 }
 
 /// Reconstructs processor metadata omitted by Qwen3.5 checkpoints from their vision config.
-public struct Qwen35ProcessorLoadingResolver: VLMProcessorLoadingResolving {
+public struct Qwen35ProcessorLoadingResolver: VLMProcessorLoadingResolver {
     public init() {}
 
-    public func processorConfigurationFallback(
+    public func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration? {
         guard context.modelType == "qwen3_5" || context.modelType == "qwen3_5_moe" else {

--- a/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
@@ -81,14 +81,16 @@ final class Qwen3VLProcessorConfigTests: XCTestCase {
 final class Qwen35ProcessorFallbackTests: XCTestCase {
 
     func testDenseFallbackEncodesVisionGeometryAndQwenDefaults() throws {
-        let model = Qwen35(try makeQwen35Configuration(modelType: "qwen3_5"))
-
         let fallback = try XCTUnwrap(
-            qwenProcessorFallback(modelType: "qwen3_5", model: model))
+            Qwen35ProcessorLoadingResolver().processorConfigurationFallback(
+                for: VLMProcessorLoadingContext(
+                    modelId: "example/qwen",
+                    modelType: "qwen3_5",
+                    configurationData: makeQwen35ConfigurationData(modelType: "qwen3_5"))))
         let config = try JSONDecoder().decode(
-            Qwen3VLProcessorConfiguration.self, from: fallback.0)
+            Qwen3VLProcessorConfiguration.self, from: fallback.data)
 
-        XCTAssertEqual(fallback.1.processorClass, "Qwen3VLProcessor")
+        XCTAssertEqual(fallback.processorType, "Qwen3VLProcessor")
         XCTAssertEqual(config.imageMean, [0.5, 0.5, 0.5])
         XCTAssertEqual(config.imageStd, [0.5, 0.5, 0.5])
         XCTAssertEqual(config.minPixels, 65_536)
@@ -100,26 +102,30 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
     }
 
     func testMoEFallbackUsesInheritedQwen35Configuration() throws {
-        let model = Qwen35MoE(
-            try makeQwen35Configuration(
-                modelType: "qwen3_5_moe", patchSize: 12, mergeSize: 2,
-                temporalPatchSize: 3))
-
         let fallback = try XCTUnwrap(
-            qwenProcessorFallback(modelType: "qwen3_5_moe", model: model))
+            Qwen35ProcessorLoadingResolver().processorConfigurationFallback(
+                for: VLMProcessorLoadingContext(
+                    modelId: "example/qwen-moe",
+                    modelType: "qwen3_5_moe",
+                    configurationData: makeQwen35ConfigurationData(
+                        modelType: "qwen3_5_moe", patchSize: 12, mergeSize: 2,
+                        temporalPatchSize: 3))))
         let config = try JSONDecoder().decode(
-            Qwen3VLProcessorConfiguration.self, from: fallback.0)
+            Qwen3VLProcessorConfiguration.self, from: fallback.data)
 
-        XCTAssertEqual(fallback.1.processorClass, "Qwen3VLProcessor")
+        XCTAssertEqual(fallback.processorType, "Qwen3VLProcessor")
         XCTAssertEqual(config.patchSize, 12)
         XCTAssertEqual(config.mergeSize, 2)
         XCTAssertEqual(config.temporalPatchSize, 3)
     }
 
     func testFallbackRejectsUnrelatedModelType() throws {
-        let model = Qwen35(try makeQwen35Configuration(modelType: "qwen3_5"))
-
-        XCTAssertNil(try qwenProcessorFallback(modelType: "qwen3_vl", model: model))
+        XCTAssertNil(
+            try Qwen35ProcessorLoadingResolver().processorConfigurationFallback(
+                for: VLMProcessorLoadingContext(
+                    modelId: "example/qwen",
+                    modelType: "qwen3_vl",
+                    configurationData: makeQwen35ConfigurationData(modelType: "qwen3_5"))))
     }
 
     func testMissingFilesUseFallback() async throws {
@@ -127,10 +133,10 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directory) }
         let fallback = try processorConfiguration(named: "FallbackProcessor")
 
-        let resolved = try await loadProcessorConfig(from: directory, fallback: fallback)
+        let resolved = try await loadProcessorConfig(from: directory) { fallback }
 
-        XCTAssertEqual(resolved.0, fallback.0)
-        XCTAssertEqual(resolved.1.processorClass, "FallbackProcessor")
+        XCTAssertEqual(resolved.data, fallback.data)
+        XCTAssertEqual(resolved.processorType, "FallbackProcessor")
     }
 
     func testPreprocessorConfigWinsOverProcessorAndFallback() async throws {
@@ -139,14 +145,14 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
         let preprocessor = try processorConfiguration(named: "Preprocessor")
         let processor = try processorConfiguration(named: "Processor")
         let fallback = try processorConfiguration(named: "Fallback")
-        try preprocessor.0.write(
+        try preprocessor.data.write(
             to: directory.appending(component: "preprocessor_config.json"))
-        try processor.0.write(to: directory.appending(component: "processor_config.json"))
+        try processor.data.write(to: directory.appending(component: "processor_config.json"))
 
-        let resolved = try await loadProcessorConfig(from: directory, fallback: fallback)
+        let resolved = try await loadProcessorConfig(from: directory) { fallback }
 
-        XCTAssertEqual(resolved.0, preprocessor.0)
-        XCTAssertEqual(resolved.1.processorClass, "Preprocessor")
+        XCTAssertEqual(resolved.data, preprocessor.data)
+        XCTAssertEqual(resolved.processorType, "Preprocessor")
     }
 
     func testProcessorConfigWinsOverFallback() async throws {
@@ -154,12 +160,12 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directory) }
         let processor = try processorConfiguration(named: "Processor")
         let fallback = try processorConfiguration(named: "Fallback")
-        try processor.0.write(to: directory.appending(component: "processor_config.json"))
+        try processor.data.write(to: directory.appending(component: "processor_config.json"))
 
-        let resolved = try await loadProcessorConfig(from: directory, fallback: fallback)
+        let resolved = try await loadProcessorConfig(from: directory) { fallback }
 
-        XCTAssertEqual(resolved.0, processor.0)
-        XCTAssertEqual(resolved.1.processorClass, "Processor")
+        XCTAssertEqual(resolved.data, processor.data)
+        XCTAssertEqual(resolved.processorType, "Processor")
     }
 
     func testMalformedPreprocessorIsNotMasked() async throws {
@@ -169,10 +175,10 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
         let fallback = try processorConfiguration(named: "Fallback")
         try Data("{".utf8).write(
             to: directory.appending(component: "preprocessor_config.json"))
-        try processor.0.write(to: directory.appending(component: "processor_config.json"))
+        try processor.data.write(to: directory.appending(component: "processor_config.json"))
 
         do {
-            _ = try await loadProcessorConfig(from: directory, fallback: fallback)
+            _ = try await loadProcessorConfig(from: directory) { fallback }
             XCTFail("Expected malformed preprocessor_config.json to throw")
         } catch let error as ProcessorConfigError {
             XCTAssertEqual(error.filename, "preprocessor_config.json")
@@ -187,7 +193,7 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
             to: directory.appending(component: "processor_config.json"))
 
         do {
-            _ = try await loadProcessorConfig(from: directory, fallback: fallback)
+            _ = try await loadProcessorConfig(from: directory) { fallback }
             XCTFail("Expected malformed processor_config.json to throw")
         } catch let error as ProcessorConfigError {
             XCTAssertEqual(error.filename, "processor_config.json")
@@ -224,12 +230,12 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
         XCTAssertThrowsError(try JSONDecoder().decode(Qwen35Configuration.self, from: data))
     }
 
-    private func makeQwen35Configuration(
+    private func makeQwen35ConfigurationData(
         modelType: String,
         patchSize: Int = 14,
         mergeSize: Int = 3,
         temporalPatchSize: Int = 4
-    ) throws -> Qwen35Configuration {
+    ) -> Data {
         let json = """
             {
                 "model_type": "\(modelType)",
@@ -264,15 +270,15 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
                 }
             }
             """
-        return try JSONDecoder().decode(
-            Qwen35Configuration.self, from: Data(json.utf8))
+        return Data(json.utf8)
     }
 
-    private func processorConfiguration(named processorClass: String) throws -> (
-        Data, BaseProcessorConfiguration
-    ) {
+    private func processorConfiguration(
+        named processorClass: String
+    ) throws -> VLMProcessorConfiguration {
         let config = BaseProcessorConfiguration(processorClass: processorClass)
-        return (try JSONEncoder().encode(config), config)
+        return VLMProcessorConfiguration(
+            data: try JSONEncoder().encode(config), processorType: processorClass)
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLProcessorConfigTests.swift
@@ -82,7 +82,7 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
 
     func testDenseFallbackEncodesVisionGeometryAndQwenDefaults() throws {
         let fallback = try XCTUnwrap(
-            Qwen35ProcessorLoadingResolver().processorConfigurationFallback(
+            Qwen35ProcessorLoadingResolver().fallbackProcessorConfiguration(
                 for: VLMProcessorLoadingContext(
                     modelId: "example/qwen",
                     modelType: "qwen3_5",
@@ -103,7 +103,7 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
 
     func testMoEFallbackUsesInheritedQwen35Configuration() throws {
         let fallback = try XCTUnwrap(
-            Qwen35ProcessorLoadingResolver().processorConfigurationFallback(
+            Qwen35ProcessorLoadingResolver().fallbackProcessorConfiguration(
                 for: VLMProcessorLoadingContext(
                     modelId: "example/qwen-moe",
                     modelType: "qwen3_5_moe",
@@ -121,7 +121,7 @@ final class Qwen35ProcessorFallbackTests: XCTestCase {
 
     func testFallbackRejectsUnrelatedModelType() throws {
         XCTAssertNil(
-            try Qwen35ProcessorLoadingResolver().processorConfigurationFallback(
+            try Qwen35ProcessorLoadingResolver().fallbackProcessorConfiguration(
                 for: VLMProcessorLoadingContext(
                     modelId: "example/qwen",
                     modelType: "qwen3_vl",

--- a/Tests/MLXLMTests/VLMProcessorLoadingRegistryTests.swift
+++ b/Tests/MLXLMTests/VLMProcessorLoadingRegistryTests.swift
@@ -1,0 +1,160 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLXVLM
+
+final class VLMProcessorLoadingRegistryTests: XCTestCase {
+
+    func testExternalResolversComposeFallbackAndTypeOverride() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fallbackData = Data(#"{"source":"external-package"}"#.utf8)
+        let registry = VLMProcessorLoadingRegistry(resolvers: [
+            TestResolver(
+                configuration: VLMProcessorConfiguration(
+                    data: fallbackData, processorType: "DeclaredProcessor")),
+            TestResolver(processorType: "ExternalProcessor"),
+        ])
+
+        let resolved = try await resolveProcessorConfiguration(
+            from: directory, context: context(), registry: registry)
+
+        XCTAssertEqual(resolved.data, fallbackData)
+        XCTAssertEqual(resolved.processorType, "ExternalProcessor")
+    }
+
+    func testMostRecentlyRegisteredResolverWinsForEachHook() throws {
+        let firstData = Data("first".utf8)
+        let secondData = Data("second".utf8)
+        let registry = VLMProcessorLoadingRegistry(resolvers: [
+            TestResolver(
+                configuration: VLMProcessorConfiguration(
+                    data: firstData, processorType: "FirstDeclared"),
+                processorType: "FirstOverride")
+        ])
+        registry.register(
+            TestResolver(
+                configuration: VLMProcessorConfiguration(
+                    data: secondData, processorType: "SecondDeclared"),
+                processorType: "SecondOverride"))
+
+        XCTAssertEqual(
+            try registry.processorConfigurationFallback(for: context())?.data,
+            secondData)
+        XCTAssertEqual(
+            try registry.processorTypeOverride(
+                for: context(), declaredProcessorType: "CheckpointProcessor"),
+            "SecondOverride")
+    }
+
+    func testNilDefersEachHookIndependently() throws {
+        let fallbackData = Data("fallback".utf8)
+        let registry = VLMProcessorLoadingRegistry(resolvers: [
+            TestResolver(
+                configuration: VLMProcessorConfiguration(
+                    data: fallbackData, processorType: "FallbackProcessor"),
+                processorType: "EarlierOverride"),
+            TestResolver(processorType: "LaterOverride"),
+        ])
+
+        XCTAssertEqual(
+            try registry.processorConfigurationFallback(for: context())?.data,
+            fallbackData)
+        XCTAssertEqual(
+            try registry.processorTypeOverride(
+                for: context(), declaredProcessorType: "CheckpointProcessor"),
+            "LaterOverride")
+    }
+
+    func testCheckpointConfigurationDoesNotInvokeFallbackResolver() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkpointData = Data(#"{"processor_class":"CheckpointProcessor"}"#.utf8)
+        try checkpointData.write(
+            to: directory.appending(component: "processor_config.json"))
+        let registry = VLMProcessorLoadingRegistry(resolvers: [ThrowingFallbackResolver()])
+
+        let resolved = try await resolveProcessorConfiguration(
+            from: directory, context: context(), registry: registry)
+
+        XCTAssertEqual(resolved.data, checkpointData)
+        XCTAssertEqual(resolved.processorType, "CheckpointProcessor")
+    }
+
+    func testBuiltInTypeRulesUseThePublicResolverPath() throws {
+        let resolver = ModelTypeProcessorOverrideResolver(processorTypes: [
+            "mistral3": "Mistral3Processor",
+            "gemma4_unified": "Gemma4UnifiedProcessor",
+        ])
+
+        XCTAssertEqual(
+            try resolver.processorTypeOverride(
+                for: context(modelType: "mistral3"),
+                declaredProcessorType: "PixtralProcessor"),
+            "Mistral3Processor")
+        XCTAssertEqual(
+            try resolver.processorTypeOverride(
+                for: context(modelType: "gemma4_unified"),
+                declaredProcessorType: "AutoProcessor"),
+            "Gemma4UnifiedProcessor")
+        XCTAssertNil(
+            try resolver.processorTypeOverride(
+                for: context(modelType: "unrelated"),
+                declaredProcessorType: "AutoProcessor"))
+    }
+
+    private func context(modelType: String = "external_vlm") -> VLMProcessorLoadingContext {
+        VLMProcessorLoadingContext(
+            modelId: "example/model",
+            modelType: modelType,
+            configurationData: Data(#"{"model_type":"external_vlm"}"#.utf8))
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(component: "VLMProcessorLoadingRegistryTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}
+
+private struct TestResolver: VLMProcessorLoadingResolving {
+    var configuration: VLMProcessorConfiguration?
+    var processorType: String?
+
+    init(
+        configuration: VLMProcessorConfiguration? = nil,
+        processorType: String? = nil
+    ) {
+        self.configuration = configuration
+        self.processorType = processorType
+    }
+
+    func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration? {
+        configuration
+    }
+
+    func processorTypeOverride(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String
+    ) throws -> String? {
+        processorType
+    }
+}
+
+private struct ThrowingFallbackResolver: VLMProcessorLoadingResolving {
+    enum Failure: Error {
+        case unexpectedlyInvoked
+    }
+
+    func processorConfigurationFallback(
+        for context: VLMProcessorLoadingContext
+    ) throws -> VLMProcessorConfiguration? {
+        throw Failure.unexpectedlyInvoked
+    }
+}

--- a/Tests/MLXLMTests/VLMProcessorLoadingRegistryTests.swift
+++ b/Tests/MLXLMTests/VLMProcessorLoadingRegistryTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class VLMProcessorLoadingRegistryTests: XCTestCase {
 
-    func testExternalResolversComposeFallbackAndTypeOverride() async throws {
+    func testExternalResolversComposeFallbackAndTypeResolution() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let fallbackData = Data(#"{"source":"external-package"}"#.utf8)
@@ -32,21 +32,21 @@ final class VLMProcessorLoadingRegistryTests: XCTestCase {
             TestResolver(
                 configuration: VLMProcessorConfiguration(
                     data: firstData, processorType: "FirstDeclared"),
-                processorType: "FirstOverride")
+                processorType: "FirstChoice")
         ])
         registry.register(
             TestResolver(
                 configuration: VLMProcessorConfiguration(
                     data: secondData, processorType: "SecondDeclared"),
-                processorType: "SecondOverride"))
+                processorType: "SecondChoice"))
 
         XCTAssertEqual(
-            try registry.processorConfigurationFallback(for: context())?.data,
+            try registry.fallbackProcessorConfiguration(for: context())?.data,
             secondData)
         XCTAssertEqual(
-            try registry.processorTypeOverride(
+            try registry.processorType(
                 for: context(), declaredProcessorType: "CheckpointProcessor"),
-            "SecondOverride")
+            "SecondChoice")
     }
 
     func testNilDefersEachHookIndependently() throws {
@@ -55,17 +55,17 @@ final class VLMProcessorLoadingRegistryTests: XCTestCase {
             TestResolver(
                 configuration: VLMProcessorConfiguration(
                     data: fallbackData, processorType: "FallbackProcessor"),
-                processorType: "EarlierOverride"),
-            TestResolver(processorType: "LaterOverride"),
+                processorType: "EarlierChoice"),
+            TestResolver(processorType: "LaterChoice"),
         ])
 
         XCTAssertEqual(
-            try registry.processorConfigurationFallback(for: context())?.data,
+            try registry.fallbackProcessorConfiguration(for: context())?.data,
             fallbackData)
         XCTAssertEqual(
-            try registry.processorTypeOverride(
+            try registry.processorType(
                 for: context(), declaredProcessorType: "CheckpointProcessor"),
-            "LaterOverride")
+            "LaterChoice")
     }
 
     func testCheckpointConfigurationDoesNotInvokeFallbackResolver() async throws {
@@ -83,24 +83,78 @@ final class VLMProcessorLoadingRegistryTests: XCTestCase {
         XCTAssertEqual(resolved.processorType, "CheckpointProcessor")
     }
 
+    func testCheckpointProcessorTypeCanBeCorrected() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkpointData = Data(#"{"processor_class":"IncorrectProcessor"}"#.utf8)
+        try checkpointData.write(
+            to: directory.appending(component: "processor_config.json"))
+        let registry = VLMProcessorLoadingRegistry(resolvers: [
+            TestResolver(processorType: "ExternalProcessor")
+        ])
+
+        let resolved = try await resolveProcessorConfiguration(
+            from: directory, context: context(), registry: registry)
+
+        XCTAssertEqual(resolved.data, checkpointData)
+        XCTAssertEqual(resolved.processorType, "ExternalProcessor")
+    }
+
+    func testExistingConfigurationWithoutProcessorClassCanBeResolved() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkpointData = Data(#"{"image_mean":[0.5,0.5,0.5]}"#.utf8)
+        try checkpointData.write(
+            to: directory.appending(component: "preprocessor_config.json"))
+        let registry = VLMProcessorLoadingRegistry(resolvers: [
+            MissingProcessorTypeResolver(processorType: "ExternalProcessor")
+        ])
+
+        let resolved = try await resolveProcessorConfiguration(
+            from: directory, context: context(), registry: registry)
+
+        XCTAssertEqual(resolved.data, checkpointData)
+        XCTAssertEqual(resolved.processorType, "ExternalProcessor")
+    }
+
+    func testExistingConfigurationWithoutProcessorClassFailsWhenUnresolved() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data(#"{"image_mean":[0.5,0.5,0.5]}"#.utf8).write(
+            to: directory.appending(component: "preprocessor_config.json"))
+
+        do {
+            _ = try await resolveProcessorConfiguration(
+                from: directory, context: context(),
+                registry: VLMProcessorLoadingRegistry())
+            XCTFail("Expected an unresolved processor type to throw")
+        } catch let error as ProcessorConfigError {
+            XCTAssertEqual(error.filename, "preprocessor_config.json")
+            guard case DecodingError.keyNotFound(let key, _) = error.underlying else {
+                return XCTFail("Expected a missing processor_class decoding error")
+            }
+            XCTAssertEqual(key.stringValue, "processor_class")
+        }
+    }
+
     func testBuiltInTypeRulesUseThePublicResolverPath() throws {
-        let resolver = ModelTypeProcessorOverrideResolver(processorTypes: [
+        let resolver = ModelTypeProcessorResolver(processorTypes: [
             "mistral3": "Mistral3Processor",
             "gemma4_unified": "Gemma4UnifiedProcessor",
         ])
 
         XCTAssertEqual(
-            try resolver.processorTypeOverride(
+            try resolver.processorType(
                 for: context(modelType: "mistral3"),
                 declaredProcessorType: "PixtralProcessor"),
             "Mistral3Processor")
         XCTAssertEqual(
-            try resolver.processorTypeOverride(
+            try resolver.processorType(
                 for: context(modelType: "gemma4_unified"),
                 declaredProcessorType: "AutoProcessor"),
             "Gemma4UnifiedProcessor")
         XCTAssertNil(
-            try resolver.processorTypeOverride(
+            try resolver.processorType(
                 for: context(modelType: "unrelated"),
                 declaredProcessorType: "AutoProcessor"))
     }
@@ -121,7 +175,7 @@ final class VLMProcessorLoadingRegistryTests: XCTestCase {
     }
 }
 
-private struct TestResolver: VLMProcessorLoadingResolving {
+private struct TestResolver: VLMProcessorLoadingResolver {
     var configuration: VLMProcessorConfiguration?
     var processorType: String?
 
@@ -133,28 +187,39 @@ private struct TestResolver: VLMProcessorLoadingResolving {
         self.processorType = processorType
     }
 
-    func processorConfigurationFallback(
+    func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration? {
         configuration
     }
 
-    func processorTypeOverride(
+    func processorType(
         for context: VLMProcessorLoadingContext,
-        declaredProcessorType: String
+        declaredProcessorType: String?
     ) throws -> String? {
         processorType
     }
 }
 
-private struct ThrowingFallbackResolver: VLMProcessorLoadingResolving {
+private struct ThrowingFallbackResolver: VLMProcessorLoadingResolver {
     enum Failure: Error {
         case unexpectedlyInvoked
     }
 
-    func processorConfigurationFallback(
+    func fallbackProcessorConfiguration(
         for context: VLMProcessorLoadingContext
     ) throws -> VLMProcessorConfiguration? {
         throw Failure.unexpectedlyInvoked
+    }
+}
+
+private struct MissingProcessorTypeResolver: VLMProcessorLoadingResolver {
+    let processorType: String
+
+    func processorType(
+        for context: VLMProcessorLoadingContext,
+        declaredProcessorType: String?
+    ) throws -> String? {
+        declaredProcessorType == nil ? processorType : nil
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes #547.

External model packages could register their models and processors, but could not control how processor metadata was loaded. This forced model-specific fixes to be hard-coded inside `VLMModelFactory`.

This PR introduces a public processor-loading resolver registry. External packages can now:

- Provide processor configuration when it is missing from a model repository.
- Correct an incorrectly declared processor type.
- Override built-in behavior without modifying MLXVLM.

Existing Qwen3.5, Mistral3, and Gemma4 special cases now use the same public mechanism. Repository configuration files remain authoritative, and fallbacks are only evaluated when those files are absent.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)