### PR TITLE
Replace MLXRandom.seed with task-local withRandomState in tests

### DIFF
--- a/Tests/MLXLMTests/ContinuationAssertions.swift
+++ b/Tests/MLXLMTests/ContinuationAssertions.swift
@@ -88,33 +88,36 @@ struct ContinuationAssertions {
     func assertWarmTextContinuation<M: LanguageModel>(
         _ model: M, file: StaticString = #filePath, line: UInt = #line
     ) throws {
-        MLXRandom.seed(7)
-        let t1 = textTokens(40)
-        let t2 = textTokens(8, seed: 3)
+        // Task-local rather than MLXRandom.seed: parallel tests must not share
+        // (or perturb) the global random stream.
+        try withRandomState(MLXRandom.RandomState(seed: 7)) {
+            let t1 = textTokens(40)
+            let t2 = textTokens(8, seed: 3)
 
-        let cacheF = try model.newCache(parameters: nil)
-        let (logitsF, _) = try prefill(model, concatenated([t1, t2], axis: 1), cache: cacheF)
+            let cacheF = try model.newCache(parameters: nil)
+            let (logitsF, _) = try prefill(model, concatenated([t1, t2], axis: 1), cache: cacheF)
 
-        let cacheD = try model.newCache(parameters: nil)
-        let (_, s0) = try prefill(model, t1, cache: cacheD)
-        var state = s0
-        var logitsD = MLXArray(0)
-        for j in 0 ..< t2.dim(1) {
-            let out = model(
-                LMInput.Text(tokens: t2[0..., j ..< (j + 1)]), cache: cacheD, state: state)
-            state = out.state
-            logitsD = out.logits[0..., -1, 0...]
+            let cacheD = try model.newCache(parameters: nil)
+            let (_, s0) = try prefill(model, t1, cache: cacheD)
+            var state = s0
+            var logitsD = MLXArray(0)
+            for j in 0 ..< t2.dim(1) {
+                let out = model(
+                    LMInput.Text(tokens: t2[0..., j ..< (j + 1)]), cache: cacheD, state: state)
+                state = out.state
+                logitsD = out.logits[0..., -1, 0...]
+            }
+            let noiseFloor = maxAbsDiff(logitsD, logitsF)
+
+            let cacheW = try model.newCache(parameters: nil)
+            let (_, s1) = try prefill(model, t1, cache: cacheW)
+            let (logitsW, _) = try prefill(model, t2, cache: cacheW, state: s1)
+
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(logitsW, logitsF), max(noiseFloor * 10, 1e-3),
+                "warm continuation diverged from full prefill (noise floor \(noiseFloor))",
+                file: file, line: line)
         }
-        let noiseFloor = maxAbsDiff(logitsD, logitsF)
-
-        let cacheW = try model.newCache(parameters: nil)
-        let (_, s1) = try prefill(model, t1, cache: cacheW)
-        let (logitsW, _) = try prefill(model, t2, cache: cacheW, state: s1)
-
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(logitsW, logitsF), max(noiseFloor * 10, 1e-3),
-            "warm continuation diverged from full prefill (noise floor \(noiseFloor))",
-            file: file, line: line)
     }
 
     /// With an image in turn 1, the rope delta that image accumulated must be carried into
@@ -122,23 +125,24 @@ struct ContinuationAssertions {
     func assertWarmImageContinuation<M: LanguageModel>(
         _ model: M, file: StaticString = #filePath, line: UInt = #line
     ) throws {
-        MLXRandom.seed(5)
-        let image = image()
-        let t1 = concatenated([textTokens(10), imageRun(), textTokens(8, seed: 5)], axis: 1)
-        let t2 = textTokens(8, seed: 9)
+        try withRandomState(MLXRandom.RandomState(seed: 5)) {
+            let image = image()
+            let t1 = concatenated([textTokens(10), imageRun(), textTokens(8, seed: 5)], axis: 1)
+            let t2 = textTokens(8, seed: 9)
 
-        let cacheF = try model.newCache(parameters: nil)
-        let (logitsF, _) = try prefill(
-            model, concatenated([t1, t2], axis: 1), image: image, cache: cacheF)
+            let cacheF = try model.newCache(parameters: nil)
+            let (logitsF, _) = try prefill(
+                model, concatenated([t1, t2], axis: 1), image: image, cache: cacheF)
 
-        let cacheW = try model.newCache(parameters: nil)
-        let (_, s1) = try prefill(model, t1, image: image, cache: cacheW)
-        let (logitsW, _) = try prefill(model, t2, cache: cacheW, state: s1)
+            let cacheW = try model.newCache(parameters: nil)
+            let (_, s1) = try prefill(model, t1, image: image, cache: cacheW)
+            let (logitsW, _) = try prefill(model, t2, cache: cacheW, state: s1)
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(logitsW, logitsF), 1e-3,
-            "state-threaded warm continuation diverged from full prefill",
-            file: file, line: line)
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(logitsW, logitsF), 1e-3,
+                "state-threaded warm continuation diverged from full prefill",
+                file: file, line: line)
+        }
     }
 
     /// Three turns, with the image in the middle one. The continuation must place that image at
@@ -147,44 +151,46 @@ struct ContinuationAssertions {
     func assertImageMidContinuationResumeState<M: LanguageModel>(
         _ model: M, file: StaticString = #filePath, line: UInt = #line
     ) throws {
-        MLXRandom.seed(3)
-        let image = image()
-        let t1 = textTokens(12)
-        let t2 = concatenated(
-            [textTokens(4, seed: 2), imageRun(), textTokens(6, seed: 4)], axis: 1)
-        let t3 = textTokens(8, seed: 6)
+        try withRandomState(MLXRandom.RandomState(seed: 3)) {
+            let image = image()
+            let t1 = textTokens(12)
+            let t2 = concatenated(
+                [textTokens(4, seed: 2), imageRun(), textTokens(6, seed: 4)], axis: 1)
+            let t3 = textTokens(8, seed: 6)
 
-        let cacheF = try model.newCache(parameters: nil)
-        let (logitsF, _) = try prefill(
-            model, concatenated([t1, t2, t3], axis: 1), image: image, cache: cacheF)
+            let cacheF = try model.newCache(parameters: nil)
+            let (logitsF, _) = try prefill(
+                model, concatenated([t1, t2, t3], axis: 1), image: image, cache: cacheF)
 
-        let cacheW = try model.newCache(parameters: nil)
-        let (_, s1) = try prefill(model, t1, cache: cacheW)
-        let (_, s2) = try prefill(model, t2, image: image, cache: cacheW, state: s1)
-        let (logitsW, _) = try prefill(model, t3, cache: cacheW, state: s2)
+            let cacheW = try model.newCache(parameters: nil)
+            let (_, s1) = try prefill(model, t1, cache: cacheW)
+            let (_, s2) = try prefill(model, t2, image: image, cache: cacheW, state: s1)
+            let (logitsW, _) = try prefill(model, t3, cache: cacheW, state: s2)
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(logitsW, logitsF), 1e-3,
-            "post-image resume state positioned the following turn wrong",
-            file: file, line: line)
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(logitsW, logitsF), 1e-3,
+                "post-image resume state positioned the following turn wrong",
+                file: file, line: line)
+        }
     }
 
     /// Windowed (chunked) prefill must agree with the single-shot forward on plain text.
     func assertWindowedTextPrefill<M: LanguageModel>(
         _ model: M, file: StaticString = #filePath, line: UInt = #line
     ) throws {
-        MLXRandom.seed(11)
-        let prompt = textTokens(40)
+        try withRandomState(MLXRandom.RandomState(seed: 11)) {
+            let prompt = textTokens(40)
 
-        let cacheS = try model.newCache(parameters: nil)
-        let (logitsS, _) = try prefill(model, prompt, cache: cacheS)
+            let cacheS = try model.newCache(parameters: nil)
+            let (logitsS, _) = try prefill(model, prompt, cache: cacheS)
 
-        let cacheC = try model.newCache(parameters: nil)
-        let (logitsC, _) = try prefill(model, prompt, cache: cacheC, stepSize: 8)
+            let cacheC = try model.newCache(parameters: nil)
+            let (logitsC, _) = try prefill(model, prompt, cache: cacheC, stepSize: 8)
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(logitsC, logitsS), 1e-3,
-            "windowed prefill diverged from single-shot", file: file, line: line)
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(logitsC, logitsS), 1e-3,
+                "windowed prefill diverged from single-shot", file: file, line: line)
+        }
     }
 
     /// Windowed prefill on an image-bearing prompt must agree with the single-shot forward — the
