### PR TITLE
Defer vision weight loading by default for MuseGlimmer

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -45,6 +45,7 @@ public struct SpeculativeDecodingConfig: Sendable {
     package enum DraftModelSource: Sendable {
         case loaded(ModelContainer)
         case deferred(bytes: Int, @Sendable () async throws -> ModelContainer)
+        case lookup(PromptLookupDraftModel.Configuration)
     }
 
     package let draftModelSource: DraftModelSource
@@ -104,6 +105,40 @@ public struct SpeculativeDecodingConfig: Sendable {
         self.memoryPolicy = memoryPolicy
     }
 
+    /// Initialize model-free speculative decoding by prompt lookup.
+    ///
+    /// Draft tokens come from n-gram matches over the session's own token
+    /// history (see ``PromptLookupDraftModel``), so no draft model is loaded,
+    /// no additional weight memory is used, and no memory policy applies. The
+    /// emitted stream is what the main model would produce on its own — a
+    /// draft is accepted only when it equals the verifier's sampled token.
+    ///
+    /// This shines on agentic/coding workloads, where generation constantly
+    /// copies spans that already appear in the context.
+    ///
+    /// - Parameters:
+    ///   - lookup: n-gram matching configuration; its
+    ///     ``PromptLookupDraftModel/Configuration/vocabularySize`` must cover
+    ///     the main model's vocabulary
+    ///   - numDraftTokens: tokens proposed per verification cycle (vLLM ships
+    ///     3–4 for its ngram speculator)
+    public init(
+        lookup: PromptLookupDraftModel.Configuration,
+        numDraftTokens: Int = 3
+    ) {
+        self.draftModelSource = .lookup(lookup)
+        self.numDraftTokens = numDraftTokens
+        self.memoryPolicy = nil
+    }
+
+    /// The prompt-lookup configuration, when this config drafts by n-gram lookup.
+    public var lookup: PromptLookupDraftModel.Configuration? {
+        if case .lookup(let configuration) = draftModelSource {
+            return configuration
+        }
+        return nil
+    }
+
     package var estimatedDraftModelBytes: Int? {
         guard case .deferred(let bytes, _) = draftModelSource else {
             return nil
@@ -117,6 +152,9 @@ public struct SpeculativeDecodingConfig: Sendable {
             draftModel
         case .deferred(_, let load):
             try await load()
+        case .lookup:
+            preconditionFailure(
+                "prompt-lookup speculation is model-free; there is no draft container to load")
         }
     }
 }
@@ -1069,6 +1107,19 @@ public final class ChatSession {
                                 "Main attention cache offsets diverged from model-cache progress")
                             let mainCacheIsAligned =
                                 kvCache.processedTokenCount == cachedTokenIds.count
+                            if let speculativeDecoding,
+                                speculativeDecoding.lookup != nil,
+                                mainCacheIsAligned,
+                                draftKVCache?.processedTokenCount != kvCache.processedTokenCount
+                            {
+                                // A prompt-lookup draft "cache" is the raw token history,
+                                // which the session ledger reproduces exactly — synthesize
+                                // it in place instead of rebuilding both caches the way an
+                                // auxiliary-model draft cache would require.
+                                let history = PromptLookupTokenCache()
+                                history.append(cachedTokenIds.map(Int32.init))
+                                draftKVCache = KVCacheStorage([history], plan: kvCachePlan)
+                            }
                             let draftCacheIsAligned: Bool
                             if let draftKVCache {
                                 assert(
@@ -1226,6 +1277,50 @@ public final class ChatSession {
 
                         if speculativeDecoding != nil, requiresMainOnlyContinuation {
                             generation = try defaultGeneration()
+                        } else if let speculativeDecoding,
+                            let lookupConfiguration = speculativeDecoding.lookup
+                        {
+                            // Prompt-lookup drafting is model-free: no container to
+                            // load, no memory policy to consult. A rebuild left no
+                            // draft storage; a cold main cache admits an empty history.
+                            if draftKVCache == nil, kvCache.processedTokenCount == 0 {
+                                draftKVCache = KVCacheStorage(
+                                    [PromptLookupTokenCache()], plan: kvCachePlan)
+                            }
+                            if let draftCacheStorage = draftKVCache,
+                                draftCacheStorage.processedTokenCount
+                                    == kvCache.processedTokenCount
+                            {
+                                let iterator = try SpeculativeTokenIterator(
+                                    input: input,
+                                    mainModel: model,
+                                    draftModel: PromptLookupDraftModel(
+                                        configuration: lookupConfiguration),
+                                    mainCacheStorage: kvCache,
+                                    draftCacheStorage: draftCacheStorage,
+                                    mainState: lmState,
+                                    parameters: generateParameters,
+                                    numDraftTokens: speculativeDecoding.numDraftTokens,
+                                    components: components)
+                                lmState = iterator.state
+                                cache = .kvcache(
+                                    .init(
+                                        main: kvCache,
+                                        draft: draftKVCache,
+                                        state: lmState,
+                                        conversation: conversation))
+                                generation = GenerationRun(
+                                    MLXLMCommon.generateTaskRecordingTokens(
+                                        promptTokenCount: input.text.tokens.size,
+                                        modelConfiguration: modelConfiguration,
+                                        tokenizer: tokenizer,
+                                        iterator: iterator,
+                                        tools: tools))
+                            } else {
+                                // A raw-cache continuation (e.g. a restored snapshot)
+                                // has no ledger to synthesize the drafter history from.
+                                generation = try defaultGeneration()
+                            }
                         } else if let speculativeDecoding {
                             var shouldFallBackBeforeLoadingDraft = false
                             if let memoryEvaluation = speculativeMemoryEvaluation {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1152,6 +1152,10 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
             processor?.didSample(token: token)
             y = .init(tokens: token)
             state = result.state
+            // The verify pass only emits tokens *after* `y`, so the
+            // prefill-sampled token must be queued here or the stream would
+            // silently start at the second generated token.
+            pendingTokens.append(token.item(Int.self))
         }
 
         // Prefill draft model, don't call didSample here -- processor tracks main model's accepted sequence only

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1029,6 +1029,13 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
     private var mainCommittedPendingTokenCount = 0
     private var draftCommittedPendingTokenCount = 0
 
+    /// Sticky single-token fallback, entered when neither a staged round nor a
+    /// trim can rewind a speculative round. Generation stays correct — it just
+    /// stops speculating.
+    private var passthrough = false
+    /// Why speculation stopped; `nil` while rounds are still speculative.
+    private(set) var passthroughReason: String? = nil
+
     // Internal metrics
     public var promptPrefillTime: TimeInterval = 0.0
     private var telemetry = SpeculativeDecodingTelemetry()
@@ -1096,11 +1103,26 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
             throw KVCacheError(
                 message: "Speculative caches must represent the same processed-token position.")
         }
-        guard
-            canTrimPromptCache(mainCacheStorage.cache),
-            canTrimPromptCache(draftCacheStorage.cache)
-        else {
-            throw KVCacheError(message: "Speculative decoding requires trimmable KV caches.")
+        guard canTrimPromptCache(draftCacheStorage.cache) else {
+            throw KVCacheError(
+                message: "Speculative decoding requires a trimmable draft KV cache.")
+        }
+        // The main cache rewinds rejected drafts either by trimming or through a
+        // staged round — which a wrapped sliding-window ring requires, because a
+        // rotating cache stops being trimmable once it wraps. Probe by opening a
+        // round at the width rounds will use and discarding it, exactly as
+        // `MTPSpeculativeTokenIterator` does, so this check cannot drift from
+        // the leaf classification.
+        if !canTrimPromptCache(mainCacheStorage.cache) {
+            guard
+                let probe = mainCacheStorage.beginRound(
+                    maximumPositions: numDraftTokens + 1)
+            else {
+                throw KVCacheError(
+                    message:
+                        "Speculative decoding requires a trimmable or stageable main KV cache.")
+            }
+            mainCacheStorage.rollback(probe)
         }
 
         self.y = input.text
@@ -1192,6 +1214,37 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         guard numDraft > 0 else {
             return
         }
+        guard !passthrough else {
+            plainRound()
+            return
+        }
+
+        // Rewinding rejected drafts must be possible *before* anything is
+        // written. A staged round presents the verify K/V beside the live
+        // caches and commits only the accepted rows, which stays exact after a
+        // rotating sliding-window cache wraps and can no longer trim. When no
+        // round can be opened (exotic topologies), fall back to trim-based
+        // rewind only while every leaf can still take back the round's width;
+        // otherwise decode without speculation rather than corrupt the cache.
+        //
+        // On the first round after a `.tokens`-returning `prepare`, `y` is the
+        // whole remaining prompt, so the round is as wide as prompt + drafts —
+        // the width must come from `y`, not from `numDraft` alone.
+        let ySize = y.cacheSequenceLength
+        let roundWidth = ySize + numDraft
+        // A cache-less model has nothing to stage or rewind: an empty round
+        // would report zero written positions and refuse any commit.
+        let round =
+            mainCache.isEmpty
+            ? nil : mainCacheStorage.beginRound(maximumPositions: roundWidth)
+        if round == nil,
+            !mainCache.allSatisfy({ $0.isTrimmable(after: roundWidth) })
+        {
+            switchToPassthrough(
+                reason: "main KV cache can neither stage nor trim a speculative round")
+            plainRound()
+            return
+        }
 
         // Draft generation: autoregressive loop with draft model
         var draftProcessor = processor?.copy()  // Copy to discard later
@@ -1211,12 +1264,17 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
             draftY = .init(tokens: draftToken)
         }
 
-        // Verification: main model processes proposals in one pass
+        // Verification: main model processes proposals in one pass. With a
+        // staged round the model runs against the round's presented caches;
+        // the live entries stay untouched until the commit below.
         let verifyTokens = [y.tokens] + draftTokens
         let verifyInput = LMInput.Text(tokens: concatenated(verifyTokens))
         let verifyStart = verifyInput.tokens.dim(0) - (numDraft + 1)
-        let mainResult = mainModel(verifyInput[text: .newAxis], cache: mainCache, state: state)
-        mainCacheStorage.commitProcessedTokens(verifyInput.cacheSequenceLength)
+        let mainResult = mainModel(
+            verifyInput[text: .newAxis], cache: round?.caches ?? mainCache, state: state)
+        if round == nil {
+            mainCacheStorage.commitProcessedTokens(verifyInput.cacheSequenceLength)
+        }
         let mainLogits = mainResult.logits
         state = mainResult.state
 
@@ -1271,9 +1329,26 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
             targetVerified: numDraft + 1
         )
 
-        // Rewind caches for rejected tokens
-        mainCacheStorage.trim(numDraft - accepted)
-        draftCacheStorage.trim(Swift.max(numDraft - accepted - 1, 0))
+        // Rewind caches for rejected tokens. Committing a staged round keeps
+        // everything `y` carried plus the accepted prefix and the correction/
+        // bonus token, and drops the rejected tail without the live caches
+        // ever holding rejected rows; it also advances the storage's
+        // processed-token timeline by exactly that much.
+        if let round {
+            mainCacheStorage.commit(round, retaining: ySize + accepted)
+        } else {
+            mainCacheStorage.trim(numDraft - accepted)
+        }
+        let draftTrimRequest = Swift.max(numDraft - accepted - 1, 0)
+        if draftCacheStorage.trim(draftTrimRequest) < draftTrimRequest,
+            !draftCache.isEmpty
+        {
+            // A draft cache that cannot rewind (e.g. its own sliding window
+            // wrapped) would desynchronize future proposals. Stop speculating
+            // rather than draft from a corrupted history. Cache-less draft
+            // models are exempt: they have nothing to rewind.
+            switchToPassthrough(reason: "draft KV cache could not rewind rejected drafts")
+        }
 
         // Apply dynamic cache quantization after rewind
         kvCachePlan.apply(to: mainCacheStorage)
@@ -1293,6 +1368,37 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
                 ])
             )
         }
