### PR TITLE
Fix SSM gradient transforms across chunks

### DIFF
--- a/Libraries/MLXLLM/Models/SSM.swift
+++ b/Libraries/MLXLLM/Models/SSM.swift
@@ -238,7 +238,6 @@ public func ssmAttn(
         )
         ys.append(y)
         state = nextState
-        asyncEval(y, nextState)
         if let currentLengths = lengths {
             lengths = currentLengths - step
         }
@@ -248,7 +247,6 @@ public func ssmAttn(
     guard let state else {
         fatalError("SSM update did not produce a state")
     }
-    eval(y, state)
     return (y, state)
 }
 

--- a/Tests/MLXLMTests/SSMTests.swift
+++ b/Tests/MLXLMTests/SSMTests.swift
@@ -4,6 +4,36 @@ import MLX
 import MLXLLM
 import Testing
 
+@Test func testSSMAttnSupportsGradientTransformsAcrossChunks() {
+    let x = MLXArray.ones([1, 5, 2, 2])
+    let aLog = MLXArray.zeros([2])
+    let inputMixing = MLXArray.ones([1, 5, 1, 3])
+    let outputMixing = MLXArray.ones([1, 5, 1, 3])
+    let residualScale = MLXArray.ones([2])
+    let dt = MLXArray.ones([1, 5, 2])
+    let dtBias = MLXArray.zeros([2])
+
+    let gradient = grad { input in
+        let (output, state) = ssmAttn(
+            x: input,
+            ALog: aLog,
+            B: inputMixing,
+            C: outputMixing,
+            D: residualScale,
+            dt: dt,
+            dtBias: dtBias,
+            step: 2
+        )
+        return output.sum() + state.sum()
+    }(x)
+    eval(gradient)
+
+    let magnitude = gradient.abs().sum().item(Float.self)
+    #expect(gradient.shape == x.shape)
+    #expect(magnitude.isFinite)
+    #expect(magnitude > 0)
+}
+
 @Test func testSSMAttnPreservesRecurrentStateDTypeAcrossChunks() throws {
     MLXRandom.seed(7)
 


### PR DESCRIPTION
## Proposed changes

Falcon-H1 fine-tuning crashed because `ssmAttn` forced evaluation while MLX was tracing a gradient transformation.

This removes the internal evaluation barriers so gradients remain connected across SSM chunks and adds a regression test covering chunked gradient computation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)