@@ -198,22 +204,24 @@ struct ContinuationAssertions {
     func assertWindowedImagePrefill<M: LanguageModel>(
         _ model: M, file: StaticString = #filePath, line: UInt = #line
     ) throws {
-        MLXRandom.seed(13)
-        let image = image()
-        let prompt = concatenated([textTokens(10), imageRun(), textTokens(12, seed: 7)], axis: 1)
+        try withRandomState(MLXRandom.RandomState(seed: 13)) {
+            let image = image()
+            let prompt = concatenated(
+                [textTokens(10), imageRun(), textTokens(12, seed: 7)], axis: 1)
 
-        let cacheS = try model.newCache(parameters: nil)
-        let (logitsS, _) = try prefill(model, prompt, image: image, cache: cacheS)
+            let cacheS = try model.newCache(parameters: nil)
+            let (logitsS, _) = try prefill(model, prompt, image: image, cache: cacheS)
 
-        for stepSize in [3, 5, 8] {
-            let cacheC = try model.newCache(parameters: nil)
-            let (logitsC, _) = try prefill(
-                model, prompt, image: image, cache: cacheC, stepSize: stepSize)
+            for stepSize in [3, 5, 8] {
+                let cacheC = try model.newCache(parameters: nil)
+                let (logitsC, _) = try prefill(
+                    model, prompt, image: image, cache: cacheC, stepSize: stepSize)
 
-            XCTAssertLessThanOrEqual(
-                maxAbsDiff(logitsC, logitsS), 1e-3,
-                "windowed image prefill diverged from single-shot at stepSize \(stepSize)",
-                file: file, line: line)
+                XCTAssertLessThanOrEqual(
+                    maxAbsDiff(logitsC, logitsS), 1e-3,
+                    "windowed image prefill diverged from single-shot at stepSize \(stepSize)",
+                    file: file, line: line)
+            }
         }
     }
 }

--- a/Tests/MLXLMTests/GatedDeltaTests.swift
+++ b/Tests/MLXLMTests/GatedDeltaTests.swift
@@ -17,16 +17,19 @@ public class GatedDeltaTests: XCTestCase {
         B: Int = 1, T: Int = 16, Hk: Int = 2, Dk: Int = 32,
         Hv: Int = 4, Dv: Int = 16, seed: UInt64 = 42
     ) -> Inputs {
-        MLXRandom.seed(seed)
-        let dtype = DType.bfloat16
-        let q = MLXRandom.normal([B, T, Hk, Dk]).asType(dtype)
-        let k = MLXRandom.normal([B, T, Hk, Dk]).asType(dtype)
-        let v = MLXRandom.normal([B, T, Hv, Dv]).asType(dtype)
-        let a = MLXRandom.normal([B, T, Hv]).asType(dtype)
-        let b = MLXRandom.normal([B, T, Hv]).asType(dtype)
-        let aLog = (MLXRandom.normal([Hv]) * MLXArray(0.1)).asType(dtype)
-        let dtBias = MLXRandom.normal([Hv]).asType(dtype)
-        return Inputs(q: q, k: k, v: v, a: a, b: b, aLog: aLog, dtBias: dtBias)
+        // Task-local rather than MLXRandom.seed: parallel tests must not
+        // share (or perturb) the global random stream.
+        withRandomState(MLXRandom.RandomState(seed: seed)) {
+            let dtype = DType.bfloat16
+            let q = MLXRandom.normal([B, T, Hk, Dk]).asType(dtype)
+            let k = MLXRandom.normal([B, T, Hk, Dk]).asType(dtype)
+            let v = MLXRandom.normal([B, T, Hv, Dv]).asType(dtype)
+            let a = MLXRandom.normal([B, T, Hv]).asType(dtype)
+            let b = MLXRandom.normal([B, T, Hv]).asType(dtype)
+            let aLog = (MLXRandom.normal([Hv]) * MLXArray(0.1)).asType(dtype)
+            let dtBias = MLXRandom.normal([Hv]).asType(dtype)
+            return Inputs(q: q, k: k, v: v, a: a, b: b, aLog: aLog, dtBias: dtBias)
+        }
     }
 
     /// Multi-chunk prefill must match single-chunk prefill at the same total T.

--- a/Tests/MLXLMTests/Gemma3nMaskTests.swift
+++ b/Tests/MLXLMTests/Gemma3nMaskTests.swift
@@ -9,39 +9,40 @@ import Testing
 struct Gemma3nMaskTests {
 
     @Test func slidingDecoderLayerAcceptsBooleanMask() {
-        MLXRandom.seed(42)
-        let config = Gemma3nTextConfiguration()
-        let layer = Gemma3nDecoderLayer(config, layerIdx: 0)
-        let sequenceLength = 4
-        let hiddenStates = MLXRandom.normal([
-            config.altupNumInputs, 1, sequenceLength, config.hiddenSize,
-        ])
-        let perLayerInput = MLXRandom.normal([
-            1, sequenceLength, config.hiddenSizePerLayerInput,
-        ])
-        let mask = createCausalMask(n: sequenceLength, offset: 0, windowSize: 2)
+        withRandomState(MLXRandom.RandomState(seed: 42)) {
+            let config = Gemma3nTextConfiguration()
+            let layer = Gemma3nDecoderLayer(config, layerIdx: 0)
+            let sequenceLength = 4
+            let hiddenStates = MLXRandom.normal([
+                config.altupNumInputs, 1, sequenceLength, config.hiddenSize,
+            ])
+            let perLayerInput = MLXRandom.normal([
+                1, sequenceLength, config.hiddenSizePerLayerInput,
+            ])
+            let mask = createCausalMask(n: sequenceLength, offset: 0, windowSize: 2)
 
-        let output = layer(
-            hiddenStates,
-            mask: .array(mask),
-            perLayerInput: perLayerInput
-        )
-        eval(output)
+            let output = layer(
+                hiddenStates,
+                mask: .array(mask),
+                perLayerInput: perLayerInput
+            )
+            eval(output)
 
-        #expect(output.shape == hiddenStates.shape)
+            #expect(output.shape == hiddenStates.shape)
 
-        // The Boolean mask must block the same positions as the equivalent
-        // additive float mask, rather than acting as an additive 1/0 mask.
-        let additiveMask = MLX.where(
-            mask, MLXArray(Float(0)), MLXArray(-Float.greatestFiniteMagnitude))
-        let reference = layer(
-            hiddenStates,
-            mask: .array(additiveMask),
-            perLayerInput: perLayerInput
-        )
-        eval(reference)
+            // The Boolean mask must block the same positions as the equivalent
+            // additive float mask, rather than acting as an additive 1/0 mask.
+            let additiveMask = MLX.where(
+                mask, MLXArray(Float(0)), MLXArray(-Float.greatestFiniteMagnitude))
+            let reference = layer(
+                hiddenStates,
+                mask: .array(additiveMask),
+                perLayerInput: perLayerInput
+            )
+            eval(reference)
 
-        #expect(allClose(output, reference, rtol: 1e-4, atol: 1e-5).item(Bool.self))
+            #expect(allClose(output, reference, rtol: 1e-4, atol: 1e-5).item(Bool.self))
+        }
     }
 
     @Test func booleanAttentionMaskKeepsItsDType() {

--- a/Tests/MLXLMTests/GlmOcrContinuationTests.swift
+++ b/Tests/MLXLMTests/GlmOcrContinuationTests.swift
@@ -59,7 +59,9 @@ final class GlmOcrContinuationTests: XCTestCase {
             """
         let config = try JSONDecoder().decode(
             GlmOcrConfiguration.self, from: Data(json.utf8))
-        return GlmOcr(config)
+        // Pin the initializer weights. Task-local rather than MLXRandom.seed:
+        // parallel tests must not share (or perturb) the global random stream.
+        return withRandomState(MLXRandom.RandomState(seed: 1)) { GlmOcr(config) }
     }
 
     /// The shared continuation equivalences, configured for GLM-OCR: image token 500, and no
@@ -113,157 +115,165 @@ final class GlmOcrContinuationTests: XCTestCase {
     /// (silently wrong positions) or reaching getRopeIndex's batchSize precondition (a trap).
     /// This is independent of the missing-state guard: here the anchor is present and valid.
     func testWarmBatchedContinuationThrows() throws {
-        MLXRandom.seed(23)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 23)) {
+            let model = try makeTinyModel()
 
-        let cache = try model.newCache(parameters: nil)
-        let (_, warmState) = try lastLogits(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(6))), cache: cache, state: nil,
-                prefill: .init()))
-        XCTAssertNotNil(warmState?[LMOutput.Key<MLXArray>("glmocr.ropeDeltas")])
+            let cache = try model.newCache(parameters: nil)
+            let (_, warmState) = try lastLogits(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(6))), cache: cache, state: nil,
+                    prefill: .init()))
+            XCTAssertNotNil(warmState?[LMOutput.Key<MLXArray>("glmocr.ropeDeltas")])
 
-        let batched = concatenated(
-            [textTokens(4, seed: 1), textTokens(4, seed: 2)], axis: 0)
-        XCTAssertEqual(batched.dim(0), 2)
+            let batched = concatenated(
+                [textTokens(4, seed: 1), textTokens(4, seed: 2)], axis: 0)
+            XCTAssertEqual(batched.dim(0), 2)
 
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: batched)), cache: cache, state: warmState,
-                prefill: .init())
-        ) { error in
-            guard
-                case ContinuationStateError.unsupportedBatchContinuation(let name)? =
-                    error as? ContinuationStateError
-            else {
-                return XCTFail(
-                    "expected ContinuationStateError.unsupportedBatchContinuation, got \(error)")
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: batched)), cache: cache, state: warmState,
+                    prefill: .init())
+            ) { error in
+                guard
+                    case ContinuationStateError.unsupportedBatchContinuation(let name)? =
+                        error as? ContinuationStateError
+                else {
+                    return XCTFail(
+                        "expected ContinuationStateError.unsupportedBatchContinuation, got \(error)"
+                    )
+                }
+                XCTAssertEqual(name, "GlmOcr")
             }
-            XCTAssertEqual(name, "GlmOcr")
         }
     }
 
     func testWarmContinuationWithoutStateThrows() throws {
-        MLXRandom.seed(19)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 19)) {
+            let model = try makeTinyModel()
 
-        let cache = try model.newCache(parameters: nil)
-        XCTAssertNoThrow(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
-                prefill: .init(stepSize: 8)),
-            "a long cold prefill carries no anchor and must not throw")
+            let cache = try model.newCache(parameters: nil)
+            XCTAssertNoThrow(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
+                    prefill: .init(stepSize: 8)),
+                "a long cold prefill carries no anchor and must not throw")
 
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(6, seed: 2))), cache: cache, state: nil,
-                prefill: .init())
-        ) { error in
-            guard
-                case ContinuationStateError.missingState(_, let key)? =
-                    error as? ContinuationStateError
-            else {
-                return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(6, seed: 2))), cache: cache,
+                    state: nil,
+                    prefill: .init())
+            ) { error in
+                guard
+                    case ContinuationStateError.missingState(_, let key)? =
+                        error as? ContinuationStateError
+                else {
+                    return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+                }
+                XCTAssertEqual(key, "glmocr.ropeDeltas")
             }
-            XCTAssertEqual(key, "glmocr.ropeDeltas")
         }
     }
 
     /// A cold prefill must always hand back an anchor — zero for a text-only
     /// prompt — so an ordinary text conversation never trips the guard.
     func testColdTextOnlyPrefillCarriesAnchor() throws {
-        MLXRandom.seed(23)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 23)) {
+            let model = try makeTinyModel()
 
-        let cache = try model.newCache(parameters: nil)
-        let (_, state) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: textTokens(10))), cache: cache, state: nil,
-                prefill: .init()))
+            let cache = try model.newCache(parameters: nil)
+            let (_, state) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: textTokens(10))), cache: cache, state: nil,
+                    prefill: .init()))
 
-        guard let anchor = state?[ropeDeltasKey] else {
-            return XCTFail("cold text-only prefill returned no rope delta")
+            guard let anchor = state?[ropeDeltasKey] else {
+                return XCTFail("cold text-only prefill returned no rope delta")
+            }
+            XCTAssertEqual(anchor.asType(.int32).item(Int.self), 0)
         }
-        XCTAssertEqual(anchor.asType(.int32).item(Int.self), 0)
     }
 
     /// Decode after a warm image-bearing continuation: the resume state carries
     /// only the anchor, so the decode path has to reach its rope-delta branch
     /// without the precomputed position ids a cold prefill would have left.
     func testDecodeAfterWarmContinuationUsesAnchor() throws {
-        MLXRandom.seed(31)
-        let model = try makeTinyModel()
-        let image = makeImage()
+        try withRandomState(MLXRandom.RandomState(seed: 31)) {
+            let model = try makeTinyModel()
+            let image = makeImage()
 
-        let t1 = concatenated([textTokens(6), imageRun(), textTokens(4, seed: 2)], axis: 1)
-        let t2 = textTokens(6, seed: 4)
-        let next = textTokens(1, seed: 8)
+            let t1 = concatenated([textTokens(6), imageRun(), textTokens(4, seed: 2)], axis: 1)
+            let t2 = textTokens(6, seed: 4)
+            let next = textTokens(1, seed: 8)
 
-        // Reference: one cold prefill of everything, then one decode step.
-        let cacheF = try model.newCache(parameters: nil)
-        let (_, stateF) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1)), image: image),
-                cache: cacheF, state: nil, prefill: .init()))
-        let decodeF = model(LMInput.Text(tokens: next), cache: cacheF, state: stateF)
+            // Reference: one cold prefill of everything, then one decode step.
+            let cacheF = try model.newCache(parameters: nil)
+            let (_, stateF) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1)), image: image),
+                    cache: cacheF, state: nil, prefill: .init()))
+            let decodeF = model(LMInput.Text(tokens: next), cache: cacheF, state: stateF)
 
-        // Warm: prefill t1, continue with t2, then decode the same token.
-        let cacheW = try model.newCache(parameters: nil)
-        let (_, s1) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
-                prefill: .init()))
-        let (_, s2) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, prefill: .init()))
-        XCTAssertNotNil(s2?[ropeDeltasKey], "continuation must hand back an anchor")
-        let decodeW = model(LMInput.Text(tokens: next), cache: cacheW, state: s2)
+            // Warm: prefill t1, continue with t2, then decode the same token.
+            let cacheW = try model.newCache(parameters: nil)
+            let (_, s1) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t1), image: image), cache: cacheW, state: nil,
+                    prefill: .init()))
+            let (_, s2) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: cacheW, state: s1, prefill: .init()))
+            XCTAssertNotNil(s2?[ropeDeltasKey], "continuation must hand back an anchor")
+            let decodeW = model(LMInput.Text(tokens: next), cache: cacheW, state: s2)
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(decodeW.logits[0..., -1, 0...], decodeF.logits[0..., -1, 0...]), 1e-3,
-            "decode after a warm continuation ignored the carried anchor")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(decodeW.logits[0..., -1, 0...], decodeF.logits[0..., -1, 0...]), 1e-3,
+                "decode after a warm continuation ignored the carried anchor")
+        }
     }
 
     // MARK: - Prompt cache round trip
 
     func testImageStateSurvivesPromptCacheRoundTrip() throws {
-        MLXRandom.seed(29)
-        let model = try makeTinyModel()
-        let image = makeImage()
+        try withRandomState(MLXRandom.RandomState(seed: 29)) {
+            let model = try makeTinyModel()
+            let image = makeImage()
 
-        let t1 = concatenated([textTokens(6), imageRun(), textTokens(6, seed: 2)], axis: 1)
-        let t2 = textTokens(8, seed: 4)
+            let t1 = concatenated([textTokens(6), imageRun(), textTokens(6, seed: 2)], axis: 1)
+            let t2 = textTokens(8, seed: 4)
 
-        let warmCache = try model.newCache(parameters: nil)
-        let (_, savedState) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
-                prefill: .init()))
-        XCTAssertNotNil(savedState)
+            let warmCache = try model.newCache(parameters: nil)
+            let (_, savedState) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
+                    prefill: .init()))
+            XCTAssertNotNil(savedState)
 
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("safetensors")
-        defer { try? FileManager.default.removeItem(at: url) }
-        try savePromptCache(url: url, cache: warmCache, state: savedState)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            try savePromptCache(url: url, cache: warmCache, state: savedState)
 
-        let snapshot = try loadPromptCacheSnapshot(url: url)
-        let (warmLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: warmCache, state: savedState,
-                prefill: .init()))
-        let (restoredLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: snapshot.cache, state: snapshot.state,
-                prefill: .init()))
+            let snapshot = try loadPromptCacheSnapshot(url: url)
+            let (warmLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: warmCache, state: savedState,
+                    prefill: .init()))
+            let (restoredLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: snapshot.cache, state: snapshot.state,
+                    prefill: .init()))
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(restoredLogits, warmLogits), 1e-6,
-            "disk-restored state diverged from the live warm continuation")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(restoredLogits, warmLogits), 1e-6,
+                "disk-restored state diverged from the live warm continuation")
 
-        let keptCache = try loadPromptCacheSnapshot(url: url).cache
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: keptCache, state: nil, prefill: .init()))
+            let keptCache = try loadPromptCacheSnapshot(url: url).cache
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: keptCache, state: nil,
+                    prefill: .init()))
+        }
     }
 }

--- a/Tests/MLXLMTests/KVCacheRoundTests.swift
+++ b/Tests/MLXLMTests/KVCacheRoundTests.swift
@@ -220,47 +220,47 @@ private struct RingSnapshot {
 
 /// Attention through the overlay, past a wrap, against a reference that never rotated.
 @Test func testOverlayAttentionPastWrapMatchesLogicalOrderReference() throws {
-    MLXRandom.seed(0)
+    try withRandomState(MLXRandom.RandomState(seed: 0)) {
+        let window = 8
+        let history = 20
+        let queries = 4
+        let heads = 2
+        let headDim = 4
+        let scale = 1.0 / Float(headDim).squareRoot()
 
-    let window = 8
-    let history = 20
-    let queries = 4
-    let heads = 2
-    let headDim = 4
-    let scale = 1.0 / Float(headDim).squareRoot()
+        let allKeys = MLXRandom.normal([1, heads, history + queries, headDim])
+        let allValues = MLXRandom.normal([1, heads, history + queries, headDim])
+        let q = MLXRandom.normal([1, heads, queries, headDim])
 
-    let allKeys = MLXRandom.normal([1, heads, history + queries, headDim])
-    let allValues = MLXRandom.normal([1, heads, history + queries, headDim])
-    let q = MLXRandom.normal([1, heads, queries, headDim])
+        let live = RotatingKVCache(maxSize: window, keep: 0)
+        for p in 0 ..< history {
+            _ = live.update(
+                keys: allKeys[0..., 0..., p ..< (p + 1), 0...],
+                values: allValues[0..., 0..., p ..< (p + 1), 0...])
+        }
 
-    let live = RotatingKVCache(maxSize: window, keep: 0)
-    for p in 0 ..< history {
-        _ = live.update(
-            keys: allKeys[0..., 0..., p ..< (p + 1), 0...],
-            values: allValues[0..., 0..., p ..< (p + 1), 0...])
+        let overlay = try #require(StagedRound([live]))
+        let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
+
+        let mask = adapter.makeMask(n: queries, windowSize: window, returnArray: false)
+        let (keys, values) = adapter.update(
+            keys: allKeys[0..., 0..., history ..< (history + queries), 0...],
+            values: allValues[0..., 0..., history ..< (history + queries), 0...])
+        let out = MLXFast.scaledDotProductAttention(
+            queries: q, keys: keys, values: values, scale: scale, mask: mask)
+
+        let queryPositions = MLXArray(Int32(history) ..< Int32(history + queries))[0..., .newAxis]
+        let keyPositions = MLXArray(Int32(0) ..< Int32(history + queries))[.newAxis]
+        let referenceMask =
+            (queryPositions .>= keyPositions) & (queryPositions .< keyPositions + Int32(window))
+        let expected = MLXFast.scaledDotProductAttention(
+            queries: q, keys: allKeys, values: allValues, scale: scale, mask: .array(referenceMask))
+
+        #expect(out.shape == expected.shape)
+        #expect(
+            allClose(out, expected, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+            "overlay attention diverged from the logical-order reference")
     }
-
-    let overlay = try #require(StagedRound([live]))
-    let adapter = try #require(overlay.caches.first as? RotatingStagedKVCache)
-
-    let mask = adapter.makeMask(n: queries, windowSize: window, returnArray: false)
-    let (keys, values) = adapter.update(
-        keys: allKeys[0..., 0..., history ..< (history + queries), 0...],
-        values: allValues[0..., 0..., history ..< (history + queries), 0...])
-    let out = MLXFast.scaledDotProductAttention(
-        queries: q, keys: keys, values: values, scale: scale, mask: mask)
-
-    let queryPositions = MLXArray(Int32(history) ..< Int32(history + queries))[0..., .newAxis]
-    let keyPositions = MLXArray(Int32(0) ..< Int32(history + queries))[.newAxis]
-    let referenceMask =
-        (queryPositions .>= keyPositions) & (queryPositions .< keyPositions + Int32(window))
-    let expected = MLXFast.scaledDotProductAttention(
-        queries: q, keys: allKeys, values: allValues, scale: scale, mask: .array(referenceMask))
-
-    #expect(out.shape == expected.shape)
-    #expect(
-        allClose(out, expected, rtol: 1e-5, atol: 1e-5).item(Bool.self),
-        "overlay attention diverged from the logical-order reference")
 }
 
 // MARK: - Invariant 3: commit equivalence

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -1215,60 +1215,62 @@ func testCacheListCopyIsIndependent() async throws {
 
 @Test
 func testQuantizedAttentionCausalMaskMatchesFullPrecision() throws {
-    MLXRandom.seed(0)
+    withRandomState(MLXRandom.RandomState(seed: 0)) {
+        let (B, nKVHeads, L, D) = (1, 2, 4, 64)
+        let scale = 1.0 / Float(D).squareRoot()
 
-    let (B, nKVHeads, L, D) = (1, 2, 4, 64)
-    let scale = 1.0 / Float(D).squareRoot()
+        // nRepeats 1 = MHA, 2 = GQA (exercises the 5-D reshape + .causal path that silently corrupts).
+        for nRepeats in [1, 2] {
+            let nQHeads = nKVHeads * nRepeats
+            let q = MLXRandom.normal([B, nQHeads, L, D])
+            let k = MLXRandom.normal([B, nKVHeads, L, D])
+            let v = MLXRandom.normal([B, nKVHeads, L, D])
 
-    // nRepeats 1 = MHA, 2 = GQA (exercises the 5-D reshape + .causal path that silently corrupts).
-    for nRepeats in [1, 2] {
-        let nQHeads = nKVHeads * nRepeats
-        let q = MLXRandom.normal([B, nQHeads, L, D])
-        let k = MLXRandom.normal([B, nKVHeads, L, D])
-        let v = MLXRandom.normal([B, nKVHeads, L, D])
+            // Reference: full-precision causal attention.
+            let reference = MLXFast.scaledDotProductAttention(
+                queries: q, keys: k, values: v, scale: scale, mask: .causal)
 
-        // Reference: full-precision causal attention.
-        let reference = MLXFast.scaledDotProductAttention(
-            queries: q, keys: k, values: v, scale: scale, mask: .causal)
+            // Path under test: quantized cache + .causal.
+            let cache = QuantizedKVCache(groupSize: 64, bits: 8)
+            let (qK, qV) = cache.updateQuantized(keys: k, values: v)
+            let out = quantizedScaledDotProductAttention(
+                queries: q, quantizedKeys: qK, quantizedValues: qV,
+                scale: scale, mask: .causal,
+                groupSize: cache.groupSize, bits: cache.bits, mode: cache.mode)
 
-        // Path under test: quantized cache + .causal.
-        let cache = QuantizedKVCache(groupSize: 64, bits: 8)
-        let (qK, qV) = cache.updateQuantized(keys: k, values: v)
-        let out = quantizedScaledDotProductAttention(
-            queries: q, quantizedKeys: qK, quantizedValues: qV,
-            scale: scale, mask: .causal,
-            groupSize: cache.groupSize, bits: cache.bits, mode: cache.mode)
-
-        #expect(out.shape == reference.shape)
-        // 8-bit quant error is << 0.1; the bug diverges by O(1).
-        let close = allClose(out, reference, rtol: 0.05, atol: 0.1).item(Bool.self)
-        #expect(
-            close, "quantized causal attention diverges from full precision (nRepeats=\(nRepeats))")
+            #expect(out.shape == reference.shape)
+            // 8-bit quant error is << 0.1; the bug diverges by O(1).
+            let close = allClose(out, reference, rtol: 0.05, atol: 0.1).item(Bool.self)
+            #expect(
+                close,
+                "quantized causal attention diverges from full precision (nRepeats=\(nRepeats))")
+        }
     }
 }
 
 @Test("quantizedScaledDotProductAttention preserves the score dtype")
 func preservesScoreDtype() {
-    MLXRandom.seed(0)
-    let (B, H, L, D) = (1, 2, 4, 64)
-    let scale = 1.0 / Float(D).squareRoot()
+    withRandomState(MLXRandom.RandomState(seed: 0)) {
+        let (B, H, L, D) = (1, 2, 4, 64)
+        let scale = 1.0 / Float(D).squareRoot()
 
-    // f32 passes even with a mis-typed fill; f16/bf16 are exactly what a
-    // float32 fill silently promotes — so assert the output keeps its dtype.
-    for dtype in [DType.float16, .bfloat16, .float32] {
-        let q = MLXRandom.normal([B, H, L, D]).asType(dtype)
-        let k = MLXRandom.normal([B, H, L, D]).asType(dtype)
-        let v = MLXRandom.normal([B, H, L, D]).asType(dtype)
+        // f32 passes even with a mis-typed fill; f16/bf16 are exactly what a
+        // float32 fill silently promotes — so assert the output keeps its dtype.
+        for dtype in [DType.float16, .bfloat16, .float32] {
+            let q = MLXRandom.normal([B, H, L, D]).asType(dtype)
+            let k = MLXRandom.normal([B, H, L, D]).asType(dtype)
+            let v = MLXRandom.normal([B, H, L, D]).asType(dtype)
 
-        let cache = QuantizedKVCache(groupSize: 64, bits: 8)
-        let (qK, qV) = cache.updateQuantized(keys: k, values: v)
-        let out = quantizedScaledDotProductAttention(
-            queries: q, quantizedKeys: qK, quantizedValues: qV,
-            scale: scale, mask: .causal,
-            groupSize: cache.groupSize, bits: cache.bits, mode: cache.mode)
+            let cache = QuantizedKVCache(groupSize: 64, bits: 8)
+            let (qK, qV) = cache.updateQuantized(keys: k, values: v)
+            let out = quantizedScaledDotProductAttention(
+                queries: q, quantizedKeys: qK, quantizedValues: qV,
+                scale: scale, mask: .causal,
+                groupSize: cache.groupSize, bits: cache.bits, mode: cache.mode)
 
-        #expect(out.dtype == dtype, "output promoted to \(out.dtype) for input \(dtype)")
-        #expect(out.asType(.float32).sum().item(Float.self).isFinite)  // no -inf → NaN
+            #expect(out.dtype == dtype, "output promoted to \(out.dtype) for input \(dtype)")
+            #expect(out.asType(.float32).sum().item(Float.self).isFinite)  // no -inf → NaN
+        }
     }
 }
 
@@ -1480,45 +1482,45 @@ private func fillOneAtATime(_ cache: RotatingKVCache, positions: Range<Int>) {
 /// reference that never rotated: every position kept in a plain array under an explicit
 /// causal-intersect-window mask over absolute positions.
 @Test func testRotatingCacheAttentionPastWrapMatchesLogicalOrderReference() {
-    MLXRandom.seed(0)
+    withRandomState(MLXRandom.RandomState(seed: 0)) {
+        let window = 8
+        let history = 20
+        let queries = 4
+        let heads = 2
+        let headDim = 4
+        let scale = 1.0 / Float(headDim).squareRoot()
 
-    let window = 8
-    let history = 20
-    let queries = 4
-    let heads = 2
-    let headDim = 4
-    let scale = 1.0 / Float(headDim).squareRoot()
+        let allKeys = MLXRandom.normal([1, heads, history + queries, headDim])
+        let allValues = MLXRandom.normal([1, heads, history + queries, headDim])
+        let q = MLXRandom.normal([1, heads, queries, headDim])
 
-    let allKeys = MLXRandom.normal([1, heads, history + queries, headDim])
-    let allValues = MLXRandom.normal([1, heads, history + queries, headDim])
-    let q = MLXRandom.normal([1, heads, queries, headDim])
+        let cache = RotatingKVCache(maxSize: window, keep: 0)
+        for p in 0 ..< history {
+            _ = cache.update(
+                keys: allKeys[0..., 0..., p ..< (p + 1), 0...],
+                values: allValues[0..., 0..., p ..< (p + 1), 0...])
+        }
 
-    let cache = RotatingKVCache(maxSize: window, keep: 0)
-    for p in 0 ..< history {
-        _ = cache.update(
-            keys: allKeys[0..., 0..., p ..< (p + 1), 0...],
-            values: allValues[0..., 0..., p ..< (p + 1), 0...])
+        let mask = cache.makeMask(n: queries, windowSize: window, returnArray: false)
+        let (cachedKeys, cachedValues) = cache.update(
+            keys: allKeys[0..., 0..., history ..< (history + queries), 0...],
+            values: allValues[0..., 0..., history ..< (history + queries), 0...])
+        let out = MLXFast.scaledDotProductAttention(
+            queries: q, keys: cachedKeys, values: cachedValues, scale: scale, mask: mask)
+
+        // Reference: all history retained, masked by absolute position.
+        let queryPositions = MLXArray(Int32(history) ..< Int32(history + queries))[0..., .newAxis]
+        let keyPositions = MLXArray(Int32(0) ..< Int32(history + queries))[.newAxis]
+        let referenceMask =
+            (queryPositions .>= keyPositions) & (queryPositions .< keyPositions + Int32(window))
+        let reference = MLXFast.scaledDotProductAttention(
+            queries: q, keys: allKeys, values: allValues, scale: scale, mask: .array(referenceMask))
+
+        #expect(out.shape == reference.shape)
+        #expect(
+            allClose(out, reference, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+            "post-wrap attention diverged from the logical-order reference")
     }
-
-    let mask = cache.makeMask(n: queries, windowSize: window, returnArray: false)
-    let (cachedKeys, cachedValues) = cache.update(
-        keys: allKeys[0..., 0..., history ..< (history + queries), 0...],
-        values: allValues[0..., 0..., history ..< (history + queries), 0...])
-    let out = MLXFast.scaledDotProductAttention(
-        queries: q, keys: cachedKeys, values: cachedValues, scale: scale, mask: mask)
-
-    // Reference: all history retained, masked by absolute position.
-    let queryPositions = MLXArray(Int32(history) ..< Int32(history + queries))[0..., .newAxis]
-    let keyPositions = MLXArray(Int32(0) ..< Int32(history + queries))[.newAxis]
-    let referenceMask =
-        (queryPositions .>= keyPositions) & (queryPositions .< keyPositions + Int32(window))
-    let reference = MLXFast.scaledDotProductAttention(
-        queries: q, keys: allKeys, values: allValues, scale: scale, mask: .array(referenceMask))
-
-    #expect(out.shape == reference.shape)
-    #expect(
-        allClose(out, reference, rtol: 1e-5, atol: 1e-5).item(Bool.self),
-        "post-wrap attention diverged from the logical-order reference")
 }
 
 // MARK: - Variance-normalized KV cache

--- a/Tests/MLXLMTests/NanbeigeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeTests.swift
@@ -40,6 +40,15 @@ final class NanbeigeTests: XCTestCase {
         return try JSONDecoder().decode(NanbeigeConfiguration.self, from: Data(json.utf8))
     }
 
+    /// Build the model with its weights pinned under a task-local random
+    /// state — task-local rather than MLXRandom.seed, so parallel tests do not
+    /// share (or perturb) the global random stream.
+    private func makeModel(_ config: NanbeigeConfiguration, seed: UInt64 = 1) -> NanbeigeModel {
+        withRandomState(MLXRandom.RandomState(seed: seed)) {
+            NanbeigeModel(config)
+        }
+    }
+
     /// Deterministic pseudo-random tokens, 1-D — the shape the default
     /// `LLMModel.prepare` chunked-prefill path expects.
     private func textTokens(_ count: Int, seed: Int = 0) -> MLXArray {
@@ -100,12 +109,12 @@ final class NanbeigeTests: XCTestCase {
     // MARK: - Cache layout
 
     func testNewCacheAllocatesOneCachePerLoopLayerPair() throws {
-        let model = NanbeigeModel(try makeConfig())
+        let model = makeModel(try makeConfig())
         XCTAssertEqual(try model.newCache(parameters: nil).count, 6)
     }
 
     func testNewCacheHonorsTypedCapacity() throws {
-        let model = NanbeigeModel(try makeConfig())
+        let model = makeModel(try makeConfig())
         let capacity = try KVCacheConfiguration.Capacity(
             maxTokens: 32, preservedPrefixTokens: 3)
         let parameters = GenerateParameters(
@@ -122,7 +131,7 @@ final class NanbeigeTests: XCTestCase {
     }
 
     func testNewCacheClampsTinyLegacyLimit() throws {
-        let model = NanbeigeModel(try makeConfig())
+        let model = makeModel(try makeConfig())
         let caches = try model.newCache(parameters: GenerateParameters(maxKVSize: 1))
 
         XCTAssertEqual(caches.count, 6)
@@ -154,14 +163,14 @@ final class NanbeigeTests: XCTestCase {
             }
             """
         let config = try JSONDecoder().decode(NanbeigeConfiguration.self, from: Data(json.utf8))
-        XCTAssertEqual(try NanbeigeModel(config).newCache(parameters: nil).count, 44)
+        XCTAssertEqual(try makeModel(config).newCache(parameters: nil).count, 44)
     }
 
     // MARK: - Sanitize
 
     func testSanitizeDropsRotaryFreqsAndTiedHead() throws {
         let tied = try makeConfig(extra: ",\n\"tie_word_embeddings\": true")
-        let model = NanbeigeModel(tied)
+        let model = makeModel(tied)
         let sanitized = model.sanitize(weights: [
             "model.layers.0.self_attn.rotary_emb.inv_freq": MLXArray([Float(1)]),
             "model.layers.0.self_attn.q_proj.weight": MLXArray([Float(1)]),
@@ -177,12 +186,12 @@ final class NanbeigeTests: XCTestCase {
     /// 1-loop forward of the same weights (guards against a port that ignores
     /// `num_loops` and silently degenerates to a single pass).
     func testSecondLoopChangesLogits() throws {
-        MLXRandom.seed(11)
-        let looped = NanbeigeModel(try makeConfig())
-        MLXRandom.seed(11)
+        // The same seed twice: both models must share weights so the only
+        // difference between them is the loop count.
+        let looped = makeModel(try makeConfig(), seed: 11)
         var singleConfig = try makeConfig()
         singleConfig.numLoops = 1
-        let single = NanbeigeModel(singleConfig)
+        let single = makeModel(singleConfig, seed: 11)
 
         let tokens = textTokens(9)[.newAxis]
         let loopedOut = looped(tokens, cache: nil)[0..., -1, 0...]
@@ -195,8 +204,7 @@ final class NanbeigeTests: XCTestCase {
     /// that breaks if the per-loop cache slices are mis-indexed — loop 2
     /// reading loop 1's keys shows up here immediately.
     func testWarmContinuationMatchesFullPrefill() throws {
-        MLXRandom.seed(7)
-        let model = NanbeigeModel(try makeConfig())
+        let model = makeModel(try makeConfig(), seed: 7)
         let t1 = textTokens(40)
         let t2 = textTokens(8, seed: 3)
         let full = concatenated([t1, t2], axis: 0)
@@ -219,14 +227,14 @@ final class NanbeigeTests: XCTestCase {
     /// `ChatConventionsProviding`, rather than the centralized `model_type`
     /// inference chains. XML is the trained default for agentic use.
     func testDeclaresXMLFunctionToolCallFormat() throws {
-        let model = NanbeigeModel(try makeConfig())
+        let model = makeModel(try makeConfig())
         XCTAssertEqual(model.toolCallFormat, .xmlFunction)
     }
 
     /// Qwen-compatible thinking tags and tool-call boundary, without claiming
     /// support for the original Qwen3 family's hard-budget transition.
     func testDeclaresTaggedReasoningProtocol() throws {
-        let model = NanbeigeModel(try makeConfig())
+        let model = makeModel(try makeConfig())
         let config = try XCTUnwrap(model.reasoningConfig)
         XCTAssertEqual(config, QwenReasoningProtocol.tagged)
         XCTAssertEqual(config.implicitEndDelimiters, ["<tool_call>"])

--- a/Tests/MLXLMTests/Qwen35ContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen35ContinuationTests.swift
@@ -65,7 +65,9 @@ final class Qwen35ContinuationTests: XCTestCase {
             """
         let config = try JSONDecoder().decode(
             Qwen35Configuration.self, from: Data(json.utf8))
-        return Qwen35(config)
+        // Pin the initializer weights. Task-local rather than MLXRandom.seed:
+        // parallel tests must not share (or perturb) the global random stream.
+        return withRandomState(MLXRandom.RandomState(seed: 1)) { Qwen35(config) }
     }
 
     /// The shared continuation equivalences, configured for Qwen3.5-VL's token ids.
@@ -103,29 +105,31 @@ final class Qwen35ContinuationTests: XCTestCase {
     /// before warm routing rather than interpreted as a batch whose size is the
     /// sequence length.
     func testRank1WarmContinuationMatchesFullPrefill() throws {
-        MLXRandom.seed(41)
-        let model = try makeTinyModel()
-        let t1 = textTokens(40)
-        let t2 = textTokens(8, seed: 3)
+        try withRandomState(MLXRandom.RandomState(seed: 41)) {
+            let model = try makeTinyModel()
+            let t1 = textTokens(40)
+            let t2 = textTokens(8, seed: 3)
 
-        let fullCache = try model.newCache(parameters: nil)
-        let (fullLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1))),
-                cache: fullCache, state: nil, prefill: .init()))
+            let fullCache = try model.newCache(parameters: nil)
+            let (fullLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1))),
+                    cache: fullCache, state: nil, prefill: .init()))
 
-        let warmCache = try model.newCache(parameters: nil)
-        let (_, state) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t1)), cache: warmCache, state: nil, prefill: .init()))
-        let (warmLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2[0])), cache: warmCache, state: state,
-                prefill: .init()))
+            let warmCache = try model.newCache(parameters: nil)
+            let (_, state) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t1)), cache: warmCache, state: nil,
+                    prefill: .init()))
+            let (warmLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2[0])), cache: warmCache, state: state,
+                    prefill: .init()))
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(warmLogits, fullLogits), 1e-3,
-            "rank-1 warm continuation diverged from full prefill")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(warmLogits, fullLogits), 1e-3,
+                "rank-1 warm continuation diverged from full prefill")
+        }
     }
 
     /// A warm cache continued without its anchor must throw. The model cannot
@@ -133,32 +137,34 @@ final class Qwen35ContinuationTests: XCTestCase {
     /// silently repositioning the remainder; a text-only prefix is refused too
     /// rather than guessed at. A cold cache needs no anchor and still works.
     func testWarmContinuationWithoutStateThrows() throws {
-        MLXRandom.seed(19)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 19)) {
+            let model = try makeTinyModel()
 
-        let cache = try model.newCache(parameters: nil)
-        XCTAssertNoThrow(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
-                prefill: .init(stepSize: 8)),
-            "a long cold prefill carries no anchor and must not throw")
+            let cache = try model.newCache(parameters: nil)
+            XCTAssertNoThrow(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
+                    prefill: .init(stepSize: 8)),
+                "a long cold prefill carries no anchor and must not throw")
 
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(6, seed: 2)[0])), cache: cache, state: nil,
-                prefill: .init())
-        ) { error in
-            guard
-                case ContinuationStateError.missingState(_, let key)? =
-                    error as? ContinuationStateError
-            else {
-                return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(6, seed: 2)[0])), cache: cache,
+                    state: nil,
+                    prefill: .init())
+            ) { error in
+                guard
+                    case ContinuationStateError.missingState(_, let key)? =
+                        error as? ContinuationStateError
+                else {
+                    return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+                }
+                XCTAssertEqual(key, "qwen35.ropeDeltas")
+                XCTAssertTrue(
+                    (error as? ContinuationStateError)?.errorDescription?
+                        .contains("loadPromptCacheSnapshot") == true,
+                    "error should name the snapshot loader")
             }
-            XCTAssertEqual(key, "qwen35.ropeDeltas")
-            XCTAssertTrue(
-                (error as? ContinuationStateError)?.errorDescription?
-                    .contains("loadPromptCacheSnapshot") == true,
-                "error should name the snapshot loader")
         }
     }
 
@@ -170,94 +176,95 @@ final class Qwen35ContinuationTests: XCTestCase {
     }
 
     func testImageStateSurvivesPromptCacheRoundTrip() throws {
-        MLXRandom.seed(17)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 17)) {
+            let model = try makeTinyModel()
 
-        let pixels = MLXRandom.normal([16, 3 * 2 * 16 * 16])
-        let frame = THW(1, 4, 4)
-        let image = LMInput.ProcessedImage(pixels: pixels, frames: [frame])
-        let bothImages = LMInput.ProcessedImage(
-            pixels: concatenated([pixels, pixels]), frames: [frame, frame])
-        let visionStart = MLXArray([Int32(502)]).expandedDimensions(axis: 0)
-        let imageRun = MLXArray([Int32](repeating: 500, count: 4)).expandedDimensions(axis: 0)
-        let turn1 = textTokens(12)
-        let turn2 = concatenated(
-            [textTokens(4, seed: 2), visionStart, imageRun, textTokens(6, seed: 4)], axis: 1)
-        let turn3 = textTokens(8, seed: 6)
-        let turn4 = concatenated(
-            [textTokens(3, seed: 8), visionStart, imageRun, textTokens(5, seed: 10)], axis: 1)
-        let full = concatenated([turn1, turn2, turn3, turn4], axis: 1)
+            let pixels = MLXRandom.normal([16, 3 * 2 * 16 * 16])
+            let frame = THW(1, 4, 4)
+            let image = LMInput.ProcessedImage(pixels: pixels, frames: [frame])
+            let bothImages = LMInput.ProcessedImage(
+                pixels: concatenated([pixels, pixels]), frames: [frame, frame])
+            let visionStart = MLXArray([Int32(502)]).expandedDimensions(axis: 0)
+            let imageRun = MLXArray([Int32](repeating: 500, count: 4)).expandedDimensions(axis: 0)
+            let turn1 = textTokens(12)
+            let turn2 = concatenated(
+                [textTokens(4, seed: 2), visionStart, imageRun, textTokens(6, seed: 4)], axis: 1)
+            let turn3 = textTokens(8, seed: 6)
+            let turn4 = concatenated(
+                [textTokens(3, seed: 8), visionStart, imageRun, textTokens(5, seed: 10)], axis: 1)
+            let full = concatenated([turn1, turn2, turn3, turn4], axis: 1)
 
-        let coldCache = try model.newCache(parameters: nil)
-        let (coldLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: full), image: bothImages), cache: coldCache,
-                state: nil, prefill: .init()))
+            let coldCache = try model.newCache(parameters: nil)
+            let (coldLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: full), image: bothImages), cache: coldCache,
+                    state: nil, prefill: .init()))
 
-        let warmCache = try model.newCache(parameters: nil)
-        let (_, turn1State) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: turn1)), cache: warmCache, state: nil,
-                prefill: .init()))
-        let (_, savedState) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: turn2), image: image), cache: warmCache,
-                state: turn1State, prefill: .init()))
-        XCTAssertNotNil(savedState)
+            let warmCache = try model.newCache(parameters: nil)
+            let (_, turn1State) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: turn1)), cache: warmCache, state: nil,
+                    prefill: .init()))
+            let (_, savedState) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: turn2), image: image), cache: warmCache,
+                    state: turn1State, prefill: .init()))
+            XCTAssertNotNil(savedState)
 
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("safetensors")
-        defer { try? FileManager.default.removeItem(at: url) }
-        try savePromptCache(url: url, cache: warmCache, state: savedState)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            try savePromptCache(url: url, cache: warmCache, state: savedState)
 
-        let snapshot = try loadPromptCacheSnapshot(url: url)
-        let missingStateCache = try loadPromptCacheSnapshot(url: url).cache
-        let (warmTextLogits, warmTextState) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: turn3)), cache: warmCache, state: savedState,
-                prefill: .init()))
-        let (restoredTextLogits, restoredTextState) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: turn3)), cache: snapshot.cache,
-                state: snapshot.state, prefill: .init()))
+            let snapshot = try loadPromptCacheSnapshot(url: url)
+            let missingStateCache = try loadPromptCacheSnapshot(url: url).cache
+            let (warmTextLogits, warmTextState) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: turn3)), cache: warmCache, state: savedState,
+                    prefill: .init()))
+            let (restoredTextLogits, restoredTextState) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: turn3)), cache: snapshot.cache,
+                    state: snapshot.state, prefill: .init()))
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(restoredTextLogits, warmTextLogits), 1e-6,
-            "disk-restored state diverged on the text continuation")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(restoredTextLogits, warmTextLogits), 1e-6,
+                "disk-restored state diverged on the text continuation")
 
-        // The negative control: restoring the KV arrays while dropping the state
-        // is what this whole feature exists to prevent. It used to decode at the
-        // wrong positions; it must now fail loudly instead.
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: turn3)), cache: missingStateCache, state: nil,
-                prefill: .init())
-        ) { error in
-            guard
-                case ContinuationStateError.missingState(_, let key)? =
-                    error as? ContinuationStateError
-            else {
-                return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+            // The negative control: restoring the KV arrays while dropping the state
+            // is what this whole feature exists to prevent. It used to decode at the
+            // wrong positions; it must now fail loudly instead.
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: turn3)), cache: missingStateCache, state: nil,
+                    prefill: .init())
+            ) { error in
+                guard
+                    case ContinuationStateError.missingState(_, let key)? =
+                        error as? ContinuationStateError
+                else {
+                    return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+                }
+                XCTAssertEqual(key, "qwen35.ropeDeltas")
             }
-            XCTAssertEqual(key, "qwen35.ropeDeltas")
+
+            let (warmImageLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: turn4), image: image), cache: warmCache,
+                    state: warmTextState, prefill: .init()))
+            let (restoredImageLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: turn4), image: image), cache: snapshot.cache,
+                    state: restoredTextState, prefill: .init()))
+
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(restoredImageLogits, warmImageLogits), 1e-6,
+                "disk-restored state diverged when a later turn added another image")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(restoredImageLogits, coldLogits), 1e-3,
+                "restored two-image continuation diverged from full prefill")
         }
-
-        let (warmImageLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: turn4), image: image), cache: warmCache,
-                state: warmTextState, prefill: .init()))
-        let (restoredImageLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: turn4), image: image), cache: snapshot.cache,
-                state: restoredTextState, prefill: .init()))
-
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(restoredImageLogits, warmImageLogits), 1e-6,
-            "disk-restored state diverged when a later turn added another image")
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(restoredImageLogits, coldLogits), 1e-3,
-            "restored two-image continuation diverged from full prefill")
     }
 
     /// The full three-turn round trip: a warm continuation whose remainder

--- a/Tests/MLXLMTests/Qwen35GDNDecodeBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35GDNDecodeBitwiseTests.swift
@@ -61,23 +61,24 @@ final class Qwen35GDNDecodeBitwiseTests: XCTestCase {
     func testDecodeConvMatchesConvolutionKernelBitwise() throws {
         let config = try tinyGDNConfiguration()
         for dtype in [DType.float16, DType.bfloat16] {
-            MLXRandom.seed(11)
-            let gdn = Qwen35GatedDeltaNet(config)
-            gdn.conv1d.update(
-                parameters: gdn.conv1d.parameters().mapValues { $0.asType(dtype) })
+            withRandomState(MLXRandom.RandomState(seed: 11)) {
+                let gdn = Qwen35GatedDeltaNet(config)
+                gdn.conv1d.update(
+                    parameters: gdn.conv1d.parameters().mapValues { $0.asType(dtype) })
 
-            let qkv = MLXRandom.normal([1, 1, gdn.convDim]).asType(dtype)
-            let convState = MLXRandom.normal(
-                [1, gdn.convKernelSize - 1, gdn.convDim]
-            ).asType(dtype)
-            eval(qkv, convState)
+                let qkv = MLXRandom.normal([1, 1, gdn.convDim]).asType(dtype)
+                let convState = MLXRandom.normal(
+                    [1, gdn.convKernelSize - 1, gdn.convDim]
+                ).asType(dtype)
+                eval(qkv, convState)
 
-            let (conv, state) = gdn.decodeConv(convState: convState, qkv: qkv)
-            let (refConv, refState) = gdn.generalConv(convState: convState, qkv: qkv)
-            eval(conv, state, refConv, refState)
+                let (conv, state) = gdn.decodeConv(convState: convState, qkv: qkv)
+                let (refConv, refState) = gdn.generalConv(convState: convState, qkv: qkv)
+                eval(conv, state, refConv, refState)
 
-            assertBitIdentical(conv, refConv, "conv output (\(dtype))")
-            assertBitIdentical(state, refState, "conv state (\(dtype))")
+                assertBitIdentical(conv, refConv, "conv output (\(dtype))")
+                assertBitIdentical(state, refState, "conv state (\(dtype))")
+            }
         }
     }
 }

--- a/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
@@ -57,41 +57,45 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
         for (e, k) in [(256, 8), (128, 8)] {
             for dtype in [DType.float16, DType.bfloat16, DType.float32] {
                 for normalize in [true, false] {
-                    MLXRandom.seed(UInt64(e + k + (normalize ? 1 : 0)))
-                    let tag = "E=\(e) K=\(k) \(dtype) norm=\(normalize)"
+                    withRandomState(
+                        MLXRandom.RandomState(seed: UInt64(e + k + (normalize ? 1 : 0)))
+                    ) {
+                        let tag = "E=\(e) K=\(k) \(dtype) norm=\(normalize)"
 
-                    // The production distribution: softmax outputs.
-                    let soft = MLX.softmax(
-                        MLXRandom.normal([rows, e]), axis: -1, precise: true
-                    ).asType(dtype)
-                    assertRouterMatchesChain(soft, k: k, normalize: normalize, "softmax \(tag)")
+                        // The production distribution: softmax outputs.
+                        let soft = MLX.softmax(
+                            MLXRandom.normal([rows, e]), axis: -1, precise: true
+                        ).asType(dtype)
+                        assertRouterMatchesChain(soft, k: k, normalize: normalize, "softmax \(tag)")
 
-                    // Heavy ties — the stable tie-break is the hard part.
-                    let ties = (MLX.round(MLXRandom.normal([rows, e]) * 2) / 2).asType(dtype)
-                    assertRouterMatchesChain(ties, k: k, normalize: normalize, "ties \(tag)")
+                        // Heavy ties — the stable tie-break is the hard part.
+                        let ties = (MLX.round(MLXRandom.normal([rows, e]) * 2) / 2).asType(dtype)
+                        assertRouterMatchesChain(ties, k: k, normalize: normalize, "ties \(tag)")
 
-                    // All-equal rows: pure index-order selection.
-                    let equal = MLX.full([rows, e], values: MLXArray(Float(0.25))).asType(dtype)
-                    assertRouterMatchesChain(equal, k: k, normalize: normalize, "all-equal \(tag)")
+                        // All-equal rows: pure index-order selection.
+                        let equal = MLX.full([rows, e], values: MLXArray(Float(0.25))).asType(dtype)
+                        assertRouterMatchesChain(
+                            equal, k: k, normalize: normalize, "all-equal \(tag)")
 
-                    // Signed zeros: compare equal, differ bitwise.
-                    let signs = MLX.where(
-                        MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
-                        MLXArray(Float(-0.0)), MLXArray(Float(0.0)))
-                    let zeros = MLX.where(
-                        MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
-                        signs, MLXRandom.normal([rows, e])
-                    ).asType(dtype)
-                    assertRouterMatchesChain(zeros, k: k, normalize: normalize, "±0 \(tag)")
+                        // Signed zeros: compare equal, differ bitwise.
+                        let signs = MLX.where(
+                            MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
+                            MLXArray(Float(-0.0)), MLXArray(Float(0.0)))
+                        let zeros = MLX.where(
+                            MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.5,
+                            signs, MLXRandom.normal([rows, e])
+                        ).asType(dtype)
+                        assertRouterMatchesChain(zeros, k: k, normalize: normalize, "±0 \(tag)")
 
-                    // NaN above everything, all NaNs tie; indices only.
-                    var nans = MLX.where(
-                        MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.05,
-                        MLXArray(Float.nan), MLXRandom.normal([rows, e])
-                    ).asType(dtype)
-                    nans[0] = MLX.full([e], values: MLXArray(Float.nan)).asType(dtype)
-                    assertRouterMatchesChain(
-                        nans, k: k, normalize: normalize, "NaN \(tag)", indicesOnly: true)
+                        // NaN above everything, all NaNs tie; indices only.
+                        var nans = MLX.where(
+                            MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.05,
+                            MLXArray(Float.nan), MLXRandom.normal([rows, e])
+                        ).asType(dtype)
+                        nans[0] = MLX.full([e], values: MLXArray(Float.nan)).asType(dtype)
+                        assertRouterMatchesChain(
+                            nans, k: k, normalize: normalize, "NaN \(tag)", indicesOnly: true)
+                    }
                 }
             }
         }

--- a/Tests/MLXLMTests/Qwen3VLContinuationTests.swift
+++ b/Tests/MLXLMTests/Qwen3VLContinuationTests.swift
@@ -66,7 +66,9 @@ final class Qwen3VLContinuationTests: XCTestCase {
             """
         let config = try JSONDecoder().decode(
             Qwen3VLConfiguration.self, from: Data(json.utf8))
-        return Qwen3VL(config)
+        // Pin the initializer weights. Task-local rather than MLXRandom.seed:
+        // parallel tests must not share (or perturb) the global random stream.
+        return withRandomState(MLXRandom.RandomState(seed: 1)) { Qwen3VL(config) }
     }
 
     /// One image with grid THW (1, 4, 4) and merge size 2 — four merged tokens
@@ -109,32 +111,33 @@ final class Qwen3VLContinuationTests: XCTestCase {
     /// A text-only follow-up may be rank-1 even though the cache was seeded by
     /// a batched image prompt. Warm routing must normalize it before slicing.
     func testRank1WarmImageContinuationMatchesFullPrefill() throws {
-        MLXRandom.seed(41)
-        let model = try makeTinyModel()
-        let image = makeImage()
-        let t1 = concatenated(
-            [textTokens(10), visionStart(), imageRun(), textTokens(8, seed: 5)], axis: 1)
-        let t2 = textTokens(8, seed: 9)
+        try withRandomState(MLXRandom.RandomState(seed: 41)) {
+            let model = try makeTinyModel()
+            let image = makeImage()
+            let t1 = concatenated(
+                [textTokens(10), visionStart(), imageRun(), textTokens(8, seed: 5)], axis: 1)
+            let t2 = textTokens(8, seed: 9)
 
-        let fullCache = try model.newCache(parameters: nil)
-        let (fullLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1)), image: image),
-                cache: fullCache, state: nil, prefill: .init()))
+            let fullCache = try model.newCache(parameters: nil)
+            let (fullLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: concatenated([t1, t2], axis: 1)), image: image),
+                    cache: fullCache, state: nil, prefill: .init()))
 
-        let warmCache = try model.newCache(parameters: nil)
-        let (_, state) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
-                prefill: .init()))
-        let (warmLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2[0])), cache: warmCache, state: state,
-                prefill: .init()))
+            let warmCache = try model.newCache(parameters: nil)
+            let (_, state) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
+                    prefill: .init()))
+            let (warmLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2[0])), cache: warmCache, state: state,
+                    prefill: .init()))
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(warmLogits, fullLogits), 1e-3,
-            "rank-1 warm continuation diverged from full prefill")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(warmLogits, fullLogits), 1e-3,
+                "rank-1 warm continuation diverged from full prefill")
+        }
     }
 
     /// With an image in turn 1, the rope delta the image accumulated must be
