### PR TITLE
MLXVLM: resolve the LFM2VL image token id from the vocabulary

### DIFF
--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -781,9 +781,16 @@ public struct LFM2VLProcessor: UserInputProcessor {
             totalImageTokens += h * w
         }
 
-        // Replace image placeholder tokens with the correct count
-        // image_token_id is 396 for LFM2 VL models
-        let imageTokenId = 396
+        // Replace image placeholder tokens with the correct count.
+        //
+        // The id is per-model, not per-family: 396 is LFM2-VL's, while
+        // LFM2.5-VL-3B declares 124907. Hardcoding it meant the expansion below
+        // scanned for a token the template never emitted, left the single
+        // placeholder in place, and the model then aborted the process in
+        // `mergeInputIdsWithImageFeatures` with "tokens: 1, features 1536".
+        // The vocabulary is the authority; the old constant stays as the
+        // fallback for a tokenizer with no `<image>` entry.
+        let imageTokenId = tokenizer.convertTokenToId("<image>") ?? 396
         var newPromptTokens = [Int]()
         var imageIdx = 0
         var i = 0


### PR DESCRIPTION
`LFM2VLProcessor.prepare` expands the image placeholder by scanning the templated
prompt for a hardcoded token id of 396. That id belongs to LFM2-VL. LFM2.5-VL-3B
declares `image_token_id` 124907, which is `<image>` in its vocabulary.

On that model the scan finds nothing, so the prompt keeps the single placeholder
the chat template emitted. Inference then looks for the id from the model config,
finds one position, and compares it against 1536 features from the vision tower:

```
MLXVLM/LFM2VL.swift:960: Fatal error: Image features and image tokens do not match: tokens: 1, features 1536
```

That is a `fatalError`, so the host process dies outright. There is no error to
catch and no crash report is written, which makes it look like an unexplained
disappearance rather than a model problem.

The two halves of the file already disagreed about where the id comes from:
`LFM2VLConfiguration` parses `image_token_id` and inference uses it, while the
processor guessed. This reads the id from the vocabulary instead and keeps 396 as
the fallback for a tokenizer with no `<image>` entry, following the
`tokenId(_:default:)` pattern already used in `MuseGlimmer.swift`.

Verified against `mlx-lfm2.5-vl-3b-4bit` on macOS: a 2048x1324 screenshot that
previously killed the process now comes back with a full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