+    }
+
+    /// One non-speculative decode step for the sticky fallback: feed the last
+    /// sampled token, sample the next, and commit exactly one position — no
+    /// rewind is ever needed, so no rewindability is required.
+    private mutating func plainRound() {
+        let result = mainModel(y[text: .newAxis], cache: mainCache, state: state)
+        mainCacheStorage.commitProcessedTokens(y.cacheSequenceLength)
+        state = result.state
+        var logits = result.logits[0..., -1, 0...]
+        logits = processor?.process(logits: logits) ?? logits
+        let token = sampler.sample(logits: logits)
+        processor?.didSample(token: token)
+        eval(token)
+        pendingTokens.append(token.item(Int.self))
+        mainCommittedPendingTokenCount = 0
+        draftCommittedPendingTokenCount = 0
+        y = .init(tokens: token)
+        kvCachePlan.apply(to: mainCacheStorage)
+    }
+
+    /// Switch to single-token generation for the remainder of the stream.
+    /// Sticky — once flipped, `next()` never returns to speculation.
+    private mutating func switchToPassthrough(reason: String) {
+        if passthroughReason == nil {
+            // One-time only; stdlib `print` is intentional — the iterator is a
+            // low-level component without access to a logger.
+            print("[SpeculativeTokenIterator] passthrough mode: \(reason)")
+            passthroughReason = reason
+        }
+        passthrough = true
     }
 
     mutating public func next() -> Int? {
@@ -1337,7 +1443,10 @@ extension SpeculativeTokenIterator: GenerationFinalizingTokenIterator {
         let mainConsumed = Swift.min(pendingIndex, mainCommittedPendingTokenCount)
         let mainLookahead = mainCommittedPendingTokenCount - mainConsumed
         if mainLookahead > 0 {
-            mainCacheStorage.trim(mainLookahead)
+            // The staged-round commit recorded how to take back positions a
+            // trim cannot (a wrapped sliding-window ring); `rewindLastRound`
+            // uses that record and falls back to a plain trim otherwise.
+            mainCacheStorage.rewindLastRound(mainLookahead)
         }
 
         let draftConsumed = Swift.min(pendingIndex, draftCommittedPendingTokenCount)

--- a/Libraries/MLXLMCommon/InferenceState.swift
+++ b/Libraries/MLXLMCommon/InferenceState.swift
@@ -49,11 +49,23 @@ package func prepareInferenceState(
 ///
 /// All custom checkpoint loaders should finalize through this function so
 /// inference-only optimizations are applied consistently.
+///
+/// Weights matching `deferredWeightPrefixes` are left lazy, see
+/// ``DeferredWeightsProviding``. Everything else is realized here.
 @discardableResult
 package func materializeModelForInference(
-    _ model: BaseLanguageModel
+    _ model: BaseLanguageModel,
+    deferredWeightPrefixes: [String] = []
 ) -> InferenceStatePreparationReport {
     let report = prepareInferenceState(in: model)
-    eval(model)
+    if deferredWeightPrefixes.isEmpty {
+        eval(model)
+    } else {
+        let materialized = model.parameters().flattened()
+            .compactMap { key, value in
+                isDeferredWeight(key, prefixes: deferredWeightPrefixes) ? nil : value
+            }
+        eval(materialized)
+    }
     return report
 }

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -37,6 +37,31 @@ public protocol AdditionalWeightFilesProviding {
     var additionalWeightFiles: [String] { get }
 }
 
+/// Weights that stay lazy at load time and materialize on first use.
+///
+/// `loadWeights` normally evaluates every tensor while loading, so the whole checkpoint is
+/// resident before the first token. A model can conform to this protocol to keep some
+/// weights lazy: they are still read, sanitized, verified, and assigned to the module tree
+/// as usual, but their bytes stay in the (memory-mapped) checkpoint until the first
+/// evaluation that uses them.
+///
+/// The motivating case is a VLM serving text-only requests: MuseGlimmer's unquantized
+/// vision stack is ~3.7 GB that a text session never touches, and on a 24 GB machine that
+/// is the difference between fitting inside and spilling past Metal's wired-memory limit.
+///
+/// The trade-offs are that the checkpoint files must remain readable until the deferred
+/// weights are first used, and that first use pays the read inside the evaluation instead
+/// of at load time.
+public protocol DeferredWeightsProviding {
+    /// Weight-name prefixes whose tensors stay lazy at load time.
+    ///
+    /// Prefixes are module paths in the post-`sanitize` layout (e.g. `"vision_tower."`).
+    /// They are matched both at the start of a name and after any `.`, so raw checkpoint
+    /// names that carry an extra leading scope (e.g. `model.vision_tower.`) are also
+    /// covered before `sanitize` runs.
+    var deferredWeightPrefixes: [String] { get }
+}
+
 /// Optional metadata a model wants written into converted safetensors.
 ///
 /// Model-specific metadata lets future loaders distinguish transformed MLX-native

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -151,7 +151,18 @@ private final class ConcurrentLoadState: @unchecked Sendable {
 /// range's I/O inside the work item), and the results are merged in file order. A file whose
 /// header cannot be parsed is loaded whole by one work item, which is exactly the serial
 /// loader's behavior for that file.
-func loadWeightArrays(urls: [URL]) throws -> (
+/// Whether `key` names a weight under one of `prefixes`.
+///
+/// Weight names are matched both before `sanitize` (raw checkpoint keys, which may carry an
+/// extra leading scope such as `model.`) and after (module paths), so a prefix matches at
+/// the start of the key or after any `.`.
+func isDeferredWeight(_ key: String, prefixes: [String]) -> Bool {
+    prefixes.contains { key.hasPrefix($0) || key.contains("." + $0) }
+}
+
+func loadWeightArrays(
+    urls: [URL], deferredWeightPrefixes: [String] = []
+) throws -> (
     weights: [String: MLXArray], metadata: [String: String]
 ) {
     struct WorkItem {
@@ -208,8 +219,15 @@ func loadWeightArrays(urls: [URL]) throws -> (
                 selected = all
             }
 
-            // force this range's I/O here, on this stream, in file-offset order
-            if !selected.isEmpty { eval(Array(selected.values)) }
+            // force this range's I/O here, on this stream, in file-offset order --
+            // except deferred weights, which stay lazy until their first use
+            let toEval =
+                deferredWeightPrefixes.isEmpty
+                ? Array(selected.values)
+                : selected.compactMap { key, value in
+                    isDeferredWeight(key, prefixes: deferredWeightPrefixes) ? nil : value
+                }
+            if !toEval.isEmpty { eval(toEval) }
             state.merge(file: item.file, weights: selected, metadata: metadata)
         } catch {
             state.record(error: error)
@@ -375,11 +393,14 @@ public func loadWeights(
     var weights = [String: MLXArray]()
     var metadata = [String: String]()
     let additionalFiles = (model as? any AdditionalWeightFilesProviding)?.additionalWeightFiles
+    let deferredPrefixes =
+        (model as? any DeferredWeightsProviding)?.deferredWeightPrefixes ?? []
     let weightURLs = try safetensorWeightURLs(
         in: modelDirectory,
         selection: weightFileSelection,
         additionalFiles: additionalFiles ?? [])
-    (weights, metadata) = try loadWeightArrays(urls: weightURLs)
+    (weights, metadata) = try loadWeightArrays(
+        urls: weightURLs, deferredWeightPrefixes: deferredPrefixes)
 
     // per-model cleanup (models can inspect metadata to customize behavior)
     weights = model.sanitize(weights: weights, metadata: metadata)
@@ -405,7 +426,7 @@ public func loadWeights(
 
     // Build derived inference-only state and realize the model while the loader
     // still has exclusive access. Forward passes must remain read-only.
-    materializeModelForInference(model)
+    materializeModelForInference(model, deferredWeightPrefixes: deferredPrefixes)
 }
 
 /// Async variant of

--- a/Libraries/MLXLMCommon/PromptLookupDecoding.swift
+++ b/Libraries/MLXLMCommon/PromptLookupDecoding.swift
@@ -1,0 +1,258 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Prompt-lookup (n-gram) speculative decoding.
+///
+/// A coding/agentic workload constantly regenerates spans that already exist in
+/// the context — identifiers, signatures, edited code, tool-call scaffolding.
+/// Decode throughput of a large dense model is memory-bandwidth-bound (every
+/// generated token reads all weights once), so the way past that roofline is
+/// emitting more than one token per weight pass. Prompt-lookup decoding drafts
+/// continuation candidates by longest-suffix n-gram match against the tokens
+/// already seen, and the main model verifies `numDraftTokens + 1` positions in
+/// a single forward — the same weight reads as one decode step. No second
+/// model, no additional weight memory.
+///
+/// This is the technique behind vLLM's `ngram` speculator and llama.cpp's
+/// lookup decoding. As there, a draft is accepted only when it matches the
+/// verifier's own sampled token, so the emitted stream is exactly what the
+/// main model would have produced on its own — prompt lookup changes how fast
+/// tokens come out, never which tokens.
+///
+/// The drafter plugs into ``SpeculativeTokenIterator`` as a synthetic
+/// ``LanguageModel``: its "KV cache" is the raw token history (so the
+/// iterator's rewind-on-reject trims it like a real cache) and its logits are
+/// a one-hot row over the vocabulary.
+
+/// Token-history "KV cache" for the prompt-lookup drafter.
+///
+/// `offset`/`trim` mirror a real cache so ``SpeculativeTokenIterator``'s
+/// bookkeeping (rewind of rejected drafts, processed-token ledger) applies to
+/// the drafter's view of history exactly as it does to the main model's KV.
+package final class PromptLookupTokenCache: KVCache {
+    package var tokens: [Int32] = []
+
+    package init() {}
+
+    package var offset: Int { tokens.count }
+    package var maxSize: Int? { nil }
+
+    package func append(_ newTokens: [Int32]) {
+        tokens.append(contentsOf: newTokens)
+    }
+
+    package var isTrimmable: Bool { true }
+
+    @discardableResult
+    package func trim(_ n: Int) -> Int {
+        let trimmed = min(max(n, 0), tokens.count)
+        tokens.removeLast(trimmed)
+        return trimmed
+    }
+
+    package func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        fatalError("PromptLookupTokenCache stores tokens, not K/V tensors")
+    }
+
+    package var state: [MLXArray] {
+        get { [MLXArray(tokens)] }
+        set { tokens = newValue.first?.asArray(Int32.self) ?? [] }
+    }
+
+    package var metaState: [String] {
+        get { [""] }
+        set {}
+    }
+
+    package func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        .none
+    }
+
+    package func copy() -> any KVCache {
+        let copy = PromptLookupTokenCache()
+        copy.tokens = tokens
+        return copy
+    }
+
+    package func innerState() -> [MLXArray] { [] }
+}
+
+/// Draft model that proposes continuations by n-gram lookup over its own
+/// token history (prompt plus accepted generation).
+///
+/// Matching follows vLLM's ngram proposer and llama.cpp's lookup decoding:
+/// the longest current suffix of length `maxNGram ... minNGram` is matched
+/// against the most recent earlier occurrence, and subsequent draft positions
+/// block-copy the tokens that followed the match. When the copied stream stops
+/// being accepted, the drafter re-matches from scratch; when no match exists
+/// it proposes a repeat of the last token, which the verifier then rejects at
+/// the ordinary cost of one round.
+///
+/// Use it anywhere a draft ``LanguageModel`` is accepted:
+///
+/// ```swift
+/// let drafter = PromptLookupDraftModel(
+///     configuration: .init(vocabularySize: 202_048))
+/// let stream = try generate(
+///     input: input, parameters: parameters, context: context,
+///     draftModel: drafter, numDraftTokens: 3)
+/// ```
+///
+/// or through ``ChatSession`` with
+/// ``SpeculativeDecodingConfig/init(lookup:numDraftTokens:)``.
+public final class PromptLookupDraftModel: Module, LanguageModel {
+
+    public struct Configuration: Sendable, Hashable {
+        /// Width of the one-hot draft logits. Must cover every token id the
+        /// model can produce (the language model's vocabulary size, not the
+        /// tokenizer's entry count when they differ).
+        public var vocabularySize: Int
+
+        /// Longest suffix the drafter tries to match (vLLM `prompt_lookup_max`).
+        public var maxNGram: Int
+
+        /// Shortest suffix worth matching (vLLM `prompt_lookup_min`). With
+        /// exact-match acceptance a short match cannot corrupt output — it can
+        /// only lower the acceptance rate — so 1 is a safe default.
+        public var minNGram: Int
+
+        /// Cap on how far back the fresh-match scan walks, bounding host-side
+        /// cost on very long histories. `nil` scans the whole history.
+        public var maxLookback: Int?
+
+        public init(
+            vocabularySize: Int,
+            maxNGram: Int = 4,
+            minNGram: Int = 1,
+            maxLookback: Int? = nil
+        ) {
+            precondition(vocabularySize > 0, "vocabularySize must be positive")
+            precondition(
+                maxNGram >= minNGram && minNGram >= 1,
+                "require maxNGram >= minNGram >= 1")
+            self.vocabularySize = vocabularySize
+            self.maxNGram = maxNGram
+            self.minNGram = minNGram
+            self.maxLookback = maxLookback
+        }
+    }
+
+    public let configuration: Configuration
+
+    /// Index into the history of the next token to block-copy, valid while the
+    /// previous prediction keeps landing in the history unchanged.
+    private var continuationSource: Int?
+    private var lastPrediction: Int32?
+
+    /// A logit large enough that softmax at any practical temperature puts all
+    /// probability on the predicted token (e^(100/T) dwarfs a vocabulary of
+    /// e^0 entries for T ≲ 5), yet small enough to survive logit processors.
+    private static let oneHotLogit: Float = 100
+
+    public init(configuration: Configuration) {
+        self.configuration = configuration
+        super.init()
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] { weights }
+
+    public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        [PromptLookupTokenCache()]
+    }
+
+    public func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        guard let history = cache.first as? PromptLookupTokenCache else {
+            throw KVCacheError(
+                message: "PromptLookupDraftModel requires its own token-history cache")
+        }
+        var tokens = input.text.tokens
+        if tokens.ndim == 2 { tokens = tokens[0] }
+        history.append(tokens.asArray(Int32.self))
+        continuationSource = nil
+        lastPrediction = nil
+        let total = input.text.tokens.size
+        prefill.progress?(total, total)
+        return .logits(LMOutput(logits: oneHotLogits(predict(history.tokens))))
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        guard let history = cache?.first as? PromptLookupTokenCache else {
+            fatalError("PromptLookupDraftModel requires its own token-history cache")
+        }
+        history.append(inputs.reshaped(-1).asArray(Int32.self))
+        return oneHotLogits(predict(history.tokens))
+    }
+
+    /// Next-token proposal: continue the current block copy when the previous
+    /// prediction landed, otherwise longest-suffix match, most recent
+    /// occurrence wins.
+    func predict(_ history: [Int32]) -> Int32 {
+        guard let last = history.last else {
+            continuationSource = nil
+            lastPrediction = nil
+            return 0
+        }
+
+        // Block copy: the verifier accepted (or the draft loop appended) our
+        // previous prediction, so keep copying the same source span.
+        if let source = continuationSource, lastPrediction == last, source < history.count - 1 {
+            let prediction = history[source]
+            continuationSource = source + 1
+            lastPrediction = prediction
+            return prediction
+        }
+
+        let count = history.count
+        let floor = configuration.maxLookback.map { Swift.max(0, count - $0) } ?? 0
+        var n = Swift.min(configuration.maxNGram, count - 1)
+        while n >= configuration.minNGram {
+            let suffixStart = count - n
+            var i = count - n - 1
+            while i >= floor {
+                if history[i] == history[suffixStart] {
+                    var matches = true
+                    var j = 1
+                    while j < n {
+                        if history[i + j] != history[suffixStart + j] {
+                            matches = false
+                            break
+                        }
+                        j += 1
+                    }
+                    if matches {
+                        let prediction = history[i + n]
+                        continuationSource = i + n + 1
+                        lastPrediction = prediction
+                        return prediction
+                    }
+                }
+                i -= 1
+            }
+            n -= 1
+        }
+
+        // No match: propose a repeat of the last token. The verifier rejects a
+        // wrong guess at the same weight-read cost as one plain decode step.
+        continuationSource = nil
+        lastPrediction = last
+        return last
+    }
+
+    /// `[1, 1, vocabularySize]` one-hot row; any sampler recovers the
+    /// prediction because the hot logit dominates the softmax.
+    private func oneHotLogits(_ token: Int32) -> MLXArray {
+        precondition(
+            Int(token) < configuration.vocabularySize,
+            "predicted token \(token) exceeds vocabularySize \(configuration.vocabularySize)")
+        let logits = MLXArray.zeros([1, 1, configuration.vocabularySize], type: Float.self)
+        logits[0, 0, Int(token)] = MLXArray(Self.oneHotLogit)
+        return logits
+    }
+}

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -17,8 +17,9 @@ import MLXNN
 //   - Full-attention layers get *no* positional encoding (`layer_rope_theta` is
 //     0 for them), while sliding layers use theta 500000.
 //   - Attention output is gated: `output * sigmoid(gate_proj(x))`.
-//   - Queries are multiplied by `qk_scale_factor` (3.87) *in addition to* the
-//     usual `1/sqrt(head_dim)` softmax scale.
+//   - Attention applies `qk_scale_factor` (3.87) *in addition to* the usual
+//     `1/sqrt(head_dim)` softmax scale (folded into the SDPA scale here; the
+//     reference multiplies it into the queries — same expression).
 //   - The ViT does window attention by permuting tokens into contiguous windows
 //     and running chunked SDPA — no banded mask is ever materialized.
 
@@ -454,7 +455,11 @@ private class MuseGlimmerTextAttention: Module {
         var keys = keyProj(x).reshaped(batch, length, kvHeads, headDimensions)
         var values = valueProj(x).reshaped(batch, length, kvHeads, headDimensions)
 
-        queries = (qkNorm(queries) * qkScaleFactor).transposed(0, 2, 1, 3)
+        // `qkScaleFactor` is folded into the SDPA softmax scale rather than
+        // multiplied into the bf16 queries: same expression, but it skips one
+        // elementwise kernel per layer and applies the factor in the kernel's
+        // fp32 accumulation. Greedy-token identical to the reference ordering.
+        queries = qkNorm(queries).transposed(0, 2, 1, 3)
         keys = qkNorm(keys).transposed(0, 2, 1, 3)
         values = values.transposed(0, 2, 1, 3)
 
@@ -469,7 +474,7 @@ private class MuseGlimmerTextAttention: Module {
             keys: keys,
             values: values,
             cache: cache,
-            scale: scale,
+            scale: scale * qkScaleFactor,
             mask: mask
         )
         output = output.transposed(0, 2, 1, 3).reshaped(batch, length, -1)

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -1501,9 +1501,14 @@ public struct MuseGlimmerProcessor: UserInputProcessor {
             messages: messages, tools: input.tools, additionalContext: input.additionalContext)
 
         guard !input.images.isEmpty else {
+            // Deliberately no attention mask: a batch-of-one text prompt has
+            // nothing to pad, the language model never reads `LMInput.text.mask`
+            // (its layer masks are built from the KV caches), and a non-nil mask
+            // makes `ChatSession` treat the turn as non-resumable — vetoing
+            // prompt-cache reuse (`carriesAttentionMask`) and forcing a full
+            // re-prefill of the conversation on every agentic turn.
             let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
-            let mask = ones(like: promptArray).asType(.int8)
-            return LMInput(text: .init(tokens: promptArray, mask: mask))
+            return LMInput(text: .init(tokens: promptArray))
         }
 
         let processed = try input.images.map {

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -253,6 +253,58 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
     }
 }
 
+// MARK: - Compiled fusions
+
+// Muse-Glimmer's block norms run 4× per layer × 52 layers for every decoded
+// token. Executed eagerly, each `MuseCenteredRMSNorm` is ~7 tiny kernel
+// launches and per-op dispatch dominates decode time. `compile` collapses the
+// elementwise regions into single kernels while executing the *same
+// operations in the same order and dtypes* as the eager reference, so outputs
+// are bit-for-bit identical (verified against the eager path on random inputs
+// and by end-to-end greedy-token comparison on the 30B checkpoint). This is
+// the same technique — with the same rationale — as `Gemma4Text.swift`.
+
+/// Exact fusion of the `MuseCenteredRMSNorm` body. `eps` arrives as a scalar
+/// fp32 array so the two eps values in play (`rms_norm_eps` for the pre-norms,
+/// `post_norm_eps` for the post-norms) share one compiled function.
+private let _centeredRMSNorm: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray =
+    compile(shapeless: true) { x, weight, eps in
+        let dtype = x.dtype
+        let f = x.asType(.float32)
+        let variance = mean(f * f, axis: -1, keepDims: true)
+        var out = f * rsqrt(variance + eps)
+        out = out * (1.0 + weight.asType(.float32))
+        return out.asType(dtype)
+    }
+
+/// `residual + centeredRMSNorm(x)` — the post-attention / post-MLP pattern in
+/// `MuseGlimmerDecoderLayer`. Args: `[residual, x, weight, eps]`.
+private let _addCenteredRMSNorm: @Sendable ([MLXArray]) -> [MLXArray] =
+    compile(shapeless: true) { args in
+        let (residual, x, weight, eps) = (args[0], args[1], args[2], args[3])
+        let dtype = x.dtype
+        let f = x.asType(.float32)
+        let variance = mean(f * f, axis: -1, keepDims: true)
+        var out = f * rsqrt(variance + eps)
+        out = out * (1.0 + weight.asType(.float32))
+        return [residual + out.asType(dtype)]
+    }
+
+/// `output * sigmoid(gate)` — the attention output gate.
+private let _sigmoidGate: @Sendable (MLXArray, MLXArray) -> MLXArray =
+    compile(shapeless: true) { output, gate in
+        output * sigmoid(gate)
+    }
+
+/// Hides a constant `MLXArray` from `Module` parameter reflection. The block
+/// norms keep their `eps` as a prebuilt scalar array for the compiled calls;
+/// storing it as a bare `MLXArray` property would make weight verification
+/// expect a matching checkpoint key.
+private final class ConstantBox {
+    let value: MLXArray
+    init(_ value: MLXArray) { self.value = value }
+}
+
 // MARK: - Norms
 
 /// RMS norm with no learnable scale — `mx.fast.rms_norm(x, None, eps)`.
@@ -280,24 +332,30 @@ private class MuseRMSNormNoScale: Module, UnaryLayer {
 /// Not the same as `MLXNN.RMSNorm` (which uses `weight` directly) and not
 /// mean-subtracting despite the name. The fp32 cast ordering follows the
 /// reference exactly — folding `1 + weight` in bf16 instead drifts enough to
-/// change decode choices.
+/// change decode choices. `MLXFast.rmsNorm(x, weight: 1 + w_f32, eps:)` is
+/// also *not* equivalent: its multiply association differs and drifts by
+/// 1 bf16 ulp on ~every call (measured). The forward therefore runs the exact
+/// reference arithmetic through `_centeredRMSNorm` / `_addCenteredRMSNorm`,
+/// which only fuse kernel launches.
 private class MuseCenteredRMSNorm: Module, UnaryLayer {
     @ModuleInfo var weight: MLXArray
     let eps: Float
+    private let epsArray: ConstantBox
 
     init(dimensions: Int, eps: Float) {
         self._weight.wrappedValue = MLXArray.zeros([dimensions])
         self.eps = eps
+        self.epsArray = ConstantBox(MLXArray(eps))
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        let dtype = x.dtype
-        let f = x.asType(.float32)
-        let variance = mean(f * f, axis: -1, keepDims: true)
-        var out = f * rsqrt(variance + eps)
-        out = out * (1.0 + weight.asType(.float32))
-        return out.asType(dtype)
+        _centeredRMSNorm(x, weight, epsArray.value)
+    }
+
+    /// `residual + self(x)` as one compiled graph.
+    func addedTo(_ residual: MLXArray, _ x: MLXArray) -> MLXArray {
+        _addCenteredRMSNorm([residual, x, weight, epsArray.value])[0]
     }
 }
 
@@ -318,7 +376,8 @@ private class MuseGlimmerTextMLP: Module, UnaryLayer {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        downProj(silu(gateProj(x)) * upProj(x))
+        // Compiled `silu(gate) * up` — identical arithmetic, one kernel.
+        downProj(compiledSiluProduct(gateProj(x), upProj(x)))
     }
 }
 
@@ -416,7 +475,7 @@ private class MuseGlimmerTextAttention: Module {
         output = output.transposed(0, 2, 1, 3).reshaped(batch, length, -1)
 
         // Gate is computed from the layer input, not the attention output.
-        output = output * sigmoid(gateProj(x))
+        output = _sigmoidGate(output, gateProj(x))
         return outputProj(output)
     }
 }
@@ -457,11 +516,9 @@ private class MuseGlimmerDecoderLayer: Module {
         mask: MLXFast.ScaledDotProductAttentionMaskMode,
         cache: KVCache?
     ) -> MLXArray {
-        var h =
-            x
-            + postAttentionLayerNorm(
-                selfAttention(inputLayerNorm(x), mask: mask, cache: cache))
-        h = h + postFeedforwardLayerNorm(mlp(preFeedforwardLayerNorm(h)))
+        var h = postAttentionLayerNorm.addedTo(
+            x, selfAttention(inputLayerNorm(x), mask: mask, cache: cache))
+        h = postFeedforwardLayerNorm.addedTo(h, mlp(preFeedforwardLayerNorm(h)))
         return h
     }
 }
@@ -1188,6 +1245,7 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
             }
             result[key] = value
         }