@@ -159,36 +162,37 @@ final class Qwen3VLContinuationTests: XCTestCase {
     /// return `.logits`, so both owe the contract: the windowed continuation (which delegates the
     /// per-chunk reports to `forEachChunk`) and the single-shot path.
     func testPrefillProgressReachesTheTotal() throws {
-        MLXRandom.seed(29)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 29)) {
+            let model = try makeTinyModel()
 
-        func events(for prompt: MLXArray, stepSize: Int?) throws -> [[Int]] {
-            final class Log: @unchecked Sendable { var events: [[Int]] = [] }
-            let log = Log()
-            var prefill = PrefillParameters(stepSize: stepSize)
-            prefill.progress = { log.events.append([$0, $1]) }
-            _ = try model.prepare(
-                LMInput(text: .init(tokens: prompt)),
-                cache: try model.newCache(parameters: nil), state: nil, prefill: prefill)
-            return log.events
+            func events(for prompt: MLXArray, stepSize: Int?) throws -> [[Int]] {
+                final class Log: @unchecked Sendable { var events: [[Int]] = [] }
+                let log = Log()
+                var prefill = PrefillParameters(stepSize: stepSize)
+                prefill.progress = { log.events.append([$0, $1]) }
+                _ = try model.prepare(
+                    LMInput(text: .init(tokens: prompt)),
+                    cache: try model.newCache(parameters: nil), state: nil, prefill: prefill)
+                return log.events
+            }
+
+            let prompt = textTokens(40)
+            for (label, stepSize) in [("windowed", 8), ("single-shot", 1024)] {
+                let events = try events(for: prompt, stepSize: stepSize)
+                XCTAssertEqual(
+                    events.last, [40, 40], "\(label) prefill must end at (total, total)")
+                XCTAssertEqual(
+                    events.map { $0[0] }, events.map { $0[0] }.sorted(),
+                    "\(label) progress must be monotone")
+                XCTAssertTrue(
+                    events.allSatisfy { $0[1] == 40 },
+                    "\(label) progress must report a stable total")
+            }
+
+            XCTAssertGreaterThan(
+                try events(for: prompt, stepSize: 8).count, 1,
+                "a windowed prefill should report more than just the terminal event")
         }
-
-        let prompt = textTokens(40)
-        for (label, stepSize) in [("windowed", 8), ("single-shot", 1024)] {
-            let events = try events(for: prompt, stepSize: stepSize)
-            XCTAssertEqual(
-                events.last, [40, 40], "\(label) prefill must end at (total, total)")
-            XCTAssertEqual(
-                events.map { $0[0] }, events.map { $0[0] }.sorted(),
-                "\(label) progress must be monotone")
-            XCTAssertTrue(
-                events.allSatisfy { $0[1] == 40 },
-                "\(label) progress must report a stable total")
-        }
-
-        XCTAssertGreaterThan(
-            try events(for: prompt, stepSize: 8).count, 1,
-            "a windowed prefill should report more than just the terminal event")
     }
 
     func testWindowedPrefillMatchesSingleShot() throws {
@@ -206,29 +210,30 @@ final class Qwen3VLContinuationTests: XCTestCase {
     /// Windowing must not change M-RoPE semantics just because an input carries
     /// a padding mask: Qwen3-VL's baseline forwards no attention mask.
     func testPaddedWindowedImagePrefillMatchesSingleShot() throws {
-        MLXRandom.seed(43)
-        let model = try makeTinyModel()
-        let image = makeImage()
-        let prompt = concatenated(
-            [textTokens(5), visionStart(), imageRun(), textTokens(12, seed: 3)], axis: 1)
-        let padding = MLXArray([Int32](repeating: 0, count: 4)).expandedDimensions(axis: 0)
-        let tokens = concatenated([prompt, padding], axis: 1)
-        let mask = MLXArray(
-            [Int32](repeating: 1, count: prompt.dim(1)) + [Int32](repeating: 0, count: 4)
-        ).expandedDimensions(axis: 0)
-        let input = LMInput(text: .init(tokens: tokens, mask: mask), image: image)
+        try withRandomState(MLXRandom.RandomState(seed: 43)) {
+            let model = try makeTinyModel()
+            let image = makeImage()
+            let prompt = concatenated(
+                [textTokens(5), visionStart(), imageRun(), textTokens(12, seed: 3)], axis: 1)
+            let padding = MLXArray([Int32](repeating: 0, count: 4)).expandedDimensions(axis: 0)
+            let tokens = concatenated([prompt, padding], axis: 1)
+            let mask = MLXArray(
+                [Int32](repeating: 1, count: prompt.dim(1)) + [Int32](repeating: 0, count: 4)
+            ).expandedDimensions(axis: 0)
+            let input = LMInput(text: .init(tokens: tokens, mask: mask), image: image)
 
-        let singleCache = try model.newCache(parameters: nil)
-        let (singleLogits, _) = try lastLogits(
-            model.prepare(input, cache: singleCache, state: nil, prefill: .init()))
+            let singleCache = try model.newCache(parameters: nil)
+            let (singleLogits, _) = try lastLogits(
+                model.prepare(input, cache: singleCache, state: nil, prefill: .init()))
 
-        let windowedCache = try model.newCache(parameters: nil)
-        let (windowedLogits, _) = try lastLogits(
-            model.prepare(input, cache: windowedCache, state: nil, prefill: .init(stepSize: 8)))
+            let windowedCache = try model.newCache(parameters: nil)
+            let (windowedLogits, _) = try lastLogits(
+                model.prepare(input, cache: windowedCache, state: nil, prefill: .init(stepSize: 8)))
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(windowedLogits, singleLogits), 1e-3,
-            "padding changed Qwen3-VL windowed M-RoPE semantics")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(windowedLogits, singleLogits), 1e-3,
+                "padding changed Qwen3-VL windowed M-RoPE semantics")
+        }
     }
 
     // MARK: - Fail-closed continuation state
