### PR TITLE
Generalise compiled decode segments to Qwen 3 Next

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -703,13 +703,6 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
 
 // MARK: - Decoder Layer
 
-/// Caches the compiled decode path can drive: their attention is the plain
-/// `cache.update` + SDPA route in `attentionWithCacheUpdate`. Quantized and
-/// turbo caches have their own routes and take the general path.
-private func hasPlainAttentionRoute(_ cache: KVCache) -> Bool {
-    !(cache is QuantizedKVCacheProtocol) && !(cache is TurboQuantKVCache)
-}
-
 final class Qwen35DecoderLayer: Module {
     let isLinear: Bool
 
@@ -767,7 +760,7 @@ final class Qwen35DecoderLayer: Module {
             if isLinear, let mambaCache = cache as? MambaCache {
                 return decodeLinearLayer(x, cache: mambaCache)
             }
-            if !isLinear, let cache, hasPlainAttentionRoute(cache) {
+            if !isLinear, let cache, usesPlainAttentionCacheRoute(cache) {
                 return decodeAttentionLayer(x, mask: attentionMask, cache: cache)
             }
         }
@@ -927,9 +920,10 @@ public class Qwen35TextModelInner: Module {
         self.ssmIdx = 0
         self.faIdx = args.fullAttentionInterval - 1
 
-        let segments = Self.decodeSchedule(for: layers)
+        let segments = CompiledDecodeSegment.schedule(
+            linearLayers: layers.map(\.isLinear))
         self.decodeSegments = segments
-        self.compiledSegments = Array(repeating: nil, count: segments.count)
+        self.compiledSegments = CompiledDecodeSegmentCache(count: segments.count)
 
         super.init()
     }
@@ -983,38 +977,8 @@ public class Qwen35TextModelInner: Module {
     /// One traced piece of a decode step: the tail of the previous
     /// full-attention layer, a run of GDN layers, then the head of the next
     /// one (whose SDPA runs between this segment and the next).
-    private struct DecodeSegment {
-        var attentionPostLayer: Int?
-        var linearLayers: [Int] = []
-        var attentionPreLayer: Int?
-
-        /// First conv/recurrent state slot in the input list (after `x` and
-        /// any [attention, gate] pair).
-        var stateInputOffset: Int { attentionPostLayer == nil ? 1 : 3 }
-        /// First [queries, gate, keys, values] slot in the output list.
-        var attentionOutputOffset: Int { 1 + 2 * linearLayers.count }
-    }
-
-    private let decodeSegments: [DecodeSegment]
-    // Lock rationale: see Qwen35SparseMoeBlock.compileLock.
-    private let compileLock = NSLock()
-    private var compiledSegments: [(([MLXArray]) -> [MLXArray])?]
-
-    private static func decodeSchedule(for layers: [Qwen35DecoderLayer]) -> [DecodeSegment] {
-        var segments: [DecodeSegment] = []
-        var current = DecodeSegment()
-        for (i, layer) in layers.enumerated() {
-            if layer.isLinear {
-                current.linearLayers.append(i)
-            } else {
-                current.attentionPreLayer = i
-                segments.append(current)
-                current = DecodeSegment(attentionPostLayer: i)
-            }
-        }
-        segments.append(current)
-        return segments
-    }
+    private let decodeSegments: [CompiledDecodeSegment]
+    private let compiledSegments: CompiledDecodeSegmentCache
 
     /// Flat argument/result lists because `compile` takes `[MLXArray]`.
     /// In: `[x]` (token ids for segment 0), then `[attention, gate]` when
@@ -1079,7 +1043,7 @@ public class Qwen35TextModelInner: Module {
                 else { return nil }
                 mambaCaches[i] = mambaCache
             } else {
-                guard let kv = cache[i], hasPlainAttentionRoute(kv) else { return nil }
+                guard let kv = cache[i], usesPlainAttentionCacheRoute(kv) else { return nil }
             }
         }
 
@@ -1094,16 +1058,11 @@ public class Qwen35TextModelInner: Module {
                 args.append(mambaCache[1]!)
             }
 
-            compileLock.lock()
-            if compiledSegments[segmentIndex] == nil {
-                // [unowned self]: see Qwen35SparseMoeBlock.callAsFunction.
-                compiledSegments[segmentIndex] = compile { [unowned self] segmentArgs in
-                    segmentBody(at: segmentIndex, segmentArgs)
-                }
+            let outputs = compiledSegments.call(
+                at: segmentIndex, arguments: args
+            ) { [unowned self] segmentArgs in
+                segmentBody(at: segmentIndex, segmentArgs)
             }
-            let fn = compiledSegments[segmentIndex]!
-            compileLock.unlock()
-            let outputs = fn(args)
 
             carry = outputs[0]
             for (i, layerIndex) in segment.linearLayers.enumerated() {

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -88,24 +88,11 @@ public final class Qwen3NextAttention: Module {
     public func callAsFunction(
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
     ) -> MLXArray {
-        let B = x.dim(0)
-        let L = x.dim(1)
-
-        let qProjOutput = qProj(x)
-        let qSplit = qProjOutput.reshaped(B, L, args.attentionHeads, -1).split(parts: 2, axis: -1)
-        var queries = qSplit[0]
-        let gate = qSplit[1].reshaped(B, L, -1)
-
-        var keys = kProj(x)
-        var values = vProj(x)
-
-        queries = qNorm(queries).transposed(0, 2, 1, 3)
-        keys = kNorm(keys.reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
-        values = values.reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+        let (queriesPreRope, gate, keysPreRope, values) = projectPreRope(x)
 
         let offset = cache?.ropeOffset
-        queries = applyRotaryPosition(rope, to: queries, offset: offset)
-        keys = applyRotaryPosition(rope, to: keys, offset: offset)
+        let queries = applyRotaryPosition(rope, to: queriesPreRope, offset: offset)
+        let keys = applyRotaryPosition(rope, to: keysPreRope, offset: offset)
 
         let output = attentionWithCacheUpdate(
             queries: queries,
@@ -115,10 +102,32 @@ public final class Qwen3NextAttention: Module {
             scale: scale,
             mask: mask
         )
-        .transposed(0, 2, 1, 3)
-        .reshaped(B, L, -1)
 
-        return oProj(sigmoidMultiply(output, gate))
+        return mergeHeadsAndProject(attention: output, gate: gate)
+    }
+
+    /// Projections before RoPE, which stays outside compiled decode segments
+    /// because its offset changes for every generated token.
+    func projectPreRope(_ x: MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        let qProjOutput = qProj(x)
+        let qSplit = qProjOutput.reshaped(B, L, args.attentionHeads, -1).split(parts: 2, axis: -1)
+        let queries = qNorm(qSplit[0]).transposed(0, 2, 1, 3)
+        let gate = qSplit[1].reshaped(B, L, -1)
+        let keys = kNorm(kProj(x).reshaped(B, L, args.kvHeads, -1)).transposed(0, 2, 1, 3)
+        let values = vProj(x).reshaped(B, L, args.kvHeads, -1).transposed(0, 2, 1, 3)
+        return (queries, gate, keys, values)
+    }
+
+    /// Head merge, output gate, and output projection after attention.
+    func mergeHeadsAndProject(attention: MLXArray, gate: MLXArray) -> MLXArray {
+        let merged =
+            attention
+            .transposed(0, 2, 1, 3)
+            .reshaped(attention.dim(0), attention.dim(2), -1)
+        return oProj(sigmoidMultiply(merged, gate))
     }
 }
 
@@ -234,6 +243,35 @@ public final class Qwen3NextGatedDeltaNet: Module {
         mask: MLXArray? = nil,
         cache: MambaCache? = nil
     ) -> MLXArray {
+        let zero = zeroStates(batch: inputs.dim(0), dtype: inputs.dtype)
+        let (output, newConvState, newRecState) = forward(
+            inputs,
+            convState: cache?[0] ?? zero.conv,
+            recState: cache?[1],
+            mask: mask)
+        if let cache {
+            cache[0] = newConvState
+            cache[1] = newRecState
+            cache.advance(inputs.dim(1))
+        }
+        return output
+    }
+
+    /// Explicit zero state used by both the general and compiled paths.
+    func zeroStates(batch: Int, dtype: DType) -> (conv: MLXArray, rec: MLXArray) {
+        (
+            MLXArray.zeros([batch, convKernelSize - 1, convDim], dtype: dtype),
+            MLXArray.zeros([batch, numVHeads, headVDim, headKDim], dtype: .float32)
+        )
+    }
+
+    /// Pure GDN body with state passed explicitly across the compiled graph.
+    func forward(
+        _ inputs: MLXArray,
+        convState: MLXArray,
+        recState: MLXArray?,
+        mask: MLXArray?
+    ) -> (output: MLXArray, convState: MLXArray, recurrentState: MLXArray) {
         let B = inputs.dim(0)
         let S = inputs.dim(1)
 
@@ -243,12 +281,6 @@ public final class Qwen3NextGatedDeltaNet: Module {
         )
 
         let dtype = inputs.dtype
-        let convState: MLXArray
-        if let cacheState = cache?[0] {
-            convState = cacheState
-        } else {
-            convState = MLXArray.zeros([B, convKernelSize - 1, convDim], dtype: dtype)
-        }
 
         var mixedQKV = concatenated(
             [q.reshaped(B, S, -1), k.reshaped(B, S, -1), v.reshaped(B, S, -1)],
@@ -260,12 +292,14 @@ public final class Qwen3NextGatedDeltaNet: Module {
                 expandedDimensions(mask, axis: -1), mixedQKV, MLXArray.zeros(like: mixedQKV))
         }
 
-        let convInput = concatenated([convState, mixedQKV], axis: 1)
-        if let cache {
-            cache[0] = contiguous(convInput[0..., (1 - convKernelSize)..., 0...])
-        }
-
-        let convOut = silu(conv1d(convInput))
+        let fusedDecode =
+            S == 1 && mask == nil
+            && (mixedQKV.dtype == .float16 || mixedQKV.dtype == .bfloat16)
+        let (convPre, newConvState) =
+            fusedDecode
+            ? decodeConv(convState: convState, qkv: mixedQKV)
+            : generalConv(convState: convState, qkv: mixedQKV)
+        let convOut = silu(convPre)
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
 
         var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim)
@@ -288,17 +322,46 @@ public final class Qwen3NextGatedDeltaNet: Module {
             b: b,
             aLog: aLog,
             dtBias: dtBias,
-            state: cache?[1],
+            state: recState,
             mask: mask
         )
 
-        if let cache {
-            cache[1] = newState
-            cache.advance(S)
-        }
-
         let normalized = norm(out, gate: z)
-        return outProj(normalized.reshaped(B, S, -1))
+        return (outProj(normalized.reshaped(B, S, -1)), newConvState, newState)
+    }
+
+    /// Single-token depthwise convolution expressed as multiply-adds so it
+    /// can fuse into a compiled decode segment. Float32 accumulation with one
+    /// final cast matches MLX's convolution kernel for fp16 and bfloat16.
+    func decodeConv(
+        convState: MLXArray, qkv: MLXArray
+    ) -> (conv: MLXArray, state: MLXArray) {
+        var accumulator =
+            convState[0..., 0, 0...].asType(.float32)
+            * conv1d.weight[0..., 0, 0].asType(.float32)
+        for tap in 1 ..< convKernelSize {
+            let row =
+                tap < convKernelSize - 1
+                ? convState[0..., tap, 0...] : qkv[0..., 0, 0...]
+            accumulator =
+                accumulator
+                + row.asType(.float32) * conv1d.weight[0..., tap, 0].asType(.float32)
+        }
+        return (
+            accumulator.asType(qkv.dtype).reshaped(convState.dim(0), 1, convDim),
+            concatenated([convState[0..., 1..., 0...], qkv], axis: 1)
+        )
+    }
+
+    /// Reference convolution used for prefill, masks, and float32 decode.
+    func generalConv(
+        convState: MLXArray, qkv: MLXArray
+    ) -> (conv: MLXArray, state: MLXArray) {
+        let convInput = concatenated([convState, qkv], axis: 1)
+        return (
+            conv1d(convInput),
+            contiguous(convInput[0..., (1 - convKernelSize)..., 0...])
+        )
     }
 }
 
@@ -415,6 +478,40 @@ final class Qwen3NextDecoderLayer: Module {
         }
         return r + (mlp as! Qwen3NextMLP)(normed)
     }
+
+    // MARK: - Compiled decode bodies
+
+    func linearLayerBody(x: MLXArray, convState: MLXArray, recState: MLXArray) -> (
+        MLXArray, MLXArray, MLXArray
+    ) {
+        let (attention, newConvState, newRecState) = linearAttn!.forward(
+            inputLayerNorm(x), convState: convState, recState: recState, mask: nil)
+        let hiddenStates = x + attention
+        return (
+            hiddenStates + mlpForward(postAttentionLayerNorm(hiddenStates)),
+            newConvState,
+            newRecState
+        )
+    }
+
+    func attentionPreBody(_ x: MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+        selfAttn!.projectPreRope(inputLayerNorm(x))
+    }
+
+    func attentionPostBody(
+        x: MLXArray, attention: MLXArray, gate: MLXArray
+    ) -> MLXArray {
+        let projected = selfAttn!.mergeHeadsAndProject(attention: attention, gate: gate)
+        let hiddenStates = x + projected
+        return hiddenStates + mlpForward(postAttentionLayerNorm(hiddenStates))
+    }
+
+    private func mlpForward(_ x: MLXArray) -> MLXArray {
+        if let moe = mlp as? Qwen3NextSparseMoeBlock {
+            return moe(x)
+        }
+        return (mlp as! Qwen3NextMLP)(x)
+    }
 }
 
 public class Qwen3NextModelInner: Module {
@@ -426,6 +523,11 @@ public class Qwen3NextModelInner: Module {
     let ssmIdx: Int
     let faIdx: Int
 
+    private let decodeSegments: [CompiledDecodeSegment]
+    private let compiledSegments: CompiledDecodeSegmentCache
+
+    var compiledDecodeSegmentCount: Int { compiledSegments.compiledCount }
+
     init(_ args: Qwen3NextConfiguration) {
         precondition(args.vocabularySize > 0)
 
@@ -434,19 +536,41 @@ public class Qwen3NextModelInner: Module {
             dimensions: args.hiddenSize
         )
 
-        self.layers = (0 ..< args.hiddenLayers).map { layerIdx in
+        let layers = (0 ..< args.hiddenLayers).map { layerIdx in
             Qwen3NextDecoderLayer(args, layerIdx: layerIdx)
         }
+        self.layers = layers
 
         self.norm = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
 
         self.ssmIdx = 0
         self.faIdx = args.fullAttentionInterval - 1
 
+        let segments = CompiledDecodeSegment.schedule(
+            linearLayers: layers.map(\.isLinear))
+        self.decodeSegments = segments
+        self.compiledSegments = CompiledDecodeSegmentCache(count: segments.count)
+
         super.init()
     }
 
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache?]? = nil) -> MLXArray {
+        forward(inputs, cache: cache, useCompiledDecode: true)
+    }
+
+    /// Internal opt-out lets correctness tests compare both paths with the
+    /// same model instance and weights.
+    func forward(
+        _ inputs: MLXArray,
+        cache: [KVCache?]?,
+        useCompiledDecode: Bool
+    ) -> MLXArray {
+        if useCompiledDecode, inputs.dim(1) == 1, let cache,
+            let output = decodeStep(inputs, cache)
+        {
+            return output
+        }
+
         var hiddenStates = embedTokens(inputs)
 
         var cacheArray = cache
@@ -465,6 +589,133 @@ public class Qwen3NextModelInner: Module {
         }
 
         return norm(hiddenStates)
+    }
+
+    // MARK: - Compiled decode segments
+
+    /// Flat segment arguments keep mutable cache state outside MLX's compiled
+    /// graphs while allowing the static work between cache writes to fuse.
+    private func segmentBody(at index: Int, _ arguments: [MLXArray]) -> [MLXArray] {
+        let segment = decodeSegments[index]
+        var hiddenStates = arguments[0]
+
+        if let post = segment.attentionPostLayer {
+            hiddenStates = layers[post].attentionPostBody(
+                x: hiddenStates, attention: arguments[1], gate: arguments[2])
+        }
+
+        var states: [MLXArray] = []
+        for (stateIndex, layerIndex) in segment.linearLayers.enumerated() {
+            let inputIndex = segment.stateInputOffset + 2 * stateIndex
+            let (output, convState, recState) = layers[layerIndex].linearLayerBody(
+                x: hiddenStates,
+                convState: arguments[inputIndex],
+                recState: arguments[inputIndex + 1])
+            hiddenStates = output
+            states.append(convState)
+            states.append(recState)
+        }
+
+        if let pre = segment.attentionPreLayer {
+            let (queries, gate, keys, values) = layers[pre].attentionPreBody(hiddenStates)
+            return [hiddenStates] + states + [queries, gate, keys, values]
+        }
+
+        if index == decodeSegments.count - 1 {
+            hiddenStates = norm(hiddenStates)
+        }
+        return [hiddenStates] + states
+    }
+
+    /// Execute one eligible single-token step through the shared compiled
+    /// segment scheduler. Returns nil for masks or cache implementations that
+    /// require the general model path.
+    private func decodeStep(_ inputs: MLXArray, _ cache: [KVCache?]) -> MLXArray? {
+        // MLX fusion currently changes low-order bfloat16/float32 results for
+        // this model. fp16 is pinned byte-identical against the general path.
+        let embedded = embedTokens(inputs)
+        guard embedded.dtype == .float16 else { return nil }
+        guard cache.count == layers.count else { return nil }
+        if createSSMMask(h: inputs, cache: cache[ssmIdx] as? MambaCache) != nil {
+            return nil
+        }
+        guard let attentionCache = cache[faIdx],
+            case .none = createAttentionMask(h: inputs, cache: attentionCache)
+        else { return nil }
+
+        var mambaCaches = [MambaCache?](repeating: nil, count: layers.count)
+        for (index, layer) in layers.enumerated() {
+            if layer.isLinear {
+                guard let mambaCache = cache[index] as? MambaCache,
+                    mambaCache[0] != nil, mambaCache[1] != nil
+                else { return nil }
+                mambaCaches[index] = mambaCache
+            } else {
+                guard let kvCache = cache[index], usesPlainAttentionCacheRoute(kvCache) else {
+                    return nil
+                }
+            }
+        }
+
+        var carry = embedded
+        var pendingAttention: [MLXArray] = []
+
+        for (segmentIndex, segment) in decodeSegments.enumerated() {
+            var arguments = [carry] + pendingAttention
+            for layerIndex in segment.linearLayers {
+                let mambaCache = mambaCaches[layerIndex]!
+                arguments.append(mambaCache[0]!)
+                arguments.append(mambaCache[1]!)
+            }
+
+            let outputs = compiledSegments.call(
+                at: segmentIndex, arguments: arguments
+            ) { [unowned self] arguments in
+                segmentBody(at: segmentIndex, arguments)
+            }
+
+            carry = outputs[0]
+            for (stateIndex, layerIndex) in segment.linearLayers.enumerated() {
+                let mambaCache = mambaCaches[layerIndex]!
+                mambaCache[0] = outputs[1 + 2 * stateIndex]
+                mambaCache[1] = outputs[2 + 2 * stateIndex]
+                mambaCache.advance(1)
+            }
+
+            pendingAttention = []
+            if let pre = segment.attentionPreLayer {
+                let outputIndex = segment.attentionOutputOffset
+                let attention = attentionCacheStep(
+                    layer: pre,
+                    queries: outputs[outputIndex],
+                    keys: outputs[outputIndex + 2],
+                    values: outputs[outputIndex + 3],
+                    cache: cache[pre]!)
+                pendingAttention = [attention, outputs[outputIndex + 1]]
+            }
+        }
+
+        return carry
+    }
+
+    /// RoPE, KV growth, and SDPA are the dynamic boundary between two static
+    /// compiled segments.
+    private func attentionCacheStep(
+        layer index: Int,
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        cache: KVCache
+    ) -> MLXArray {
+        let attention = layers[index].selfAttn!
+        let offset = cache.ropeOffset
+        return attentionWithCacheUpdate(
+            queries: applyRotaryPosition(attention.rope, to: queries, offset: offset),
+            keys: applyRotaryPosition(attention.rope, to: keys, offset: offset),
+            values: values,
+            cache: cache,
+            scale: attention.scale,
+            mask: .none)
     }
 }
 
@@ -489,7 +740,17 @@ public class Qwen3NextModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
-        var out = model(inputs, cache: cache)
+        forward(inputs, cache: cache, useCompiledDecode: true)
+    }
+
+    /// Internal opt-out used by the exact compiled/general oracle.
+    func forward(
+        _ inputs: MLXArray,
+        cache: [KVCache]?,
+        useCompiledDecode: Bool
+    ) -> MLXArray {
+        var out = model.forward(
+            inputs, cache: cache, useCompiledDecode: useCompiledDecode)
         if let lmHead {
             out = lmHead(out)
         } else {

--- a/Libraries/MLXLMCommon/AttentionUtils.swift
+++ b/Libraries/MLXLMCommon/AttentionUtils.swift
@@ -1,6 +1,14 @@
 import Foundation
 import MLX
 
+/// Whether attention can be split around a plain `KVCache.update` call.
+///
+/// Quantized and TurboQuant caches own their complete attention operation, so
+/// compiled model segments must leave those cache routes on the general path.
+package func usesPlainAttentionCacheRoute(_ cache: KVCache) -> Bool {
+    !(cache is QuantizedKVCacheProtocol) && !(cache is TurboQuantKVCache)
+}
+
 /// Attention utilities that match Python mlx-lm's interface
 ///
 /// This provides a single function that automatically routes to quantized or regular

--- a/Libraries/MLXLMCommon/CompiledDecodeSegments.swift
+++ b/Libraries/MLXLMCommon/CompiledDecodeSegments.swift
@@ -1,0 +1,83 @@
+import Foundation
+import MLX
+
+/// One static-shaped piece of a hybrid model's single-token decode graph.
+///
+/// Full-attention cache writes split segments because the cache grows at every
+/// token and cannot be mutated inside an MLX compiled function. Linear-layer
+/// state is passed explicitly through the compiled function instead.
+package struct CompiledDecodeSegment: Sendable, Equatable {
+    package var attentionPostLayer: Int?
+    package var linearLayers: [Int]
+    package var attentionPreLayer: Int?
+
+    package init(
+        attentionPostLayer: Int? = nil,
+        linearLayers: [Int] = [],
+        attentionPreLayer: Int? = nil
+    ) {
+        self.attentionPostLayer = attentionPostLayer
+        self.linearLayers = linearLayers
+        self.attentionPreLayer = attentionPreLayer
+    }
+
+    /// First linear-state input, after the hidden state and an optional
+    /// `[attention, gate]` pair.
+    package var stateInputOffset: Int { attentionPostLayer == nil ? 1 : 3 }
+
+    /// First `[queries, gate, keys, values]` output after the hidden state and
+    /// two updated state tensors per linear layer.
+    package var attentionOutputOffset: Int { 1 + 2 * linearLayers.count }
+
+    /// Build the maximal segments separated by full-attention cache writes.
+    package static func schedule(linearLayers: [Bool]) -> [Self] {
+        var segments: [Self] = []
+        var current = Self()
+        for (index, isLinear) in linearLayers.enumerated() {
+            if isLinear {
+                current.linearLayers.append(index)
+            } else {
+                current.attentionPreLayer = index
+                segments.append(current)
+                current = Self(attentionPostLayer: index)
+            }
+        }
+        segments.append(current)
+        return segments
+    }
+}
+
+/// Lazily compiles and retains one MLX function for every decode segment.
+///
+/// Models create this after their schedule is known. Compilation remains lazy
+/// because model weights are loaded after initialization. The lock ensures two
+/// concurrent first decode calls cannot install different traces.
+package final class CompiledDecodeSegmentCache {
+    private let lock = NSLock()
+    private var functions: [(([MLXArray]) -> [MLXArray])?]
+
+    package init(count: Int) {
+        precondition(count > 0, "compiled decode requires at least one segment")
+        self.functions = Array(repeating: nil, count: count)
+    }
+
+    package var compiledCount: Int {
+        lock.withLock { functions.compactMap { $0 }.count }
+    }
+
+    package func call(
+        at index: Int,
+        arguments: [MLXArray],
+        body: @escaping ([MLXArray]) -> [MLXArray]
+    ) -> [MLXArray] {
+        let function = lock.withLock {
+            if let function = functions[index] {
+                return function
+            }
+            let function = compile(body)
+            functions[index] = function
+            return function
+        }
+        return function(arguments)
+    }
+}

--- a/Tests/MLXLMTests/Qwen3NextCompiledDecodeTests.swift
+++ b/Tests/MLXLMTests/Qwen3NextCompiledDecodeTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+
+final class Qwen3NextCompiledDecodeTests: XCTestCase {
+    private struct Snapshot: Equatable {
+        let shape: [Int]
+        let dtype: DType
+        let bytes: Data
+
+        init(_ array: MLXArray) {
+            let contents = array.asData(access: .copy)
+            self.shape = contents.shape
+            self.dtype = contents.dType
+            self.bytes = contents.data
+        }
+    }
+
+    private struct RunResult {
+        let logits: [Snapshot]
+        let cacheState: [Snapshot]
+        let offsets: [Int]
+    }
+
+    private func configuration(
+        headDim: Int = 8,
+        quantizable: Bool = false
+    ) throws -> Qwen3NextConfiguration {
+        let hiddenSize = quantizable ? 64 : 16
+        let intermediateSize = quantizable ? 128 : 32
+        let linearHeadDim = quantizable ? 32 : 8
+        let expertSize = quantizable ? 64 : 16
+        let json = """
+            {
+                "hidden_size": \(hiddenSize), "num_hidden_layers": 4,
+                "intermediate_size": \(intermediateSize),
+                "num_attention_heads": 2, "num_key_value_heads": 1, "head_dim": \(headDim),
+                "linear_num_value_heads": 2, "linear_num_key_heads": 2,
+                "linear_key_head_dim": \(linearHeadDim),
+                "linear_value_head_dim": \(linearHeadDim),
+                "linear_conv_kernel_dim": 4,
+                "num_experts": 4, "num_experts_per_tok": 2, "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": \(expertSize), "mlp_only_layers": [],
+                "moe_intermediate_size": \(expertSize), "rms_norm_eps": 1e-6,
+                "vocab_size": 32,
+                "rope_theta": 10000.0, "partial_rotary_factor": 0.25,
+                "max_position_embeddings": 128, "norm_topk_prob": true,
+                "tie_word_embeddings": true, "attention_bias": false,
+                "full_attention_interval": 2
+            }
+            """
+        return try JSONDecoder().decode(
+            Qwen3NextConfiguration.self, from: Data(json.utf8))
+    }
+
+    private func run(
+        _ model: Qwen3NextModel,
+        tokens: [Int32],
+        compiled: Bool,
+        cache makeCache: (Qwen3NextModel) throws -> [KVCache] = {
+            try $0.newCache(parameters: nil)
+        }
+    ) throws -> RunResult {
+        let cache = try makeCache(model)
+        var logits: [Snapshot] = []
+        for token in tokens {
+            let output = model.forward(
+                MLXArray([token]).reshaped(1, 1),
+                cache: cache,
+                useCompiledDecode: compiled)
+            eval(output)
+            logits.append(Snapshot(output))
+        }
+        return RunResult(
+            logits: logits,
+            cacheState: cache.flatMap { $0.innerState() }.map(Snapshot.init),
+            offsets: cache.map(\.offset))
+    }
+
+    func testSharedScheduleSplitsAtAttentionWrites() {
+        let segments = CompiledDecodeSegment.schedule(
+            linearLayers: [true, false, true, true, false])
+
+        XCTAssertEqual(
+            segments,
+            [
+                .init(linearLayers: [0], attentionPreLayer: 1),
+                .init(attentionPostLayer: 1, linearLayers: [2, 3], attentionPreLayer: 4),
+                .init(attentionPostLayer: 4),
+            ])
+    }
+
+    func testDecodeConvolutionMatchesGeneralKernelExactly() throws {
+        let config = try configuration()
+        for dtype in [DType.float16, DType.bfloat16] {
+            MLXRandom.seed(29)
+            let gdn = Qwen3NextGatedDeltaNet(config)
+            gdn.conv1d.update(
+                parameters: gdn.conv1d.parameters().mapValues { $0.asType(dtype) })
+            let qkv = MLXRandom.normal([1, 1, gdn.convDim]).asType(dtype)
+            let state = MLXRandom.normal(
+                [1, gdn.convKernelSize - 1, gdn.convDim]
+            ).asType(dtype)
+
+            let fused = gdn.decodeConv(convState: state, qkv: qkv)
+            let general = gdn.generalConv(convState: state, qkv: qkv)
+
+            XCTAssertEqual(
+                Snapshot(fused.conv), Snapshot(general.conv), "conv differs for \(dtype)")
+            XCTAssertEqual(
+                Snapshot(fused.state), Snapshot(general.state), "state differs for \(dtype)")
+        }
+    }
+
+    func testCompiledDecodeMatchesGeneralPathExactly() throws {
+        for dtype in [DType.float16, DType.bfloat16] {
+            MLXRandom.seed(31)
+            let model = Qwen3NextModel(try configuration())
+            model.update(parameters: model.parameters().mapValues { $0.asType(dtype) })
+            let tokens = [Int32(1), 7, 3, 9, 2]
+
+            let general = try run(model, tokens: tokens, compiled: false)
+            let compiled = try run(model, tokens: tokens, compiled: true)
+
+            XCTAssertEqual(compiled.logits, general.logits, "logits differ for \(dtype)")
+            XCTAssertEqual(
+                compiled.cacheState, general.cacheState, "cache state differs for \(dtype)")
+            XCTAssertEqual(compiled.offsets, general.offsets)
+            XCTAssertEqual(compiled.offsets, [0, 5, 0, 5])
+            if dtype == .float16 {
+                XCTAssertGreaterThan(model.model.compiledDecodeSegmentCount, 0)
+            } else {
+                XCTAssertEqual(model.model.compiledDecodeSegmentCount, 0)
+            }
+        }
+    }
+
+    func testQuantizedCacheKeepsExactGeneralFallback() throws {
+        MLXRandom.seed(37)
+        let model = Qwen3NextModel(try configuration(headDim: 32))
+        model.update(parameters: model.parameters().mapValues { $0.asType(.float16) })
+        let tokens = [Int32(2), 4, 6]
+        let quantizedCache: (Qwen3NextModel) throws -> [KVCache] = { model in
+            try model.newCache(parameters: nil).map { cache in
+                cache is MambaCache
+                    ? cache : QuantizedKVCache(groupSize: 32, bits: 8)
+            }
+        }
+
+        let general = try run(
+            model, tokens: tokens, compiled: false, cache: quantizedCache)
+        let fallback = try run(
+            model, tokens: tokens, compiled: true, cache: quantizedCache)
+
+        XCTAssertEqual(fallback.logits, general.logits)
+        XCTAssertEqual(fallback.cacheState, general.cacheState)
+        XCTAssertEqual(fallback.offsets, general.offsets)
+        XCTAssertEqual(model.model.compiledDecodeSegmentCount, 0)
+    }
+
+    func testQuantizedWeightsCompileAndMatchExactly() throws {
+        MLXRandom.seed(39)
+        let model = Qwen3NextModel(
+            try configuration(headDim: 32, quantizable: true))
+        model.update(parameters: model.parameters().mapValues { $0.asType(.float16) })
+        quantize(model: model, groupSize: 32, bits: 4)
+        let tokens = [Int32(3), 8, 1, 5]
+
+        let general = try run(model, tokens: tokens, compiled: false)
+        let compiled = try run(model, tokens: tokens, compiled: true)
+
+        XCTAssertEqual(compiled.logits, general.logits)
+        XCTAssertEqual(compiled.cacheState, general.cacheState)
+        XCTAssertEqual(compiled.offsets, general.offsets)
+        XCTAssertGreaterThan(model.model.compiledDecodeSegmentCount, 0)
+    }
+
+    func testModelDeallocatesAfterCompiledDecode() throws {
+        MLXRandom.seed(41)
+        var model: Qwen3NextModel? = Qwen3NextModel(try configuration())
+        model!.update(parameters: model!.parameters().mapValues { $0.asType(.float16) })
+        var cache: [KVCache]? = try model!.newCache(parameters: nil)
+
+        for token in [Int32(1), 2, 3] {
+            let output = model!(MLXArray([token]).reshaped(1, 1), cache: cache)
+            eval(output)
+        }
+
+        weak let inner = model!.model
+        weak let linearAttention = model!.modules()
+            .compactMap { $0 as? Qwen3NextGatedDeltaNet }.first
+        XCTAssertNotNil(inner)
+        XCTAssertNotNil(linearAttention)
+        XCTAssertGreaterThan(model!.model.compiledDecodeSegmentCount, 0)
+
+        model = nil
+        cache = nil
+
+        XCTAssertNil(inner, "compiled segments retained the model")
+        XCTAssertNil(linearAttention, "compiled segments retained their linear-attention layer")
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

Qwen 3 Next previously executed each decoder layer separately during single-token generation, which adds dispatch overhead and slows token generation. Qwen 3.5 already reduced this overhead using compiled decode segments, but that implementation was model-specific.

This PR:

- Extracts the decode-segment schedule and thread-safe compiled-function cache into `MLXLMCommon`.
- Updates Qwen 3.5 to use the shared implementation without changing its behaviour.
- Adds compiled single-token decode segments to Qwen 3 Next.
- Keeps changing KV-cache operations outside compiled graphs.
- Supports fp16 activations, including models with 4-bit quantised weights.
- Falls back to the existing implementation for bfloat16, float32, quantised KV caches, and TurboQuant KV caches where exact equivalence has not been established.

Tests compare generated logits and every cache tensor byte-for-byte between the compiled and existing paths. They also cover quantized weights, unsupported-cache fallback, segment scheduling, and model deallocation.

On a warmed synthetic 16-layer Qwen 3 Next model with 4-bit weights, interleaved measurements showed approximately 35–38% lower median decode latency, corresponding to 1.55–1.60× throughput. Compilation time was excluded.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)