### PR TITLE
Tune TurboFlash query grouping for short decode

### DIFF
--- a/Libraries/MLXLMCommon/TurboQuantKernels.swift
+++ b/Libraries/MLXLMCommon/TurboQuantKernels.swift
@@ -1726,23 +1726,37 @@ enum TurboQuantKernelOps {
     nonisolated(unsafe) private static var flashSinglePassKernels: [String: MLXFast.MLXFastKernel] =
         [:]
 
-    /// NR0: number of query rows processed per SIMD group in the multi-row amortized kernel.
-    ///
-    /// Ported from llama.cpp V2.1: each threadgroup loads K/V packed data once and reuses
-    /// it across NR0 queries. At NR0=2, the KV dequant cost is halved per query.
-    ///
-    /// NR0=2 is conservative, register pressure is ~24 extra floats per thread (for dim=128).
-    /// Apple M-series GPUs have 96 registers per thread (384 bytes), so this fits comfortably.
-    ///
-    /// Override via environment variable `TURBO_FLASH_NR0` (must be power of 2).
-    static let flashNR0: Int = {
+    /// Explicit NR0 override for profiling and device-specific tuning.
+    /// Values must be powers of two so query groups remain naturally aligned.
+    private static let flashNR0Override: Int? = {
         if let envValue = ProcessInfo.processInfo.environment["TURBO_FLASH_NR0"],
             let parsed = Int(envValue), parsed > 0, (parsed & (parsed - 1)) == 0
         {
             return parsed
         }
-        return 2  // default, conservative starting point
+        return nil
     }()
+
+    /// Choose the number of query rows processed by each SIMD group during decode.
+    ///
+    /// NR0=2 amortizes packed K/V decoding across two query rows and remains the
+    /// long-context default. Immediately above the single-dispatch ceiling,
+    /// however, that reuse does not repay the lost parallelism for small query
+    /// batches. Keep one row per group in the measured crossover region.
+    static func automaticFlashDecodeNR0(tokenCount: Int, totalQueries: Int, dim: Int) -> Int {
+        if tokenCount > flashSinglePassMaxTokens && tokenCount <= 256
+            && (16 ... 32).contains(totalQueries) && (dim == 64 || dim == 128)
+        {
+            return 1
+        }
+        return 2
+    }
+
+    private static func flashDecodeNR0(tokenCount: Int, totalQueries: Int, dim: Int) -> Int {
+        flashNR0Override
+            ?? automaticFlashDecodeNR0(
+                tokenCount: tokenCount, totalQueries: totalQueries, dim: dim)
+    }
 
     /// Default block size for TurboFlashAttention two-pass approach.
     /// Each SIMD group processes this many tokens per block.
@@ -2307,12 +2321,14 @@ enum TurboQuantKernelOps {
         dim: Int,
         valRotation: MLXArray? = nil,
         blockSize: Int? = nil,
-        singleDispatch: Bool? = nil
+        singleDispatch: Bool? = nil,
+        nr0: Int? = nil
     ) -> MLXArray {
         // An explicit block size is used by block-sweep callers and therefore
         // always selects the two-pass implementation. The optional override is
         // internal test/benchmark plumbing; normal callers use the conservative
         // context ceiling above.
+        // `nr0` is also internal test/benchmark plumbing for exact A/B comparisons.
         let kernelSupportsSingleDispatch =
             tokenCount > 0
             && (2 ... 4).contains(keyBits) && (2 ... 4).contains(valueBits)
@@ -2334,7 +2350,9 @@ enum TurboQuantKernelOps {
         let blockSize = blockSize ?? flashBlockSize
         let numBlocks = (tokenCount + blockSize - 1) / blockSize
         let totalQ = rotatedQueries.dim(0)
-        let nr0 = flashNR0
+        let nr0 =
+            nr0
+            ?? flashDecodeNR0(tokenCount: tokenCount, totalQueries: totalQ, dim: dim)
 
         // Use NR0 multi-row kernel when totalQ is evenly divisible by NR0 and NR0 > 1.
         // Falls back to NR0=1 (original kernel) for remainder queries or when NR0=1.
@@ -2408,7 +2426,7 @@ enum TurboQuantKernelOps {
         let blockSize = blockSize ?? flashBlockSize
         let numBlocks = (tokenCount + blockSize - 1) / blockSize
         let totalQ = rotatedQueries.dim(0)
-        let nr0 = flashNR0
+        let nr0 = flashNR0Override ?? 2
 
         // NR0 groups read one kv head (kv_indices[0]) for all rows; only valid
         // when the GQA repeat factor is a multiple of nr0 so aligned groups can

--- a/Tests/MLXLMTests/TurboQuantTests.swift
+++ b/Tests/MLXLMTests/TurboQuantTests.swift
@@ -741,6 +741,111 @@ struct TurboFlashAttentionTests {
         }
     }
 
+    @Test func shortDecodeNR0PolicyIsBitExact() {
+        struct Shape {
+            let dim: Int
+            let keyBits: Int
+            let valueBits: Int
+            let queryHeads: Int
+            let keyValueHeads: Int
+            let tokenCount: Int
+        }
+
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 129, totalQueries: 16, dim: 64) == 1)
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 256, totalQueries: 32, dim: 128) == 1)
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 128, totalQueries: 32, dim: 128) == 2)
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 257, totalQueries: 32, dim: 128) == 2)
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 256, totalQueries: 33, dim: 128) == 2)
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 256, totalQueries: 15, dim: 128) == 2)
+        #expect(
+            TurboQuantKernelOps.automaticFlashDecodeNR0(
+                tokenCount: 256, totalQueries: 32, dim: 96) == 2)
+
+        let shapes = [
+            Shape(
+                dim: 64, keyBits: 2, valueBits: 2,
+                queryHeads: 16, keyValueHeads: 4, tokenCount: 129),
+            Shape(
+                dim: 64, keyBits: 4, valueBits: 4,
+                queryHeads: 32, keyValueHeads: 8, tokenCount: 256),
+            Shape(
+                dim: 128, keyBits: 3, valueBits: 3,
+                queryHeads: 24, keyValueHeads: 4, tokenCount: 256),
+            Shape(
+                dim: 128, keyBits: 4, valueBits: 2,
+                queryHeads: 32, keyValueHeads: 8, tokenCount: 129),
+        ]
+
+        for (shapeIndex, shape) in shapes.enumerated() {
+            let repeatCount = shape.queryHeads / shape.keyValueHeads
+            let keyCodec = MSECodec(
+                dim: shape.dim, bits: shape.keyBits, seed: UInt64(200 + shapeIndex))
+            let valueCodec = MSECodec(
+                dim: shape.dim, bits: shape.valueBits, seed: UInt64(300 + shapeIndex))
+            let rawKeys = MLXRandom.normal([
+                shape.keyValueHeads * shape.tokenCount, shape.dim,
+            ])
+            let rawValues = MLXRandom.normal([
+                shape.keyValueHeads * shape.tokenCount, shape.dim,
+            ])
+            let (keyPacked, keyNorms) = TurboQuantKernelOps.fusedEncodeWHT(
+                input: rawKeys, whtSigns: keyCodec.whtSigns!,
+                boundaries: keyCodec.boundaries, codebook: keyCodec.codebook,
+                bits: shape.keyBits, dim: shape.dim)
+            let (valuePacked, valueNorms) = TurboQuantKernelOps.fusedEncodeWHT(
+                input: rawValues, whtSigns: valueCodec.whtSigns!,
+                boundaries: valueCodec.boundaries, codebook: valueCodec.codebook,
+                bits: shape.valueBits, dim: shape.dim)
+            let keyWidth = TurboQuantPacking.packedWidth(
+                count: shape.dim, bits: shape.keyBits)
+            let valueWidth = TurboQuantPacking.packedWidth(
+                count: shape.dim, bits: shape.valueBits)
+            let keys = keyPacked.reshaped(
+                shape.keyValueHeads, shape.tokenCount, keyWidth)
+            let values = valuePacked.reshaped(
+                shape.keyValueHeads, shape.tokenCount, valueWidth)
+            let keyNormsByHead = keyNorms.reshaped(
+                shape.keyValueHeads, shape.tokenCount)
+            let valueNormsByHead = valueNorms.reshaped(
+                shape.keyValueHeads, shape.tokenCount)
+            let queries =
+                MLXRandom.normal([shape.queryHeads, shape.dim])
+                / sqrt(Float(shape.dim))
+
+            func run(_ nr0: Int) -> MLXArray {
+                TurboQuantKernelOps.turboFlashAttention(
+                    rotatedQueries: queries,
+                    keyPacked: keys, keyNorms: keyNormsByHead,
+                    keyCodebook: keyCodec.codebook,
+                    valPacked: values, valNorms: valueNormsByHead,
+                    valCodebook: valueCodec.codebook,
+                    tokenCount: shape.tokenCount, repeatCount: repeatCount,
+                    keyBits: shape.keyBits, valueBits: shape.valueBits, dim: shape.dim,
+                    valRotation: valueCodec.rotation,
+                    singleDispatch: false, nr0: nr0)
+            }
+
+            let oneRow = run(1)
+            let twoRows = run(2)
+            eval(oneRow, twoRows)
+            #expect(
+                oneRow.asArray(Float.self) == twoRows.asArray(Float.self),
+                "NR0 scheduling changed output for shape \(shape)")
+        }
+    }
+
     /// Microbenchmark: fused vs separated at various token counts
     @Test func microbenchFlashVsSeparated() {
         let dim = 128


### PR DESCRIPTION
## Proposed changes

TurboFlash currently processes two query rows together (`NR0=2`) to reuse decoded key/value data. This helps at longer context lengths, but benchmarks showed that it reduces GPU parallelism immediately after the single-dispatch path ends.

This PR introduces a conservative scheduling policy:

- Uses one query row per GPU group (`NR0=1`) for contexts of 129–256 tokens, 16–32 query rows, and head dimensions of 64 or 128.
- Keeps the existing `NR0=2` behavior for all other shapes and longer contexts.
- Preserves the `TURBO_FLASH_NR0` environment override for manual tuning.
- Adds bit-exact tests covering 2-bit, 3-bit, 4-bit, and mixed key/value configurations, including fused value rotation.

On my Apple M2, the selected region was approximately 2–13% faster in the interleaved benchmarks. The optimization does not change model calculations or output values; it only changes how identical work is scheduled on the GPU. More aggressive `NR0=4` scheduling was tested but intentionally excluded because it regressed some shapes.

No corresponding issue.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)