@@ -237,47 +242,49 @@ final class Qwen3VLContinuationTests: XCTestCase {
     /// silently repositioning the remainder. A cold cache needs no anchor, so a
     /// long cold prefill through the same windowed path still works.
     func testWarmContinuationWithoutStateThrows() throws {
-        MLXRandom.seed(19)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 19)) {
+            let model = try makeTinyModel()
 
-        let cache = try model.newCache(parameters: nil)
-        XCTAssertNoThrow(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
-                prefill: .init(stepSize: 8)),
-            "a long cold prefill carries no anchor and must not throw")
+            let cache = try model.newCache(parameters: nil)
+            XCTAssertNoThrow(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(40))), cache: cache, state: nil,
+                    prefill: .init(stepSize: 8)),
+                "a long cold prefill carries no anchor and must not throw")
 
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: textTokens(6, seed: 2))), cache: cache, state: nil,
-                prefill: .init())
-        ) { error in
-            guard
-                case ContinuationStateError.missingState(_, let key)? =
-                    error as? ContinuationStateError
-            else {
-                return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: textTokens(6, seed: 2))), cache: cache, state: nil,
+                    prefill: .init())
+            ) { error in
+                guard
+                    case ContinuationStateError.missingState(_, let key)? =
+                        error as? ContinuationStateError
+                else {
+                    return XCTFail("expected ContinuationStateError.missingState, got \(error)")
+                }
+                XCTAssertEqual(key, "qwen35vl.ropeDeltas")
             }
