### PR TITLE
Share fused Qwen3.5 router top-k across LLM and VLM

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -12,109 +12,6 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
-// MARK: - Fused router top-k
-
-/// One-kernel replacement for the decode router tail: `chainRouterTopK`
-/// fully sorts all `E` experts (`ArgPartition::eval_gpu` delegates to
-/// `gpu_merge_sort`) just to name `K` — three serial dispatches, three
-/// encoder-wide barriers, where barrier-bound decode needs one.
-///
-/// Bit-identical to the chain by construction: the sort is stable
-/// (`sort.h`'s `LessThan` compares values only, ties keep input order), so
-/// counting the elements ranked strictly above `i` — with the index packed
-/// into the low bits of a monotone bit key as the tie-break — reproduces
-/// each winner's slot. `±0.0` normalises to one bit pattern (they compare
-/// equal but differ bitwise), NaN maps above `+inf` (all NaNs tie), and the
-/// sum accumulates sequentially in the output dtype from zero, in slot
-/// order, matching `reduce.metal`'s `thread_reduce`.
-private let routerTopKSource = """
-    uint row = threadgroup_position_in_grid.y;
-    uint t = thread_position_in_threadgroup.x;
-
-    threadgroup ulong sk[E_];
-    threadgroup float top_v[K_];
-
-    float v = static_cast<float>(gates[row * E_ + t]);
-    uint b = (v == 0.0f) ? 0u : as_type<uint>(v);
-    uint mono = isnan(v) ? 0xFFFFFFFFu : (b ^ ((uint)(((int)b) >> 31) | 0x80000000u));
-    ulong key = (((ulong)mono) << 32) | (ulong)t;
-    sk[t] = key;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    int above = 0;
-    for (uint j = 0; j < E_; ++j) {
-        above += (sk[j] > key) ? 1 : 0;
-    }
-    if (above < K_) {
-        top_v[K_ - 1 - above] = v;
-        inds[row * K_ + (K_ - 1 - above)] = t;
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    if (t == 0) {
-        T acc = static_cast<T>(0);
-        for (int q = 0; q < K_; ++q) {
-            acc = static_cast<T>(top_v[q]) + acc;
-        }
-        for (int q = 0; q < K_; ++q) {
-            T s = static_cast<T>(top_v[q]);
-            scores[row * K_ + q] = NORM_ ? (s / acc) : s;
-        }
-    }
-    """
-
-private final class RouterTopKKernel: Sendable {
-    static let shared = RouterTopKKernel()
-    let kernel: MLXFast.MLXFastKernel
-
-    private init() {
-        kernel = MLXFast.metalKernel(
-            name: "router_topk_norm",
-            inputNames: ["gates"],
-            outputNames: ["inds", "scores"],
-            source: routerTopKSource
-        )
-    }
-}
-
-/// Metal's threads-per-threadgroup ceiling; one thread per expert, so past
-/// this the dispatch is invalid, not just slow.
-private let maxFusedRouterExperts = 1024
-
-/// Top-`k` + optional normalisation over the last axis in one dispatch:
-/// `(indices, scores)` shaped `[..., k]`, bit-identical to
-/// `chainRouterTopK`, `uint32` indices included. One threadgroup per row
-/// with an `O(E²)` rank count — callers gate this on the single-row decode
-/// case. Internal so the bitwise test can reach it.
-func fusedRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
-    let e = gates.dim(-1)
-    let rows = gates.size / e
-    let shape = Array(gates.shape.dropLast()) + [k]
-    let out = RouterTopKKernel.shared.kernel(
-        [gates],
-        template: [
-            ("T", gates.dtype), ("E_", e), ("K_", k), ("NORM_", normalize ? 1 : 0),
-        ],
-        grid: (e, rows, 1),
-        threadGroup: (e, 1, 1),
-        outputShapes: [shape, shape],
-        outputDTypes: [.uint32, gates.dtype]
-    )
-    return (out[0], out[1])
-}
-
-/// The three-dispatch router tail the fused kernel replaces — the prefill
-/// path, and the bitwise test's reference.
-func chainRouterTopK(_ gates: MLXArray, k: Int, normalize: Bool) -> (MLXArray, MLXArray) {
-    let kth = gates.dim(-1) - k
-    let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
-    var scores = MLX.takeAlong(gates, inds, axis: -1)
-    if normalize {
-        scores = scores / scores.sum(axis: -1, keepDims: true)
-    }
-    return (inds, scores)
-}
-
 // MARK: - Configuration
 
 private enum RopeParametersCodingKey: String, CodingKey {
@@ -678,7 +575,8 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         var gates = gate(x)
         gates = MLX.softmax(gates, axis: -1, precise: true)
 
-        let (inds, scores) = routerTopK(gates, k: topK)
+        let (inds, scores) = moeRouterTopK(
+            gates, k: topK, normalize: normTopkProb)
 
         let y = switchMLP(x, inds)
         let combined = weightedExpertSum(y, scores)
@@ -687,17 +585,6 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         sharedY = sigmoid(sharedExpertGate(x)) * sharedY
 
         return combined + sharedY
-    }
-
-    /// Decode (one row): the fused kernel, one dispatch instead of three
-    /// barriers, bit-identical. Prefill: the chain — many rows make the
-    /// `O(E²)` rank count the wrong shape, and there is no barrier to save.
-    private func routerTopK(_ gates: MLXArray, k: Int) -> (MLXArray, MLXArray) {
-        let e = gates.dim(-1)
-        if gates.size == e, e <= maxFusedRouterExperts {
-            return fusedRouterTopK(gates, k: k, normalize: normTopkProb)
-        }
-        return chainRouterTopK(gates, k: k, normalize: normTopkProb)
     }
 }
 

