### PR TITLE
Temporarily disable the Xcode 27 integration build on pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -133,7 +133,9 @@ jobs:
   # needs a macOS 27 host, which no hosted image offers yet (see #499).
   integration_build_xcode27:
     needs: lint
-    if: github.repository == 'ml-explore/mlx-swift-lm'
+    # Temporarily disabled. To restore, put back:
+    #   if: github.repository == 'ml-explore/mlx-swift-lm'
+    if: false
     # Public preview label, see actions/runner-images#14404.
     runs-on: xcode-27
     timeout-minutes: 60


### PR DESCRIPTION
The Xcode 27 integration build job no longer runs on pull requests. The job condition is now false, and the original repository condition stays in a comment above it so it is easy to put back.