-            XCTAssertEqual(key, "qwen35vl.ropeDeltas")
         }
     }
 
     /// A cold prefill must always hand back an anchor — zero for a text-only
     /// prompt — so an ordinary text conversation never trips the guard.
     func testColdTextOnlyPrefillCarriesAnchor() throws {
-        MLXRandom.seed(23)
-        let model = try makeTinyModel()
+        try withRandomState(MLXRandom.RandomState(seed: 23)) {
+            let model = try makeTinyModel()
 
-        let cache = try model.newCache(parameters: nil)
-        let (_, state) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: textTokens(10))), cache: cache, state: nil,
-                prefill: .init()))
+            let cache = try model.newCache(parameters: nil)
+            let (_, state) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: textTokens(10))), cache: cache, state: nil,
+                    prefill: .init()))
 
-        guard let anchor = state?[LMOutput.Key<MLXArray>("qwen35vl.ropeDeltas")] else {
-            return XCTFail("cold text-only prefill returned no rope delta")
+            guard let anchor = state?[LMOutput.Key<MLXArray>("qwen35vl.ropeDeltas")] else {
+                return XCTFail("cold text-only prefill returned no rope delta")
+            }
+            XCTAssertEqual(anchor.asType(.int32).item(Int.self), 0)
         }
-        XCTAssertEqual(anchor.asType(.int32).item(Int.self), 0)
     }
 
     // MARK: - Prompt cache round trip
