### PR TITLE
Fuse Qwen GDN input projections

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1180,7 +1180,7 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
         }
     }
 
-    public func prepareForInference() throws {
+    public func prepare() throws {
         for layer in model.layers {
             if let linearAttn = layer.linearAttn {
                 _ = try linearAttn.prepareFusedInputProjection()
@@ -1289,8 +1289,8 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
         try languageModel.newCache(parameters: parameters)
     }
 
-    public func prepareForInference() throws {
-        try languageModel.prepareForInference()
+    public func prepare() throws {
+        try languageModel.prepare()
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -168,7 +168,7 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
 
 // MARK: - GatedDeltaNet
 
-final class Qwen35GatedDeltaNet: Module {
+final class Qwen35GatedDeltaNet: Module, InferenceStatePreparable {
     let hiddenSize: Int
     let numVHeads: Int
     let numKHeads: Int
@@ -187,8 +187,7 @@ final class Qwen35GatedDeltaNet: Module {
 
     // Inference-only physical projection. The four registered modules remain
     // as views so checkpoint, adapter, and parameter paths do not change.
-    private var fusedInProj: QuantizedLinear?
-    private var fusedInputProjectionAttempted = false
+    private let fusedInputProjection = FusedQuantizedLinearProjectionCache()
     var fusedInputProjectionEnabled = qwen35FourGDNEnabled
 
     @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
@@ -250,71 +249,65 @@ final class Qwen35GatedDeltaNet: Module {
         let replacesInputProjection = parameters.flattened().contains { key, _ in
             inputProjectionPrefixes.contains(where: key.hasPrefix)
         }
-        let result = try super.update(
-            parameters: parameters, verify: verify, path: path, modulePath: modulePath)
-        if replacesInputProjection {
-            invalidateFusedInputProjection()
+        defer {
+            // Parameter updates are incremental and can throw after changing an
+            // earlier tensor. Invalidate on both success and failure so a stale
+            // physical projection can never remain published.
+            if replacesInputProjection {
+                fusedInputProjection.invalidate()
+            }
         }
-        return result
+        return try super.update(
+            parameters: parameters, verify: verify, path: path, modulePath: modulePath)
     }
 
     override func updateModule(key: String, _ value: Any) throws {
-        try super.updateModule(key: key, value)
-        if key == "in_proj_qkv" || key == "in_proj_z"
+        let replacesInputProjection =
+            key == "in_proj_qkv" || key == "in_proj_z"
             || key == "in_proj_b" || key == "in_proj_a"
-        {
-            invalidateFusedInputProjection()
+        defer {
+            // This is conservative when the setter itself rejects the value,
+            // and necessary when a bulk update changed an earlier key first.
+            if replacesInputProjection {
+                fusedInputProjection.invalidate()
+            }
         }
+        try super.updateModule(key: key, value)
     }
 
-    private func invalidateFusedInputProjection() {
-        fusedInProj = nil
-        fusedInputProjectionAttempted = false
-    }
-
-    var hasFusedInputProjection: Bool { fusedInProj != nil }
+    var hasFusedInputProjection: Bool { fusedInputProjection.isPrepared }
 
     /// Build one physical quantized projection while retaining the four named
     /// module paths as storage-sharing views. This runs at most once between
     /// parameter/module updates; failed eligibility checks are not repeated on
-    /// every token.
+    /// every token. The model loader calls this before publishing the model;
+    /// forward passes never invoke it.
     @discardableResult
-    func prepareFusedInputProjection() -> Bool {
-        guard fusedInputProjectionEnabled else { return false }
-        if fusedInProj != nil { return true }
-        guard !fusedInputProjectionAttempted else { return false }
-        fusedInputProjectionAttempted = true
-
-        guard
-            let projection = fuseQuantizedLinearProjections([
+    func prepareFusedInputProjection() throws -> Bool {
+        try fusedInputProjection.prepare(
+            enabled: fusedInputProjectionEnabled,
+            linears: [
                 inProjQKV, inProjZ, inProjB, inProjA,
-            ])
-        else {
-            return false
-        }
-        guard projection.sourceViews.count == 4,
-            (try? update(
+            ]
+        ) { sourceViews in
+            try update(
                 modules: ModuleChildren(values: [
-                    "in_proj_qkv": .value(projection.sourceViews[0]),
-                    "in_proj_z": .value(projection.sourceViews[1]),
-                    "in_proj_b": .value(projection.sourceViews[2]),
-                    "in_proj_a": .value(projection.sourceViews[3]),
-                ]), verify: [])) != nil
-        else {
-            return false
+                    "in_proj_qkv": .value(sourceViews[0]),
+                    "in_proj_z": .value(sourceViews[1]),
+                    "in_proj_b": .value(sourceViews[2]),
+                    "in_proj_a": .value(sourceViews[3]),
+                ]), verify: [])
         }
+    }
 
-        // updateModule invalidates while the views are installed. Publish the
-        // fused projection only after the stable source topology is in place.
-        fusedInputProjectionAttempted = true
-        fusedInProj = projection.fused
-        return true
+    func prepareForInference() throws {
+        _ = try prepareFusedInputProjection()
     }
 
     func projectInputs(_ inputs: MLXArray, batch: Int, sequence: Int) -> (
         qkv: MLXArray, z: MLXArray, b: MLXArray, a: MLXArray
     ) {
-        guard prepareFusedInputProjection(), let fusedInProj else {
+        guard fusedInputProjectionEnabled, let fusedInProj = fusedInputProjection.fused else {
             return (
                 inProjQKV(inputs),
                 inProjZ(inputs).reshaped(batch, sequence, numVHeads, headVDim),

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -185,6 +185,12 @@ final class Qwen35GatedDeltaNet: Module {
     @ModuleInfo(key: "in_proj_b") var inProjB: Linear
     @ModuleInfo(key: "in_proj_a") var inProjA: Linear
 
+    // Inference-only physical projection. The four registered modules remain
+    // as views so checkpoint, adapter, and parameter paths do not change.
+    private var fusedInProj: QuantizedLinear?
+    private var fusedInputProjectionAttempted = false
+    var fusedInputProjectionEnabled = qwen35FourGDNEnabled
+
     @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
     @ParameterInfo(key: "A_log") var aLog: MLXArray
 
@@ -231,6 +237,104 @@ final class Qwen35GatedDeltaNet: Module {
         _outProj.wrappedValue = Linear(valueDim, hiddenSize, bias: false)
 
         super.init()
+    }
+
+    @discardableResult
+    override func update(
+        parameters: ModuleParameters, verify: VerifyUpdate,
+        path: [String] = [], modulePath: [String] = []
+    ) throws -> Self {
+        let inputProjectionPrefixes = [
+            "in_proj_qkv.", "in_proj_z.", "in_proj_b.", "in_proj_a.",
+        ]
+        let replacesInputProjection = parameters.flattened().contains { key, _ in
+            inputProjectionPrefixes.contains(where: key.hasPrefix)
+        }
+        let result = try super.update(
+            parameters: parameters, verify: verify, path: path, modulePath: modulePath)
+        if replacesInputProjection {
+            invalidateFusedInputProjection()
+        }
+        return result
+    }
+
+    override func updateModule(key: String, _ value: Any) throws {
+        try super.updateModule(key: key, value)
+        if key == "in_proj_qkv" || key == "in_proj_z"
+            || key == "in_proj_b" || key == "in_proj_a"
+        {
+            invalidateFusedInputProjection()
+        }
+    }
+
+    private func invalidateFusedInputProjection() {
+        fusedInProj = nil
+        fusedInputProjectionAttempted = false
+    }
+
+    var hasFusedInputProjection: Bool { fusedInProj != nil }
+
+    /// Build one physical quantized projection while retaining the four named
+    /// module paths as storage-sharing views. This runs at most once between
+    /// parameter/module updates; failed eligibility checks are not repeated on
+    /// every token.
+    @discardableResult
+    func prepareFusedInputProjection() -> Bool {
+        guard fusedInputProjectionEnabled else { return false }
+        if fusedInProj != nil { return true }
+        guard !fusedInputProjectionAttempted else { return false }
+        fusedInputProjectionAttempted = true
+
+        guard
+            let projection = fuseQuantizedLinearProjections([
+                inProjQKV, inProjZ, inProjB, inProjA,
+            ])
+        else {
+            return false
+        }
+        guard projection.sourceViews.count == 4,
+            (try? update(
+                modules: ModuleChildren(values: [
+                    "in_proj_qkv": .value(projection.sourceViews[0]),
+                    "in_proj_z": .value(projection.sourceViews[1]),
+                    "in_proj_b": .value(projection.sourceViews[2]),
+                    "in_proj_a": .value(projection.sourceViews[3]),
+                ]), verify: [])) != nil
+        else {
+            return false
+        }
+
+        // updateModule invalidates while the views are installed. Publish the
+        // fused projection only after the stable source topology is in place.
+        fusedInputProjectionAttempted = true
+        fusedInProj = projection.fused
+        return true
+    }
+
+    func projectInputs(_ inputs: MLXArray, batch: Int, sequence: Int) -> (
+        qkv: MLXArray, z: MLXArray, b: MLXArray, a: MLXArray
+    ) {
+        guard prepareFusedInputProjection(), let fusedInProj else {
+            return (
+                inProjQKV(inputs),
+                inProjZ(inputs).reshaped(batch, sequence, numVHeads, headVDim),
+                inProjB(inputs),
+                inProjA(inputs)
+            )
+        }
+
+        let projected = fusedInProj(inputs)
+        let qkvEnd = keyDim * 2 + valueDim
+        let zEnd = qkvEnd + valueDim
+        let bEnd = zEnd + numVHeads
+        let aEnd = bEnd + numVHeads
+        return (
+            projected[0..., 0..., ..<qkvEnd],
+            projected[0..., 0..., qkvEnd ..< zEnd].reshaped(
+                batch, sequence, numVHeads, headVDim),
+            projected[0..., 0..., zEnd ..< bEnd],
+            projected[0..., 0..., bEnd ..< aEnd]
+        )
     }
 
     func callAsFunction(
@@ -285,10 +389,7 @@ final class Qwen35GatedDeltaNet: Module {
         let B = x.dim(0)
         let S = x.dim(1)
 
-        var qkv = inProjQKV(x)
-        let z = inProjZ(x).reshaped(B, S, numVHeads, headVDim)
-        let b = inProjB(x)
-        let a = inProjA(x)
+        var (qkv, z, b, a) = projectInputs(x, batch: B, sequence: S)
 
         if let mask {
             qkv = MLX.where(mask[.ellipsis, .newAxis], qkv, 0)

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -168,7 +168,7 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
 
 // MARK: - GatedDeltaNet
 
-final class Qwen35GatedDeltaNet: Module, InferenceStatePreparable {
+final class Qwen35GatedDeltaNet: Module {
     let hiddenSize: Int
     let numVHeads: Int
     let numKHeads: Int
@@ -298,10 +298,6 @@ final class Qwen35GatedDeltaNet: Module, InferenceStatePreparable {
                     "in_proj_a": .value(sourceViews[3]),
                 ]), verify: [])
         }
-    }
-
-    func prepareForInference() throws {
-        _ = try prepareFusedInputProjection()
     }
 
     func projectInputs(_ inputs: MLXArray, batch: Int, sequence: Int) -> (
@@ -1184,6 +1180,14 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
         }
     }
 
+    public func prepareForInference() throws {
+        for layer in model.layers {
+            if let linearAttn = layer.linearAttn {
+                _ = try linearAttn.prepareFusedInputProjection()
+            }
+        }
+    }
+
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         let hasMTPWeights = weights.keys.contains { $0.contains("mtp.") }
         let hasUnsanitizedConv1d = weights.contains { key, value in
@@ -1283,6 +1287,10 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
 
     public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
         try languageModel.newCache(parameters: parameters)
+    }
+
+    public func prepareForInference() throws {
+        try languageModel.prepareForInference()
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXLMCommon/Adapters/ModelAdapter.swift
+++ b/Libraries/MLXLMCommon/Adapters/ModelAdapter.swift
@@ -19,12 +19,21 @@ public enum ModelAdapterError: Error {
 public protocol ModelAdapter: Sendable {
 
     /// Loads the adapter into the specified model.
+    ///
+    /// Prefer ``LanguageModel/load(adapter:)`` when invoking an adapter so the
+    /// model can rebuild derived inference state after the topology change.
     func load(into model: LanguageModel) throws
 
     /// Permanently fuses the adapter into the specified model.
+    ///
+    /// Prefer ``LanguageModel/fuse(with:)`` when invoking an adapter so the
+    /// model can rebuild derived inference state after the topology change.
     func fuse(with model: LanguageModel) throws
 
     /// Unloads the adapter from the specified model.
+    ///
+    /// Prefer ``LanguageModel/unload(adapter:)`` when invoking an adapter so
+    /// the model can rebuild derived inference state after the topology change.
     func unload(from model: LanguageModel)
 }
 
@@ -42,6 +51,7 @@ extension LanguageModel {
     /// try model.load(adapter: adapter)
     /// ```
     public func load(adapter: ModelAdapter) throws {
+        defer { prepareInferenceState(in: self) }
         try adapter.load(into: self)
     }
 
@@ -54,6 +64,7 @@ extension LanguageModel {
     /// try model.fuse(with: adapter)
     /// ```
     public func fuse(with adapter: ModelAdapter) throws {
+        defer { prepareInferenceState(in: self) }
         try adapter.fuse(with: self)
     }
 
@@ -67,6 +78,7 @@ extension LanguageModel {
     /// ```
     public func unload(adapter: ModelAdapter) {
         adapter.unload(from: self)
+        prepareInferenceState(in: self)
     }
 
     /// Temporarily loads an adapter, performs a synchronous action, then unloads the adapter.
@@ -85,8 +97,10 @@ extension LanguageModel {
     ) throws -> R {
         defer {
             adapter.unload(from: self)
+            prepareInferenceState(in: self)
         }
         try adapter.load(into: self)
+        prepareInferenceState(in: self)
         let result = try perform()
         return result
     }
@@ -107,8 +121,10 @@ extension LanguageModel {
     ) async throws -> R {
         defer {
             adapter.unload(from: self)
+            prepareInferenceState(in: self)
         }
         try adapter.load(into: self)
+        prepareInferenceState(in: self)
         let result = try await perform()
         return result
     }

--- a/Libraries/MLXLMCommon/FusedQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/FusedQuantizedLinear.swift
@@ -21,6 +21,110 @@ package struct FusedQuantizedLinearProjection {
     package let sourceViews: [QuantizedLinear]
 }
 
+/// A fused projection could not replace its source modules atomically.
+///
+/// `rollbackError` is non-nil only when restoring the original source modules
+/// also failed; callers can then surface both failures while retaining the
+/// conservative unfused execution path.
+package struct FusedQuantizedLinearPreparationError: Error, CustomStringConvertible {
+    package let installationError: any Error
+    package let rollbackError: (any Error)?
+
+    package var description: String {
+        if let rollbackError {
+            return "unable to install fused projection views (\(installationError)); "
+                + "restoring the original projections also failed (\(rollbackError))"
+        }
+        return "unable to install fused projection views (\(installationError)); "
+            + "the original projections were restored"
+    }
+}
+
+/// Lifecycle state for a physical projection derived from several registered
+/// quantized linears.
+///
+/// The cache is intentionally not synchronized. Its only mutating operations
+/// run during model loading or an explicit model update, both of which require
+/// exclusive access. Inference only reads ``fused`` after the model has been
+/// published, avoiding a lock in the token-generation hot path.
+package final class FusedQuantizedLinearProjectionCache {
+    private enum State {
+        case unprepared
+        case preparing
+        case ready
+        case ineligible
+    }
+
+    private var state = State.unprepared
+    package private(set) var fused: QuantizedLinear?
+
+    package init() {}
+
+    package var isPrepared: Bool {
+        state == .ready && fused != nil
+    }
+
+    /// Drop derived state after any source-module or source-parameter update.
+    /// Invalidations caused by installing the cache's own storage-sharing views
+    /// are ignored; the preparation transaction publishes `fused` only after
+    /// every view has been installed successfully.
+    package func invalidate() {
+        guard state != .preparing else { return }
+        fused = nil
+        state = .unprepared
+    }
+
+    /// Build and publish the fused projection once for the current source
+    /// topology. A failed or ineligible attempt is terminal until a subsequent
+    /// source update calls ``invalidate()``.
+    @discardableResult
+    package func prepare(
+        enabled: Bool,
+        linears: [Linear],
+        installSourceModules: ([Linear]) throws -> Void
+    ) throws -> Bool {
+        guard enabled else { return false }
+
+        switch state {
+        case .ready:
+            return fused != nil
+        case .preparing, .ineligible:
+            return false
+        case .unprepared:
+            break
+        }
+
+        state = .preparing
+        guard let projection = fuseQuantizedLinearProjections(linears),
+            projection.sourceViews.count == linears.count
+        else {
+            state = .ineligible
+            return false
+        }
+
+        do {
+            try installSourceModules(projection.sourceViews)
+        } catch let installationError {
+            let rollbackError: (any Error)?
+            do {
+                try installSourceModules(linears)
+                rollbackError = nil
+            } catch let error {
+                rollbackError = error
+            }
+            fused = nil
+            state = .ineligible
+            throw FusedQuantizedLinearPreparationError(
+                installationError: installationError,
+                rollbackError: rollbackError)
+        }
+
+        fused = projection.fused
+        state = .ready
+        return true
+    }
+}
+
 /// Coalesce compatible quantized linears along their output dimension.
 ///
 /// This is intentionally stricter than merely casting to `QuantizedLinear`:

--- a/Libraries/MLXLMCommon/FusedQuantizedLinear.swift
+++ b/Libraries/MLXLMCommon/FusedQuantizedLinear.swift
@@ -1,0 +1,119 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Default-on rollback switch for the Qwen 3.5/3.6 four-projection GDN fusion.
+package let qwen35FourGDNEnabled: Bool = {
+    let raw = ProcessInfo.processInfo.environment["MLX_QWEN_FOUR_GDN"]?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+    return raw != "0" && raw != "false" && raw != "off"
+}()
+
+/// A fused quantized projection and checkpoint-shaped views into its storage.
+///
+/// The views let a model keep its public/checkpoint module topology without
+/// retaining a second physical copy of the quantized weights.
+package struct FusedQuantizedLinearProjection {
+    package let fused: QuantizedLinear
+    package let sourceViews: [QuantizedLinear]
+}
+
+/// Coalesce compatible quantized linears along their output dimension.
+///
+/// This is intentionally stricter than merely casting to `QuantizedLinear`:
+/// custom subclasses may add behavior, adapters, or state that cannot be
+/// represented by one stock quantized matmul. Incompatible inputs return
+/// `nil` and callers keep their original projections.
+package func fuseQuantizedLinearProjections(
+    _ linears: [Linear]
+) -> FusedQuantizedLinearProjection? {
+    guard linears.count > 1 else { return nil }
+
+    let projections = linears.compactMap { $0 as? QuantizedLinear }
+    guard projections.count == linears.count,
+        zip(linears, projections).allSatisfy({ linear, projection in
+            ObjectIdentifier(type(of: linear)) == ObjectIdentifier(QuantizedLinear.self)
+                && linear === projection
+        }),
+        let first = projections.first,
+        first.bias == nil,
+        first.weight.ndim == 2,
+        first.weight.dim(0) == first.shape.0,
+        first.scales.ndim == 2,
+        first.scales.dim(0) == first.shape.0,
+        first.biases == nil || first.biases?.shape == first.scales.shape
+    else {
+        return nil
+    }
+
+    let hasQuantizationBiases = first.biases != nil
+    guard
+        projections.allSatisfy({ projection in
+            projection.bias == nil
+                && projection.bits == first.bits
+                && projection.groupSize == first.groupSize
+                && projection.mode == first.mode
+                && projection.shape.1 == first.shape.1
+                && projection.weight.ndim == 2
+                && projection.weight.dim(0) == projection.shape.0
+                && projection.weight.dim(1) == first.weight.dim(1)
+                && projection.weight.dtype == first.weight.dtype
+                && projection.scales.ndim == 2
+                && projection.scales.dim(0) == projection.shape.0
+                && projection.scales.dim(1) == first.scales.dim(1)
+                && projection.scales.dtype == first.scales.dtype
+                && (projection.biases != nil) == hasQuantizationBiases
+                && (projection.biases == nil || projection.biases?.shape == projection.scales.shape)
+                && projection.biases?.dtype == first.biases?.dtype
+        })
+    else {
+        return nil
+    }
+
+    let fusedWeight = concatenated(projections.map(\.weight), axis: 0)
+    let fusedScales = concatenated(projections.map(\.scales), axis: 0)
+    let fusedBiases =
+        hasQuantizationBiases
+        ? concatenated(projections.compactMap(\.biases), axis: 0)
+        : nil
+
+    // Realize the concatenations once. The fused projection and the named
+    // source views below then share this materialized backing storage.
+    eval(fusedWeight, fusedScales)
+    if let fusedBiases {
+        eval(fusedBiases)
+    }
+
+    let fused = QuantizedLinear(
+        weight: fusedWeight,
+        bias: nil,
+        scales: fusedScales,
+        biases: fusedBiases,
+        groupSize: first.groupSize,
+        bits: first.bits,
+        mode: first.mode)
+    fused.freeze()
+
+    var start = 0
+    let sourceViews = projections.map { projection in
+        let end = start + projection.shape.0
+        defer { start = end }
+
+        let rows = start ..< end
+        let view = QuantizedLinear(
+            weight: fusedWeight[rows],
+            bias: nil,
+            scales: fusedScales[rows],
+            biases: fusedBiases.map { $0[rows] },
+            groupSize: first.groupSize,
+            bits: first.bits,
+            mode: first.mode)
+        view.freeze()
+        return view
+    }
+
+    return FusedQuantizedLinearProjection(fused: fused, sourceViews: sourceViews)
+}

--- a/Libraries/MLXLMCommon/InferenceState.swift
+++ b/Libraries/MLXLMCommon/InferenceState.swift
@@ -1,0 +1,68 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// A module with derived inference state that must be built after checkpoint
+/// parameters have been installed and before the model is published to callers.
+///
+/// Preparation deliberately belongs to the loading lifecycle rather than a
+/// forward pass: implementations may materialize arrays or replace storage-
+/// sharing module views and therefore must run while the loader or explicit
+/// model-topology owner has exclusive access to the model.
+package protocol InferenceStatePreparable: AnyObject {
+    func prepareForInference() throws
+}
+
+package struct InferenceStatePreparationFailure {
+    package let moduleType: String
+    package let error: any Error
+}
+
+package struct InferenceStatePreparationReport {
+    package let failures: [InferenceStatePreparationFailure]
+
+    package var succeeded: Bool { failures.isEmpty }
+}
+
+private let inferenceStateLogger = Logger(
+    subsystem: "mlx-swift-lm", category: "inference-state")
+
+/// Prepare every participating module after checkpoint loading or an explicit
+/// model-topology update.
+///
+/// Take a snapshot before invoking callbacks because a callback may replace
+/// child modules while preserving their checkpoint-visible topology. A failed
+/// optional optimization is logged and reported while the model remains usable
+/// through its unfused path.
+@discardableResult
+package func prepareInferenceState(in model: Module) -> InferenceStatePreparationReport {
+    let modules = model.modules()
+    var failures: [InferenceStatePreparationFailure] = []
+    for module in modules {
+        guard let preparable = module as? any InferenceStatePreparable else { continue }
+        do {
+            try preparable.prepareForInference()
+        } catch {
+            let moduleType = String(reflecting: type(of: preparable))
+            failures.append(.init(moduleType: moduleType, error: error))
+            inferenceStateLogger.error(
+                "Failed to prepare inference state for \(moduleType): \(String(describing: error))")
+        }
+    }
+    return InferenceStatePreparationReport(failures: failures)
+}
+
+/// Prepare derived state and realize a fully loaded model before publication.
+///
+/// All custom checkpoint loaders should finalize through this function so
+/// inference-only optimizations are applied consistently.
+@discardableResult
+package func materializeModelForInference(
+    _ model: Module
+) -> InferenceStatePreparationReport {
+    let report = prepareInferenceState(in: model)
+    eval(model)
+    return report
+}

--- a/Libraries/MLXLMCommon/InferenceState.swift
+++ b/Libraries/MLXLMCommon/InferenceState.swift
@@ -4,19 +4,8 @@ import Foundation
 import MLX
 import MLXNN
 
-/// A module with derived inference state that must be built after checkpoint
-/// parameters have been installed and before the model is published to callers.
-///
-/// Preparation deliberately belongs to the loading lifecycle rather than a
-/// forward pass: implementations may materialize arrays or replace storage-
-/// sharing module views and therefore must run while the loader or explicit
-/// model-topology owner has exclusive access to the model.
-package protocol InferenceStatePreparable: AnyObject {
-    func prepareForInference() throws
-}
-
 package struct InferenceStatePreparationFailure {
-    package let moduleType: String
+    package let modelType: String
     package let error: any Error
 }
 
@@ -29,29 +18,31 @@ package struct InferenceStatePreparationReport {
 private let inferenceStateLogger = Logger(
     subsystem: "mlx-swift-lm", category: "inference-state")
 
-/// Prepare every participating module after checkpoint loading or an explicit
-/// model-topology update.
+/// Prepare a language model after checkpoint loading or an explicit topology
+/// update.
 ///
-/// Take a snapshot before invoking callbacks because a callback may replace
-/// child modules while preserving their checkpoint-visible topology. A failed
-/// optional optimization is logged and reported while the model remains usable
-/// through its unfused path.
+/// A failed optional optimization is logged and reported while the model
+/// remains usable through its unfused path. `BaseLanguageModel` values outside
+/// the inference lifecycle, such as rerankers, require no preparation.
 @discardableResult
-package func prepareInferenceState(in model: Module) -> InferenceStatePreparationReport {
-    let modules = model.modules()
-    var failures: [InferenceStatePreparationFailure] = []
-    for module in modules {
-        guard let preparable = module as? any InferenceStatePreparable else { continue }
-        do {
-            try preparable.prepareForInference()
-        } catch {
-            let moduleType = String(reflecting: type(of: preparable))
-            failures.append(.init(moduleType: moduleType, error: error))
-            inferenceStateLogger.error(
-                "Failed to prepare inference state for \(moduleType): \(String(describing: error))")
-        }
+package func prepareInferenceState(
+    in model: BaseLanguageModel
+) -> InferenceStatePreparationReport {
+    guard let languageModel = model as? any LanguageModel else {
+        return InferenceStatePreparationReport(failures: [])
     }
-    return InferenceStatePreparationReport(failures: failures)
+
+    do {
+        try languageModel.prepareForInference()
+        return InferenceStatePreparationReport(failures: [])
+    } catch {
+        let modelType = String(reflecting: type(of: languageModel))
+        inferenceStateLogger.error(
+            "Failed to prepare inference state for \(modelType): \(String(describing: error))")
+        return InferenceStatePreparationReport(failures: [
+            .init(modelType: modelType, error: error)
+        ])
+    }
 }
 
 /// Prepare derived state and realize a fully loaded model before publication.
@@ -60,7 +51,7 @@ package func prepareInferenceState(in model: Module) -> InferenceStatePreparatio
 /// inference-only optimizations are applied consistently.
 @discardableResult
 package func materializeModelForInference(
-    _ model: Module
+    _ model: BaseLanguageModel
 ) -> InferenceStatePreparationReport {
     let report = prepareInferenceState(in: model)
     eval(model)

--- a/Libraries/MLXLMCommon/InferenceState.swift
+++ b/Libraries/MLXLMCommon/InferenceState.swift
@@ -33,7 +33,7 @@ package func prepareInferenceState(
     }
 
     do {
-        try languageModel.prepareForInference()
+        try languageModel.prepare()
         return InferenceStatePreparationReport(failures: [])
     } catch {
         let modelType = String(reflecting: type(of: languageModel))

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -314,7 +314,7 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
     /// Implementations may materialize arrays or replace storage-sharing
     /// module views. The library invokes this lifecycle hook while it has
     /// exclusive access to the model; inference calls must remain read-only.
-    func prepareForInference() throws
+    func prepare() throws
 
     /// Prepare the cache state and consume the ``LMInput``.
     ///
@@ -376,7 +376,7 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 
 extension LanguageModel {
     /// Most language models have no derived inference state to prepare.
-    public func prepareForInference() throws {}
+    public func prepare() throws {}
 
     @available(
         *, deprecated, renamed: "prepare(_:cache:state:prefill:)",

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -308,6 +308,14 @@ public enum PrepareResult {
 /// - the ``TokenIterator`` accumulates this information into a ``GenerateResult``
 public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 
+    /// Build derived state after checkpoint or adapter topology updates and
+    /// before the model is used for inference.
+    ///
+    /// Implementations may materialize arrays or replace storage-sharing
+    /// module views. The library invokes this lifecycle hook while it has
+    /// exclusive access to the model; inference calls must remain read-only.
+    func prepareForInference() throws
+
     /// Prepare the cache state and consume the ``LMInput``.
     ///
     /// `state` is the ``LMOutput/state`` a caller carried over from earlier
@@ -367,6 +375,9 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 }
 
 extension LanguageModel {
+    /// Most language models have no derived inference state to prepare.
+    public func prepareForInference() throws {}
+
     @available(
         *, deprecated, renamed: "prepare(_:cache:state:prefill:)",
         message:

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -358,7 +358,8 @@ private func topLevelSafetensorURLs(in modelDirectory: URL) -> [URL] {
 /// This function loads model weight `safetensor` files in the given `modelDirectory`,
 /// calls ``BaseLanguageModel/sanitize(weights:metadata:)`` to allow per-model preprocessing,
 /// applies optional quantization, and
-/// updates the model with the weights.
+/// updates the model with the weights. Derived inference-only state is prepared after the
+/// checkpoint update and before the model is evaluated and returned to callers.
 ///
 /// The weight files are chosen from `model.safetensors.index.json` when it names files that
 /// exist, and otherwise by the conventional `model*.safetensors` names. A model can name extra
@@ -402,5 +403,7 @@ public func loadWeights(
     let parameters = ModuleParameters.unflattened(weights)
     try model.update(parameters: parameters, verify: [.all])
 
-    eval(model)
+    // Build derived inference-only state and realize the model while the loader
+    // still has exclusive access. Forward passes must remain read-only.
+    materializeModelForInference(model)
 }

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -470,8 +470,10 @@ public func loadParoQuantModel<T: LanguageModel>(
         return (paroConfig.groupSize, paroConfig.bits, .affine)
     }
 
-    // 12. Materialize the @ParameterInfo tensors
-    eval(model)
+    // 12. Prepare generic inference-only state, then materialize the model.
+    // This must follow the final IO-layer topology update above, just like the
+    // standard checkpoint-loading path.
+    materializeModelForInference(model)
     logger.info("ParoQuant model loaded and evaluated")
 
     // 13. Load tokenizer

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -464,6 +464,12 @@ enum Qwen35Language {
         @ModuleInfo(key: "in_proj_b") var inProjB: Linear
         @ModuleInfo(key: "in_proj_a") var inProjA: Linear
 
+        // Inference-only physical projection. The four registered modules
+        // remain as views so checkpoint and adapter paths stay unchanged.
+        private var fusedInProj: QuantizedLinear?
+        private var fusedInputProjectionAttempted = false
+        var fusedInputProjectionEnabled = qwen35FourGDNEnabled
+
         @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
         @ParameterInfo(key: "A_log") var aLog: MLXArray
 
@@ -511,6 +517,98 @@ enum Qwen35Language {
             super.init()
         }
 
+        @discardableResult
+        override func update(
+            parameters: ModuleParameters, verify: VerifyUpdate,
+            path: [String] = [], modulePath: [String] = []
+        ) throws -> Self {
+            let inputProjectionPrefixes = [
+                "in_proj_qkv.", "in_proj_z.", "in_proj_b.", "in_proj_a.",
+            ]
+            let replacesInputProjection = parameters.flattened().contains { key, _ in
+                inputProjectionPrefixes.contains(where: key.hasPrefix)
+            }
+            let result = try super.update(
+                parameters: parameters, verify: verify, path: path, modulePath: modulePath)
+            if replacesInputProjection {
+                invalidateFusedInputProjection()
+            }
+            return result
+        }
+
+        override func updateModule(key: String, _ value: Any) throws {
+            try super.updateModule(key: key, value)
+            if key == "in_proj_qkv" || key == "in_proj_z"
+                || key == "in_proj_b" || key == "in_proj_a"
+            {
+                invalidateFusedInputProjection()
+            }
+        }
+
+        private func invalidateFusedInputProjection() {
+            fusedInProj = nil
+            fusedInputProjectionAttempted = false
+        }
+
+        var hasFusedInputProjection: Bool { fusedInProj != nil }
+
+        @discardableResult
+        func prepareFusedInputProjection() -> Bool {
+            guard fusedInputProjectionEnabled else { return false }
+            if fusedInProj != nil { return true }
+            guard !fusedInputProjectionAttempted else { return false }
+            fusedInputProjectionAttempted = true
+
+            guard
+                let projection = fuseQuantizedLinearProjections([
+                    inProjQKV, inProjZ, inProjB, inProjA,
+                ])
+            else {
+                return false
+            }
+            guard projection.sourceViews.count == 4,
+                (try? update(
+                    modules: ModuleChildren(values: [
+                        "in_proj_qkv": .value(projection.sourceViews[0]),
+                        "in_proj_z": .value(projection.sourceViews[1]),
+                        "in_proj_b": .value(projection.sourceViews[2]),
+                        "in_proj_a": .value(projection.sourceViews[3]),
+                    ]), verify: [])) != nil
+            else {
+                return false
+            }
+
+            fusedInputProjectionAttempted = true
+            fusedInProj = projection.fused
+            return true
+        }
+
+        func projectInputs(_ inputs: MLXArray, batch: Int, sequence: Int) -> (
+            qkv: MLXArray, z: MLXArray, b: MLXArray, a: MLXArray
+        ) {
+            guard prepareFusedInputProjection(), let fusedInProj else {
+                return (
+                    inProjQKV(inputs),
+                    inProjZ(inputs).reshaped(batch, sequence, numVHeads, headVDim),
+                    inProjB(inputs),
+                    inProjA(inputs)
+                )
+            }
+
+            let projected = fusedInProj(inputs)
+            let qkvEnd = keyDim * 2 + valueDim
+            let zEnd = qkvEnd + valueDim
+            let bEnd = zEnd + numVHeads
+            let aEnd = bEnd + numVHeads
+            return (
+                projected[0..., 0..., ..<qkvEnd],
+                projected[0..., 0..., qkvEnd ..< zEnd].reshaped(
+                    batch, sequence, numVHeads, headVDim),
+                projected[0..., 0..., zEnd ..< bEnd],
+                projected[0..., 0..., bEnd ..< aEnd]
+            )
+        }
+
         func callAsFunction(
             _ inputs: MLXArray,
             mask: MLXArray? = nil,
@@ -520,10 +618,8 @@ enum Qwen35Language {
             let B = inputs.dim(0)
             let S = inputs.dim(1)
 
-            var mixedQKV = inProjQKV(inputs)
-            let z = inProjZ(inputs).reshaped(B, S, numVHeads, headVDim)
-            let b = inProjB(inputs)
-            let a = inProjA(inputs)
+            var (mixedQKV, z, b, a) = projectInputs(
+                inputs, batch: B, sequence: S)
 
             let convState: MLXArray
             if let cacheState = cache?[0] {

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1039,7 +1039,7 @@ enum Qwen35Language {
             }
         }
 
-        func prepareForInference() throws {
+        func prepare() throws {
             for layer in model.layers {
                 if let linearAttn = layer.linearAttn {
                     _ = try linearAttn.prepareFusedInputProjection()
@@ -1104,8 +1104,8 @@ public class Qwen35: Module, VLMModel {
         languageModel.makeCache(capacity: try parameters?.effectiveKVCacheCapacity())
     }
 
-    public func prepareForInference() throws {
-        try languageModel.prepareForInference()
+    public func prepare() throws {
+        try languageModel.prepare()
     }
 
     private func mergeInputIdsWithImageFeatures(

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -447,7 +447,7 @@ enum Qwen35Language {
         }
     }
 
-    final class GatedDeltaNet: Module, InferenceStatePreparable {
+    final class GatedDeltaNet: Module {
         let hiddenSize: Int
         let numVHeads: Int
         let numKHeads: Int
@@ -566,10 +566,6 @@ enum Qwen35Language {
                         "in_proj_a": .value(sourceViews[3]),
                     ]), verify: [])
             }
-        }
-
-        func prepareForInference() throws {
-            _ = try prepareFusedInputProjection()
         }
 
         func projectInputs(_ inputs: MLXArray, batch: Int, sequence: Int) -> (
@@ -1042,6 +1038,14 @@ enum Qwen35Language {
                 return KVCacheSimple()
             }
         }
+
+        func prepareForInference() throws {
+            for layer in model.layers {
+                if let linearAttn = layer.linearAttn {
+                    _ = try linearAttn.prepareFusedInputProjection()
+                }
+            }
+        }
     }
 }
 
@@ -1098,6 +1102,10 @@ public class Qwen35: Module, VLMModel {
 
     public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
         languageModel.makeCache(capacity: try parameters?.effectiveKVCacheCapacity())
+    }
+
+    public func prepareForInference() throws {
+        try languageModel.prepareForInference()
     }
 
     private func mergeInputIdsWithImageFeatures(

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -447,7 +447,7 @@ enum Qwen35Language {
         }
     }
 
-    final class GatedDeltaNet: Module {
+    final class GatedDeltaNet: Module, InferenceStatePreparable {
         let hiddenSize: Int
         let numVHeads: Int
         let numKHeads: Int
@@ -466,8 +466,7 @@ enum Qwen35Language {
 
         // Inference-only physical projection. The four registered modules
         // remain as views so checkpoint and adapter paths stay unchanged.
-        private var fusedInProj: QuantizedLinear?
-        private var fusedInputProjectionAttempted = false
+        private let fusedInputProjection = FusedQuantizedLinearProjectionCache()
         var fusedInputProjectionEnabled = qwen35FourGDNEnabled
 
         @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
@@ -528,65 +527,55 @@ enum Qwen35Language {
             let replacesInputProjection = parameters.flattened().contains { key, _ in
                 inputProjectionPrefixes.contains(where: key.hasPrefix)
             }
-            let result = try super.update(
-                parameters: parameters, verify: verify, path: path, modulePath: modulePath)
-            if replacesInputProjection {
-                invalidateFusedInputProjection()
+            defer {
+                if replacesInputProjection {
+                    fusedInputProjection.invalidate()
+                }
             }
-            return result
+            return try super.update(
+                parameters: parameters, verify: verify, path: path, modulePath: modulePath)
         }
 
         override func updateModule(key: String, _ value: Any) throws {
-            try super.updateModule(key: key, value)
-            if key == "in_proj_qkv" || key == "in_proj_z"
+            let replacesInputProjection =
+                key == "in_proj_qkv" || key == "in_proj_z"
                 || key == "in_proj_b" || key == "in_proj_a"
-            {
-                invalidateFusedInputProjection()
+            defer {
+                if replacesInputProjection {
+                    fusedInputProjection.invalidate()
+                }
             }
+            try super.updateModule(key: key, value)
         }
 
-        private func invalidateFusedInputProjection() {
-            fusedInProj = nil
-            fusedInputProjectionAttempted = false
-        }
-
-        var hasFusedInputProjection: Bool { fusedInProj != nil }
+        var hasFusedInputProjection: Bool { fusedInputProjection.isPrepared }
 
         @discardableResult
-        func prepareFusedInputProjection() -> Bool {
-            guard fusedInputProjectionEnabled else { return false }
-            if fusedInProj != nil { return true }
-            guard !fusedInputProjectionAttempted else { return false }
-            fusedInputProjectionAttempted = true
-
-            guard
-                let projection = fuseQuantizedLinearProjections([
+        func prepareFusedInputProjection() throws -> Bool {
+            try fusedInputProjection.prepare(
+                enabled: fusedInputProjectionEnabled,
+                linears: [
                     inProjQKV, inProjZ, inProjB, inProjA,
-                ])
-            else {
-                return false
-            }
-            guard projection.sourceViews.count == 4,
-                (try? update(
+                ]
+            ) { sourceViews in
+                try update(
                     modules: ModuleChildren(values: [
-                        "in_proj_qkv": .value(projection.sourceViews[0]),
-                        "in_proj_z": .value(projection.sourceViews[1]),
-                        "in_proj_b": .value(projection.sourceViews[2]),
-                        "in_proj_a": .value(projection.sourceViews[3]),
-                    ]), verify: [])) != nil
-            else {
-                return false
+                        "in_proj_qkv": .value(sourceViews[0]),
+                        "in_proj_z": .value(sourceViews[1]),
+                        "in_proj_b": .value(sourceViews[2]),
+                        "in_proj_a": .value(sourceViews[3]),
+                    ]), verify: [])
             }
+        }
 
-            fusedInputProjectionAttempted = true
-            fusedInProj = projection.fused
-            return true
+        func prepareForInference() throws {
+            _ = try prepareFusedInputProjection()
         }
 
         func projectInputs(_ inputs: MLXArray, batch: Int, sequence: Int) -> (
             qkv: MLXArray, z: MLXArray, b: MLXArray, a: MLXArray
         ) {
-            guard prepareFusedInputProjection(), let fusedInProj else {
+            guard fusedInputProjectionEnabled, let fusedInProj = fusedInputProjection.fused else {
                 return (
                     inProjQKV(inputs),
                     inProjZ(inputs).reshaped(batch, sequence, numVHeads, headVDim),

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -32,7 +32,7 @@ private final class PreparedSidecarDeclaringModel: TwoLayerModel,
     private(set) var preparationCount = 0
     private(set) var projectorValuesAtPreparation: [Float] = []
 
-    func prepareForInference() throws {
+    func prepare() throws {
         preparationCount += 1
         projectorValuesAtPreparation = projector.weight.asArray(Float.self)
     }
@@ -55,7 +55,7 @@ private final class FailingInferenceStateModel: Module, LanguageModel,
 
     let kvHeads: [Int] = []
 
-    func prepareForInference() throws {
+    func prepare() throws {
         throw ExpectedFailure.preparation
     }
 

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -25,9 +25,10 @@ private final class SidecarDeclaringModel: TwoLayerModel, AdditionalWeightFilesP
 }
 
 private final class PreparedSidecarDeclaringModel: TwoLayerModel,
-    AdditionalWeightFilesProviding, InferenceStatePreparable
+    AdditionalWeightFilesProviding, LanguageModel, KVCacheDimensionProvider
 {
     var additionalWeightFiles: [String] { ["projector.safetensors"] }
+    let kvHeads: [Int] = []
     private(set) var preparationCount = 0
     private(set) var projectorValuesAtPreparation: [Float] = []
 
@@ -35,13 +36,37 @@ private final class PreparedSidecarDeclaringModel: TwoLayerModel,
         preparationCount += 1
         projectorValuesAtPreparation = projector.weight.asArray(Float.self)
     }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        layer(inputs)
+    }
 }
 
-private final class FailingInferenceStateModel: Module, InferenceStatePreparable {
+private final class FailingInferenceStateModel: Module, LanguageModel,
+    KVCacheDimensionProvider
+{
     enum ExpectedFailure: Error { case preparation }
+
+    let kvHeads: [Int] = []
 
     func prepareForInference() throws {
         throw ExpectedFailure.preparation
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        inputs
     }
 }
 
@@ -161,7 +186,7 @@ final class LoadWeightsTests: XCTestCase {
 
         XCTAssertFalse(report.succeeded)
         XCTAssertEqual(report.failures.count, 1)
-        XCTAssertTrue(report.failures[0].moduleType.contains("FailingInferenceStateModel"))
+        XCTAssertTrue(report.failures[0].modelType.contains("FailingInferenceStateModel"))
         XCTAssertTrue(
             report.failures[0].error is FailingInferenceStateModel.ExpectedFailure)
     }

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -24,6 +24,27 @@ private final class SidecarDeclaringModel: TwoLayerModel, AdditionalWeightFilesP
     var additionalWeightFiles: [String] { ["projector.safetensors"] }
 }
 
+private final class PreparedSidecarDeclaringModel: TwoLayerModel,
+    AdditionalWeightFilesProviding, InferenceStatePreparable
+{
+    var additionalWeightFiles: [String] { ["projector.safetensors"] }
+    private(set) var preparationCount = 0
+    private(set) var projectorValuesAtPreparation: [Float] = []
+
+    func prepareForInference() throws {
+        preparationCount += 1
+        projectorValuesAtPreparation = projector.weight.asArray(Float.self)
+    }
+}
+
+private final class FailingInferenceStateModel: Module, InferenceStatePreparable {
+    enum ExpectedFailure: Error { case preparation }
+
+    func prepareForInference() throws {
+        throw ExpectedFailure.preparation
+    }
+}
+
 final class LoadWeightsTests: XCTestCase {
 
     // MARK: - Concurrent loading
@@ -133,6 +154,16 @@ final class LoadWeightsTests: XCTestCase {
         XCTAssertEqual(weightLoadConcurrency(processorCount: 8), 8)
         XCTAssertEqual(weightLoadConcurrency(processorCount: 14), 14)
         XCTAssertEqual(weightLoadConcurrency(processorCount: 32), 16)
+    }
+
+    func testInferencePreparationFailureIsReportedWithoutEscaping() {
+        let report = prepareInferenceState(in: FailingInferenceStateModel())
+
+        XCTAssertFalse(report.succeeded)
+        XCTAssertEqual(report.failures.count, 1)
+        XCTAssertTrue(report.failures[0].moduleType.contains("FailingInferenceStateModel"))
+        XCTAssertTrue(
+            report.failures[0].error is FailingInferenceStateModel.ExpectedFailure)
     }
 
     // MARK: - Index
@@ -321,6 +352,19 @@ final class LoadWeightsTests: XCTestCase {
         try loadWeights(modelDirectory: directory, model: model)
 
         XCTAssertEqual(model.projector.weight.asArray(Float.self), [1, 2, 3, 4])
+    }
+
+    func testLoadWeightsPreparesInferenceStateAfterInstallingParameters() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try writeSidecarCheckpoint(in: directory)
+
+        let model = PreparedSidecarDeclaringModel()
+        try loadWeights(modelDirectory: directory, model: model)
+
+        XCTAssertEqual(model.preparationCount, 1)
+        XCTAssertEqual(model.projectorValuesAtPreparation, [1, 2, 3, 4])
     }
 
     func testLoadWeightsFailsWhenTheSidecarIsNotDeclared() throws {

--- a/Tests/MLXLMTests/ModelAdapterLifecycleTests.swift
+++ b/Tests/MLXLMTests/ModelAdapterLifecycleTests.swift
@@ -18,7 +18,7 @@ private final class AdapterLifecycleModel: Module, LanguageModel, KVCacheDimensi
         super.init()
     }
 
-    func prepareForInference() throws {
+    func prepare() throws {
         preparationCount += 1
     }
 

--- a/Tests/MLXLMTests/ModelAdapterLifecycleTests.swift
+++ b/Tests/MLXLMTests/ModelAdapterLifecycleTests.swift
@@ -7,9 +7,7 @@ import XCTest
 
 @testable import MLXLMCommon
 
-private final class AdapterLifecycleModel: Module, LanguageModel,
-    InferenceStatePreparable, KVCacheDimensionProvider
-{
+private final class AdapterLifecycleModel: Module, LanguageModel, KVCacheDimensionProvider {
     @ModuleInfo(key: "projection") var projection: Linear
 
     let kvHeads: [Int] = []

--- a/Tests/MLXLMTests/ModelAdapterLifecycleTests.swift
+++ b/Tests/MLXLMTests/ModelAdapterLifecycleTests.swift
@@ -1,0 +1,105 @@
+// Copyright © 2026 Apple Inc.
+
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+
+private final class AdapterLifecycleModel: Module, LanguageModel,
+    InferenceStatePreparable, KVCacheDimensionProvider
+{
+    @ModuleInfo(key: "projection") var projection: Linear
+
+    let kvHeads: [Int] = []
+    private(set) var preparationCount = 0
+
+    override init() {
+        _projection.wrappedValue = Linear(weight: MLXArray.eye(2))
+        super.init()
+    }
+
+    func prepareForInference() throws {
+        preparationCount += 1
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        projection(inputs)
+    }
+}
+
+private struct ReplacingModelAdapter: ModelAdapter {
+    enum ExpectedFailure: Error { case load }
+
+    let failWhileLoading: Bool
+
+    init(failWhileLoading: Bool = false) {
+        self.failWhileLoading = failWhileLoading
+    }
+
+    func load(into model: LanguageModel) throws {
+        guard let model = model as? AdapterLifecycleModel else {
+            throw ModelAdapterError.incompatibleModelType
+        }
+        try replaceProjection(in: model)
+        if failWhileLoading {
+            throw ExpectedFailure.load
+        }
+    }
+
+    func fuse(with model: LanguageModel) throws {
+        try load(into: model)
+    }
+
+    func unload(from model: LanguageModel) {
+        guard let model = model as? AdapterLifecycleModel else { return }
+        do {
+            try replaceProjection(in: model)
+        } catch {
+            XCTFail("adapter test fixture could not restore its projection: \(error)")
+        }
+    }
+
+    private func replaceProjection(in model: AdapterLifecycleModel) throws {
+        try model.update(
+            modules: ModuleChildren(values: [
+                "projection": .value(Linear(weight: MLXArray.eye(2)))
+            ]), verify: [])
+    }
+}
+
+final class ModelAdapterLifecycleTests: XCTestCase {
+    func testConvenienceOperationsPrepareExactlyOncePerTopologyBoundary() throws {
+        let model = AdapterLifecycleModel()
+        let adapter = ReplacingModelAdapter()
+
+        try model.load(adapter: adapter)
+        XCTAssertEqual(model.preparationCount, 1)
+
+        try model.fuse(with: adapter)
+        XCTAssertEqual(model.preparationCount, 2)
+
+        model.unload(adapter: adapter)
+        XCTAssertEqual(model.preparationCount, 3)
+
+        try model.perform(with: adapter) {
+            XCTAssertEqual(model.preparationCount, 4)
+        }
+        XCTAssertEqual(model.preparationCount, 5)
+    }
+
+    func testThrowingAdapterStillPreparesPartiallyMutatedModel() {
+        let model = AdapterLifecycleModel()
+        let adapter = ReplacingModelAdapter(failWhileLoading: true)
+
+        XCTAssertThrowsError(try model.load(adapter: adapter))
+        XCTAssertEqual(model.preparationCount, 1)
+    }
+}

--- a/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
+++ b/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
@@ -9,15 +9,6 @@ import XCTest
 @testable import MLXLLM
 @testable import MLXVLM
 
-private final class Qwen35GDNTestWrapper: Module {
-    @ModuleInfo(key: "gdn") var gdn: Qwen35GatedDeltaNet
-
-    init(_ gdn: Qwen35GatedDeltaNet) {
-        _gdn.wrappedValue = gdn
-        super.init()
-    }
-}
-
 final class Qwen35FusedGDNProjectionTests: XCTestCase {
 
     private let configurationJSON = """
@@ -192,12 +183,14 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         XCTAssertFalse(layer.hasFusedInputProjection)
     }
 
-    func testLoadTimePreparationWalksNestedModules() throws {
-        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+    func testLanguageModelLifecyclePreparesNestedGDNModules() throws {
+        let model = Qwen35TextModel(try llmConfiguration())
+        let layer = try XCTUnwrap(
+            model.modules().compactMap { $0 as? Qwen35GatedDeltaNet }.first)
         try quantize(layer)
         XCTAssertFalse(layer.hasFusedInputProjection)
 
-        prepareInferenceState(in: Qwen35GDNTestWrapper(layer))
+        try model.prepareForInference()
 
         XCTAssertTrue(layer.hasFusedInputProjection)
     }

--- a/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
+++ b/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
@@ -9,6 +9,15 @@ import XCTest
 @testable import MLXLLM
 @testable import MLXVLM
 
+private final class Qwen35GDNTestWrapper: Module {
+    @ModuleInfo(key: "gdn") var gdn: Qwen35GatedDeltaNet
+
+    init(_ gdn: Qwen35GatedDeltaNet) {
+        _gdn.wrappedValue = gdn
+        super.init()
+    }
+}
+
 final class Qwen35FusedGDNProjectionTests: XCTestCase {
 
     private let configurationJSON = """
@@ -98,6 +107,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
             eval(reference.qkv, reference.z, reference.b, reference.a)
 
             layer.fusedInputProjectionEnabled = true
+            XCTAssertTrue(try layer.prepareFusedInputProjection())
             let fused = layer.projectInputs(input, batch: batch, sequence: sequence)
             eval(fused.qkv, fused.z, fused.b, fused.a)
 
@@ -119,6 +129,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         eval(reference)
 
         layer.fusedInputProjectionEnabled = true
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
         let fused = layer(input)
         eval(fused)
 
@@ -136,6 +147,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         eval(reference.qkv, reference.z, reference.b, reference.a)
 
         layer.fusedInputProjectionEnabled = true
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
         let fused = layer.projectInputs(input, batch: 1, sequence: 7)
         eval(fused.qkv, fused.z, fused.b, fused.a)
 
@@ -144,6 +156,50 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         assertBitIdentical(fused.z, reference.z, "VLM z")
         assertBitIdentical(fused.b, reference.b, "VLM b")
         assertBitIdentical(fused.a, reference.a, "VLM a")
+    }
+
+    func testForwardDoesNotMutateOrLazilyPrepareFusion() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        let modulesBefore = [
+            ObjectIdentifier(layer.inProjQKV),
+            ObjectIdentifier(layer.inProjZ),
+            ObjectIdentifier(layer.inProjB),
+            ObjectIdentifier(layer.inProjA),
+        ]
+
+        let output = layer(MLXRandom.normal([1, 3, 64]).asType(.bfloat16))
+        eval(output)
+
+        XCTAssertFalse(layer.hasFusedInputProjection)
+        XCTAssertEqual(
+            modulesBefore,
+            [
+                ObjectIdentifier(layer.inProjQKV),
+                ObjectIdentifier(layer.inProjZ),
+                ObjectIdentifier(layer.inProjB),
+                ObjectIdentifier(layer.inProjA),
+            ])
+    }
+
+    func testVLMForwardDoesNotLazilyPrepareFusion() throws {
+        let layer = Qwen35Language.GatedDeltaNet(try vlmConfiguration())
+        try quantize(layer)
+
+        let output = layer(MLXRandom.normal([1, 3, 64]).asType(.bfloat16))
+        eval(output)
+
+        XCTAssertFalse(layer.hasFusedInputProjection)
+    }
+
+    func testLoadTimePreparationWalksNestedModules() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        XCTAssertFalse(layer.hasFusedInputProjection)
+
+        prepareInferenceState(in: Qwen35GDNTestWrapper(layer))
+
+        XCTAssertTrue(layer.hasFusedInputProjection)
     }
 
     func testIncompatibleProjectionPoliciesFallBack() throws {
@@ -160,7 +216,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
                     QuantizedLinear(layer.inProjA, groupSize: 32, bits: 4)),
             ]), verify: [])
 
-        XCTAssertFalse(layer.prepareFusedInputProjection())
+        XCTAssertFalse(try layer.prepareFusedInputProjection())
         XCTAssertFalse(layer.hasFusedInputProjection)
     }
 
@@ -172,7 +228,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         try layer.update(
             modules: ModuleChildren(values: ["in_proj_qkv": .value(adapted)]), verify: [])
 
-        XCTAssertFalse(layer.prepareFusedInputProjection())
+        XCTAssertFalse(try layer.prepareFusedInputProjection())
         XCTAssertFalse(layer.hasFusedInputProjection)
         XCTAssertTrue(layer.inProjQKV is QLoRALinear)
     }
@@ -182,7 +238,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         try quantize(layer)
         let keysBefore = Set(layer.parameters().flattened().map(\.0))
 
-        XCTAssertTrue(layer.prepareFusedInputProjection())
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
 
         let keysAfter = Set(layer.parameters().flattened().map(\.0))
         XCTAssertEqual(keysAfter, keysBefore)
@@ -196,7 +252,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
     func testParameterAndModuleUpdatesInvalidateFusion() throws {
         let layer = Qwen35GatedDeltaNet(try llmConfiguration())
         try quantize(layer)
-        XCTAssertTrue(layer.prepareFusedInputProjection())
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
 
         let replacement =
             layer.inProjQKV.weight
@@ -207,14 +263,113 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
                 "in_proj_qkv.weight": replacement
             ]), verify: [])
         XCTAssertFalse(layer.hasFusedInputProjection)
-        XCTAssertTrue(layer.prepareFusedInputProjection())
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
 
         let adapted = try XCTUnwrap(
             LoRALinear.from(linear: layer.inProjQKV, rank: 4, scale: 1) as? Linear)
         try layer.update(
             modules: ModuleChildren(values: ["in_proj_qkv": .value(adapted)]), verify: [])
         XCTAssertFalse(layer.hasFusedInputProjection)
-        XCTAssertFalse(layer.prepareFusedInputProjection())
+        XCTAssertFalse(try layer.prepareFusedInputProjection())
+    }
+
+    func testThrowingParameterUpdateInvalidatesPublishedFusion() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
+
+        let replacement =
+            layer.inProjQKV.weight
+            + MLXArray.zeros(
+                layer.inProjQKV.weight.shape, dtype: layer.inProjQKV.weight.dtype)
+        XCTAssertThrowsError(
+            try layer.update(
+                parameters: ModuleParameters.unflattened([
+                    "in_proj_qkv.weight": replacement,
+                    "unknown.weight": MLXArray.zeros([1]),
+                ]), verify: .noUnusedKeys))
+
+        XCTAssertFalse(layer.hasFusedInputProjection)
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
+    }
+
+    func testRejectedModuleUpdateInvalidatesPublishedFusion() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
+
+        XCTAssertThrowsError(
+            try layer.updateModule(
+                key: "in_proj_qkv",
+                Conv1d(inputChannels: 1, outputChannels: 1, kernelSize: 1)))
+
+        XCTAssertFalse(layer.hasFusedInputProjection)
+        XCTAssertTrue(try layer.prepareFusedInputProjection())
+    }
+
+    func testFailedPreparationDoesNotRetryUntilInvalidated() throws {
+        enum ExpectedFailure: Error { case install }
+
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        let linears = [layer.inProjQKV, layer.inProjZ, layer.inProjB, layer.inProjA]
+        let cache = FusedQuantizedLinearProjectionCache()
+        var installAttempts = 0
+        var installedModules: [[Linear]] = []
+
+        XCTAssertThrowsError(
+            try cache.prepare(enabled: true, linears: linears) { modules in
+                installAttempts += 1
+                installedModules.append(modules)
+                if installAttempts == 1 {
+                    throw ExpectedFailure.install
+                }
+            }
+        ) { error in
+            let preparationError = error as? FusedQuantizedLinearPreparationError
+            XCTAssertNotNil(preparationError)
+            XCTAssertNil(preparationError?.rollbackError)
+        }
+        XCTAssertEqual(installAttempts, 2, "the second installation restores the originals")
+        XCTAssertEqual(
+            installedModules[1].map(ObjectIdentifier.init),
+            linears.map(ObjectIdentifier.init))
+
+        XCTAssertFalse(
+            try cache.prepare(enabled: true, linears: linears) { _ in
+                installAttempts += 1
+            })
+        XCTAssertEqual(installAttempts, 2)
+
+        cache.invalidate()
+        XCTAssertTrue(
+            try cache.prepare(enabled: true, linears: linears) { _ in
+                installAttempts += 1
+            })
+        XCTAssertEqual(installAttempts, 3)
+    }
+
+    func testRollbackFailureIsIncludedInPreparationError() throws {
+        enum ExpectedFailure: Error { case install, rollback }
+
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        let linears = [layer.inProjQKV, layer.inProjZ, layer.inProjB, layer.inProjA]
+        let cache = FusedQuantizedLinearProjectionCache()
+        var installAttempts = 0
+
+        XCTAssertThrowsError(
+            try cache.prepare(enabled: true, linears: linears) { _ in
+                installAttempts += 1
+                throw installAttempts == 1
+                    ? ExpectedFailure.install : ExpectedFailure.rollback
+            }
+        ) { error in
+            let preparationError = error as? FusedQuantizedLinearPreparationError
+            XCTAssertNotNil(preparationError?.rollbackError)
+        }
+        XCTAssertEqual(installAttempts, 2)
+        XCTAssertFalse(cache.isPrepared)
     }
 
     /// Opt-in paired benchmark for a local Qwen 3.5 checkpoint.
@@ -252,7 +407,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
             for layer in layers {
                 layer.fusedInputProjectionEnabled = fused
                 if fused {
-                    XCTAssertTrue(layer.prepareFusedInputProjection())
+                    XCTAssertTrue(try layer.prepareFusedInputProjection())
                 }
             }
             return model

--- a/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
+++ b/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
@@ -190,7 +190,7 @@ final class Qwen35FusedGDNProjectionTests: XCTestCase {
         try quantize(layer)
         XCTAssertFalse(layer.hasFusedInputProjection)
 
-        try model.prepareForInference()
+        try model.prepare()
 
         XCTAssertTrue(layer.hasFusedInputProjection)
     }

--- a/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
+++ b/Tests/MLXLMTests/Qwen35FusedGDNProjectionTests.swift
@@ -1,0 +1,344 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXVLM
+
+final class Qwen35FusedGDNProjectionTests: XCTestCase {
+
+    private let configurationJSON = """
+        {
+            "model_type": "qwen3_5_text",
+            "hidden_size": 64,
+            "num_hidden_layers": 2,
+            "intermediate_size": 64,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 32,
+            "linear_num_value_heads": 4,
+            "linear_num_key_heads": 2,
+            "linear_key_head_dim": 32,
+            "linear_value_head_dim": 32,
+            "linear_conv_kernel_dim": 4,
+            "vocab_size": 32,
+            "full_attention_interval": 2,
+            "num_experts": 0,
+            "num_experts_per_tok": 0
+        }
+        """
+
+    private func llmConfiguration() throws -> Qwen35TextConfiguration {
+        try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Data(configurationJSON.utf8))
+    }
+
+    private func vlmConfiguration() throws -> MLXVLM.Qwen35Configuration.TextConfiguration {
+        try JSONDecoder().decode(
+            MLXVLM.Qwen35Configuration.TextConfiguration.self,
+            from: Data(configurationJSON.utf8))
+    }
+
+    private func assertBitIdentical(
+        _ actual: MLXArray, _ expected: MLXArray, _ label: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.dtype, expected.dtype, "\(label): dtype", file: file, line: line)
+        XCTAssertEqual(actual.shape, expected.shape, "\(label): shape", file: file, line: line)
+        let actualValues = actual.asType(.float32).asArray(Float.self)
+        let expectedValues = expected.asType(.float32).asArray(Float.self)
+        let mismatches = zip(actualValues, expectedValues).lazy.filter {
+            $0.bitPattern != $1.bitPattern
+        }.count
+        XCTAssertEqual(
+            mismatches, 0, "\(label): \(mismatches)/\(actualValues.count) values differ",
+            file: file, line: line)
+    }
+
+    private func quantize(_ layer: Qwen35GatedDeltaNet) throws {
+        try layer.update(
+            modules: ModuleChildren(values: [
+                "in_proj_qkv": .value(
+                    QuantizedLinear(layer.inProjQKV, groupSize: 32, bits: 4)),
+                "in_proj_z": .value(
+                    QuantizedLinear(layer.inProjZ, groupSize: 32, bits: 4)),
+                "in_proj_b": .value(
+                    QuantizedLinear(layer.inProjB, groupSize: 32, bits: 4)),
+                "in_proj_a": .value(
+                    QuantizedLinear(layer.inProjA, groupSize: 32, bits: 4)),
+            ]), verify: [])
+    }
+
+    private func quantize(_ layer: Qwen35Language.GatedDeltaNet) throws {
+        try layer.update(
+            modules: ModuleChildren(values: [
+                "in_proj_qkv": .value(
+                    QuantizedLinear(layer.inProjQKV, groupSize: 32, bits: 4)),
+                "in_proj_z": .value(
+                    QuantizedLinear(layer.inProjZ, groupSize: 32, bits: 4)),
+                "in_proj_b": .value(
+                    QuantizedLinear(layer.inProjB, groupSize: 32, bits: 4)),
+                "in_proj_a": .value(
+                    QuantizedLinear(layer.inProjA, groupSize: 32, bits: 4)),
+            ]), verify: [])
+    }
+
+    func testLLMFusedProjectionIsBitIdenticalForDecodeAndPrefill() throws {
+        for (batch, sequence) in [(1, 1), (2, 7)] {
+            let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+            try quantize(layer)
+            let input = MLXRandom.normal([batch, sequence, 64]).asType(.bfloat16)
+
+            layer.fusedInputProjectionEnabled = false
+            let reference = layer.projectInputs(input, batch: batch, sequence: sequence)
+            eval(reference.qkv, reference.z, reference.b, reference.a)
+
+            layer.fusedInputProjectionEnabled = true
+            let fused = layer.projectInputs(input, batch: batch, sequence: sequence)
+            eval(fused.qkv, fused.z, fused.b, fused.a)
+
+            XCTAssertTrue(layer.hasFusedInputProjection)
+            assertBitIdentical(fused.qkv, reference.qkv, "qkv B\(batch) S\(sequence)")
+            assertBitIdentical(fused.z, reference.z, "z B\(batch) S\(sequence)")
+            assertBitIdentical(fused.b, reference.b, "b B\(batch) S\(sequence)")
+            assertBitIdentical(fused.a, reference.a, "a B\(batch) S\(sequence)")
+        }
+    }
+
+    func testLLMFullGDNForwardIsBitIdentical() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        let input = MLXRandom.normal([1, 5, 64]).asType(.bfloat16)
+
+        layer.fusedInputProjectionEnabled = false
+        let reference = layer(input)
+        eval(reference)
+
+        layer.fusedInputProjectionEnabled = true
+        let fused = layer(input)
+        eval(fused)
+
+        XCTAssertTrue(layer.hasFusedInputProjection)
+        assertBitIdentical(fused, reference, "full GDN")
+    }
+
+    func testVLMFusedProjectionIsBitIdentical() throws {
+        let layer = Qwen35Language.GatedDeltaNet(try vlmConfiguration())
+        try quantize(layer)
+        let input = MLXRandom.normal([1, 7, 64]).asType(.bfloat16)
+
+        layer.fusedInputProjectionEnabled = false
+        let reference = layer.projectInputs(input, batch: 1, sequence: 7)
+        eval(reference.qkv, reference.z, reference.b, reference.a)
+
+        layer.fusedInputProjectionEnabled = true
+        let fused = layer.projectInputs(input, batch: 1, sequence: 7)
+        eval(fused.qkv, fused.z, fused.b, fused.a)
+
+        XCTAssertTrue(layer.hasFusedInputProjection)
+        assertBitIdentical(fused.qkv, reference.qkv, "VLM qkv")
+        assertBitIdentical(fused.z, reference.z, "VLM z")
+        assertBitIdentical(fused.b, reference.b, "VLM b")
+        assertBitIdentical(fused.a, reference.a, "VLM a")
+    }
+
+    func testIncompatibleProjectionPoliciesFallBack() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try layer.update(
+            modules: ModuleChildren(values: [
+                "in_proj_qkv": .value(
+                    QuantizedLinear(layer.inProjQKV, groupSize: 32, bits: 4)),
+                "in_proj_z": .value(
+                    QuantizedLinear(layer.inProjZ, groupSize: 32, bits: 4)),
+                "in_proj_b": .value(
+                    QuantizedLinear(layer.inProjB, groupSize: 32, bits: 8)),
+                "in_proj_a": .value(
+                    QuantizedLinear(layer.inProjA, groupSize: 32, bits: 4)),
+            ]), verify: [])
+
+        XCTAssertFalse(layer.prepareFusedInputProjection())
+        XCTAssertFalse(layer.hasFusedInputProjection)
+    }
+
+    func testAdapterProjectionFallsBack() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        let adapted = try XCTUnwrap(
+            LoRALinear.from(linear: layer.inProjQKV, rank: 4, scale: 1) as? Linear)
+        try layer.update(
+            modules: ModuleChildren(values: ["in_proj_qkv": .value(adapted)]), verify: [])
+
+        XCTAssertFalse(layer.prepareFusedInputProjection())
+        XCTAssertFalse(layer.hasFusedInputProjection)
+        XCTAssertTrue(layer.inProjQKV is QLoRALinear)
+    }
+
+    func testCheckpointTopologyIsPreserved() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        let keysBefore = Set(layer.parameters().flattened().map(\.0))
+
+        XCTAssertTrue(layer.prepareFusedInputProjection())
+
+        let keysAfter = Set(layer.parameters().flattened().map(\.0))
+        XCTAssertEqual(keysAfter, keysBefore)
+        XCTAssertTrue(keysAfter.contains("in_proj_qkv.weight"))
+        XCTAssertTrue(keysAfter.contains("in_proj_z.weight"))
+        XCTAssertTrue(keysAfter.contains("in_proj_b.weight"))
+        XCTAssertTrue(keysAfter.contains("in_proj_a.weight"))
+        XCTAssertFalse(keysAfter.contains { $0.contains("fused") })
+    }
+
+    func testParameterAndModuleUpdatesInvalidateFusion() throws {
+        let layer = Qwen35GatedDeltaNet(try llmConfiguration())
+        try quantize(layer)
+        XCTAssertTrue(layer.prepareFusedInputProjection())
+
+        let replacement =
+            layer.inProjQKV.weight
+            + MLXArray.zeros(
+                layer.inProjQKV.weight.shape, dtype: layer.inProjQKV.weight.dtype)
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                "in_proj_qkv.weight": replacement
+            ]), verify: [])
+        XCTAssertFalse(layer.hasFusedInputProjection)
+        XCTAssertTrue(layer.prepareFusedInputProjection())
+
+        let adapted = try XCTUnwrap(
+            LoRALinear.from(linear: layer.inProjQKV, rank: 4, scale: 1) as? Linear)
+        try layer.update(
+            modules: ModuleChildren(values: ["in_proj_qkv": .value(adapted)]), verify: [])
+        XCTAssertFalse(layer.hasFusedInputProjection)
+        XCTAssertFalse(layer.prepareFusedInputProjection())
+    }
+
+    /// Opt-in paired benchmark for a local Qwen 3.5 checkpoint.
+    ///
+    /// The same model and materialized weights are used for both paths, with
+    /// alternating order, to avoid cross-process Metal-cache and load noise:
+    ///
+    /// ```sh
+    /// MLX_QWEN_GDN_BENCH_MODEL=/path/to/model \
+    ///   swift test -c release --filter testRealCheckpointBenchmark
+    /// ```
+    func testRealCheckpointBenchmark() throws {
+        guard
+            let path = ProcessInfo.processInfo.environment["MLX_QWEN_GDN_BENCH_MODEL"],
+            !path.isEmpty
+        else {
+            throw XCTSkip("set MLX_QWEN_GDN_BENCH_MODEL to run the real-model benchmark")
+        }
+
+        let directory = URL(filePath: path)
+        let configurationData = try Data(
+            contentsOf: directory.appendingPathComponent("config.json"))
+        let configuration = try JSONDecoder().decode(
+            MLXLLM.Qwen35Configuration.self, from: configurationData)
+        let baseConfiguration = try JSONDecoder().decode(
+            BaseConfiguration.self, from: configurationData)
+        func loadModel(fused: Bool) throws -> Qwen35Model {
+            let model = Qwen35Model(configuration)
+            try loadWeights(
+                modelDirectory: directory,
+                model: model,
+                perLayerQuantization: baseConfiguration.perLayerQuantization)
+            let layers = model.modules().compactMap { $0 as? Qwen35GatedDeltaNet }
+            XCTAssertFalse(layers.isEmpty)
+            for layer in layers {
+                layer.fusedInputProjectionEnabled = fused
+                if fused {
+                    XCTAssertTrue(layer.prepareFusedInputProjection())
+                }
+            }
+            return model
+        }
+
+        // Two models keep independently compiled decode traces, while sharing
+        // one process's Metal pipeline cache and runtime conditions.
+        let baselineModel = try loadModel(fused: false)
+        let fusedModel = try loadModel(fused: true)
+        let fusedLayerCount = fusedModel.modules().compactMap { $0 as? Qwen35GatedDeltaNet }
+            .count
+
+        let promptLength = 512
+        let prompt = MLXArray((0 ..< promptLength).map { Int32(($0 % 32_000) + 1) })
+        let parameters = GenerateParameters(
+            maxTokens: 64, temperature: 0,
+            prefill: PrefillParameters(stepSize: 128))
+
+        func run(_ model: Qwen35Model) throws -> (
+            prefill: Double, decode: Double, tokens: [Int]
+        ) {
+            var iterator = try TokenIterator(
+                input: LMInput(tokens: prompt), model: model, parameters: parameters)
+            let start = CFAbsoluteTimeGetCurrent()
+            var tokens: [Int] = []
+            while let token = iterator.next() {
+                tokens.append(token)
+            }
+            return (
+                iterator.promptPrefillTime,
+                CFAbsoluteTimeGetCurrent() - start,
+                tokens
+            )
+        }
+
+        // Compile and warm each independent model before alternating AB / BA.
+        let baselineWarmup = try run(baselineModel)
+        let fusedWarmup = try run(fusedModel)
+        XCTAssertEqual(fusedWarmup.tokens, baselineWarmup.tokens)
+
+        var baselinePrefill: [Double] = []
+        var fusedPrefill: [Double] = []
+        var baselineDecode: [Double] = []
+        var fusedDecode: [Double] = []
+        var referenceTokens = baselineWarmup.tokens
+        for pair in 0 ..< 4 {
+            let order = pair.isMultiple(of: 2) ? [false, true] : [true, false]
+            for fused in order {
+                let result = try run(fused ? fusedModel : baselineModel)
+                XCTAssertEqual(result.tokens, referenceTokens)
+                referenceTokens = result.tokens
+                if fused {
+                    fusedPrefill.append(result.prefill)
+                    fusedDecode.append(result.decode)
+                } else {
+                    baselinePrefill.append(result.prefill)
+                    baselineDecode.append(result.decode)
+                }
+            }
+        }
+
+        func median(_ values: [Double]) -> Double {
+            let sorted = values.sorted()
+            return (sorted[1] + sorted[2]) / 2
+        }
+
+        let baselinePrefillMedian = median(baselinePrefill)
+        let fusedPrefillMedian = median(fusedPrefill)
+        let baselineDecodeMedian = median(baselineDecode)
+        let fusedDecodeMedian = median(fusedDecode)
+        let checksum = referenceTokens.reduce(into: UInt64(0)) { checksum, token in
+            checksum = checksum &* 1_099_511_628_211 &+ UInt64(bitPattern: Int64(token))
+        }
+        print(
+            String(
+                format:
+                    "[four-gdn] layers=%d prefill baseline=%.4fs fused=%.4fs speedup=%.2f%% decode baseline=%.4fs fused=%.4fs speedup=%.2f%% baselineTPS=%.2f fusedTPS=%.2f checksum=%llu",
+                fusedLayerCount,
+                baselinePrefillMedian,
+                fusedPrefillMedian,
+                100 * (baselinePrefillMedian / fusedPrefillMedian - 1),
+                baselineDecodeMedian,
+                fusedDecodeMedian,
+                100 * (baselineDecodeMedian / fusedDecodeMedian - 1),
+                Double(referenceTokens.count) / baselineDecodeMedian,
+                Double(referenceTokens.count) / fusedDecodeMedian,
+                checksum))
+    }
+}


### PR DESCRIPTION
## Proposed changes

Qwen 3.5’s Gated Delta Network currently runs four separate quantized projections over the same input. Each projection starts another GPU operation, adding overhead during text generation.

This PR combines those four projections into one operation and then splits the result into the expected outputs. It applies to both text-only and vision-language Qwen 3.5 models.

The optimization is enabled only when the projections use compatible standard quantization. Models using adapters, custom quantizers, or mixed quantization settings automatically keep the existing path. Checkpoint parameter names remain unchanged.

On my Apple M2 16GB RAM running `Qwen3.5-9B-4bit`, using alternating same-process comparisons:

- Prompt processing improved by approximately 3.3%.
- Token generation improved from 16.62 to 17.39 tokens/second, approximately 4.6%.
- Both paths generated identical output tokens.

The optimization can be disabled with `MLX_QWEN_FOUR_GDN=0` if needed.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md)](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
  - No public API documentation changes were required; the complete DocC warnings-as-errors check passed.