+
         return result
     }
 }
@@ -1195,6 +1253,22 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
 extension MuseGlimmer: LoRAModel {
     public var loraLayers: [Module] {
         languageModel.model.layers
+    }
+}
+
+extension MuseGlimmer: DeferredWeightsProviding {
+    /// The vision stack loads lazily by default.
+    ///
+    /// The checkpoint's vision weights are unquantized (~3.7 GB of bf16 in the 4-bit
+    /// repo) and a text-only session never evaluates them, so materializing them at
+    /// load time only pushes the working set past Metal's wired limit on 24 GB
+    /// machines (19.4 GB vs a 19.07 GB `recommendedMaxWorkingSetSize` on an M4 Pro).
+    /// Deferring them cuts the resident model to ~15.7 GB with bit-identical text
+    /// output. The first image or video input evaluates the tower, which reads the
+    /// weights from the memory-mapped checkpoint at that point -- image results are
+    /// unchanged, they just pay the read on first use.
+    public var deferredWeightPrefixes: [String] {
+        ["vision_tower.", "vision_adapter.", "vision_projection."]
     }
 }
 

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -1279,6 +1279,63 @@ public class ChatSessionTests: XCTestCase {
         XCTAssertNil(completionInfo?.speculativeDecodingTelemetry)
     }
 