@@ -285,46 +292,48 @@ final class Qwen3VLContinuationTests: XCTestCase {
     /// The end-to-end shape this feature exists for: save a warm image-bearing
     /// cache with its anchor, restore both, and continue equivalently.
     func testImageStateSurvivesPromptCacheRoundTrip() throws {
-        MLXRandom.seed(29)
-        let model = try makeTinyModel()
-        let image = makeImage()
+        try withRandomState(MLXRandom.RandomState(seed: 29)) {
+            let model = try makeTinyModel()
+            let image = makeImage()
 
-        let t1 = concatenated(
-            [textTokens(6), visionStart(), imageRun(), textTokens(6, seed: 2)], axis: 1)
-        let t2 = textTokens(8, seed: 4)
+            let t1 = concatenated(
+                [textTokens(6), visionStart(), imageRun(), textTokens(6, seed: 2)], axis: 1)
+            let t2 = textTokens(8, seed: 4)
 
-        let warmCache = try model.newCache(parameters: nil)
-        let (_, savedState) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
-                prefill: .init()))
-        XCTAssertNotNil(savedState)
+            let warmCache = try model.newCache(parameters: nil)
+            let (_, savedState) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t1), image: image), cache: warmCache, state: nil,
+                    prefill: .init()))
+            XCTAssertNotNil(savedState)
 
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("safetensors")
-        defer { try? FileManager.default.removeItem(at: url) }
-        try savePromptCache(url: url, cache: warmCache, state: savedState)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            try savePromptCache(url: url, cache: warmCache, state: savedState)
 
