### PR TITLE
Suspend instead of blocking cooperative threads while weights load

### DIFF
--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -231,7 +231,7 @@ public final class EmbedderModelFactory: GenericModelFactory {
         async let tokenizerTask = tokenizerLoader.load(
             from: configuration.tokenizerDirectory)
 
-        try loadWeights(
+        try await loadWeights(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection)

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -730,7 +730,7 @@ public final class LLMModelFactory: GenericModelFactory {
         async let tokenizerTask = tokenizerLoader.load(
             from: configuration.tokenizerDirectory)
 
-        try loadWeights(
+        try await loadWeights(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection)

--- a/Libraries/MLXLMCommon/Documentation.docc/porting.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/porting.md
@@ -300,7 +300,7 @@ public init(dimensions: Int, eps: Float = 1e-5) {
 }
 ```
 
-Note that the weight is given an initial value and shape based on the parameters to the initializer. In typical inference use, these values will be replaced when the weights are loaded (``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)``).
+Note that the weight is given an initial value and shape based on the parameters to the initializer. In typical inference use, these values will be replaced when the weights are loaded (``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)-8b333``).
 
 * Note: If the property names in Python don't make good Swift names, you can use the `@ParameterInfo` property wrapper to specify the key: `@ParameterInfo(key: "some_weight") var weight: MLXArray`
 

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -404,3 +404,32 @@ public func loadWeights(
 
     eval(model)
 }
+
+/// Async variant of
+/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)``.
+///
+/// Loading blocks its thread on file I/O and fans out with `DispatchQueue.concurrentPerform`.
+/// Swift concurrency's cooperative threads must never block, so this overload runs the load
+/// on a global queue and suspends the caller instead. Async callers resolve to this overload;
+/// the synchronous one remains for synchronous code such as model conversion.
+public func loadWeights(
+    modelDirectory: URL, model: BaseLanguageModel,
+    quantization: BaseConfiguration.Quantization? = nil,
+    perLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil,
+    weightFileSelection: WeightFileSelection = .automatic
+) async throws {
+    let model = SendableBox(model)
+    try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<Void, any Error>) in
+        DispatchQueue.global(qos: .userInitiated).async {
+            continuation.resume(
+                with: Result {
+                    try loadWeights(
+                        modelDirectory: modelDirectory, model: model.consume(),
+                        quantization: quantization,
+                        perLayerQuantization: perLayerQuantization,
+                        weightFileSelection: weightFileSelection)
+                })
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -406,7 +406,7 @@ public func loadWeights(
 }
 
 /// Async variant of
-/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)``.
+/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)-6eqw7``.
 ///
 /// Loading blocks its thread on file I/O and fans out with `DispatchQueue.concurrentPerform`.
 /// Swift concurrency's cooperative threads must never block, so this overload runs the load

--- a/Libraries/MLXLMCommon/MTPDrafterModelFactory.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModelFactory.swift
@@ -92,7 +92,7 @@ public final class MTPDrafterModelFactory: GenericModelFactory {
                 configurationURL.lastPathComponent, configuration.name, error)
         }
 
-        try loadWeights(
+        try await loadWeights(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection

--- a/Libraries/MLXLMCommon/ModelConversion.swift
+++ b/Libraries/MLXLMCommon/ModelConversion.swift
@@ -218,7 +218,7 @@ public enum ModelConversionError: LocalizedError, Equatable {
 /// Quantize and save an already-instantiated model from a compatible safetensors directory.
 ///
 /// The function loads safetensors weights, runs the model's sanitizer through
-/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)``, applies quantization,
+/// ``loadWeights(modelDirectory:model:quantization:perLayerQuantization:weightFileSelection:)-6eqw7``, applies quantization,
 /// writes safetensors shards and an index, copies tokenizer/config sidecar files, and updates
 /// `config.json` with the requested quantization block.
 public func convert(

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -444,7 +444,7 @@ public final class VLMModelFactory: GenericModelFactory {
             context: processorLoadingContext,
             registry: processorLoadingRegistry)
 
-        try loadWeights(
+        try await loadWeights(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection)

--- a/Tests/MLXLMTests/LoadWeightsTests.swift
+++ b/Tests/MLXLMTests/LoadWeightsTests.swift
@@ -350,6 +350,36 @@ final class LoadWeightsTests: XCTestCase {
         XCTAssertEqual(model.projector.weight.asArray(Float.self), [1, 2, 3, 4])
     }
 
+    func testAsyncLoadWeightsMatchesTheSynchronousOverload() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try writeSidecarCheckpoint(in: directory)
+
+        // In an async context this resolves to the async overload, which suspends the caller
+        // and runs the load on a global queue instead of blocking a cooperative thread.
+        let model = SidecarDeclaringModel()
+        try await loadWeights(modelDirectory: directory, model: model)
+
+        XCTAssertEqual(model.projector.weight.asArray(Float.self), [1, 2, 3, 4])
+    }
+
+    func testAsyncLoadWeightsPropagatesErrors() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try writeSidecarCheckpoint(in: directory)
+
+        // same undeclared-sidecar failure as the synchronous overload
+        let model = TwoLayerModel()
+        do {
+            try await loadWeights(modelDirectory: directory, model: model)
+            XCTFail("expected the keyNotFound error the synchronous overload throws")
+        } catch {
+            // expected
+        }
+    }
+
     /// Writes a checkpoint whose index names only `model.safetensors` while the head lives in
     /// `projector.safetensors`, the `jinaai/jina-reranker-v3-mlx` layout.
     private func writeSidecarCheckpoint(in directory: URL) throws {


### PR DESCRIPTION
## Proposed changes

Follow-up to a review comment on #575: the `loadWeights` API is synchronous and blocks its thread on file I/O and `DispatchQueue.concurrentPerform`, but every model factory calls it from an async context. That parks a Swift concurrency cooperative thread for the whole load, which is an anti-pattern and a potential source of thread starvation, since the cooperative pool only has one thread per core and expects them to never block.

This PR adds an `async` overload of `loadWeights` that hops to a global GCD queue and suspends the caller instead of blocking it. The four async model factories (LLM, VLM, embedders, MTP drafter) now use it. The synchronous overload is unchanged and remains for synchronous callers such as model conversion.

No performance change.

Note: downstream code that calls `loadWeights` from an async context will now resolve to the async overload and needs to add `await`.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)