+    func testPromptLookupSpeculationEmitsTelemetryAcrossTurns() async throws {
+        let session = ChatSession(
+            model(),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                lookup: .init(vocabularySize: 100), numDraftTokens: 3),
+            generateParameters: GenerateParameters(maxTokens: 6, temperature: 0))
+
+        let first = try await collectGeneration(session.streamDetails(to: "first"))
+        XCTAssertFalse(first.text.isEmpty)
+        let firstTelemetry = try XCTUnwrap(first.info.speculativeDecodingTelemetry)
+        XCTAssertGreaterThan(firstTelemetry.roundCount, 0)
+        XCTAssertEqual(firstTelemetry.emittedTokenCount, first.info.generationTokenCount)
+
+        // The default test tokenizer renders a fresh prompt every turn, so the
+        // second turn takes the rebuild path and must recreate the drafter's
+        // token history rather than fall back to plain generation.
+        let second = try await collectGeneration(session.streamDetails(to: "second"))
+        XCTAssertFalse(second.text.isEmpty)
+        let secondTelemetry = try XCTUnwrap(second.info.speculativeDecodingTelemetry)
+        XCTAssertGreaterThan(secondTelemetry.roundCount, 0)
+    }
+
+    func testPromptLookupSpeculationReusesMainCacheAcrossTurns() async throws {
+        let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
+        var lengthIterator = renderedLengths.makeAsyncIterator()
+        let tokenizer = PrefixPreservingTokenizer(renderedLengthContinuation: continuation)
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: ModelConfiguration(id: "test"),
+            messageGenerator: DefaultMessageGenerator())
+        let session = ChatSession(
+            model(processor: processor),
+            speculativeDecoding: SpeculativeDecodingConfig(
+                lookup: .init(vocabularySize: 100), numDraftTokens: 2),
+            generateParameters: GenerateParameters(maxTokens: 3, temperature: 0))
+
+        _ = try await session.respond(to: "first")
+        let firstRenderedLengthValue = await lengthIterator.next()
+        let firstRenderedLength = try XCTUnwrap(firstRenderedLengthValue)
+
+        var completionInfo: GenerateCompletionInfo?
+        for try await item in session.streamDetails(to: "second") {
+            if let info = item.info {
+                completionInfo = info
+            }
+        }
+
+        let secondRenderedLengthValue = await lengthIterator.next()
+        let secondRenderedLength = try XCTUnwrap(secondRenderedLengthValue)
+        let info = try XCTUnwrap(completionInfo)
+        // Reuse must survive speculation: the second turn prefilled at most the
+        // rendered suffix, never the whole transcript.
+        XCTAssertLessThanOrEqual(
+            info.promptTokenCount, secondRenderedLength - firstRenderedLength)
+        XCTAssertNotNil(info.speculativeDecodingTelemetry)
+    }
+
     func testActiveSpeculativeDecodingSafelyRebuildsAcrossTurns() async throws {
         let (renderedLengths, continuation) = AsyncStream<Int>.makeStream()
         var lengthIterator = renderedLengths.makeAsyncIterator()

--- a/Tests/MLXLMTests/MuseGlimmerTests.swift
+++ b/Tests/MLXLMTests/MuseGlimmerTests.swift
@@ -1016,8 +1016,27 @@ struct MuseGlimmerImageBudgetTests {
     }
 }
 
