### PR TITLE
RotatingKVCache: make trim wrap-aware instead of corrupting the ring

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -568,6 +568,16 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     private var step: Int
     private var idx: Int = 0
 
+    /// Whether the buffer is in ring layout: rows at `idx...` chronologically precede
+    /// rows at `keep ..< idx`. `nil` only after restoring a legacy metaState, where the
+    /// layout is derived on demand: of the states legacy code could save, exactly the
+    /// wrapped ring has a mid-buffer write position with more history than rows behind it.
+    private var wrappedFlag: Bool? = false
+
+    private var wrapped: Bool {
+        wrappedFlag ?? (idx < (keys?.dim(2) ?? 0) && offset > idx)
+    }
+
     /// Model-native sliding-window caches deliberately keep their architectural
     /// window and do not participate in requested-capacity validation.
     package var capacityOrigin = CapacityOrigin.modelNative
@@ -607,10 +617,13 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     private func temporalOrder(_ array: MLXArray) -> MLXArray {
-        // Rearrange the cache into temporal order, slicing off the end if unused
+        // Rearrange the cache into temporal order, slicing off the end if unused.
+        // `idx` bounds the live rows: after a post-wrap trim the logical `offset`
+        // exceeds the rows actually held, so the layout question is `wrapped`,
+        // never an `idx`/`offset` comparison.
         if idx == array.dim(2) {
             return array
-        } else if idx < offset {
+        } else if wrapped {
             return concatenated(
                 [
                     array[.ellipsis, ..<keep, 0...],
@@ -694,6 +707,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
 
         offset += keys.dim(2)
         idx = self.keys!.dim(2)
+        wrappedFlag = false
 
         return (self.keys!, self.values!)
     }
@@ -704,13 +718,13 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         let S = keys.dim(2)
         let kHeadDim = keys.dim(3)
         let vHeadDim = values.dim(3)
-        let prev = offset
 
-        // May not have hit the max size yet, so potentially keep growing the cache
-        if self.keys == nil
-            || (prev >= self.keys!.dim(2) && self.keys!.dim(2) < maxCacheSize)
-        {
-            let newSize = min(step, maxCacheSize - prev)
+        // May not have hit the max size yet, so potentially keep growing the cache.
+        // Fill is tracked by `idx`, not `offset`: after a post-wrap trim the logical
+        // offset exceeds the rows actually held, and growth must resume from the rows.
+        let filled = self.keys?.dim(2) ?? 0
+        if self.keys == nil || (!wrapped && idx >= filled && filled < maxCacheSize) {
+            let newSize = min(step, maxCacheSize - filled)
 
             let kShape = [B, nKVHeads, newSize, kHeadDim]
             let vShape = [B, nKVHeads, newSize, vHeadDim]
@@ -724,7 +738,6 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
                 self.keys = newK
                 self.values = newV
             }
-            idx = prev
         }
 
         // Trim if needed
@@ -738,6 +751,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         // Rotate if we've hit the end
         if idx == maxCacheSize {
             idx = keep
+            wrappedFlag = true
         }
 
         // Assign
@@ -746,11 +760,12 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         offset += S
         idx += S
 
-        // Return the appropriate cache slice
-        if offset < maxCacheSize {
+        // Return the appropriate cache slice: live rows are bounded by `idx` in
+        // temporal layout, while a wrapped ring is fully live.
+        if !wrapped, idx < self.keys!.dim(2) {
             return (
-                self.keys![.ellipsis, ..<offset, 0...],
-                self.values![.ellipsis, ..<offset, 0...]
+                self.keys![.ellipsis, ..<idx, 0...],
+                self.values![.ellipsis, ..<idx, 0...]
             )
         }
         return (self.keys!, self.values!)
@@ -769,10 +784,10 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     public override var state: [MLXArray] {
         get {
             guard let keys = self.keys, let values = self.values else { return [] }
-            if offset < keys.dim(2) {
+            if !wrapped, idx < keys.dim(2) {
                 return [
-                    keys[.ellipsis, ..<offset, 0...],
-                    values[.ellipsis, ..<offset, 0...],
+                    keys[.ellipsis, ..<idx, 0...],
+                    values[.ellipsis, ..<idx, 0...],
                 ]
             } else {
                 return [keys, values]
@@ -793,12 +808,12 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         get {
             return [
                 String(keep), String(maxCacheSize), String(step), String(offset), String(idx),
-                capacityOrigin.rawValue,
+                capacityOrigin.rawValue, String(wrapped),
             ]
         }
         set {
-            guard newValue.count == 5 || newValue.count == 6 else {
-                fatalError("RotatingKVCache metaState must have 5 or 6 values")
+            guard (5 ... 7).contains(newValue.count) else {
+                fatalError("RotatingKVCache metaState must have 5 to 7 values")
             }
             guard let keepVal = Int(newValue[0]),
                 let stepVal = Int(newValue[2]),
@@ -820,13 +835,22 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
             self.step = stepVal
             self.offset = offsetVal
             self.idx = idxVal
-            if newValue.count == 6 {
+            if newValue.count >= 6 {
                 guard let origin = CapacityOrigin(rawValue: newValue[5]) else {
                     fatalError("Invalid RotatingKVCache capacity origin '\(newValue[5])'")
                 }
                 self.capacityOrigin = origin
             } else {
                 self.capacityOrigin = .modelNative
+            }
+            if newValue.count == 7 {
+                guard let wrappedValue = Bool(newValue[6]) else {
+                    fatalError("Invalid RotatingKVCache wrapped flag '\(newValue[6])'")
+                }
+                self.wrappedFlag = wrappedValue
+            } else {
+                // Legacy metaState: derive the layout lazily via `wrapped`.
+                self.wrappedFlag = nil
             }
         }
     }
@@ -836,12 +860,40 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public override func isTrimmable(after positions: Int) -> Bool {
+        // This is the *exact rewind* predicate: past the window a trim is merely
+        // consistent (see `trim`), because rows the rewound writes overwrote are
+        // gone. Consumers that must undo writes exactly -- the staged-round and
+        // prompt-cache-reuse machinery -- key off this and fall back to staging,
+        // snapshots, or a rebuild once it turns false.
         offset + positions < maxCacheSize
     }
 
+    /// Rewind the newest `n` positions.
+    ///
+    /// Before the ring wraps this is exact bookkeeping. After it wraps, the ring is
+    /// linearized and the newest rows are cut: the cache stays consistent and the
+    /// logical offset rewinds, but rows the rewound writes overwrote at the old edge
+    /// of the window cannot come back, so the window is up to `n` rows short until
+    /// it refills. Callers that need an exact rewind must gate on
+    /// ``isTrimmable(after:)`` instead of calling this unconditionally.
     @discardableResult
     public override func trim(_ n: Int) -> Int {
-        let trimmed = min(offset, n)
+        guard n > 0 else { return 0 }
+        if wrapped, let keys = self.keys, let values = self.values {
+            // Ring layout: linearize to temporal order, then cut the newest rows.
+            // The pinned `keep` prefix is never evictable, so it bounds the cut.
+            let live = keys.dim(2)
+            let trimmed = Swift.min(n, live - keep)
+            guard trimmed > 0 else { return 0 }
+            let bound = live - trimmed
+            self.keys = temporalOrder(keys)[.ellipsis, ..<bound, 0...]
+            self.values = temporalOrder(values)[.ellipsis, ..<bound, 0...]
+            idx = bound
+            offset -= trimmed
+            wrappedFlag = false
+            return trimmed
+        }
+        let trimmed = Swift.min(Swift.min(offset, idx), n)
         offset -= trimmed
         idx -= trimmed
         return trimmed
@@ -852,9 +904,12 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         n: Int, windowSize: Int?, returnArray: Bool
     ) -> MLXFast.ScaledDotProductAttentionMaskMode {
         if n > 1 {
-            // Multi-token case
+            // Multi-token case. The mask must span the rows the write will present:
+            // in temporal layout that is the live rows (`idx`), which fall below the
+            // logical offset after a post-wrap trim.
             let actualWindowSize = windowSize ?? maxCacheSize
-            let cappedOffset = min(maxCacheSize - 1, offset)
+            let liveRows = wrapped ? maxCacheSize : idx
+            let cappedOffset = min(maxCacheSize - 1, liveRows)
 
             // Decide if we need an array mask
             if cappedOffset + n > actualWindowSize || returnArray {
@@ -875,7 +930,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
                     currentIdx = 0
                 }
 
-                let maskSize = offset < maxCacheSize ? offset + 1 : maxCacheSize
+                let maskSize = (!wrapped && idx < maxCacheSize) ? idx + 1 : maxCacheSize
                 let mask = MLXArray(0 ..< Int32(maskSize)) .>= Int32(maskSize - windowSize)
 
                 // Roll the mask to account for rotation
@@ -888,7 +943,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public var debugDescription: String {
-        "\(String(describing: Self.self)) offset: \(offset), maxSize: \(maxCacheSize.description), keep: \(keep), idx: \(idx)"
+        "\(String(describing: Self.self)) offset: \(offset), maxSize: \(maxCacheSize.description), keep: \(keep), idx: \(idx), wrapped: \(wrapped)"
     }
 
     public override func copy() -> any KVCache {
@@ -2071,14 +2126,20 @@ private func restoreCacheFromMetaState(
     case "RotatingKVCache":
         try validatePromptCache(
             className: className, state: state, stateCounts: [0, 2],
-            metadata: metaState, metadataCounts: [5, 6])
+            metadata: metaState, metadataCounts: [5, 6, 7])
         let values = try promptCacheIntegers(metaState.prefix(5), className: className)
-        if metaState.count == 6,
+        if metaState.count >= 6,
             RotatingKVCache.CapacityOrigin(rawValue: metaState[5]) == nil
         {
             throw KVCacheError(
                 message:
                     "Corrupt prompt cache: invalid RotatingKVCache capacity origin '\(metaState[5])'."
+            )
+        }
+        if metaState.count == 7, Bool(metaState[6]) == nil {
+            throw KVCacheError(
+                message:
+                    "Corrupt prompt cache: invalid RotatingKVCache wrapped flag '\(metaState[6])'."
             )
         }
 

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -568,10 +568,11 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     private var step: Int
     private var idx: Int = 0
 
-    /// Whether the buffer is in ring layout: rows at `idx...` chronologically precede
-    /// rows at `keep ..< idx`. `nil` only after restoring a legacy metaState, where the
-    /// layout is derived on demand: of the states legacy code could save, exactly the
-    /// wrapped ring has a mid-buffer write position with more history than rows behind it.
+    /// In ring layout all rows are live, with `idx...` preceding `keep ..< idx`.
+    /// At the end of the buffer the ring is already in temporal order. Otherwise,
+    /// temporal layout holds only the first `idx` rows, even when `offset` is larger.
+    /// `nil` defers legacy inference until arrays and metadata have both been restored.
+    /// Every write or trim resolves it before changing either buffers or counters.
     private var wrappedFlag: Bool? = false
 
     private var wrapped: Bool {
@@ -772,6 +773,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     }
 
     public override func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        wrappedFlag = wrapped
         let result =
             if keys.dim(2) == 1 {
                 updateInPlace(keys: keys, values: values)
@@ -849,7 +851,8 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
                 }
                 self.wrappedFlag = wrappedValue
             } else {
-                // Legacy metaState: derive the layout lazily via `wrapped`.
+                // Either setter may run first. Defer inference until the restored
+                // arrays are available, then freeze the layout before any mutation.
                 self.wrappedFlag = nil
             }
         }
@@ -876,26 +879,30 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
     /// of the window cannot come back, so the window is up to `n` rows short until
     /// it refills. Callers that need an exact rewind must gate on
     /// ``isTrimmable(after:)`` instead of calling this unconditionally.
+    /// Once older rows have been evicted, trimming stops at the pinned `keep` prefix.
     @discardableResult
     public override func trim(_ n: Int) -> Int {
-        guard n > 0 else { return 0 }
-        if wrapped, let keys = self.keys, let values = self.values {
-            // Ring layout: linearize to temporal order, then cut the newest rows.
-            // The pinned `keep` prefix is never evictable, so it bounds the cut.
-            let live = keys.dim(2)
-            let trimmed = Swift.min(n, live - keep)
-            guard trimmed > 0 else { return 0 }
-            let bound = live - trimmed
+        guard n > 0, let keys, let values else { return 0 }
+        wrappedFlag = wrapped
+        let live = wrapped ? keys.dim(2) : idx
+        // A gap between history and live rows means eviction has occurred. Preserve
+        // the pinned prefix regardless of layout, including after repeated trims.
+        // Without a gap, an exact rewind can still remove any of the original rows.
+        let minimum = offset > live ? Swift.min(keep, live) : 0
+        let trimmed = Swift.min(n, live - minimum)
+        guard trimmed > 0 else { return 0 }
+        let bound = live - trimmed
+
+        if wrapped || keys.dim(2) > maxCacheSize {
+            // Linearize a ring before cutting its newest rows. Also shrink oversized
+            // prefill buffers: the next single-token write compacts those buffers to
+            // maxCacheSize and must not treat a discarded suffix as live history.
             self.keys = temporalOrder(keys)[.ellipsis, ..<bound, 0...]
             self.values = temporalOrder(values)[.ellipsis, ..<bound, 0...]
-            idx = bound
-            offset -= trimmed
-            wrappedFlag = false
-            return trimmed
         }
-        let trimmed = Swift.min(Swift.min(offset, idx), n)
+        idx = bound
         offset -= trimmed
-        idx -= trimmed
+        wrappedFlag = false
         return trimmed
     }
 

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -160,6 +160,9 @@ private final class ProtocolDefaultTrimmabilityCache: KVCache {
 }
 
 @Test func testRotatingKVCacheIsNotTrimmableAtOrPastWindow() {
+    // `isTrimmable` is the *exact rewind* predicate. Past the window a trim is
+    // merely consistent (the window loses its oldest rows), so this must stay
+    // false to keep the staged-round and prompt-cache-reuse machinery exact.
     let cache = RotatingKVCache(maxSize: 8)
 
     cache.offset = 8
@@ -630,7 +633,9 @@ func testCacheSerialization(creator: (() -> any KVCache)) async throws {
     let rotating = try #require(restored.first as? RotatingKVCache)
 
     #expect(rotating.capacityOrigin == .modelNative)
-    #expect(rotating.metaState == ["0", "32", "256", "1", "1", "modelNative"])
+    // Legacy metadata has no wrapped flag; the restored cache derives it (an
+    // unwrapped layout here) and re-serializes with the flag appended.
+    #expect(rotating.metaState == ["0", "32", "256", "1", "1", "modelNative", "false"])
 }
 
 @Test func testPromptCacheRoundTripPreservesEmptyCaches() throws {
@@ -2075,4 +2080,159 @@ private func fillOneAtATime(_ cache: RotatingKVCache, positions: Range<Int>) {
     #expect(varn.tileSize == 32)
     #expect(varn.sinkhornIterations == 8)
     #expect(varn.compressionStart == 8)
+}
+
+// MARK: - RotatingKVCache wrap-aware trim
+//
+// Trimming a wrapped ring used to silently corrupt it (the ring invariants cannot
+// express a hole in the timeline). A wrapped trim now linearizes the ring to temporal
+// order and cuts the newest rows: consistent and clamped, though not exact -- rows the
+// rewound writes overwrote at the old edge of the window cannot come back, which is why
+// `isTrimmable` stays false past the window for the exact-rewind machinery. Every
+// consumer of the buffer (writes, masks, state) now bounds live rows by `idx` instead
+// of assuming the logical `offset` still equals the fill.
+
+@Test func testRotatingTrimAfterWrapCutsNewestAndKeepsChronology() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)  // wrapped ring holding 12 ..< 20
+
+    let trimmed = cache.trim(3)  // rewind 17, 18, 19
+
+    #expect(trimmed == 3)
+    #expect(cache.offset == 17)
+    let view = try #require(cache.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(12 ..< 17), "trim did not cut the newest rows")
+    #expect(encodedPositions(view.1).map { -$0 } == Array(12 ..< 17), "values diverged from keys")
+}
+
+@Test func testRotatingTrimAfterWrapClampsToNonPinnedSpan() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 2)
+    fillOneAtATime(cache, positions: 0 ..< 13)  // pinned [0, 1], ring holds 7 ..< 13
+
+    let trimmed = cache.trim(100)
+
+    #expect(trimmed == 6, "the pinned prefix must bound the cut")
+    #expect(cache.offset == 7)
+    let view = try #require(cache.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == [0, 1], "the pinned prefix must survive a maximal trim")
+}
+
+@Test func testRotatingSingleTokenRegrowthAfterWrapTrimPresentsOnlyLiveRows() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+    cache.trim(3)  // holds 12 ..< 17
+
+    // The buffer regrows from 5 rows; the presentation must never include the
+    // freshly allocated (dead) rows.
+    let (k, v) = positionedKV(17 ..< 18)
+    let presented = cache.update(keys: k, values: v)
+    #expect(encodedPositions(presented.0) == Array(12 ..< 18))
+    #expect(cache.offset == 18)
+
+    // Refill through the rotation boundary and verify chronology survives re-wrapping.
+    fillOneAtATime(cache, positions: 18 ..< 25)
+    #expect(cache.offset == 25)
+    let view = try #require(cache.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(17 ..< 25))
+}
+
+@Test func testRotatingMultiTokenWriteAfterWrapTrimStaysChronological() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+    cache.trim(3)  // holds 12 ..< 17
+
+    // The speculative verify shape: a multi-token write straight after a rewind.
+    let (k, v) = positionedKV(17 ..< 21)
+    let presented = cache.update(keys: k, values: v)
+    #expect(encodedPositions(presented.0) == Array(12 ..< 21))
+    #expect(cache.offset == 21)
+
+    fillOneAtATime(cache, positions: 21 ..< 24)
+    let view = try #require(cache.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(16 ..< 24))
+}
+
+@Test func testRotatingRepeatedTrimAfterWrapTakesTemporalPath() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    #expect(cache.trim(2) == 2)  // ring path: holds 12 ..< 18
+    #expect(cache.trim(2) == 2)  // temporal path: holds 12 ..< 16
+
+    #expect(cache.offset == 16)
+    let view = try #require(cache.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(12 ..< 16))
+}
+
+@Test func testRotatingWrapTrimSurvivesCopyAndMetaStateRoundTrip() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    let copied = try #require(cache.copy() as? RotatingKVCache)
+    #expect(copied.trim(3) == 3)
+    let view = try #require(copied.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(12 ..< 17))
+    #expect(cache.offset == 20, "trimming the copy must not touch the original")
+}
+
+@Test func testRotatingLegacyMetaStateDerivesRingLayout() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+
+    // A cache saved before the wrapped flag existed has 6 metaState values; the
+    // ring layout must be derived, not assumed away.
+    let legacyMetaState = Array(cache.metaState.dropLast())
+    #expect(legacyMetaState.count == 6)
+
+    let restored = RotatingKVCache(maxSize: 8, keep: 0)
+    restored.state = cache.state.map { $0[.ellipsis] }
+    restored.metaState = legacyMetaState
+
+    let view = try #require(restored.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(12 ..< 20), "legacy restore lost the ring layout")
+    #expect(restored.trim(3) == 3)
+    let trimmedView = try #require(restored.logicalView(tail: 8))
+    #expect(encodedPositions(trimmedView.0) == Array(12 ..< 17))
+}
+
+@Test func testRotatingSingleTokenMaskAfterWrapTrimMatchesEquivalentFreshCache() throws {
+    // After a wrapped trim the cache holds 5 live rows; the sliding-window mask for
+    // the next single-token step must match a fresh cache holding the same rows.
+    let windowSize = 4
+
+    let trimmedCache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(trimmedCache, positions: 0 ..< 20)
+    trimmedCache.trim(3)  // 5 live rows
+
+    let freshCache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(freshCache, positions: 0 ..< 5)  // 5 live rows
+
+    let trimmedMask = trimmedCache.makeMask(n: 1, windowSize: windowSize, returnArray: false)
+    let freshMask = freshCache.makeMask(n: 1, windowSize: windowSize, returnArray: false)
+
+    guard case .array(let trimmedArray) = trimmedMask, case .array(let freshArray) = freshMask
+    else {
+        Issue.record("expected array masks, got \(trimmedMask) and \(freshMask)")
+        return
+    }
+    #expect(trimmedArray.shape == freshArray.shape)
+    #expect((trimmedArray .== freshArray).all().item(Bool.self))
+}
+
+@Test func testRotatingMultiTokenMaskWidthMatchesPresentationAfterWrapTrim() throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+    cache.trim(3)  // 5 live rows
+
+    // Models build the mask before the write; its key width must equal the rows the
+    // write presents, or attention shapes diverge.
+    let mask = cache.makeMask(n: 3, windowSize: 4, returnArray: true)
+    let (k, v) = positionedKV(17 ..< 20)
+    let presented = cache.update(keys: k, values: v)
+
+    guard case .array(let maskArray) = mask else {
+        Issue.record("expected an array mask, got \(mask)")
+        return
+    }
+    #expect(maskArray.dim(-1) == presented.0.dim(2))
 }

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -2195,6 +2195,259 @@ private func fillOneAtATime(_ cache: RotatingKVCache, positions: Range<Int>) {
     #expect(encodedPositions(trimmedView.0) == Array(12 ..< 17))
 }
 
+@Test(arguments: [5, 6, 7])
+func testRotatingRestoredTrimAtRingBoundary(metadataCount: Int) throws {
+    let source = RotatingKVCache(maxSize: 8)
+    fillOneAtATime(source, positions: 0 ..< 16)
+
+    let restored = RotatingKVCache(maxSize: 8)
+    restored.state = source.state.map { $0[.ellipsis] }
+    restored.metaState = Array(source.metaState.prefix(metadataCount))
+
+    #expect(restored.trim(3) == 3)
+    #expect(restored.offset == 13)
+    let view = try #require(restored.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(8 ..< 13))
+    #expect(encodedPositions(view.1) == Array(8 ..< 13).map { -$0 })
+    #expect(restored.state.allSatisfy { $0.dim(2) == 5 })
+}
+
+@Test(arguments: [5, 6, 7])
+func testRotatingRestoredTrimKeepsKeysAndValuesAligned(metadataCount: Int) throws {
+    let source = RotatingKVCache(maxSize: 8)
+    fillOneAtATime(source, positions: 0 ..< 20)
+
+    let restored = RotatingKVCache(maxSize: 8)
+    restored.state = source.state.map { $0[.ellipsis] }
+    restored.metaState = Array(source.metaState.prefix(metadataCount))
+
+    // The shortened key buffer ends before the old write index. Its new shape
+    // must not change how the value buffer is ordered during the same trim.
+    #expect(restored.trim(5) == 5)
+    #expect(restored.offset == 15)
+    let view = try #require(restored.logicalView(tail: 8))
+    #expect(encodedPositions(view.0) == Array(12 ..< 15))
+    #expect(encodedPositions(view.1) == Array(12 ..< 15).map { -$0 })
+}
+
+private func expectRotatingContents(
+    _ cache: RotatingKVCache, _ positions: [Int],
+    sourceLocation: SourceLocation = #_sourceLocation
+) throws {
+    let view = try #require(cache.logicalView(tail: Int.max), sourceLocation: sourceLocation)
+    #expect(view.0.dim(2) == positions.count, sourceLocation: sourceLocation)
+    #expect(view.1.dim(2) == positions.count, sourceLocation: sourceLocation)
+    #expect(
+        cache.state.allSatisfy { $0.dim(2) == positions.count }, sourceLocation: sourceLocation)
+    // Empty MLX arrays need no host readback.
+    if !positions.isEmpty {
+        #expect(encodedPositions(view.0) == positions, sourceLocation: sourceLocation)
+        #expect(encodedPositions(view.1) == positions.map { -$0 }, sourceLocation: sourceLocation)
+    }
+}
+
+@Test(arguments: [5, 6, 7], [false, true])
+func testRotatingRestorationAcceptsEitherSetterOrder(
+    metadataCount: Int, metadataFirst: Bool
+) throws {
+    for count in [3, 8, 9, 16, 20] {
+        for prefill in [false, true] {
+            let source = RotatingKVCache(maxSize: 8, step: 4)
+            if prefill {
+                let (k, v) = positionedKV(0 ..< count)
+                _ = source.update(keys: k, values: v)
+            } else {
+                fillOneAtATime(source, positions: 0 ..< count)
+            }
+            let metadata = Array(source.metaState.prefix(metadataCount))
+            let arrays = source.state.map { $0[.ellipsis] }
+            // The saved capacity must replace the constructor's capacity before inference.
+            let restored = RotatingKVCache(maxSize: 1)
+            if metadataFirst {
+                restored.metaState = metadata
+                restored.state = arrays
+            } else {
+                restored.state = arrays
+                restored.metaState = metadata
+            }
+
+            let start = prefill ? 0 : max(0, count - 8)
+            try expectRotatingContents(restored, Array(start ..< count))
+            #expect(restored.trim(2) == 2)
+            #expect(restored.offset == count - 2)
+            try expectRotatingContents(restored, Array(start ..< (count - 2)))
+        }
+    }
+}
+
+@Test(arguments: [5, 6, 7], [false, true])
+func testRotatingRestoredShortChronologicalBufferCanGrow(
+    metadataCount: Int, metadataFirst: Bool
+) throws {
+    let source = RotatingKVCache(maxSize: 8)
+    fillOneAtATime(source, positions: 0 ..< 20)
+    // Legacy updateConcat could leave maxSize - 1 chronological rows when given
+    // an empty append. idx < maxSize && offset > idx cannot identify its layout.
+    let empty = positionedKV(20 ..< 20)
+    _ = source.update(keys: empty.0, values: empty.1)
+    try expectRotatingContents(source, Array(13 ..< 20))
+
+    let restored = RotatingKVCache(maxSize: 8)
+    let metadata = Array(source.metaState.prefix(metadataCount))
+    let arrays = source.state.map { $0[.ellipsis] }
+    if metadataFirst {
+        restored.metaState = metadata
+        restored.state = arrays
+    } else {
+        restored.state = arrays
+        restored.metaState = metadata
+    }
+    #expect(restored.metaState.last == "false")
+    fillOneAtATime(restored, positions: 20 ..< 21)
+    try expectRotatingContents(restored, Array(13 ..< 21))
+    #expect(restored.trim(3) == 3)
+    try expectRotatingContents(restored, Array(13 ..< 18))
+}
+
+@Test(arguments: [5, 6, 7], [13, 14, 20])
+func testRotatingRestoredTrimPreservesPinnedPrefix(metadataCount: Int, count: Int) throws {
+    let source = RotatingKVCache(maxSize: 8, keep: 2)
+    fillOneAtATime(source, positions: 0 ..< count)
+
+    for firstTrim in [3, 100] {
+        let restored = RotatingKVCache(maxSize: 8)
+        restored.state = source.state.map { $0[.ellipsis] }
+        restored.metaState = Array(source.metaState.prefix(metadataCount))
+        let removed = min(firstTrim, 6)
+        #expect(restored.trim(firstTrim) == removed)
+        try expectRotatingContents(
+            restored, [0, 1] + Array((count - 6) ..< (count - removed)))
+        // The second trim operates on temporal storage, even if the first used a ring.
+        #expect(restored.trim(100) == 6 - removed)
+        #expect(restored.trim(1) == 0)
+        #expect(restored.offset == count - 6)
+        try expectRotatingContents(restored, [0, 1])
+
+        let next = restored.offset
+        fillOneAtATime(restored, positions: next ..< (next + 8))
+        try expectRotatingContents(restored, [0, 1] + Array((next + 2) ..< (next + 8)))
+    }
+    try expectRotatingContents(source, [0, 1] + Array((count - 6) ..< count))
+}
+
+@Test(arguments: [1, 2, 5, 8])
+func testRotatingTrimBeforeEvictionCanRewindThroughPrefix(count: Int) throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: 2)
+    fillOneAtATime(cache, positions: 0 ..< count)
+    let metadata = cache.metaState
+    #expect(cache.trim(0) == 0)
+    #expect(cache.trim(-1) == 0)
+    #expect(cache.metaState == metadata)
+    #expect(cache.trim(100) == count)
+    #expect(cache.offset == 0)
+    try expectRotatingContents(cache, [])
+    fillOneAtATime(cache, positions: 0 ..< 3)
+    try expectRotatingContents(cache, [0, 1, 2])
+}
+
+@Test(arguments: [0, 2], [1, 3])
+func testRotatingTrimOversizedPrefillThenResume(keep: Int, nextCount: Int) throws {
+    let cache = RotatingKVCache(maxSize: 8, keep: keep, step: 4)
+    fillOneAtATime(cache, positions: 0 ..< 20)
+    let (k, v) = positionedKV(20 ..< 23)
+    _ = cache.update(keys: k, values: v)  // ten chronological rows
+    #expect(cache.trim(5) == 5)
+    #expect(cache.offset == 18)
+    let prefix = Array(0 ..< keep)
+    try expectRotatingContents(cache, prefix + Array((13 + keep) ..< 18))
+
+    let mask = cache.makeMask(n: nextCount, windowSize: 8, returnArray: true)
+    let next = positionedKV(18 ..< (18 + nextCount))
+    let presented = cache.update(keys: next.0, values: next.1)
+    let expected = prefix + Array((13 + keep) ..< (18 + nextCount))
+    #expect(encodedPositions(presented.0) == expected)
+    #expect(encodedPositions(presented.1) == expected.map { -$0 })
+    if case .array(let array) = mask {
+        #expect(array.dim(-1) == presented.0.dim(2))
+    }
+    fillOneAtATime(cache, positions: (18 + nextCount) ..< 30)
+    try expectRotatingContents(cache, prefix + Array((22 + keep) ..< 30))
+}
+
+@Test(arguments: [5, 6, 7])
+func testRotatingTrimSurvivesPromptCachePersistenceAndCopy(metadataCount: Int) throws {
+    let source = RotatingKVCache(maxSize: 8)
+    fillOneAtATime(source, positions: 0 ..< 16)
+    let url = tempURL()
+    let legacyURL = tempURL()
+    let roundTripURL = tempURL()
+    defer {
+        for file in [url, legacyURL, roundTripURL] {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+    try savePromptCache(url: url, cache: [source])
+    // Exercise the real file loader with each historical metadata format.
+    let (arrays, savedMetadata) = try loadArraysAndMetadata(url: url)
+    var metadata = savedMetadata
+    for index in metadataCount ..< 7 {
+        metadata.removeValue(forKey: "0.0.\(index)")
+    }
+    // MLX loads lazily, so keep the source files intact while their arrays are live.
+    try save(arrays: arrays, metadata: metadata, url: legacyURL)
+    let (loaded, _) = try loadPromptCache(url: legacyURL)
+    let restored = try #require(loaded.first as? RotatingKVCache)
+    #expect(restored.trim(3) == 3)
+    try expectRotatingContents(restored, Array(8 ..< 13))
+
+    // A post-trim cache has more history than live rows; its explicit false flag
+    // must survive serialization instead of being inferred from those counters.
+    try savePromptCache(url: roundTripURL, cache: [restored])
+    let (reloaded, _) = try loadPromptCache(url: roundTripURL)
+    let roundTrip = try #require(reloaded.first as? RotatingKVCache)
+    let copied = try #require(roundTrip.copy() as? RotatingKVCache)
+    #expect(copied.trim(2) == 2)
+    fillOneAtATime(copied, positions: 11 ..< 20)
+    try expectRotatingContents(copied, Array(12 ..< 20))
+    try expectRotatingContents(roundTrip, Array(8 ..< 13))
+    try expectRotatingContents(restored, Array(8 ..< 13))
+    try expectRotatingContents(source, Array(8 ..< 16))
+    #expect(roundTrip.offset == 13)
+    #expect(source.offset == 16)
+}
+
+@Test(arguments: [5, 6, 7], [1, 3])
+func testRotatingRestoredTrimAttentionMatchesSurvivingContext(
+    metadataCount: Int, queryCount: Int
+) throws {
+    let keys = deterministicTensor(shape: [1, 2, 20, 4], salt: 1).asType(.float32)
+    let values = deterministicTensor(shape: [1, 2, 20, 4], salt: 2).asType(.float32)
+    let queries = deterministicTensor(shape: [1, 2, queryCount, 4], salt: 3).asType(.float32)
+    let source = RotatingKVCache(maxSize: 8)
+    for p in 0 ..< 20 {
+        _ = source.update(
+            keys: keys[.ellipsis, p ..< (p + 1), 0...],
+            values: values[.ellipsis, p ..< (p + 1), 0...])
+    }
+    let restored = RotatingKVCache(maxSize: 8)
+    restored.state = source.state.map { $0[.ellipsis] }
+    restored.metaState = Array(source.metaState.prefix(metadataCount))
+    #expect(restored.trim(5) == 5)  // only positions 12, 13, 14 survive
+    let mask = restored.makeMask(n: queryCount, windowSize: 4, returnArray: false)
+    let (cachedKeys, cachedValues) = restored.update(
+        keys: keys[.ellipsis, 15 ..< (15 + queryCount), 0...],
+        values: values[.ellipsis, 15 ..< (15 + queryCount), 0...])
+    let output = MLXFast.scaledDotProductAttention(
+        queries: queries, keys: cachedKeys, values: cachedValues, scale: 0.5, mask: mask)
+    let reference = MLXFast.scaledDotProductAttention(
+        queries: queries,
+        keys: keys[.ellipsis, 12 ..< (15 + queryCount), 0...],
+        values: values[.ellipsis, 12 ..< (15 + queryCount), 0...],
+        scale: 0.5,
+        mask: .array(createCausalMask(n: queryCount, offset: 3, windowSize: 4)))
+    #expect(allClose(output, reference, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+}
+
 @Test func testRotatingSingleTokenMaskAfterWrapTrimMatchesEquivalentFreshCache() throws {
     // After a wrapped trim the cache holds 5 live rows; the sliding-window mask for
     // the next single-token step must match a fresh cache holding the same rows.


### PR DESCRIPTION
## Proposed changes

Continuing with usage of Muse Glimmer, I have found another issue...

`RotatingKVCache` is a fixed-size, circular memory that sliding-window models (like Muse-Glimmer) use to remember recent context: once it fills up, new tokens overwrite the oldest ones ("wrapping").

**The problem:** `trim(_:)`  used by speculative decoding to rewind tokens that were generated ahead of time but rejected assumed the cache had never wrapped. On a wrapped cache it just decremented the counters, which left stale entries in the *middle* of the logical timeline instead of removing the newest ones. Result: silently corrupted context for anything trimming past the window boundary. In practice this capped speculative decoding at `prompt + generation < window size`.

**The fix:** trimming a wrapped cache now first unrolls the ring back into chronological order, then cuts the newest rows always consistent, and clamped so it never touches the pinned prefix (`keep`) region.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