-        let snapshot = try loadPromptCacheSnapshot(url: url)
-        let (warmLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: warmCache, state: savedState,
-                prefill: .init()))
-        let (restoredLogits, _) = try lastLogits(
-            model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: snapshot.cache, state: snapshot.state,
-                prefill: .init()))
+            let snapshot = try loadPromptCacheSnapshot(url: url)
+            let (warmLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: warmCache, state: savedState,
+                    prefill: .init()))
+            let (restoredLogits, _) = try lastLogits(
+                model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: snapshot.cache, state: snapshot.state,
+                    prefill: .init()))
 
-        XCTAssertLessThanOrEqual(
-            maxAbsDiff(restoredLogits, warmLogits), 1e-6,
-            "disk-restored state diverged from the live warm continuation")
+            XCTAssertLessThanOrEqual(
+                maxAbsDiff(restoredLogits, warmLogits), 1e-6,
+                "disk-restored state diverged from the live warm continuation")
 
-        // Dropping the state on restore is the bug this feature prevents; it
-        // must fail loudly rather than decode at the wrong positions.
-        let keptCache = try loadPromptCacheSnapshot(url: url).cache
-        XCTAssertThrowsError(
-            try model.prepare(
-                LMInput(text: .init(tokens: t2)), cache: keptCache, state: nil, prefill: .init()))
+            // Dropping the state on restore is the bug this feature prevents; it
+            // must fail loudly rather than decode at the wrong positions.
+            let keptCache = try loadPromptCacheSnapshot(url: url).cache
+            XCTAssertThrowsError(
+                try model.prepare(
+                    LMInput(text: .init(tokens: t2)), cache: keptCache, state: nil, prefill: .init()
+                ))
+        }
     }
 }

--- a/Tests/MLXLMTests/RoPEApplicationTests.swift
+++ b/Tests/MLXLMTests/RoPEApplicationTests.swift
@@ -6,51 +6,54 @@ import Testing
 @testable import MLXLLM
 @testable import MLXLMCommon
 