+@Suite("MuseGlimmer text-only prepare")
+struct MuseGlimmerTextOnlyPrepareTests {
+
+    /// A text-only turn must not carry an attention mask: a batch of one has
+    /// nothing to pad, the model never reads `LMInput.text.mask`, and
+    /// `ChatSession` treats a masked input as non-resumable — vetoing prompt
+    /// cache reuse and re-prefilling the whole conversation on every agentic
+    /// turn.
+    @Test("text-only input carries no attention mask")
+    func noMaskWithoutImages() async throws {
+        let processor = MuseGlimmerProcessor(
+            MuseGlimmerProcessorConfiguration(),
+            tokenizer: MuseGlimmerStubTokenizer())
+        let input = try await processor.prepare(input: UserInput(prompt: "hello"))
+        #expect(input.text.mask == nil)
+        #expect(input.text.tokens.shape == [1, 4])
+    }
+}
+
 /// Minimal tokenizer: the budget tests only exercise `preprocess`, which never
-/// touches it.
+/// touches it, and the text-only prepare test only needs a fixed template.
 private struct MuseGlimmerStubTokenizer: Tokenizer {
     func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
     func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
@@ -1030,7 +1049,7 @@ private struct MuseGlimmerStubTokenizer: Tokenizer {
         messages: [[String: any Sendable]],
         tools: [[String: any Sendable]]?,
         additionalContext: [String: any Sendable]?
-    ) throws -> [Int] { [] }
+    ) throws -> [Int] { [1, 2, 3, 4] }
 }
 
 @Suite("MuseGlimmer agentic protocol")

