### PR TITLE
Share fused MoE router top-k across models

### DIFF
--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -281,8 +281,16 @@ class GraniteMoeHybridTopKGating: Module {
 
     func callAsFunction(_ hiddenStates: MLXArray) -> (MLXArray, MLXArray) {
         let logits = layer(hiddenStates)
-        let indices = MLX.argPartition(-logits, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
-        let topKLogits = MLX.takeAlong(logits, indices, axis: -1)
+        let indices: MLXArray
+        let topKLogits: MLXArray
+        if supportsFusedRouterTopK(logits, k: topK) {
+            (indices, topKLogits) = fusedRouterTopK(
+                selection: logits, values: logits, k: topK,
+                normalize: false, order: .descending)
+        } else {
+            indices = MLX.argPartition(-logits, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+            topKLogits = MLX.takeAlong(logits, indices, axis: -1)
+        }
         let gates = MLX.softmax(topKLogits, axis: -1, precise: true)
         return (indices, gates)
     }

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -355,8 +355,17 @@ class JambaSparseMoeBlock: Module {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         let gates = router(x)
         let k = numExpertsPerTok
-        let inds = stopGradient(MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k])
-        var scores = MLX.takeAlong(gates, inds, axis: -1)
+        let inds: MLXArray
+        var scores: MLXArray
+        if supportsFusedRouterTopK(gates, k: k) {
+            (inds, scores) = fusedRouterTopK(
+                selection: gates, values: gates, k: k,
+                normalize: false, order: .descending)
+        } else {
+            inds = stopGradient(
+                MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k])
+            scores = MLX.takeAlong(gates, inds, axis: -1)
+        }
         scores = MLX.softmax(scores, axis: -1, precise: true)
 
         let y = switchMLP(x, inds)

--- a/Libraries/MLXLLM/Models/Mixtral.swift
+++ b/Libraries/MLXLLM/Models/Mixtral.swift
@@ -138,10 +138,20 @@ class MixtralSparseMoeBlock: Module {
         let gates = gate(x)
 
         let k = topK
-        let inds = MLX.stopGradient(MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k])
+        let inds: MLXArray
+        let selectedLogits: MLXArray
+        if supportsFusedRouterTopK(gates, k: k) {
+            (inds, selectedLogits) = fusedRouterTopK(
+                selection: gates, values: gates, k: k,
+                normalize: false, order: .descending)
+        } else {
+            inds = MLX.stopGradient(
+                MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k])
+            selectedLogits = MLX.takeAlong(gates, inds, axis: -1)
+        }
         // Mixtral applies the softmax over the *selected* expert logits (after top-k),
         // unlike the softmax-then-select ordering used by e.g. Qwen3MoE.
-        let scores = MLX.softmax(MLX.takeAlong(gates, inds, axis: -1), axis: -1, precise: true)
+        let scores = MLX.softmax(selectedLogits, axis: -1, precise: true)
 
         let y = switchMLP(x, inds)
         return weightedExpertSum(y, scores)

--- a/Libraries/MLXLLM/Models/OlmoE.swift
+++ b/Libraries/MLXLLM/Models/OlmoE.swift
@@ -113,11 +113,19 @@ class OlmoeSparseMoeBlock: Module, UnaryLayer {
         let routingWeights = MLX.softmax(routerLogits, axis: -1, precise: true)
 
         let k = topK
-        let inds = MLX.argPartition(-routingWeights, kth: k - 1, axis: -1)[.ellipsis, ..<k]
-        var scores = MLX.takeAlong(routingWeights, inds, axis: -1)
-
-        if normTopkProb {
-            scores = scores / MLX.sum(scores, axis: -1, keepDims: true)
+        let inds: MLXArray
+        let scores: MLXArray
+        if supportsFusedRouterTopK(routingWeights, k: k) {
+            (inds, scores) = fusedRouterTopK(
+                selection: routingWeights, values: routingWeights, k: k,
+                normalize: normTopkProb, order: .descending)
+        } else {
+            inds = MLX.argPartition(-routingWeights, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+            var selected = MLX.takeAlong(routingWeights, inds, axis: -1)
+            if normTopkProb {
+                selected = selected / MLX.sum(selected, axis: -1, keepDims: true)
+            }
+            scores = selected
         }
 
         let y = switchMLP(x, inds)

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -135,11 +135,19 @@ class Qwen3MoESparseMoeBlock: Module, UnaryLayer {
         let softGates = MLX.softmax(gates, axis: -1, precise: true)
 
         let k = topK
-        let inds = MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k]
-        var scores = MLX.takeAlong(softGates, inds, axis: -1)
-
-        if normTopkProb {
-            scores = scores / MLX.sum(scores, axis: -1, keepDims: true)
+        let inds: MLXArray
+        let scores: MLXArray
+        if supportsFusedRouterTopK(gates, k: k) {
+            (inds, scores) = fusedRouterTopK(
+                selection: gates, values: softGates, k: k,
+                normalize: normTopkProb, order: .descending)
+        } else {
+            inds = MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+            var selected = MLX.takeAlong(softGates, inds, axis: -1)
+            if normTopkProb {
+                selected = selected / MLX.sum(selected, axis: -1, keepDims: true)
+            }
+            scores = selected
         }
 
         let y = switchMLP(x, inds)

--- a/Libraries/MLXLMCommon/MoERouterTopK.swift
+++ b/Libraries/MLXLMCommon/MoERouterTopK.swift
@@ -2,10 +2,10 @@ import MLX
 
 // MARK: - Fused router top-k
 
-/// One-kernel replacement for the decode router tail: `chainRouterTopK`
-/// fully sorts all `E` experts (`ArgPartition::eval_gpu` delegates to
-/// `gpu_merge_sort`) just to name `K` — three serial dispatches, three
-/// encoder-wide barriers, where barrier-bound decode needs one.
+/// One-kernel replacement for the decode router tail. Generic MLX router code
+/// fully sorts all experts to name K winners, then gathers their score values
+/// and may normalize them. For a single decode row, one threadgroup can do the
+/// same work without the serial dispatch boundaries.
 ///
 /// Bit-identical to the chain by construction: the sort is stable
 /// (`sort.h`'s `LessThan` compares values only, ties keep input order), so
@@ -15,6 +15,10 @@ import MLX
 /// equal but differ bitwise), NaN maps above `+inf` (all NaNs tie), and the
 /// sum accumulates sequentially in the output dtype from zero, in slot
 /// order, matching `reduce.metal`'s `thread_reduce`.
+///
+/// `selection` determines the winning experts; `values` supplies the scores
+/// returned for those experts. Keeping them separate covers routers such as
+/// Qwen 3, which selects on logits but weights experts with probabilities.
 private let routerTopKSource = """
     uint row = threadgroup_position_in_grid.y;
     uint t = thread_position_in_threadgroup.x;
@@ -22,10 +26,11 @@ private let routerTopKSource = """
     threadgroup ulong sk[E_];
     threadgroup float top_v[K_];
 
-    float v = static_cast<float>(gates[row * E_ + t]);
+    float v = static_cast<float>(selection[row * E_ + t]);
     uint b = (v == 0.0f) ? 0u : as_type<uint>(v);
     uint mono = isnan(v) ? 0xFFFFFFFFu : (b ^ ((uint)(((int)b) >> 31) | 0x80000000u));
-    ulong key = (((ulong)mono) << 32) | (ulong)t;
+    uint tie = DESCENDING_ ? (0xFFFFFFFFu - t) : t;
+    ulong key = (((ulong)mono) << 32) | (ulong)tie;
     sk[t] = key;
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -34,8 +39,9 @@ private let routerTopKSource = """
         above += (sk[j] > key) ? 1 : 0;
     }
     if (above < K_) {
-        top_v[K_ - 1 - above] = v;
-        inds[row * K_ + (K_ - 1 - above)] = t;
+        uint slot = DESCENDING_ ? (uint)above : (uint)(K_ - 1 - above);
+        top_v[slot] = static_cast<float>(values[row * E_ + t]);
+        inds[row * K_ + slot] = t;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -46,7 +52,7 @@ private let routerTopKSource = """
         }
         for (int q = 0; q < K_; ++q) {
             T s = static_cast<T>(top_v[q]);
-            scores[row * K_ + q] = NORM_ ? (s / acc) : s;
+            scores[row * K_ + q] = NORMALIZE_ ? (s / acc) : s;
         }
     }
     """
@@ -58,16 +64,70 @@ private final class RouterTopKKernel: Sendable {
     private init() {
         kernel = MLXFast.metalKernel(
             name: "router_topk_norm",
-            inputNames: ["gates"],
+            inputNames: ["selection", "values"],
             outputNames: ["inds", "scores"],
             source: routerTopKSource
         )
     }
 }
 
-/// Metal's threads-per-threadgroup ceiling; one thread per expert, so past
-/// this the dispatch is invalid, not just slow.
-private let maxFusedRouterExperts = 1024
+/// Metal's threads-per-threadgroup ceiling. The fused router uses one thread
+/// per expert, so larger routers must retain the generic MLX path.
+package let maxFusedRouterExperts = 1024
+
+/// Winner order produced by the generic router expression being replaced.
+///
+/// `argPartition(values, kth: E-K)[(E-K)...]` yields the selected values in
+/// ascending order, while `argPartition(-values, kth: K-1)[..<K]` yields them
+/// in descending order. Expert output reduction is order-sensitive, so the
+/// fused path must preserve that distinction exactly.
+package enum FusedRouterTopKOrder {
+    case ascending
+    case descending
+}
+
+/// Whether a router tensor can use the fused single-row Metal path.
+package func supportsFusedRouterTopK(_ selection: MLXArray, k: Int) -> Bool {
+    let e = selection.dim(-1)
+    return selection.size == e && e <= maxFusedRouterExperts && k > 0 && k <= e
+        && selection.dtype.isFloatingPoint
+}
+
+/// Fused top-k selection, selected-value gather, and optional normalization.
+/// Callers are responsible for restricting production use to the single-row
+/// decode shape with ``supportsFusedRouterTopK(_:k:)``.
+package func fusedRouterTopK(
+    selection: MLXArray,
+    values: MLXArray,
+    k: Int,
+    normalize: Bool,
+    order: FusedRouterTopKOrder
+) -> (indices: MLXArray, scores: MLXArray) {
+    precondition(selection.shape == values.shape, "router selection/value shapes must match")
+    precondition(selection.dtype == values.dtype, "router selection/value dtypes must match")
+
+    let e = selection.dim(-1)
+    precondition(e <= maxFusedRouterExperts, "fused router exceeds Metal threadgroup limit")
+    precondition(k > 0 && k <= e, "invalid fused router top-k")
+
+    let rows = selection.size / e
+    let shape = Array(selection.shape.dropLast()) + [k]
+    let out = RouterTopKKernel.shared.kernel(
+        [selection, values],
+        template: [
+            ("T", selection.dtype),
+            ("E_", e),
+            ("K_", k),
+            ("NORMALIZE_", normalize ? 1 : 0),
+            ("DESCENDING_", order == .descending ? 1 : 0),
+        ],
+        grid: (e, rows, 1),
+        threadGroup: (e, 1, 1),
+        outputShapes: [shape, shape],
+        outputDTypes: [.uint32, values.dtype]
+    )
+    return (out[0], out[1])
+}
 
 /// Top-`k` + optional normalisation over the last axis in one dispatch:
 /// `(indices, scores)` shaped `[..., k]`, bit-identical to
@@ -76,20 +136,9 @@ private let maxFusedRouterExperts = 1024
 func fusedRouterTopK(
     _ gates: MLXArray, k: Int, normalize: Bool
 ) -> (indices: MLXArray, scores: MLXArray) {
-    let e = gates.dim(-1)
-    let rows = gates.size / e
-    let shape = Array(gates.shape.dropLast()) + [k]
-    let out = RouterTopKKernel.shared.kernel(
-        [gates],
-        template: [
-            ("T", gates.dtype), ("E_", e), ("K_", k), ("NORM_", normalize ? 1 : 0),
-        ],
-        grid: (e, rows, 1),
-        threadGroup: (e, 1, 1),
-        outputShapes: [shape, shape],
-        outputDTypes: [.uint32, gates.dtype]
+    fusedRouterTopK(
+        selection: gates, values: gates, k: k, normalize: normalize, order: .ascending
     )
-    return (out[0], out[1])
 }
 
 /// The three-dispatch router tail the fused kernel replaces — the prefill
@@ -111,8 +160,7 @@ func chainRouterTopK(
 package func moeRouterTopK(
     _ gates: MLXArray, k: Int, normalize: Bool
 ) -> (indices: MLXArray, scores: MLXArray) {
-    let e = gates.dim(-1)
-    if gates.size == e, e <= maxFusedRouterExperts {
+    if supportsFusedRouterTopK(gates, k: k) {
         return fusedRouterTopK(gates, k: k, normalize: normalize)
     }
     return chainRouterTopK(gates, k: k, normalize: normalize)

--- a/Tests/MLXLMTests/MoERouterFusedIntegrationTests.swift
+++ b/Tests/MLXLMTests/MoERouterFusedIntegrationTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+@testable import MLXLLM
+
+final class MoERouterFusedIntegrationTests: XCTestCase {
+    private let input = MLXArray([
+        Float(0.25), -0.5, 0.75, 1.0, -1.25, 0.125, 0.625, -0.875,
+    ]).reshaped(1, 1, 8)
+
+    private func decode<T: Decodable>(_ type: T.Type, _ json: String) throws -> T {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    private func assertBitIdentical(
+        _ actual: MLXArray, _ expected: MLXArray,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        eval(actual, expected)
+        XCTAssertEqual(actual.dtype, expected.dtype, file: file, line: line)
+        XCTAssertEqual(actual.shape, expected.shape, file: file, line: line)
+        let actualBits = actual.asType(.float32).asArray(Float.self).map(\.bitPattern)
+        let expectedBits = expected.asType(.float32).asArray(Float.self).map(\.bitPattern)
+        XCTAssertEqual(actualBits, expectedBits, file: file, line: line)
+    }
+
+    private func descendingIndices(_ selection: MLXArray, k: Int) -> MLXArray {
+        MLX.argPartition(-selection, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+    }
+
+    func testQwen3MoEDecodeMatchesGenericRouter() throws {
+        let config = try decode(
+            Qwen3MoEConfiguration.self,
+            """
+            {
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "intermediate_size": 16,
+                "num_attention_heads": 2,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "decoder_sparse_step": 1,
+                "mlp_only_layers": [],
+                "moe_intermediate_size": 12,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 32,
+                "num_key_value_heads": 1,
+                "head_dim": 4,
+                "norm_topk_prob": true
+            }
+            """)
+        MLXRandom.seed(101)
+        let block = Qwen3MoESparseMoeBlock(config)
+
+        let actual = block(input)
+        let logits = block.gate(input)
+        let probabilities = MLX.softmax(logits, axis: -1, precise: true)
+        let indices = descendingIndices(logits, k: block.topK)
+        var scores = MLX.takeAlong(probabilities, indices, axis: -1)
+        scores = scores / MLX.sum(scores, axis: -1, keepDims: true)
+        let expected = weightedExpertSum(block.switchMLP(input, indices), scores)
+
+        assertBitIdentical(actual, expected)
+    }
+
+    func testOlmoEDecodeMatchesGenericRouter() throws {
+        let config = try decode(
+            OlmoEConfiguration.self,
+            """
+            {
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "intermediate_size": 12,
+                "num_attention_heads": 2,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 32,
+                "num_key_value_heads": 1,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "norm_topk_prob": true
+            }
+            """)
+        MLXRandom.seed(102)
+        let block = OlmoeSparseMoeBlock(config)
+
+        let actual = block(input)
+        let probabilities = MLX.softmax(block.gate(input), axis: -1, precise: true)
+        let indices = descendingIndices(probabilities, k: block.topK)
+        var scores = MLX.takeAlong(probabilities, indices, axis: -1)
+        scores = scores / MLX.sum(scores, axis: -1, keepDims: true)
+        let expected = weightedExpertSum(block.switchMLP(input, indices), scores)
+
+        assertBitIdentical(actual, expected)
+    }
+
+    func testMixtralDecodeMatchesGenericRouter() throws {
+        let config = try decode(
+            MixtralConfiguration.self,
+            """
+            {
+                "hidden_size": 8,
+                "intermediate_size": 12,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "num_local_experts": 4,
+                "num_experts_per_tok": 2
+            }
+            """)
+        MLXRandom.seed(103)
+        let block = MixtralSparseMoeBlock(config)
+
+        let actual = block(input)
+        let logits = block.gate(input)
+        let indices = descendingIndices(logits, k: block.topK)
+        let scores = MLX.softmax(
+            MLX.takeAlong(logits, indices, axis: -1), axis: -1, precise: true)
+        let expected = weightedExpertSum(block.switchMLP(input, indices), scores)
+
+        assertBitIdentical(actual, expected)
+    }
+
+    func testJambaDecodeMatchesGenericRouter() throws {
+        let config = try decode(
+            JambaConfiguration.self,
+            """
+            {
+                "model_type": "jamba",
+                "hidden_size": 8,
+                "intermediate_size": 12,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "attn_layer_offset": 0,
+                "attn_layer_period": 1,
+                "expert_layer_offset": 0,
+                "expert_layer_period": 1,
+                "mamba_d_conv": 2,
+                "mamba_d_state": 4,
+                "mamba_expand": 2,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "rms_norm_eps": 1e-5,
+                "max_position_embeddings": 32,
+                "vocab_size": 32
+            }
+            """)
+        MLXRandom.seed(104)
+        let block = JambaSparseMoeBlock(config)
+
+        let actual = block(input)
+        let logits = block.router(input)
+        let indices = descendingIndices(logits, k: block.numExpertsPerTok)
+        let scores = MLX.softmax(
+            MLX.takeAlong(logits, indices, axis: -1), axis: -1, precise: true)
+        let expected = weightedExpertSum(block.switchMLP(input, indices), scores)
+
+        assertBitIdentical(actual, expected)
+    }
+
+    func testGraniteMoeHybridDecodeMatchesGenericRouter() {
+        MLXRandom.seed(105)
+        let router = GraniteMoeHybridTopKGating(inputSize: 8, numExperts: 4, topK: 2)
+
+        let actual = router(input)
+        let logits = router.layer(input)
+        let expectedIndices = descendingIndices(logits, k: router.topK)
+        let expectedScores = MLX.softmax(
+            MLX.takeAlong(logits, expectedIndices, axis: -1), axis: -1, precise: true)
+        eval(actual.0, actual.1, expectedIndices, expectedScores)
+
+        XCTAssertEqual(
+            actual.0.reshaped(-1).asArray(UInt32.self),
+            expectedIndices.reshaped(-1).asArray(UInt32.self))
+        assertBitIdentical(actual.1, expectedScores)
+    }
+}

--- a/Tests/MLXLMTests/SwitchLayersTests.swift
+++ b/Tests/MLXLMTests/SwitchLayersTests.swift
@@ -3,6 +3,39 @@ import MLXLMCommon
 import XCTest
 
 final class SwitchLayersTests: XCTestCase {
+    private func assertBitIdentical(
+        _ actual: MLXArray, _ expected: MLXArray, _ label: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.dtype, expected.dtype, "\(label): dtype", file: file, line: line)
+        XCTAssertEqual(actual.shape, expected.shape, "\(label): shape", file: file, line: line)
+        let a = actual.asType(.float32).asArray(Float.self)
+        let b = expected.asType(.float32).asArray(Float.self)
+        let mismatches = zip(a, b).filter { $0.bitPattern != $1.bitPattern }.count
+        XCTAssertEqual(
+            mismatches, 0, "\(label): \(mismatches)/\(a.count) elements differ bitwise",
+            file: file, line: line)
+    }
+
+    private func referenceRouterTopK(
+        selection: MLXArray, values: MLXArray, k: Int,
+        normalize: Bool, order: FusedRouterTopKOrder
+    ) -> (MLXArray, MLXArray) {
+        let indices: MLXArray
+        switch order {
+        case .ascending:
+            let kth = selection.dim(-1) - k
+            indices = MLX.argPartition(selection, kth: kth, axis: -1)[.ellipsis, kth...]
+        case .descending:
+            indices = MLX.argPartition(-selection, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+        }
+        var scores = MLX.takeAlong(values, indices, axis: -1)
+        if normalize {
+            scores = scores / scores.sum(axis: -1, keepDims: true)
+        }
+        return (indices, scores)
+    }
+
     func testWeightedExpertSumMatchesGenericExpression() {
         let outputs = MLXArray(0 ..< 24).asType(.float32).reshaped(2, 3, 4)
         let weights = MLXArray([Float](arrayLiteral: 0.25, 0.75, 1.0, 0.0, 0.5, 0.5))
@@ -13,5 +46,43 @@ final class SwitchLayersTests: XCTestCase {
 
         eval(expected, actual)
         XCTAssertTrue(allClose(actual, expected).item(Bool.self))
+    }
+
+    func testFusedRouterTopKPreservesOrderAndSeparateScoreValues() {
+        let rows = 32
+        let e = 128
+        let k = 8
+
+        for dtype in [DType.float16, DType.bfloat16, DType.float32] {
+            for order in [FusedRouterTopKOrder.ascending, .descending] {
+                for normalize in [false, true] {
+                    MLXRandom.seed(UInt64(1000 + (normalize ? 1 : 0)))
+                    // Rounded selection values force stable-tie behavior; the
+                    // positive score tensor exercises selection and weighting
+                    // from different inputs as used by Qwen 3 MoE.
+                    let selection = (MLX.round(MLXRandom.normal([rows, e]) * 2) / 2)
+                        .asType(dtype)
+                    let values = MLX.softmax(
+                        MLXRandom.normal([rows, e]), axis: -1, precise: true
+                    ).asType(dtype)
+
+                    let reference = referenceRouterTopK(
+                        selection: selection, values: values, k: k,
+                        normalize: normalize, order: order)
+                    let fused = fusedRouterTopK(
+                        selection: selection, values: values, k: k,
+                        normalize: normalize, order: order)
+                    eval(reference.0, reference.1, fused.0, fused.1)
+
+                    XCTAssertEqual(
+                        fused.0.reshaped(-1).asArray(UInt32.self),
+                        reference.0.reshaped(-1).asArray(UInt32.self),
+                        "\(dtype) \(order) norm=\(normalize): expert order")
+                    assertBitIdentical(
+                        fused.1, reference.1,
+                        "\(dtype) \(order) norm=\(normalize): selected scores")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Mixture-of-Experts models contain several feed-forward networks called “experts.” For every generated token, a router selects a small number of those experts and combines their outputs.

The existing generic router performs this work as several consecutive GPU operations:

1. Select the top experts.
2. Gather their routing scores.
3. Optionally normalize those scores.

These operations process very little data during single-token generation, so repeatedly launching separate GPU operations can cost more than the calculations themselves. Qwen 3.5 already avoids this overhead with a decode-specific Metal kernel.

This PR moves that kernel into `MLXLMCommon`, generalizes it, and shares it with:

- Qwen 3 MoE
- OLMoE
- Mixtral
- Jamba
- Granite MoE Hybrid
- Qwen 3.5, which retains its existing optimized behavior

The shared implementation supports the differences between these model families, including:

- Selecting experts from one tensor while gathering weights from another.
- Preserving ascending or descending expert order.
- Optional score normalization.
- Stable handling of equal routing scores.

The optimized path is deliberately limited to single-token decoding with at most 1,024 experts. Prompt processing and other multi-row inputs continue using the existing generic MLX implementation, where its sorting algorithm is more appropriate.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed) — No user-facing documentation change is required because this is a package-internal optimization; explanatory API documentation was added alongside the shared implementation.