-@Suite(.serialized)
 struct RoPEApplicationTests {
 
     /// Gemma3nAttention applies rope, updates the cache and applies rope again.
     /// Ensure that it is correctly implemented.  We can observe prefill vs single token
     /// generaton and they should produce the same answers if implemented correctly.
     @Test func gemma3nAttentionTest() {
-        let config = Gemma3nTextConfiguration()
-        let attention = Gemma3nAttention(config, layerIdx: 3)
+        // Task-local rather than MLXRandom.seed: parallel tests must not share
+        // (or perturb) the global random stream. The scope covers the module
+        // initializer too, so the attention weights are pinned as well.
+        withRandomState(MLXRandom.RandomState(seed: 42)) {
+            let config = Gemma3nTextConfiguration()
+            let attention = Gemma3nAttention(config, layerIdx: 3)
 
-        #expect(!attention.isKvSharedLayer)
+            #expect(!attention.isKvSharedLayer)
 
-        let B = 1
-        let L = 4
-        let D = config.hiddenSize
+            let B = 1
+            let L = 4
+            let D = config.hiddenSize
 
-        MLXRandom.seed(42)
-        let x = MLXRandom.normal([B, L, D])
-        eval(x)
+            let x = MLXRandom.normal([B, L, D])
+            eval(x)
 
-        // Batch: process all L tokens at once with a causal mask
-        let cacheBatch = KVCacheSimple()
-        let causalMask = createAttentionMask(h: x, cache: cacheBatch)
-        let outputBatch = attention(x, mask: causalMask, cache: cacheBatch)
-        eval(outputBatch)
+            // Batch: process all L tokens at once with a causal mask
+            let cacheBatch = KVCacheSimple()
+            let causalMask = createAttentionMask(h: x, cache: cacheBatch)
+            let outputBatch = attention(x, mask: causalMask, cache: cacheBatch)
+            eval(outputBatch)
 
-        // Sequential: process one token at a time (mask=.none since L=1 with cache)
-        let cacheSeq = KVCacheSimple()
-        var seqOutputs: [MLXArray] = []
-        for i in 0 ..< L {
-            let token = x[0..., i ..< (i + 1), 0...]
-            let mask = createAttentionMask(h: token, cache: cacheSeq)
-            let out = attention(token, mask: mask, cache: cacheSeq)
-            seqOutputs.append(out)
+            // Sequential: process one token at a time (mask=.none since L=1 with cache)
+            let cacheSeq = KVCacheSimple()
+            var seqOutputs: [MLXArray] = []
+            for i in 0 ..< L {
+                let token = x[0..., i ..< (i + 1), 0...]
+                let mask = createAttentionMask(h: token, cache: cacheSeq)
+                let out = attention(token, mask: mask, cache: cacheSeq)
+                seqOutputs.append(out)
+            }
+            let outputSeq = concatenated(seqOutputs, axis: 1)
+            eval(outputSeq)
+
+            // With correct RoPE these would match.  The buggy code would use
+            // different offsets for keys/queries.
+            let match = allClose(outputBatch, outputSeq, atol: 1e-4)
+            eval(match)
+            print(outputBatch)
+            print(outputSeq)
+            print(abs(outputSeq - outputBatch))
+            #expect(match.item(Bool.self))
         }
-        let outputSeq = concatenated(seqOutputs, axis: 1)
-        eval(outputSeq)
-
-        // With correct RoPE these would match.  The buggy code would use
-        // different offsets for keys/queries.
-        let match = allClose(outputBatch, outputSeq, atol: 1e-4)
-        eval(match)
-        print(outputBatch)
-        print(outputSeq)
-        print(abs(outputSeq - outputBatch))
-        #expect(match.item(Bool.self))
     }
 }

--- a/Tests/MLXLMTests/SSMTests.swift
+++ b/Tests/MLXLMTests/SSMTests.swift
@@ -18,155 +18,155 @@ private func expectAllClose(
 }
 
 @Test func testSSMAttnChunkedMatchesUnchunkedValuesAndGradients() {
-    MLXRandom.seed(11)
+    withRandomState(MLXRandom.RandomState(seed: 11)) {
+        let batch = 1
+        let sequence = 5
+        let heads = 4
+        let headDimension = 3
+        let groups = 2
+        let stateDimension = 3
 
-    let batch = 1
-    let sequence = 5
-    let heads = 4
-    let headDimension = 3
-    let groups = 2
-    let stateDimension = 3
+        let parameters = [
+            MLXRandom.normal([batch, sequence, heads, headDimension]),
+            MLXRandom.normal([heads]) * 0.1,
+            MLXRandom.normal([batch, sequence, groups, stateDimension]) * 0.2,
+            MLXRandom.normal([batch, sequence, groups, stateDimension]) * 0.2,
+            MLXRandom.normal([heads]) * 0.2,
+            MLXRandom.normal([batch, sequence, heads]) * 0.1,
+            MLXRandom.normal([heads]) * 0.1,
+            MLXRandom.normal([batch, heads, headDimension, stateDimension]) * 0.2,
+        ]
 
-    let parameters = [
-        MLXRandom.normal([batch, sequence, heads, headDimension]),
-        MLXRandom.normal([heads]) * 0.1,
-        MLXRandom.normal([batch, sequence, groups, stateDimension]) * 0.2,
-        MLXRandom.normal([batch, sequence, groups, stateDimension]) * 0.2,
-        MLXRandom.normal([heads]) * 0.2,
-        MLXRandom.normal([batch, sequence, heads]) * 0.1,
-        MLXRandom.normal([heads]) * 0.1,
-        MLXRandom.normal([batch, heads, headDimension, stateDimension]) * 0.2,
-    ]
+        func forward(_ parameters: [MLXArray], step: Int) -> (MLXArray, MLXArray) {
+            ssmAttn(
+                x: parameters[0],
+                ALog: parameters[1],
+                B: parameters[2],
+                C: parameters[3],
+                D: parameters[4],
+                dt: parameters[5],
+                dtBias: parameters[6],
+                state: parameters[7],
+                step: step
+            )
+        }
 
-    func forward(_ parameters: [MLXArray], step: Int) -> (MLXArray, MLXArray) {
-        ssmAttn(
-            x: parameters[0],
-            ALog: parameters[1],
-            B: parameters[2],
-            C: parameters[3],
-            D: parameters[4],
-            dt: parameters[5],
-            dtBias: parameters[6],
-            state: parameters[7],
-            step: step
-        )
-    }
+        let (referenceOutput, referenceState) = forward(parameters, step: sequence)
 
-    let (referenceOutput, referenceState) = forward(parameters, step: sequence)
+        func valueAndGradient(step: Int) -> ([MLXArray], [MLXArray]) {
+            valueAndGrad(
+                { parameters in
+                    let (output, state) = forward(parameters, step: step)
+                    return [(output.square().mean() + state.square().mean())]
+                },
+                argumentNumbers: parameters.indices
+            )(parameters)
+        }
 
-    func valueAndGradient(step: Int) -> ([MLXArray], [MLXArray]) {
-        valueAndGrad(
-            { parameters in
-                let (output, state) = forward(parameters, step: step)
-                return [(output.square().mean() + state.square().mean())]
-            },
-            argumentNumbers: parameters.indices
-        )(parameters)
-    }
+        let (referenceValue, referenceGradients) = valueAndGradient(step: sequence)
+        #expect(referenceGradients.count == parameters.count)
+        let gradientLabels = ["x", "ALog", "B", "C", "D", "dt", "dtBias", "state"]
 
-    let (referenceValue, referenceGradients) = valueAndGradient(step: sequence)
-    #expect(referenceGradients.count == parameters.count)
-    let gradientLabels = ["x", "ALog", "B", "C", "D", "dt", "dtBias", "state"]
+        for step in [1, 2, 3] {
+            let (chunkedOutput, chunkedState) = forward(parameters, step: step)
+            let (chunkedValue, chunkedGradients) = valueAndGradient(step: step)
+            eval(
+                chunkedOutput, chunkedState, chunkedValue, chunkedGradients, referenceOutput,
+                referenceState, referenceValue, referenceGradients)
 
-    for step in [1, 2, 3] {
-        let (chunkedOutput, chunkedState) = forward(parameters, step: step)
-        let (chunkedValue, chunkedGradients) = valueAndGradient(step: step)
-        eval(
-            chunkedOutput, chunkedState, chunkedValue, chunkedGradients, referenceOutput,
-            referenceState, referenceValue, referenceGradients)
-
-        expectAllClose(chunkedOutput, referenceOutput, label: "output (step \(step))")
-        expectAllClose(chunkedState, referenceState, label: "state (step \(step))")
-        expectAllClose(chunkedValue[0], referenceValue[0], label: "loss (step \(step))")
-        #expect(chunkedGradients.count == parameters.count)
-        for (index, pair) in zip(chunkedGradients, referenceGradients).enumerated() {
-            expectAllClose(
-                pair.0, pair.1, label: "\(gradientLabels[index]) gradient (step \(step))",
-                rtol: 5e-4, atol: 5e-5)
+            expectAllClose(chunkedOutput, referenceOutput, label: "output (step \(step))")
+            expectAllClose(chunkedState, referenceState, label: "state (step \(step))")
+            expectAllClose(chunkedValue[0], referenceValue[0], label: "loss (step \(step))")
+            #expect(chunkedGradients.count == parameters.count)
+            for (index, pair) in zip(chunkedGradients, referenceGradients).enumerated() {
+                expectAllClose(
+                    pair.0, pair.1, label: "\(gradientLabels[index]) gradient (step \(step))",
+                    rtol: 5e-4, atol: 5e-5)
+            }
         }
     }
 }
 
 @Test func testSSMAttnFinalStateGradientCrossesChunkBoundaries() {
-    MLXRandom.seed(12)
+    withRandomState(MLXRandom.RandomState(seed: 12)) {
+        let sequence = 5
+        let x = MLXRandom.normal([1, sequence, 2, 2])
+        let aLog = MLXRandom.normal([2]) * 0.1
+        let inputMixing = MLXRandom.normal([1, sequence, 1, 3]) * 0.2
+        let outputMixing = MLXArray.zeros([1, sequence, 1, 3])
+        let residualScale = MLXArray.zeros([2])
+        let dt = MLXRandom.normal([1, sequence, 2]) * 0.1
+        let dtBias = MLXRandom.normal([2]) * 0.1
 
-    let sequence = 5
-    let x = MLXRandom.normal([1, sequence, 2, 2])
-    let aLog = MLXRandom.normal([2]) * 0.1
-    let inputMixing = MLXRandom.normal([1, sequence, 1, 3]) * 0.2
-    let outputMixing = MLXArray.zeros([1, sequence, 1, 3])
-    let residualScale = MLXArray.zeros([2])
-    let dt = MLXRandom.normal([1, sequence, 2]) * 0.1
-    let dtBias = MLXRandom.normal([2]) * 0.1
+        let gradient = grad { input in
+            let (_, state) = ssmAttn(
+                x: input,
+                ALog: aLog,
+                B: inputMixing,
+                C: outputMixing,
+                D: residualScale,
+                dt: dt,
+                dtBias: dtBias,
+                step: 2
+            )
+            return state.square().sum()
+        }(x)
+        eval(gradient)
 
-    let gradient = grad { input in
-        let (_, state) = ssmAttn(
-            x: input,
+        let firstChunkMagnitude = gradient[0..., ..<2, 0..., 0...].abs().sum().item(Float.self)
+        #expect(firstChunkMagnitude.isFinite)
+        #expect(firstChunkMagnitude > 0, "final state is disconnected from the first chunk")
+    }
+}
+
+@Test func testSSMAttnPreservesRecurrentStateDTypeAcrossChunks() throws {
+    withRandomState(MLXRandom.RandomState(seed: 7)) {
+        let dtype = DType.bfloat16
+        let batch = 1
+        let sequence = 5
+        let heads = 4
+        let headDim = 3
+        let groups = 2
+        let stateDim = 8
+
+        let x = MLXRandom.normal([batch, sequence, heads, headDim]).asType(dtype)
+        let aLog = MLXRandom.normal([heads]).asType(dtype)
+        let B = MLXRandom.normal([batch, sequence, groups, stateDim]).asType(dtype)
+        let C = MLXRandom.normal([batch, sequence, groups, stateDim]).asType(dtype)
+        let D = MLXRandom.normal([heads]).asType(dtype)
+        let dt = MLXRandom.normal([batch, sequence, heads]).asType(dtype)
+        let dtBias = MLXRandom.normal([heads]).asType(dtype)
+
+        let (freshY, freshState) = ssmAttn(
+            x: x,
             ALog: aLog,
-            B: inputMixing,
-            C: outputMixing,
-            D: residualScale,
+            B: B,
+            C: C,
+            D: D,
             dt: dt,
             dtBias: dtBias,
             step: 2
         )
-        return state.square().sum()
-    }(x)
-    eval(gradient)
+        eval(freshY, freshState)
 
-    let firstChunkMagnitude = gradient[0..., ..<2, 0..., 0...].abs().sum().item(Float.self)
-    #expect(firstChunkMagnitude.isFinite)
-    #expect(firstChunkMagnitude > 0, "final state is disconnected from the first chunk")
-}
+        #expect(freshY.dtype == dtype)
+        #expect(freshState.dtype == dtype)
 
-@Test func testSSMAttnPreservesRecurrentStateDTypeAcrossChunks() throws {
-    MLXRandom.seed(7)
+        let previousState = MLXRandom.normal([batch, heads, headDim, stateDim]).asType(dtype)
+        let (continuedY, continuedState) = ssmAttn(
+            x: x,
+            ALog: aLog,
+            B: B,
+            C: C,
+            D: D,
+            dt: dt,
+            dtBias: dtBias,
+            state: previousState,
+            step: 2
+        )
+        eval(continuedY, continuedState)
 
-    let dtype = DType.bfloat16
-    let batch = 1
-    let sequence = 5
-    let heads = 4
-    let headDim = 3
-    let groups = 2
-    let stateDim = 8
-
-    let x = MLXRandom.normal([batch, sequence, heads, headDim]).asType(dtype)
-    let aLog = MLXRandom.normal([heads]).asType(dtype)
-    let B = MLXRandom.normal([batch, sequence, groups, stateDim]).asType(dtype)
-    let C = MLXRandom.normal([batch, sequence, groups, stateDim]).asType(dtype)
-    let D = MLXRandom.normal([heads]).asType(dtype)
-    let dt = MLXRandom.normal([batch, sequence, heads]).asType(dtype)
-    let dtBias = MLXRandom.normal([heads]).asType(dtype)
-
-    let (freshY, freshState) = ssmAttn(
-        x: x,
-        ALog: aLog,
-        B: B,
-        C: C,
-        D: D,
-        dt: dt,
-        dtBias: dtBias,
-        step: 2
-    )
-    eval(freshY, freshState)
-
-    #expect(freshY.dtype == dtype)
-    #expect(freshState.dtype == dtype)
-
-    let previousState = MLXRandom.normal([batch, heads, headDim, stateDim]).asType(dtype)
-    let (continuedY, continuedState) = ssmAttn(
-        x: x,
-        ALog: aLog,
-        B: B,
-        C: C,
-        D: D,
-        dt: dt,
-        dtBias: dtBias,
-        state: previousState,
-        step: 2
-    )
-    eval(continuedY, continuedState)
-
-    #expect(continuedY.dtype == dtype)
-    #expect(continuedState.dtype == previousState.dtype)
+        #expect(continuedY.dtype == dtype)
+        #expect(continuedState.dtype == previousState.dtype)
+    }
 }


### PR DESCRIPTION
## Proposed changes

Fixes #577.

Many tests seeded the process-wide random stream via `MLXRandom.seed`. That was fine when tests ran serially, but Swift Testing runs suites in parallel by default: any two tests consuming the global stream concurrently interleave their draws, so seeded tests were neither isolated nor reproducible.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