--- a/Tests/MLXLMTests/PromptLookupDecodingTests.swift
+++ b/Tests/MLXLMTests/PromptLookupDecodingTests.swift
@@ -1,0 +1,236 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import Testing
+
+@testable import MLXLMCommon
+
+/// Deterministic verifier whose `prepare` returns `.logits`, the shape of every
+/// wired VLM prefill (and of `ChatSession`'s Muse path). Each logit row predicts
+/// a high-margin transition from the token at the same position, so batched
+/// verification and token-by-token decoding compute the same function and any
+/// equality failure points at the speculative plumbing, not at kernel drift.
+private final class TransitionOracleModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let vocabularySize: Int
+    var kvHeads: [Int] { [] }
+
+    init(vocabularySize: Int) {
+        self.vocabularySize = vocabularySize
+        super.init()
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?,
+        prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        let total = input.text.tokens.size
+        prefill.progress?(total, total)
+        return .logits(LMOutput(logits: callAsFunction(input.text.tokens, cache: nil)))
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenIds = inputs.reshaped(-1).asArray(Int.self)
+        var logits = [Float](repeating: -100, count: tokenIds.count * vocabularySize)
+        for (position, token) in tokenIds.enumerated() {
+            logits[position * vocabularySize + (token * 31 + 7) % vocabularySize] = 100
+        }
+        return MLXArray(logits, [1, tokenIds.count, vocabularySize])
+    }
+}
+
+@Suite("Prompt-lookup decoding")
+struct PromptLookupDecodingTests {
+
+    private func drafter(
+        maxNGram: Int = 4, minNGram: Int = 1, maxLookback: Int? = nil
+    ) -> PromptLookupDraftModel {
+        PromptLookupDraftModel(
+            configuration: .init(
+                vocabularySize: 100, maxNGram: maxNGram, minNGram: minNGram,
+                maxLookback: maxLookback))
+    }
+
+    // MARK: - Token-history cache
+
+    @Test func tokenCacheTracksAppendsAndClampsTrims() {
+        let cache = PromptLookupTokenCache()
+        #expect(cache.offset == 0)
+        #expect(cache.isTrimmable)
+        cache.append([1, 2, 3, 4])
+        #expect(cache.offset == 4)
+        #expect(cache.trim(2) == 2)
+        #expect(cache.tokens == [1, 2])
+        #expect(cache.trim(5) == 2)
+        #expect(cache.offset == 0)
+        #expect(cache.trim(-3) == 0)
+    }
+
+    @Test func tokenCacheCopyIsIndependent() {
+        let cache = PromptLookupTokenCache()
+        cache.append([9, 8, 7])
+        guard let copy = cache.copy() as? PromptLookupTokenCache else {
+            Issue.record("copy() changed the cache type")
+            return
+        }
+        copy.append([6])
+        #expect(cache.tokens == [9, 8, 7])
+        #expect(copy.tokens == [9, 8, 7, 6])
+    }
+
+    @Test func tokenCacheStateRoundTripsThroughMLXArrays() {
+        let cache = PromptLookupTokenCache()
+        cache.append([5, 6, 7])
+        let restored = PromptLookupTokenCache()
+        restored.state = cache.state
+        #expect(restored.tokens == [5, 6, 7])
+        #expect(restored.offset == 3)
+    }
+
+    // MARK: - n-gram matching
+
+    @Test func predictsTheContinuationOfTheLongestSuffixMatch() {
+        #expect(drafter().predict([1, 2, 3, 4, 7, 5, 1, 2, 3, 4]) == 7)
+    }
+
+    @Test func mostRecentOccurrenceWins() {
+        // [3, 4] occurs twice with different continuations; the later one is used.
+        #expect(drafter(maxNGram: 2).predict([3, 4, 8, 0, 3, 4, 9, 1, 3, 4]) == 9)
+    }
+
+    @Test func acceptedPredictionsBlockCopyTheMatchedSpan() {
+        let model = drafter()
+        var history: [Int32] = [1, 2, 3, 4, 5, 6, 9, 1, 2, 3]
+        var predicted = [Int32]()
+        for _ in 0 ..< 3 {
+            let token = model.predict(history)
+            predicted.append(token)
+            history.append(token)  // the verifier accepted it
+        }
+        #expect(predicted == [4, 5, 6])
+    }
+
+    @Test func rejectedPredictionTriggersAFreshMatch() {
+        let model = drafter()
+        #expect(model.predict([1, 2, 3, 4, 7, 5, 1, 2, 3, 4]) == 7)
+        // The verifier sampled 5 instead of the predicted 7: the stale block
+        // copy must be abandoned and the suffix re-matched from scratch.
+        #expect(model.predict([1, 2, 3, 4, 7, 5, 1, 2, 3, 4, 5]) == 1)
+    }
+
+    @Test func minNGramSuppressesShortMatches() {
+        // Only a 1-gram match exists; with minNGram 2 it must be skipped and
+        // the drafter falls back to repeating the last token.
+        #expect(drafter(maxNGram: 3, minNGram: 2).predict([1, 5, 2, 9, 5]) == 5)
+        #expect(drafter(maxNGram: 3, minNGram: 1).predict([1, 5, 2, 9, 5]) == 2)
+    }
+
+    @Test func maxLookbackBoundsTheScan() {
+        // The only [7, 8] match starts at position 0, outside a lookback of 4.
+        #expect(drafter(maxNGram: 2, maxLookback: 4).predict([7, 8, 3, 0, 1, 2, 7, 8]) == 8)
+        #expect(drafter(maxNGram: 2).predict([7, 8, 3, 0, 1, 2, 7, 8]) == 3)
+    }
+
+    @Test func emptyHistoryProposesTokenZero() {
+        #expect(drafter().predict([]) == 0)
+    }
+
+    @Test func configurationRejectsInvalidNGramBounds() {
+        // Covered by preconditions at init; here pin the valid boundary.
+        let configuration = PromptLookupDraftModel.Configuration(
+            vocabularySize: 1, maxNGram: 1, minNGram: 1)
+        #expect(configuration.maxNGram == 1)
+    }
+
+    // MARK: - one-hot logits
+
+    @Test func prepareEmitsOneHotLogitsForTheMatchedContinuation() throws {
+        let model = drafter()
+        let cache = try model.newCache(parameters: nil)
+        let result = try model.prepare(
+            LMInput(tokens: MLXArray([1, 2, 3, 1, 2] as [Int32])),
+            cache: cache, state: nil, prefill: .init())
+        guard case .logits(let output) = result else {
+            Issue.record("prompt-lookup prepare must return logits")
+            return
+        }
+        #expect(output.logits.shape == [1, 1, 100])
+        #expect(output.logits.argMax(axis: -1).item(Int.self) == 3)
+    }
+
+    // MARK: - configuration surface
+
+    @Test func speculativeConfigExposesPromptLookup() {
+        let config = SpeculativeDecodingConfig(
+            lookup: .init(vocabularySize: 100), numDraftTokens: 4)
+        #expect(config.lookup != nil)
+        #expect(config.numDraftTokens == 4)
+        #expect(config.estimatedDraftModelBytes == nil)
+    }
+
+    // MARK: - end-to-end against a deterministic verifier
+
+    private func generate(
+        prompt: [Int32], maxTokens: Int, drafts: Int?
+    ) async throws -> (tokens: [Int], telemetry: SpeculativeDecodingTelemetry?) {
+        let vocabularySize = 100
+        let processor = TestInputProcessor(
+            tokenizer: TestTokenizer(vocabularySize: vocabularySize),
+            configuration: ModelConfiguration(id: "prompt-lookup-test"),
+            messageGenerator: DefaultMessageGenerator())
+        let context = ModelContext(
+            configuration: processor.configuration,
+            model: TransitionOracleModel(vocabularySize: vocabularySize),
+            processor: processor,
+            tokenizer: processor.tokenizer)
+        let input = LMInput(tokens: MLXArray(prompt))
+        let parameters = GenerateParameters(maxTokens: maxTokens, temperature: 0.0)
+
+        var tokens = [Int]()
+        var telemetry: SpeculativeDecodingTelemetry?
+        if let drafts {
+            for await generation in try generateTokens(
+                input: input, parameters: parameters, context: context,
+                draftModel: drafter(), numDraftTokens: drafts
+            ) {
+                if let token = generation.token { tokens.append(token) }
+                if let info = generation.info {
+                    telemetry = info.speculativeDecodingTelemetry
+                }
+            }
+        } else {
+            for await generation in try generateTokens(
+                input: input, parameters: parameters, context: context
+            ) {
+                if let token = generation.token { tokens.append(token) }
+            }
+        }
+        return (tokens, telemetry)
+    }
+
+    @Test(arguments: [2, 3, 8])
+    func promptLookupMatchesPlainGenerationOnRepetitiveContext(drafts: Int) async throws {
+        // The prompt repeats the transition orbit's opening span, so generated
+        // tokens re-enter known context and block copies land.
+        let prompt: [Int32] = [0, 7, 24, 51, 88, 35, 0]
+        let plain = try await generate(prompt: prompt, maxTokens: 24, drafts: nil)
+        let speculative = try await generate(prompt: prompt, maxTokens: 24, drafts: drafts)
+
+        #expect(plain.tokens.count == 24)
+        #expect(speculative.tokens == plain.tokens)
+        let telemetry = try #require(speculative.telemetry)
+        #expect(telemetry.acceptanceRate > 0)
+    }
+
+    @Test func promptLookupMatchesPlainGenerationWhenNothingMatches() async throws {
+        // No structure to copy: every proposal is the repeat-last fallback and
+        // the verifier rejects it, at no cost to correctness.
+        let prompt: [Int32] = [92, 85, 2, 95, 55]
+        let plain = try await generate(prompt: prompt, maxTokens: 16, drafts: nil)
+        let speculative = try await generate(prompt: prompt, maxTokens: 16, drafts: 3)
+
+        #expect(plain.tokens.count == 16)
+        #expect(speculative.tokens == plain.tokens)
+    }
+}