--- a/Libraries/MLXLMCommon/MoERouterTopK.swift
+++ b/Libraries/MLXLMCommon/MoERouterTopK.swift
@@ -1,0 +1,119 @@
+import MLX
+
+// MARK: - Fused router top-k
+
+/// One-kernel replacement for the decode router tail: `chainRouterTopK`
+/// fully sorts all `E` experts (`ArgPartition::eval_gpu` delegates to
+/// `gpu_merge_sort`) just to name `K` — three serial dispatches, three
+/// encoder-wide barriers, where barrier-bound decode needs one.
+///
+/// Bit-identical to the chain by construction: the sort is stable
+/// (`sort.h`'s `LessThan` compares values only, ties keep input order), so
+/// counting the elements ranked strictly above `i` — with the index packed
+/// into the low bits of a monotone bit key as the tie-break — reproduces
+/// each winner's slot. `±0.0` normalises to one bit pattern (they compare
+/// equal but differ bitwise), NaN maps above `+inf` (all NaNs tie), and the
+/// sum accumulates sequentially in the output dtype from zero, in slot
+/// order, matching `reduce.metal`'s `thread_reduce`.
+private let routerTopKSource = """
+    uint row = threadgroup_position_in_grid.y;
+    uint t = thread_position_in_threadgroup.x;
+
+    threadgroup ulong sk[E_];
+    threadgroup float top_v[K_];
+
+    float v = static_cast<float>(gates[row * E_ + t]);
+    uint b = (v == 0.0f) ? 0u : as_type<uint>(v);
+    uint mono = isnan(v) ? 0xFFFFFFFFu : (b ^ ((uint)(((int)b) >> 31) | 0x80000000u));
+    ulong key = (((ulong)mono) << 32) | (ulong)t;
+    sk[t] = key;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    int above = 0;
+    for (uint j = 0; j < E_; ++j) {
+        above += (sk[j] > key) ? 1 : 0;
+    }
+    if (above < K_) {
+        top_v[K_ - 1 - above] = v;
+        inds[row * K_ + (K_ - 1 - above)] = t;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (t == 0) {
+        T acc = static_cast<T>(0);
+        for (int q = 0; q < K_; ++q) {
+            acc = static_cast<T>(top_v[q]) + acc;
+        }
+        for (int q = 0; q < K_; ++q) {
+            T s = static_cast<T>(top_v[q]);
+            scores[row * K_ + q] = NORM_ ? (s / acc) : s;
+        }
+    }
+    """
+
+private final class RouterTopKKernel: Sendable {
+    static let shared = RouterTopKKernel()
+    let kernel: MLXFast.MLXFastKernel
+
+    private init() {
+        kernel = MLXFast.metalKernel(
+            name: "router_topk_norm",
+            inputNames: ["gates"],
+            outputNames: ["inds", "scores"],
+            source: routerTopKSource
+        )
+    }
+}
+
+/// Metal's threads-per-threadgroup ceiling; one thread per expert, so past
+/// this the dispatch is invalid, not just slow.
+private let maxFusedRouterExperts = 1024
+
+/// Top-`k` + optional normalisation over the last axis in one dispatch:
+/// `(indices, scores)` shaped `[..., k]`, bit-identical to
+/// `chainRouterTopK`, `uint32` indices included. One threadgroup per row
+/// with an `O(E²)` rank count. Internal so the bitwise test can reach it.
+func fusedRouterTopK(
+    _ gates: MLXArray, k: Int, normalize: Bool
+) -> (indices: MLXArray, scores: MLXArray) {
+    let e = gates.dim(-1)
+    let rows = gates.size / e
+    let shape = Array(gates.shape.dropLast()) + [k]
+    let out = RouterTopKKernel.shared.kernel(
+        [gates],
+        template: [
+            ("T", gates.dtype), ("E_", e), ("K_", k), ("NORM_", normalize ? 1 : 0),
+        ],
+        grid: (e, rows, 1),
+        threadGroup: (e, 1, 1),
+        outputShapes: [shape, shape],
+        outputDTypes: [.uint32, gates.dtype]
+    )
+    return (out[0], out[1])
+}
+
+/// The three-dispatch router tail the fused kernel replaces — the prefill
+/// path, larger expert sets, and the bitwise test's reference.
+func chainRouterTopK(
+    _ gates: MLXArray, k: Int, normalize: Bool
+) -> (indices: MLXArray, scores: MLXArray) {
+    let kth = gates.dim(-1) - k
+    let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, (kth)...]
+    var scores = MLX.takeAlong(gates, inds, axis: -1)
+    if normalize {
+        scores = scores / scores.sum(axis: -1, keepDims: true)
+    }
+    return (inds, scores)
+}
+
+/// Selects experts using the fused kernel for a single decode row and the
+/// reference chain for prefill, batched decode, or unsupported expert counts.
+package func moeRouterTopK(
+    _ gates: MLXArray, k: Int, normalize: Bool
+) -> (indices: MLXArray, scores: MLXArray) {
+    let e = gates.dim(-1)
+    if gates.size == e, e <= maxFusedRouterExperts {
+        return fusedRouterTopK(gates, k: k, normalize: normalize)
+    }
+    return chainRouterTopK(gates, k: k, normalize: normalize)
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -658,12 +658,8 @@ enum Qwen35Language {
             var gates = gate(x)
             gates = MLX.softmax(gates, axis: -1, precise: true)
 
-            let kth = gates.dim(-1) - topK
-            let inds = MLX.argPartition(gates, kth: kth, axis: -1)[.ellipsis, kth...]
-            var scores = MLX.takeAlong(gates, inds, axis: -1)
-            if normTopkProb {
-                scores = scores / scores.sum(axis: -1, keepDims: true)
-            }
+            let (inds, scores) = moeRouterTopK(
+                gates, k: topK, normalize: normTopkProb)
 
             let y = switchMLP(x, inds)
             let combined = weightedExpertSum(y, scores)

--- a/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
@@ -7,7 +7,7 @@
 import MLX
 import XCTest
 
-@testable import MLXLLM
+@testable import MLXLMCommon
 
 final class Qwen35RouterTopKBitwiseTests: XCTestCase {
 
@@ -94,6 +94,34 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
                         nans, k: k, normalize: normalize, "NaN \(tag)", indicesOnly: true)
                 }
             }
