### PR TITLE
Strengthen chunked SSM gradient tests

### DIFF
--- a/Tests/MLXLMTests/SSMTests.swift
+++ b/Tests/MLXLMTests/SSMTests.swift
@@ -4,17 +4,103 @@ import MLX
 import MLXLLM
 import Testing
 
-@Test func testSSMAttnSupportsGradientTransformsAcrossChunks() {
-    let x = MLXArray.ones([1, 5, 2, 2])
-    let aLog = MLXArray.zeros([2])
-    let inputMixing = MLXArray.ones([1, 5, 1, 3])
-    let outputMixing = MLXArray.ones([1, 5, 1, 3])
-    let residualScale = MLXArray.ones([2])
-    let dt = MLXArray.ones([1, 5, 2])
-    let dtBias = MLXArray.zeros([2])
+private func expectAllClose(
+    _ actual: MLXArray, _ expected: MLXArray, label: String, rtol: Double = 1e-4,
+    atol: Double = 1e-5
+) {
+    guard actual.shape == expected.shape else {
+        Issue.record("\(label) shape \(actual.shape) != \(expected.shape)")
+        return
+    }
+    #expect(
+        allClose(actual, expected, rtol: rtol, atol: atol).item(Bool.self),
+        "\(label) values differ")
+}
+
+@Test func testSSMAttnChunkedMatchesUnchunkedValuesAndGradients() {
+    MLXRandom.seed(11)
+
+    let batch = 1
+    let sequence = 5
+    let heads = 4
+    let headDimension = 3
+    let groups = 2
+    let stateDimension = 3
+
+    let parameters = [
+        MLXRandom.normal([batch, sequence, heads, headDimension]),
+        MLXRandom.normal([heads]) * 0.1,
+        MLXRandom.normal([batch, sequence, groups, stateDimension]) * 0.2,
+        MLXRandom.normal([batch, sequence, groups, stateDimension]) * 0.2,
+        MLXRandom.normal([heads]) * 0.2,
+        MLXRandom.normal([batch, sequence, heads]) * 0.1,
+        MLXRandom.normal([heads]) * 0.1,
+        MLXRandom.normal([batch, heads, headDimension, stateDimension]) * 0.2,
+    ]
+
+    func forward(_ parameters: [MLXArray], step: Int) -> (MLXArray, MLXArray) {
+        ssmAttn(
+            x: parameters[0],
+            ALog: parameters[1],
+            B: parameters[2],
+            C: parameters[3],
+            D: parameters[4],
+            dt: parameters[5],
+            dtBias: parameters[6],
+            state: parameters[7],
+            step: step
+        )
+    }
+
+    let (referenceOutput, referenceState) = forward(parameters, step: sequence)
+
+    func valueAndGradient(step: Int) -> ([MLXArray], [MLXArray]) {
+        valueAndGrad(
+            { parameters in
+                let (output, state) = forward(parameters, step: step)
+                return [(output.square().mean() + state.square().mean())]
+            },
+            argumentNumbers: parameters.indices
+        )(parameters)
+    }
+
+    let (referenceValue, referenceGradients) = valueAndGradient(step: sequence)
+    #expect(referenceGradients.count == parameters.count)
+    let gradientLabels = ["x", "ALog", "B", "C", "D", "dt", "dtBias", "state"]
+
+    for step in [1, 2, 3] {
+        let (chunkedOutput, chunkedState) = forward(parameters, step: step)
+        let (chunkedValue, chunkedGradients) = valueAndGradient(step: step)
+        eval(
+            chunkedOutput, chunkedState, chunkedValue, chunkedGradients, referenceOutput,
+            referenceState, referenceValue, referenceGradients)
+
+        expectAllClose(chunkedOutput, referenceOutput, label: "output (step \(step))")
+        expectAllClose(chunkedState, referenceState, label: "state (step \(step))")
+        expectAllClose(chunkedValue[0], referenceValue[0], label: "loss (step \(step))")
+        #expect(chunkedGradients.count == parameters.count)
+        for (index, pair) in zip(chunkedGradients, referenceGradients).enumerated() {
+            expectAllClose(
+                pair.0, pair.1, label: "\(gradientLabels[index]) gradient (step \(step))",
+                rtol: 5e-4, atol: 5e-5)
+        }
+    }
+}
+
+@Test func testSSMAttnFinalStateGradientCrossesChunkBoundaries() {
+    MLXRandom.seed(12)
+
+    let sequence = 5
+    let x = MLXRandom.normal([1, sequence, 2, 2])
+    let aLog = MLXRandom.normal([2]) * 0.1
+    let inputMixing = MLXRandom.normal([1, sequence, 1, 3]) * 0.2
+    let outputMixing = MLXArray.zeros([1, sequence, 1, 3])
+    let residualScale = MLXArray.zeros([2])
+    let dt = MLXRandom.normal([1, sequence, 2]) * 0.1
+    let dtBias = MLXRandom.normal([2]) * 0.1
 
     let gradient = grad { input in
-        let (output, state) = ssmAttn(
+        let (_, state) = ssmAttn(
             x: input,
             ALog: aLog,
             B: inputMixing,
@@ -24,14 +110,13 @@ import Testing
             dtBias: dtBias,
             step: 2
         )
-        return output.sum() + state.sum()
+        return state.square().sum()
     }(x)
     eval(gradient)
 
-    let magnitude = gradient.abs().sum().item(Float.self)
-    #expect(gradient.shape == x.shape)
-    #expect(magnitude.isFinite)
-    #expect(magnitude > 0)
+    let firstChunkMagnitude = gradient[0..., ..<2, 0..., 0...].abs().sum().item(Float.self)
+    #expect(firstChunkMagnitude.isFinite)
+    #expect(firstChunkMagnitude > 0, "final state is disconnected from the first chunk")
 }
 
 @Test func testSSMAttnPreservesRecurrentStateDTypeAcrossChunks() throws {


### PR DESCRIPTION
## Proposed changes

Follow-up to #571.

The regression test added in #571 verified that `grad` completed and produced a finite, nonzero gradient for `x`. However, `ssmAttn` includes the residual path `x * D`, so that assertion could still pass even if the recurrent gradient graph were disconnected across chunk boundaries.

This PR strengthens the regression coverage by:

- comparing chunk sizes 1, 2, and 3 against a single-chunk reference;
- verifying output, final recurrent state, and loss equivalence;
- comparing gradients for `x`, `ALog`, `B`, `C`, `D`, `dt`, `dtBias`, and the incoming recurrent state;
- adding a state-only loss with `D = 0`, proving that inputs in the first chunk influence the final recurrent state through the cross-chunk recurrence.

This is a test-only change and does not alter any behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed; test-only change)