--- a/Tests/MLXLMTests/SpeculativeRoundRewindTests.swift
+++ b/Tests/MLXLMTests/SpeculativeRoundRewindTests.swift
@@ -1,0 +1,312 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import Testing
+
+@testable import MLXLMCommon
+
+/// Deterministic causal model that keeps a real sliding-window ring.
+///
+/// Logits depend only on the input token (high-margin affine transition), so
+/// batched verification and token-by-token decoding compute the same function;
+/// the K/V writes are real, so speculative rounds run against a genuine
+/// `RotatingKVCache` — including past the wrap, where the ring stops being
+/// trimmable and rejected drafts can only be taken back by a staged round.
+private final class RingTransitionModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let vocabularySize: Int
+    let windowSize: Int
+    var kvHeads: [Int] { [1] }
+
+    init(vocabularySize: Int, windowSize: Int) {
+        self.vocabularySize = vocabularySize
+        self.windowSize = windowSize
+        super.init()
+    }
+
+    func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        [RotatingKVCache(maxSize: windowSize, keep: 0)]
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenIds = inputs.reshaped(-1).asArray(Int.self)
+        if let first = cache?.first {
+            let entry = MLXArray.zeros([1, 1, tokenIds.count, 4])
+            _ = first.update(keys: entry, values: entry)
+        }
+        var logits = [Float](repeating: -100, count: tokenIds.count * vocabularySize)
+        for (position, token) in tokenIds.enumerated() {
+            logits[position * vocabularySize + (token * 31 + 7) % vocabularySize] = 100
+        }
+        return MLXArray(logits, [1, tokenIds.count, vocabularySize])
+    }
+}
+
+/// Cache-less deterministic model; `multiplier`/`increment` select whether it
+/// agrees with `RingTransitionModel` (31, 7) or diverges to force rejections.
+private final class CachelessTransitionModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let vocabularySize: Int
+    let multiplier: Int
+    let increment: Int
+    var kvHeads: [Int] { [] }
+
+    init(vocabularySize: Int, multiplier: Int = 31, increment: Int = 7) {
+        self.vocabularySize = vocabularySize
+        self.multiplier = multiplier
+        self.increment = increment
+        super.init()
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenIds = inputs.reshaped(-1).asArray(Int.self)
+        var logits = [Float](repeating: -100, count: tokenIds.count * vocabularySize)
+        for (position, token) in tokenIds.enumerated() {
+            logits[position * vocabularySize + (token * multiplier + increment) % vocabularySize] =
+                100
+        }
+        return MLXArray(logits, [1, tokenIds.count, vocabularySize])
+    }
+}
+
+/// Unknown-to-the-round-factory cache that mirrors `RotatingKVCache` through
+/// the predictive trimmability query: once `wrapAt` is crossed it can neither
+/// be staged (unsupported kind) nor trimmed, which is exactly the topology the
+/// iterator's passthrough fallback exists for.
+private final class WrapCountingKVCache: KVCache {
+    var offset: Int = 0
+    let wrapAt: Int
+
+    init(wrapAt: Int) {
+        self.wrapAt = wrapAt
+    }
+
+    var maxSize: Int? { wrapAt }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        offset += keys.dim(-2)
+        return (keys, values)
+    }
+
+    var state: [MLXArray] {
+        get { [] }
+        set {}
+    }
+
+    var metaState: [String] {
+        get { [] }
+        set {}
+    }
+
+    var isTrimmable: Bool { isTrimmable(after: 0) }
+
+    func isTrimmable(after positions: Int) -> Bool {
+        offset + positions < wrapAt
+    }
+
+    @discardableResult
+    func trim(_ n: Int) -> Int {
+        guard isTrimmable else { return 0 }
+        let removed = Swift.min(n, offset)
+        offset -= removed
+        return removed
+    }
+
+    func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        .none
+    }
+
+    func copy() -> any KVCache {
+        let copy = WrapCountingKVCache(wrapAt: wrapAt)
+        copy.offset = offset
+        return copy
+    }
+
+    func innerState() -> [MLXArray] { [] }
+}
+
+/// `CachelessTransitionModel` variant that owns a `WrapCountingKVCache`.
+private final class WrapCachedTransitionModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let vocabularySize: Int
+    let wrapAt: Int
+    let multiplier: Int
+    let increment: Int
+    var kvHeads: [Int] { [1] }
+
+    init(vocabularySize: Int, wrapAt: Int, multiplier: Int = 31, increment: Int = 7) {
+        self.vocabularySize = vocabularySize
+        self.wrapAt = wrapAt
+        self.multiplier = multiplier
+        self.increment = increment
+        super.init()
+    }
+
+    func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        [WrapCountingKVCache(wrapAt: wrapAt)]
+    }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state _: LMOutput.State?, prefill _: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenIds = inputs.reshaped(-1).asArray(Int.self)
+        if let first = cache?.first {
+            let entry = MLXArray.zeros([1, 1, tokenIds.count, 4])
+            _ = first.update(keys: entry, values: entry)
+        }
+        var logits = [Float](repeating: -100, count: tokenIds.count * vocabularySize)
+        for (position, token) in tokenIds.enumerated() {
+            logits[position * vocabularySize + (token * multiplier + increment) % vocabularySize] =
+                100
+        }
+        return MLXArray(logits, [1, tokenIds.count, vocabularySize])
+    }
+}
+
+@Suite("Speculative round rewind", .serialized)
+struct SpeculativeRoundRewindTests {
+
+    private let vocabularySize = 100
+    /// Opening span of the (t * 31 + 7) % 100 orbit.
+    private let prompt: [Int32] = [0, 7, 24, 51, 88, 35, 92]
+
+    private func plainTokens(model: any LanguageModel, maxTokens: Int) async throws -> [Int] {
+        let processor = TestInputProcessor(
+            tokenizer: TestTokenizer(vocabularySize: vocabularySize),
+            configuration: ModelConfiguration(id: "round-rewind-test"),
+            messageGenerator: DefaultMessageGenerator())
+        let context = ModelContext(
+            configuration: processor.configuration,
+            model: model,
+            processor: processor,
+            tokenizer: processor.tokenizer)
+        var tokens = [Int]()
+        for await generation in try generateTokens(
+            input: LMInput(tokens: MLXArray(prompt)),
+            parameters: GenerateParameters(maxTokens: maxTokens, temperature: 0.0),
+            context: context
+        ) {
+            if let token = generation.token { tokens.append(token) }
+        }
+        return tokens
+    }
+
+    private func speculativeRun(
+        mainModel: any LanguageModel,
+        draftModel: any LanguageModel,
+        maxTokens: Int,
+        numDraftTokens: Int
+    ) throws -> (tokens: [Int], iterator: SpeculativeTokenIterator) {
+        var iterator = try SpeculativeTokenIterator(
+            input: LMInput(tokens: MLXArray(prompt)),
+            mainModel: mainModel,
+            draftModel: draftModel,
+            parameters: GenerateParameters(maxTokens: maxTokens, temperature: 0.0),
+            numDraftTokens: numDraftTokens)
+        var tokens = [Int]()
+        while let token = iterator.next() {
+            tokens.append(token)
+        }
+        return (tokens, iterator)
+    }
+
+    @Test(arguments: [2, 3, 4])
+    func stagedRoundsMatchPlainGenerationAcrossTheWrap(drafts: Int) async throws {
+        // Window 16, prompt 7, 48 generated tokens: the ring wraps early and
+        // most rounds run in the regime a trim cannot rewind.
+        let main = RingTransitionModel(vocabularySize: vocabularySize, windowSize: 16)
+        let plain = try await plainTokens(model: main, maxTokens: 48)
+        #expect(plain.count == 48)
+
+        let accepting = try speculativeRun(
+            mainModel: main,
+            draftModel: CachelessTransitionModel(vocabularySize: vocabularySize),
+            maxTokens: 48, numDraftTokens: drafts)
+        #expect(accepting.tokens == plain)
+        #expect(accepting.iterator.passthroughReason == nil)
+        let telemetry = try #require(accepting.iterator.speculativeDecodingTelemetry)
+        #expect(telemetry.acceptanceRate > 0.9)
+    }
+
+    @Test(arguments: [2, 3, 4])
+    func rejectedRoundsRewindExactlyAcrossTheWrap(drafts: Int) async throws {
+        // A divergent drafter makes nearly every round commit `retaining` well
+        // below what it wrote — past the wrap that rewind is the staged path.
+        let main = RingTransitionModel(vocabularySize: vocabularySize, windowSize: 16)
+        let plain = try await plainTokens(model: main, maxTokens: 48)
+
+        let rejecting = try speculativeRun(
+            mainModel: main,
+            draftModel: CachelessTransitionModel(
+                vocabularySize: vocabularySize, multiplier: 17, increment: 13),
+            maxTokens: 48, numDraftTokens: drafts)
+        #expect(rejecting.tokens == plain)
+        #expect(rejecting.iterator.passthroughReason == nil)
+    }
+
+    @Test func unstageableWrappedMainCacheFallsBackToPassthrough() async throws {
+        // An unknown cache type is admitted write-through only while it can
+        // still trim; once it wraps the iterator must stop speculating and
+        // keep emitting the plain stream.
+        let main = WrapCachedTransitionModel(vocabularySize: vocabularySize, wrapAt: 12)
+        let plain = try await plainTokens(model: main, maxTokens: 32)
+        #expect(plain.count == 32)
+
+        let run = try speculativeRun(
+            mainModel: main,
+            draftModel: CachelessTransitionModel(vocabularySize: vocabularySize),
+            maxTokens: 32, numDraftTokens: 3)
+        #expect(run.tokens == plain)
+        let reason = try #require(run.iterator.passthroughReason)
+        #expect(reason.contains("main KV cache"))
+    }
+
+    @Test func draftCacheThatCannotRewindFallsBackToPassthrough() async throws {
+        // The drafter's own sliding window wraps; a rejected round then cannot
+        // take its drafts back out of the draft cache, so speculation stops
+        // rather than propose from a corrupted history.
+        let main = CachelessTransitionModel(vocabularySize: vocabularySize)
+        let plain = try await plainTokens(model: main, maxTokens: 32)
+
+        let run = try speculativeRun(
+            mainModel: main,
+            draftModel: WrapCachedTransitionModel(
+                vocabularySize: vocabularySize, wrapAt: 10, multiplier: 17, increment: 13),
+            maxTokens: 32, numDraftTokens: 3)
+        #expect(run.tokens == plain)
+        let reason = try #require(run.iterator.passthroughReason)
+        #expect(reason.contains("draft KV cache"))
+    }
+
+    @Test func cachelessDraftModelsKeepSpeculatingThroughRejections() async throws {
+        // `trim` on an empty cache list reports zero; that must not be read as
+        // a rewind failure for draft models that keep no KV state at all.
+        let main = CachelessTransitionModel(vocabularySize: vocabularySize)
+        let plain = try await plainTokens(model: main, maxTokens: 24)
+
+        let run = try speculativeRun(
+            mainModel: main,
+            draftModel: CachelessTransitionModel(
+                vocabularySize: vocabularySize, multiplier: 17, increment: 13),
+            maxTokens: 24, numDraftTokens: 3)
+        #expect(run.tokens == plain)
+        #expect(run.iterator.passthroughReason == nil)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Today while I was using Lampo for helping me with some coding tasks at work I discovered disappointing performance of the Muse Glimmer model. So I have implemented two decode-path optimizations for Muse-Glimmer-30B, both bit-identical to the reference:

**1. Compiled kernel fusions.** The model runs 4 `MuseCenteredRMSNorm`s × 52 layers per decoded token; eagerly that's ~7 kernel launches each and dispatch overhead dominates. Now fuses the norm body, residual-add+norm, attention sigmoid gate, and MLP `silu·up` with `compile(shapeless: true)`  same ops, same order, same dtypes as the eager code (same technique as `Gemma4Text.swift`). Verified bitwise-identical: 288/288 norm self-test vs the eager reference, plus end-to-end greedy token comparison on the 4-bit checkpoint. (Note: `MLXFast.rmsNorm` with a folded `1+weight` is *not* an equivalent rewrite  it drifts 1 bf16 ulp and changes decode choices; documented in-source.) @CharlieTLe please if you got time: review this.

**2. Vision weights lazy loading by default.** *Added`DeferredWeightsProviding` protocol, `Load.swift` plumbing, MuseGlimmer conformance, and the measurement table 19.42→15.68 GB, 4.55→3.44 s load, ~13.2→~15.0 tok/s decode, identical greedy tokens and vision checksum.)*

### Vision lazy loading

Muse-Glimmer-30B-4bit is a dense VLM whose vision tower ships unquantized (bf16, ~3.7 GB). Text-only users pay for it anyway: on a 24 GB M4 Pro the full 19.4 GB of weights exceeds the Metal wired limit (19.07 GB `recommendedMaxWorkingSetSize`), causing page eviction during decode and dropping throughput to ~13 tok/s.

This change set makes vision weights lazy **by default**, with no API changes required by callers.

#### Benchmarks

Measured on an M4 Pro 24 GB (2048-token prompt, 256 greedy decode, 4-bit checkpoint):

| | Before | After |
|---|---|---|
| Resident memory after load (text-only) | 19.42 GB | **15.68 GB** |
| Load time | 4.55 s | **3.44 s** |
| Decode | ~13.2 tok/s | **~15.0 tok/s** |

Correctness is unchanged: greedy token streams are bitwise-identical to the eager baseline, and a forced materialization of all vision weights produces a checksum identical to eager loading (815 arrays). Models that don't adopt the protocol are unaffected (default is no deferred prefixes).

In the next few days I will try to see if there is some performance that can be squeezed out of it as unfortunately I have got limited hardware at the moment to work with ... 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
