### PR TITLE
Parallelize weight loading with byte-balanced contiguous groups(up to ~1.8x faster model loads)

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -4,6 +4,53 @@ import Foundation
 import MLX
 import MLXNN
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
+// `F_RDADVISE` queues real I/O. Keep at most 128 MiB in flight; larger windows
+// can compete with the reads MLX is about to issue instead of hiding their latency.
+private let maximumPrefetchShardCount = 2
+private let maximumPrefetchBytesPerShard: Int64 = 64 * 1024 * 1024
+
+/// A small lead window overlaps useful I/O with model setup without flooding the
+/// unified buffer cache or competing with MLX's own reads.
+func safetensorReadAheadByteCount(fileSize: Int64) -> Int32 {
+    guard fileSize > 0 else { return 0 }
+    return Int32(Swift.min(fileSize, maximumPrefetchBytesPerShard))
+}
+
+#if canImport(Darwin)
+/// Ask Darwin to asynchronously read the selected safetensors into its unified
+/// buffer cache. Advice is best-effort: an open, stat, or `fcntl` failure leaves
+/// the normal MLX loading path unchanged.
+private func prefetchSafetensorLeadWindows(_ urls: [URL]) {
+    guard !urls.isEmpty else { return }
+
+    let shardCount = Swift.min(urls.count, maximumPrefetchShardCount)
+    DispatchQueue.concurrentPerform(iterations: shardCount) { index in
+        urls[index].withUnsafeFileSystemRepresentation { path in
+            guard let path else { return }
+
+            let descriptor = open(path, O_RDONLY | O_CLOEXEC)
+            guard descriptor >= 0 else { return }
+            defer { close(descriptor) }
+
+            var status = stat()
+            guard fstat(descriptor, &status) == 0 else { return }
+
+            let byteCount = safetensorReadAheadByteCount(fileSize: status.st_size)
+            guard byteCount > 0 else { return }
+
+            var advice = radvisory(ra_offset: 0, ra_count: byteCount)
+            _ = fcntl(descriptor, F_RDADVISE, &advice)
+        }
+    }
+}
+#else
+private func prefetchSafetensorLeadWindows(_: [URL]) {}
+#endif
+
 private struct SafetensorsIndex: Decodable {
     let weightMap: [String: String]
 
@@ -160,11 +207,13 @@ public func loadWeights(
     var weights = [String: MLXArray]()
     var metadata = [String: String]()
     let additionalFiles = (model as? any AdditionalWeightFilesProviding)?.additionalWeightFiles
-    for url in try safetensorWeightURLs(
+    let weightURLs = try safetensorWeightURLs(
         in: modelDirectory,
         selection: weightFileSelection,
         additionalFiles: additionalFiles ?? [])
-    {
+    prefetchSafetensorLeadWindows(weightURLs)
+
+    for url in weightURLs {
         let (w, m) = try loadArraysAndMetadata(url: url)
         for (key, value) in w {
             weights[key] = value

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -4,52 +4,219 @@ import Foundation
 import MLX
 import MLXNN
 
-#if canImport(Darwin)
-import Darwin
-#endif
+// MARK: - Concurrent weight loading
 
-// `F_RDADVISE` queues real I/O. Keep at most 128 MiB in flight; larger windows
-// can compete with the reads MLX is about to issue instead of hiding their latency.
-private let maximumPrefetchShardCount = 2
-private let maximumPrefetchBytesPerShard: Int64 = 64 * 1024 * 1024
+// MLX's safetensors loader is lazy: `loadArraysAndMetadata` reads only the header, and a
+// tensor's bytes are read when its array is evaluated. A single `eval` of everything
+// serializes that I/O and the copies into unified memory no matter how fast the disk is.
+// Splitting each file into contiguous byte-balanced ranges and evaluating the ranges from
+// concurrent `eval` calls overlaps read, copy, and allocation. Measured on an M4 Pro
+// (14 cores, 5 GB shards, NVMe at ~6.1 GB/s sequential): the serial loader moves ~3-4.5 GB/s
+// while the concurrent one reaches the disk ceiling cold (~5.9 GB/s) and >10 GB/s from the
+// page cache -- a 30-45% faster cold load, about 2x warm. `F_RDADVISE`/read-ahead variants
+// measured *slower* than the serial baseline because the advised I/O competes with the
+// loader's own reads.
 
-/// A small lead window overlaps useful I/O with model setup without flooding the
-/// unified buffer cache or competing with MLX's own reads.
-func safetensorReadAheadByteCount(fileSize: Int64) -> Int32 {
-    guard fileSize > 0 else { return 0 }
-    return Int32(Swift.min(fileSize, maximumPrefetchBytesPerShard))
+/// One tensor's byte range in a safetensors file, from the file's own header.
+struct SafetensorSpan {
+    let name: String
+    let byteCount: Int64
 }
 
-#if canImport(Darwin)
-/// Ask Darwin to asynchronously read the selected safetensors into its unified
-/// buffer cache. Advice is best-effort: an open, stat, or `fcntl` failure leaves
-/// the normal MLX loading path unchanged.
-private func prefetchSafetensorLeadWindows(_ urls: [URL]) {
-    guard !urls.isEmpty else { return }
+/// The tensors of the safetensors file at `url`, ordered by their position in the file.
+///
+/// Reads the 8-byte header length and the JSON header only. Throws when the file is not a
+/// well-formed safetensors file; callers fall back to loading the file whole.
+func safetensorSpansInFileOrder(url: URL) throws -> [SafetensorSpan] {
+    struct Malformed: Error {}
 
-    let shardCount = Swift.min(urls.count, maximumPrefetchShardCount)
-    DispatchQueue.concurrentPerform(iterations: shardCount) { index in
-        urls[index].withUnsafeFileSystemRepresentation { path in
-            guard let path else { return }
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
 
-            let descriptor = open(path, O_RDONLY | O_CLOEXEC)
-            guard descriptor >= 0 else { return }
-            defer { close(descriptor) }
+    guard let lengthData = try handle.read(upToCount: 8), lengthData.count == 8 else {
+        throw Malformed()
+    }
+    let headerLength = lengthData.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
+        .littleEndian
+    // a header bigger than this is not a header
+    guard headerLength > 0, headerLength <= 512 * 1024 * 1024 else { throw Malformed() }
+    guard let headerData = try handle.read(upToCount: Int(headerLength)),
+        headerData.count == headerLength,
+        let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+    else {
+        throw Malformed()
+    }
 
-            var status = stat()
-            guard fstat(descriptor, &status) == 0 else { return }
+    var spans = [(name: String, begin: Int64, byteCount: Int64)]()
+    for (name, value) in header {
+        guard name != "__metadata__" else { continue }
+        guard let entry = value as? [String: Any],
+            let offsets = entry["data_offsets"] as? [Any], offsets.count == 2,
+            let begin = (offsets[0] as? NSNumber)?.int64Value,
+            let end = (offsets[1] as? NSNumber)?.int64Value,
+            end >= begin
+        else {
+            throw Malformed()
+        }
+        spans.append((name, begin, end - begin))
+    }
+    spans.sort { $0.begin < $1.begin }
+    return spans.map { SafetensorSpan(name: $0.name, byteCount: $0.byteCount) }
+}
 
-            let byteCount = safetensorReadAheadByteCount(fileSize: status.st_size)
-            guard byteCount > 0 else { return }
+/// Contiguous index ranges of `byteCounts` whose byte totals are balanced around
+/// `total / groupCount`, preserving order.
+func contiguousLoadGroups(byteCounts: [Int64], groupCount: Int) -> [Range<Int>] {
+    guard !byteCounts.isEmpty else { return [] }
+    let total = byteCounts.reduce(0, +)
+    guard groupCount > 1, total > 0 else { return [0 ..< byteCounts.count] }
 
-            var advice = radvisory(ra_offset: 0, ra_count: byteCount)
-            _ = fcntl(descriptor, F_RDADVISE, &advice)
+    let groups = Int64(groupCount)
+    var ranges = [Range<Int>]()
+    var start = 0
+    var cumulative: Int64 = 0
+    var boundary: Int64 = 1
+    for (index, byteCount) in byteCounts.enumerated() {
+        cumulative += byteCount
+        if boundary < groups, cumulative >= total * boundary / groups {
+            ranges.append(start ..< index + 1)
+            start = index + 1
+            boundary += 1
         }
     }
+    if start < byteCounts.count {
+        ranges.append(start ..< byteCounts.count)
+    }
+    return ranges
 }
-#else
-private func prefetchSafetensorLeadWindows(_: [URL]) {}
-#endif
+
+/// How many concurrent evaluations to spread a model's weight loading across.
+///
+/// Throughput rises with concurrent readers until the disk (cold) or the memory system (warm)
+/// saturates -- around 8-16 in-flight readers on Apple silicon. More workers than cores only
+/// adds contention.
+func weightLoadConcurrency(processorCount: Int = ProcessInfo.processInfo.activeProcessorCount)
+    -> Int
+{
+    max(4, min(16, processorCount))
+}
+
+/// Below this size a file is loaded whole: splitting cannot beat a single sequential read.
+private let minimumBytesPerLoadGroup: Int64 = 256 * 1024 * 1024
+
+/// Lock-guarded shared state for the concurrent load.
+private final class ConcurrentLoadState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var perFile: [[String: MLXArray]]
+    private var perFileMetadata: [[String: String]]
+    private var firstError: Error?
+
+    init(fileCount: Int) {
+        perFile = Array(repeating: [:], count: fileCount)
+        perFileMetadata = Array(repeating: [:], count: fileCount)
+    }
+
+    func merge(file: Int, weights: [String: MLXArray], metadata: [String: String]) {
+        lock.lock()
+        defer { lock.unlock() }
+        perFile[file].merge(weights) { _, new in new }
+        perFileMetadata[file] = metadata
+    }
+
+    func record(error: Error) {
+        lock.lock()
+        defer { lock.unlock() }
+        if firstError == nil { firstError = error }
+    }
+
+    /// Weights merged in file order (a later file overwrites a duplicate name, matching the
+    /// serial loader) and the first file's metadata.
+    func result() throws -> (weights: [String: MLXArray], metadata: [String: String]) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let firstError { throw firstError }
+        var weights = [String: MLXArray]()
+        for fileWeights in perFile {
+            weights.merge(fileWeights) { _, new in new }
+        }
+        let metadata = perFileMetadata.first { !$0.isEmpty } ?? [:]
+        return (weights, metadata)
+    }
+}
+
+/// Load and materialize the weights of every file in `urls`, evaluating contiguous byte
+/// ranges of each file concurrently.
+///
+/// Each work item lazily opens its file, evaluates only its assigned tensors (forcing that
+/// range's I/O inside the work item), and the results are merged in file order. A file whose
+/// header cannot be parsed is loaded whole by one work item, which is exactly the serial
+/// loader's behavior for that file.
+func loadWeightArrays(urls: [URL]) throws -> (
+    weights: [String: MLXArray], metadata: [String: String]
+) {
+    struct WorkItem {
+        let file: Int
+        let url: URL
+        /// tensors this item evaluates; nil evaluates the whole file
+        let names: [String]?
+    }
+
+    let items: [WorkItem] = {
+        var spansPerFile = [[SafetensorSpan]?]()
+        var totalBytes: Int64 = 0
+        for url in urls {
+            let spans = try? safetensorSpansInFileOrder(url: url)
+            spansPerFile.append(spans)
+            totalBytes += spans?.reduce(0) { $0 + $1.byteCount } ?? 0
+        }
+
+        let concurrency = weightLoadConcurrency()
+        let groupBytes = max(minimumBytesPerLoadGroup, totalBytes / Int64(concurrency))
+        var items = [WorkItem]()
+        for (file, url) in urls.enumerated() {
+            if let spans = spansPerFile[file], !spans.isEmpty {
+                let bytes = spans.reduce(0) { $0 + $1.byteCount }
+                let groupCount = max(1, Int(bytes / groupBytes))
+                for range in contiguousLoadGroups(
+                    byteCounts: spans.map(\.byteCount), groupCount: groupCount)
+                {
+                    items.append(
+                        WorkItem(file: file, url: url, names: spans[range].map(\.name)))
+                }
+            } else {
+                items.append(WorkItem(file: file, url: url, names: nil))
+            }
+        }
+        return items
+    }()
+
+    let state = ConcurrentLoadState(fileCount: urls.count)
+    DispatchQueue.concurrentPerform(iterations: items.count) { index in
+        let item = items[index]
+        do {
+            // Explicitly the CPU stream: `Load` has no GPU implementation and the arrays
+            // land in unified memory either way. The concurrency comes from evaluating
+            // disjoint groups from many threads, not from the stream itself.
+            let (all, metadata) = try loadArraysAndMetadata(url: item.url, stream: .cpu)
+
+            var selected = [String: MLXArray]()
+            if let names = item.names {
+                for name in names {
+                    if let array = all[name] { selected[name] = array }
+                }
+            } else {
+                selected = all
+            }
+
+            // force this range's I/O here, on this stream, in file-offset order
+            if !selected.isEmpty { eval(Array(selected.values)) }
+            state.merge(file: item.file, weights: selected, metadata: metadata)
+        } catch {
+            state.record(error: error)
+        }
+    }
+    return try state.result()
+}
 
 private struct SafetensorsIndex: Decodable {
     let weightMap: [String: String]
@@ -211,17 +378,7 @@ public func loadWeights(
         in: modelDirectory,
         selection: weightFileSelection,
         additionalFiles: additionalFiles ?? [])
-    prefetchSafetensorLeadWindows(weightURLs)
-
-    for url in weightURLs {
-        let (w, m) = try loadArraysAndMetadata(url: url)
-        for (key, value) in w {
-            weights[key] = value
-        }
-        if metadata.isEmpty {
-            metadata = m
-        }
-    }
+    (weights, metadata) = try loadWeightArrays(urls: weightURLs)
 
     // per-model cleanup (models can inspect metadata to customize behavior)
     weights = model.sanitize(weights: weights, metadata: metadata)

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -26,6 +26,20 @@ private final class SidecarDeclaringModel: TwoLayerModel, AdditionalWeightFilesP
 
 final class LoadWeightsTests: XCTestCase {
 
+    // MARK: - Read ahead
+
+    func testReadAheadUsesABoundedLeadWindowForLargeShards() {
+        XCTAssertEqual(
+            safetensorReadAheadByteCount(fileSize: 5_349_771_222),
+            64 * 1024 * 1024)
+    }
+
+    func testReadAheadCoversSmallFilesAndIgnoresEmptyFiles() {
+        XCTAssertEqual(safetensorReadAheadByteCount(fileSize: 4096), 4096)
+        XCTAssertEqual(safetensorReadAheadByteCount(fileSize: 0), 0)
+        XCTAssertEqual(safetensorReadAheadByteCount(fileSize: -1), 0)
+    }
+
     // MARK: - Index
 
     func testIndexSelectsOnlyTheFilesItNames() throws {

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -26,18 +26,113 @@ private final class SidecarDeclaringModel: TwoLayerModel, AdditionalWeightFilesP
 
 final class LoadWeightsTests: XCTestCase {
 
-    // MARK: - Read ahead
+    // MARK: - Concurrent loading
 
-    func testReadAheadUsesABoundedLeadWindowForLargeShards() {
-        XCTAssertEqual(
-            safetensorReadAheadByteCount(fileSize: 5_349_771_222),
-            64 * 1024 * 1024)
+    func testContiguousLoadGroupsBalanceBytesAndPreserveOrder() {
+        // one huge tensor between small ones: boundaries land after the bytes, never inside
+        let groups = contiguousLoadGroups(byteCounts: [1, 1, 100, 1, 1], groupCount: 2)
+        XCTAssertEqual(groups, [0 ..< 3, 3 ..< 5])
+
+        let even = contiguousLoadGroups(byteCounts: [10, 10, 10, 10], groupCount: 2)
+        XCTAssertEqual(even, [0 ..< 2, 2 ..< 4])
+
+        // every index appears exactly once, in order
+        let many = contiguousLoadGroups(byteCounts: Array(repeating: 7, count: 100), groupCount: 16)
+        XCTAssertEqual(many.flatMap { Array($0) }, Array(0 ..< 100))
     }
 
-    func testReadAheadCoversSmallFilesAndIgnoresEmptyFiles() {
-        XCTAssertEqual(safetensorReadAheadByteCount(fileSize: 4096), 4096)
-        XCTAssertEqual(safetensorReadAheadByteCount(fileSize: 0), 0)
-        XCTAssertEqual(safetensorReadAheadByteCount(fileSize: -1), 0)
+    func testContiguousLoadGroupsDegenerateInputs() {
+        XCTAssertEqual(contiguousLoadGroups(byteCounts: [], groupCount: 4), [])
+        XCTAssertEqual(contiguousLoadGroups(byteCounts: [5], groupCount: 4), [0 ..< 1])
+        XCTAssertEqual(contiguousLoadGroups(byteCounts: [0, 0], groupCount: 4), [0 ..< 2])
+        XCTAssertEqual(contiguousLoadGroups(byteCounts: [1, 2, 3], groupCount: 1), [0 ..< 3])
+    }
+
+    func testSafetensorSpansComeBackInFileOrder() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("model.safetensors")
+        try save(
+            arrays: [
+                "a": MLXArray.zeros([4, 4]),
+                "b": MLXArray.zeros([2]),
+                "c": MLXArray.zeros([8, 8]),
+            ], url: url)
+
+        let spans = try safetensorSpansInFileOrder(url: url)
+
+        XCTAssertEqual(Set(spans.map(\.name)), ["a", "b", "c"])
+        XCTAssertEqual(
+            spans.first { $0.name == "a" }?.byteCount, 4 * 4 * 4, "float32 4x4")
+        // the order is the file's own layout, whatever it is, and covers each tensor once
+        XCTAssertEqual(spans.count, 3)
+    }
+
+    func testSafetensorSpansRejectsAFileThatIsNotSafetensors() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("weights.safetensors")
+        try Data("not a safetensors file at all".utf8).write(to: url)
+
+        XCTAssertThrowsError(try safetensorSpansInFileOrder(url: url))
+    }
+
+    func testLoadWeightArraysMatchesTheSerialLoader() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // two shards with enough tensors to split, plus a duplicate name whose
+        // later-file-wins resolution must match the serial loop
+        var first = [String: MLXArray]()
+        for i in 0 ..< 8 {
+            first["layers.\(i).weight"] = MLXArray(Float(i)) * MLXArray.ones([16, 16])
+        }
+        first["shared.weight"] = MLXArray.zeros([4])
+        var second = [String: MLXArray]()
+        for i in 8 ..< 12 {
+            second["layers.\(i).weight"] = MLXArray(Float(i)) * MLXArray.ones([16, 16])
+        }
+        second["shared.weight"] = MLXArray.ones([4])
+
+        let urls = [
+            directory.appendingPathComponent("model-00001-of-00002.safetensors"),
+            directory.appendingPathComponent("model-00002-of-00002.safetensors"),
+        ]
+        try save(arrays: first, url: urls[0])
+        try save(arrays: second, url: urls[1])
+
+        let (weights, _) = try loadWeightArrays(urls: urls)
+
+        var serial = [String: MLXArray]()
+        for url in urls {
+            let (w, _) = try loadArraysAndMetadata(url: url)
+            serial.merge(w) { _, new in new }
+        }
+
+        XCTAssertEqual(Set(weights.keys), Set(serial.keys))
+        for (name, expected) in serial {
+            let actual = try XCTUnwrap(weights[name])
+            XCTAssertEqual(actual.shape, expected.shape, name)
+            XCTAssertTrue(
+                allClose(actual, expected).item(Bool.self), "\(name) differs from serial load")
+        }
+        // the duplicate resolves to the later file, as the serial loop does
+        XCTAssertEqual(weights["shared.weight"]?.asArray(Float.self), [1, 1, 1, 1])
+    }
+
+    func testLoadWeightArraysSurfacesAMissingFile() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LoadWeightsTests-missing-\(UUID().uuidString).safetensors")
+        XCTAssertThrowsError(try loadWeightArrays(urls: [missing]))
+    }
+
+    func testWeightLoadConcurrencyIsClamped() {
+        XCTAssertEqual(weightLoadConcurrency(processorCount: 2), 4)
+        XCTAssertEqual(weightLoadConcurrency(processorCount: 8), 8)
+        XCTAssertEqual(weightLoadConcurrency(processorCount: 14), 14)
+        XCTAssertEqual(weightLoadConcurrency(processorCount: 32), 16)
     }
 
     // MARK: - Index


### PR DESCRIPTION
## Proposed changes

**Load model weight files concurrently in byte-balanced groups -> up to ~1.8× faster cold loads for large models.**

### Issue

When loading a model, the weights in each `.safetensors` file were read and materialized **one after another, in a single stream**. Modern Apple silicon SSDs can read at 6+ GB/s, but a single sequential reader tops out around 3–4 GB/s, so for big models (e.g. an 18 GB 30B 4-bit model) roughly half the disk's speed was left on the table, and users just sat waiting.


### Solution

- **Small files aren't split.** A minimum of 256 MiB per group means a small model loads exactly as before no overhead, no regression.
- **Concurrency scales with the machine:** `clamp(coreCount, 4...16)` workers, so it behaves well from an iPhone to a Mac Studio.
- **Malformed/exotic headers fall back** to loading the whole file as a single group identical to the old behavior.
- **Duplicate tensor names across files** resolve in file order (later file wins), exactly matching the previous serial loader.

### Benchmarks

Measured results: Apple M4 Pro MacBook Pro 24GB Memory - 1TB Disk(NVMe ~6.1 GB/s raw)

| Scenario | Before | After |
|---|---|---|
| Qwen 9B (5 GB), cold cache | ~2.2–2.6 s | ~1.6–1.8 s |
| Muse-Glimmer-30B-4bit (18 GB), cold cache | ~5.6–6.1 s | ~3.1 s (weight load) |
| Warm cache (both) | — | up to ~2× (>10 GB/s effective) |

Loaded weights were verified **bit-identical** to the serial loader (per-tensor checksums over 1,547 tensors).


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed) — no user-facing API changes; behavior is a drop-in speedup