+        }
+    }
+
+    func testMoERouterTopKMatchesChainAcrossDispatchPaths() {
+        let cases = [
+            (shape: [1, 256], k: 8, label: "single-row fused"),
+            (shape: [4, 256], k: 8, label: "multi-row chain"),
+            (shape: [1, 1025], k: 8, label: "expert-limit chain"),
+        ]
+
+        for testCase in cases {
+            let gates = MLX.softmax(
+                MLXRandom.normal(testCase.shape), axis: -1, precise: true
+            ).asType(.float16)
+            let (wantInds, wantScores) = chainRouterTopK(
+                gates, k: testCase.k, normalize: true)
+            let (gotInds, gotScores) = moeRouterTopK(
+                gates, k: testCase.k, normalize: true)
+            eval(wantInds, wantScores, gotInds, gotScores)
+
+            XCTAssertEqual(
+                gotInds.reshaped(-1).asArray(UInt32.self),
+                wantInds.reshaped(-1).asArray(UInt32.self),
+                "\(testCase.label): expert selection order")
+            assertBitIdentical(
+                gotScores.reshaped(-1, testCase.k),
+                wantScores.reshaped(-1, testCase.k),
+                "\(testCase.label): scores")
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

This is a follow-up port of [PR #469](https://github.com/ml-explore/mlx-swift-lm/pull/469), which introduced a bit-identical fused MoE router Top-K kernel for Qwen3.5/3.6 but only wired it into the text-model implementation. The Qwen3.5 vision-language path continued using the unfused `argPartition` → `takeAlong` → normalize chain.

This change:

- Moves the fused kernel, reference implementation, and dispatch policy into `MLXLMCommon`.
- Uses the shared `moeRouterTopK` function in both `MLXLLM` and `MLXVLM`.
- Selects the fused kernel only for single-row decode with at most 1024 experts.
- Preserves the original chain for prefill, batched inputs, and larger expert counts.
- Keeps the shared function package-internal, without adding public API.

## Testing

- Extended the bitwise tests to cover the fused and fallback dispatch paths.
- Confirmed the fused output remains bit-identical to the reference chain.
- Full package test suite passes.
- `MLXLMCommon` documentation build passes.

This PR does not claim a measured VLM speedup yet; it ports the previously validated text-path optimization and removes the implementation divergence between the two Qwen3.5 paths.
## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
