### PR TITLE
Leverage GitHub workflows to keep PR labels up-to-date

### DIFF
--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -46,6 +46,20 @@ function onStart(labels) {
 // for a change.
 const INFRA_PREFIX = "Infra: ";
 
+// The names these steps carried before they gained the prefix. A fork pull
+// request runs its own copy of the CI workflow, so a copy branched before the
+// rename still reports the old names. Retire this list together with the
+// matching one in the mlx-ops config, once no open pull request predates it.
+const LEGACY_INFRA_STEPS = [
+  "Verify MetalToolchain installed",
+  "Assert Xcode 27 and the macOS 27 SDK",
+  "Install MetalToolchain",
+];
+
+function isInfraStep(name) {
+  return name.startsWith(INFRA_PREFIX) || LEGACY_INFRA_STEPS.includes(name);
+}
+
 // The three orderings below carry the whole correctness of this function.
 // The no-failed-step test comes first, so a timeout or a lost runner reads as
 // "run it again" rather than as a fault. The infrastructure test comes before
@@ -68,7 +82,7 @@ function classify({ conclusion, jobs, labels }) {
       .map((step) => step.name));
 
   if (failedSteps.length === 0) return "needs-ci";
-  if (failedSteps.every((name) => name.startsWith(INFRA_PREFIX))) return "needs-ci";
+  if (failedSteps.every(isInfraStep)) return "needs-ci";
   if (failedJobs.length === 1 && failedJobs[0].name === "lint") return "needs-lint";
   return "needs-changes";
 }
@@ -104,8 +118,11 @@ async function jobSummaries(github, { owner, repo, runId }) {
 }
 
 // workflow_run.pull_requests can be empty when the head repository is a fork,
-// so the number is found from the head commit instead. The fallback covers a
-// commit the association index has not caught up with.
+// so the number is found from the head commit instead. A commit can belong to
+// more than one open pull request when branches are stacked, so prefer the one
+// whose head it is: choosing a sibling makes the caller's head comparison
+// discard a run that was not stale. The last resort covers a commit the
+// association index has not caught up with.
 async function findPullRequest(github, { owner, repo, headSha }) {
   const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
     owner, repo, commit_sha: headSha,

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -92,7 +92,50 @@ function onSynchronize(labels) {
   return { add: missing(labels, keep), remove: present(labels, candidates) };
 }
 
+async function jobSummaries(github, { owner, repo, runId }) {
+  const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+    owner, repo, run_id: runId, per_page: 100,
+  });
+  return jobs.map((job) => ({
+    name: job.name,
+    conclusion: job.conclusion,
+    steps: (job.steps ?? []).map((step) => ({ name: step.name, conclusion: step.conclusion })),
+  }));
+}
+
+// workflow_run.pull_requests can be empty when the head repository is a fork,
+// so the number is found from the head commit instead. The fallback covers a
+// commit the association index has not caught up with.
+async function findPullRequest(github, { owner, repo, headSha }) {
+  const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+    owner, repo, commit_sha: headSha,
+  });
+  const open = associated.data.find((pull) => pull.state === "open");
+  if (open) return open;
+
+  const pulls = await github.paginate(github.rest.pulls.list, {
+    owner, repo, state: "open", per_page: 100,
+  });
+  return pulls.find((pull) => pull.head.sha === headSha) ?? null;
+}
+
+// Adds before it removes. The reverse order leaves a window in which the pull
+// request carries no state label at all, and a reader would see it as untriaged.
+async function applyLabels(github, { owner, repo, number, add, remove }) {
+  if (add.length > 0) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: add });
+  }
+  for (const name of remove) {
+    try {
+      await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+    } catch (error) {
+      if (error.status !== 404) throw error;
+    }
+  }
+}
+
 module.exports = {
   STATE_LABELS, RUNNING, INFRA_PREFIX,
   onStart, onComplete, onSynchronize,
+  jobSummaries, findPullRequest, applyLabels,
 };

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -79,4 +79,20 @@ function onComplete({ conclusion, jobs, labels }) {
   return { add: missing(labels, [chosen]), remove: present(labels, candidates) };
 }
 
-module.exports = { STATE_LABELS, RUNNING, INFRA_PREFIX, onStart, onComplete };
+// A cat-* label proves a scan finished. Without this guard, a contributor who
+// pushes twice before the scanner reaches them would be queued for CI on code
+// no scan has read, and CI runs contributor code on the self-hosted mac.
+function onSynchronize(labels) {
+  const scanned = labels.some((name) => name.startsWith("cat-"));
+  // `keep` decides what survives the clear, and the add list is derived from it
+  // separately. Driving both from one list would delete the needs-ci this means
+  // to keep, as soon as the add was suppressed for already being there.
+  const keep = scanned ? ["needs-ci"] : [];
+  const candidates = [RUNNING, ...STATE_LABELS.filter((name) => !keep.includes(name))];
+  return { add: missing(labels, keep), remove: present(labels, candidates) };
+}
+
+module.exports = {
+  STATE_LABELS, RUNNING, INFRA_PREFIX,
+  onStart, onComplete, onSynchronize,
+};

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -43,18 +43,8 @@ function onStart(labels) {
 // clear it, so it must never ask the author for a change.
 const INFRA_PREFIX = "Infra: ";
 
-// These are the old step names, from before the prefix. A fork pull request runs
-// its own copy of the CI workflow, so a copy branched before the rename still
-// reports the old names. Delete this list when no open pull request is older
-// than the rename.
-const LEGACY_INFRA_STEPS = [
-  "Verify MetalToolchain installed",
-  "Assert Xcode 27 and the macOS 27 SDK",
-  "Install MetalToolchain",
-];
-
 function isInfraStep(name) {
-  return name.startsWith(INFRA_PREFIX) || LEGACY_INFRA_STEPS.includes(name);
+  return name.startsWith(INFRA_PREFIX);
 }
 
 // Each pull request runs its own copy of pull_request.yml, which may be older

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -41,4 +41,42 @@ function onStart(labels) {
   return { add: missing(labels, [RUNNING]), remove: present(labels, PREVIOUS_OUTCOME) };
 }
 
-module.exports = { STATE_LABELS, RUNNING, onStart };
+// A step whose name starts with this prefix reports the runner image, not the
+// contribution. Only a re-run can clear it, so it must never ask the author
+// for a change.
+const INFRA_PREFIX = "Infra: ";
+
+// The three orderings below carry the whole correctness of this function.
+// The no-failed-step test comes first, so a timeout or a lost runner reads as
+// "run it again" rather than as a fault. The infrastructure test comes before
+// the lint test, so a MetalToolchain failure never reads as bad formatting.
+// needs-lint claims formatting is the only thing to fix, so it requires lint to
+// be the only failed job. Any other failure alongside it means more work than
+// that label admits.
+function classify({ conclusion, jobs, labels }) {
+  const failedJobs = jobs.filter((job) => job.conclusion === "failure");
+
+  if (failedJobs.length === 0) {
+    if (conclusion !== "success") return "needs-ci";
+    const approved = labels.includes("approved") || labels.includes("ready-to-merge");
+    return approved ? "ready-to-merge" : "needs-review";
+  }
+
+  const failedSteps = failedJobs.flatMap((job) =>
+    (job.steps ?? [])
+      .filter((step) => step.conclusion === "failure")
+      .map((step) => step.name));
+
+  if (failedSteps.length === 0) return "needs-ci";
+  if (failedSteps.every((name) => name.startsWith(INFRA_PREFIX))) return "needs-ci";
+  if (failedJobs.length === 1 && failedJobs[0].name === "lint") return "needs-lint";
+  return "needs-changes";
+}
+
+function onComplete({ conclusion, jobs, labels }) {
+  const chosen = classify({ conclusion, jobs, labels });
+  const candidates = [RUNNING, ...STATE_LABELS.filter((name) => name !== chosen)];
+  return { add: missing(labels, [chosen]), remove: present(labels, candidates) };
+}
+
+module.exports = { STATE_LABELS, RUNNING, INFRA_PREFIX, onStart, onComplete };

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -80,11 +80,9 @@ function contractOf(jobs) {
   return null;
 }
 
-// Do not reorder these tests. A failed job with no failed step means a timeout
-// or a lost runner. That result asks for another run, and never asks the author
-// for a change. The build-machine test comes before the lint test, so a
-// MetalToolchain failure never counts as a formatting problem. needs-lint says
-// formatting is the only thing to fix, so only lint failing alone gets it.
+// Keep the three needs-ci checks above the needs-lint check. If one moves
+// down, classify returns needs-lint or needs-changes for a failure the
+// author cannot fix.
 function classify({ conclusion, jobs, labels }) {
   const failedJobs = jobs.filter((job) => job.conclusion === "failure");
 
@@ -99,8 +97,11 @@ function classify({ conclusion, jobs, labels }) {
       .filter((step) => step.conclusion === "failure")
       .map((step) => step.name));
 
+  // A failed job usually has one failed step, which names what broke. After a
+  // timeout or a lost runner, the job fails with no failed step.
   if (failedSteps.length === 0) return "needs-ci";
   if (failedSteps.every(isInfraStep)) return "needs-ci";
+  if (contractOf(jobs) !== CONTRACT) return "needs-ci";
   if (failedJobs.length === 1 && failedJobs[0].name === "lint") return "needs-lint";
   return "needs-changes";
 }

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -57,6 +57,29 @@ function isInfraStep(name) {
   return name.startsWith(INFRA_PREFIX) || LEGACY_INFRA_STEPS.includes(name);
 }
 
+// Each pull request runs its own copy of pull_request.yml, which may be older
+// than these rules. That copy names this number in a step. If the numbers match,
+// a failing run can give needs-lint or needs-changes. If not, a failing run gets
+// needs-ci. When you rename a step, change this number and the workflow's number
+// together. To stop needs-lint and needs-changes on every pull request, change
+// this number only.
+const CONTRACT = 1;
+
+const CONTRACT_PREFIX = "Contract: ";
+
+// Returns null when no step names a number, and when the text is not digits.
+// Both mean there is no number to compare, so a failing run gets needs-ci.
+function contractOf(jobs) {
+  for (const job of jobs) {
+    for (const step of job.steps ?? []) {
+      if (!step.name.startsWith(CONTRACT_PREFIX)) continue;
+      const digits = step.name.slice(CONTRACT_PREFIX.length).trim();
+      return /^[0-9]+$/.test(digits) ? Number(digits) : null;
+    }
+  }
+  return null;
+}
+
 // Do not reorder these tests. A failed job with no failed step means a timeout
 // or a lost runner. That result asks for another run, and never asks the author
 // for a change. The build-machine test comes before the lint test, so a
@@ -149,6 +172,7 @@ async function applyLabels(github, { owner, repo, number, add, remove }) {
 
 module.exports = {
   STATE_LABELS, RUNNING, INFRA_PREFIX,
+  CONTRACT, CONTRACT_PREFIX, contractOf,
   onStart, onComplete, onSynchronize,
   jobSummaries, findPullRequest, applyLabels,
 };

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -1,0 +1,44 @@
+"use strict";
+
+// The labels this script manages. It never removes a label outside this list,
+// so a separate effort on another label cannot collide with it.
+const STATE_LABELS = [
+  "needs-scan",
+  "needs-ci",
+  "needs-lint",
+  "needs-changes",
+  "needs-review",
+  "approved",
+  "ready-to-merge",
+];
+
+const RUNNING = "ci-running";
+
+// The labels that describe the run that just ended. approved and
+// ready-to-merge survive a start on purpose: a maintainer may approve while a
+// run is in progress, and onComplete reads that as evidence.
+const PREVIOUS_OUTCOME = [
+  "needs-ci",
+  "needs-lint",
+  "needs-changes",
+  "needs-review",
+];
+
+function present(labels, candidates) {
+  const held = new Set(labels);
+  return candidates.filter((name) => held.has(name));
+}
+
+// Never ask GitHub to add a label the pull request already holds. The add is a
+// no-op there, so suppressing it means a decision that changes nothing costs no
+// API call at all.
+function missing(labels, candidates) {
+  const held = new Set(labels);
+  return candidates.filter((name) => !held.has(name));
+}
+
+function onStart(labels) {
+  return { add: missing(labels, [RUNNING]), remove: present(labels, PREVIOUS_OUTCOME) };
+}
+
+module.exports = { STATE_LABELS, RUNNING, onStart };

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// The labels this script manages. It never removes a label outside this list,
-// so a separate effort on another label cannot collide with it.
+// The script removes only a label on this list. It does not touch any other
+// label.
 const STATE_LABELS = [
   "needs-scan",
   "needs-ci",
@@ -14,9 +14,8 @@ const STATE_LABELS = [
 
 const RUNNING = "ci-running";
 
-// The labels that describe the run that just ended. approved and
-// ready-to-merge survive a start on purpose: a maintainer may approve while a
-// run is in progress, and onComplete reads that as evidence.
+// approved and ready-to-merge are absent on purpose. onComplete needs to see an
+// approval that arrived during the run.
 const PREVIOUS_OUTCOME = [
   "needs-ci",
   "needs-lint",
@@ -29,9 +28,7 @@ function present(labels, candidates) {
   return candidates.filter((name) => held.has(name));
 }
 
-// Never ask GitHub to add a label the pull request already holds. The add is a
-// no-op there, so suppressing it means a decision that changes nothing costs no
-// API call at all.
+// Never ask GitHub to add a label the pull request already has.
 function missing(labels, candidates) {
   const held = new Set(labels);
   return candidates.filter((name) => !held.has(name));
@@ -41,15 +38,15 @@ function onStart(labels) {
   return { add: missing(labels, [RUNNING]), remove: present(labels, PREVIOUS_OUTCOME) };
 }
 
-// A step whose name starts with this prefix reports the runner image, not the
-// contribution. Only a re-run can clear it, so it must never ask the author
-// for a change.
+// A step whose name starts with this prefix reports a problem in the runner
+// image. It does not report a problem in the contribution. Only a re-run can
+// clear it, so it must never ask the author for a change.
 const INFRA_PREFIX = "Infra: ";
 
-// The names these steps carried before they gained the prefix. A fork pull
-// request runs its own copy of the CI workflow, so a copy branched before the
-// rename still reports the old names. This list can go once no open pull
-// request predates the rename.
+// These are the old step names, from before the prefix. A fork pull request runs
+// its own copy of the CI workflow, so a copy branched before the rename still
+// reports the old names. Delete this list when no open pull request is older
+// than the rename.
 const LEGACY_INFRA_STEPS = [
   "Verify MetalToolchain installed",
   "Assert Xcode 27 and the macOS 27 SDK",
@@ -60,13 +57,11 @@ function isInfraStep(name) {
   return name.startsWith(INFRA_PREFIX) || LEGACY_INFRA_STEPS.includes(name);
 }
 
-// The three orderings below carry the whole correctness of this function.
-// The no-failed-step test comes first, so a timeout or a lost runner reads as
-// "run it again" rather than as a fault. The infrastructure test comes before
-// the lint test, so a MetalToolchain failure never reads as bad formatting.
-// needs-lint claims formatting is the only thing to fix, so it requires lint to
-// be the only failed job. Any other failure alongside it means more work than
-// that label admits.
+// Do not reorder these tests. A failed job with no failed step means a timeout
+// or a lost runner. That result asks for another run, and never asks the author
+// for a change. The build-machine test comes before the lint test, so a
+// MetalToolchain failure never counts as a formatting problem. needs-lint says
+// formatting is the only thing to fix, so only lint failing alone gets it.
 function classify({ conclusion, jobs, labels }) {
   const failedJobs = jobs.filter((job) => job.conclusion === "failure");
 
@@ -93,14 +88,14 @@ function onComplete({ conclusion, jobs, labels }) {
   return { add: missing(labels, [chosen]), remove: present(labels, candidates) };
 }
 
-// A cat-* label proves a scan finished. Without this guard, a contributor who
-// pushes twice before the scanner reaches them would be queued for CI on code
-// no scan has read, and CI runs contributor code on the self-hosted mac.
+// Only a triaged pull request goes back in the queue, and a cat-* label is the
+// mark of that. If no cat-* label is present, the stale labels still go, and the
+// script adds nothing.
 function onSynchronize(labels) {
   const scanned = labels.some((name) => name.startsWith("cat-"));
-  // `keep` decides what survives the clear, and the add list is derived from it
-  // separately. Driving both from one list would delete the needs-ci this means
-  // to keep, as soon as the add was suppressed for already being there.
+  // Two lists on purpose. `keep` says what not to remove. The add list says what
+  // to write, and is empty when the label is already there. If you merge the two
+  // lists, a pull request that already has needs-ci loses it.
   const keep = scanned ? ["needs-ci"] : [];
   const candidates = [RUNNING, ...STATE_LABELS.filter((name) => !keep.includes(name))];
   return { add: missing(labels, keep), remove: present(labels, candidates) };
@@ -117,12 +112,11 @@ async function jobSummaries(github, { owner, repo, runId }) {
   }));
 }
 
-// workflow_run.pull_requests can be empty when the head repository is a fork,
-// so the number is found from the head commit instead. A commit can belong to
-// more than one open pull request when branches are stacked, so prefer the one
-// whose head it is: choosing a sibling makes the caller's head comparison
-// discard a run that was not stale. The last resort covers a commit the
-// association index has not caught up with.
+// GitHub can send an empty pull request list for a fork, so the number comes
+// from the head commit instead. One commit can belong to two open pull requests
+// when branches are stacked. If this picks the wrong one, its head has moved,
+// the caller treats the run as stale, and neither pull request gets a label. The
+// last search covers a commit GitHub has not linked yet.
 async function findPullRequest(github, { owner, repo, headSha }) {
   const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
     owner, repo, commit_sha: headSha,
@@ -137,8 +131,9 @@ async function findPullRequest(github, { owner, repo, headSha }) {
   return pulls.find((pull) => pull.head.sha === headSha) ?? null;
 }
 
-// Adds before it removes. The reverse order leaves a window in which the pull
-// request carries no state label at all, and a reader would see it as untriaged.
+// This function adds labels before it removes labels. In the other order, the
+// pull request has no label for a short time. A reader of the list then sees it
+// as untriaged.
 async function applyLabels(github, { owner, repo, number, add, remove }) {
   if (add.length > 0) {
     await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: add });

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -48,8 +48,8 @@ const INFRA_PREFIX = "Infra: ";
 
 // The names these steps carried before they gained the prefix. A fork pull
 // request runs its own copy of the CI workflow, so a copy branched before the
-// rename still reports the old names. Retire this list together with the
-// matching one in the mlx-ops config, once no open pull request predates it.
+// rename still reports the old names. This list can go once no open pull
+// request predates the rename.
 const LEGACY_INFRA_STEPS = [
   "Verify MetalToolchain installed",
   "Assert Xcode 27 and the macOS 27 SDK",

--- a/.github/scripts/ci-state.js
+++ b/.github/scripts/ci-state.js
@@ -110,7 +110,8 @@ async function findPullRequest(github, { owner, repo, headSha }) {
   const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
     owner, repo, commit_sha: headSha,
   });
-  const open = associated.data.find((pull) => pull.state === "open");
+  const open = associated.data.find((pull) => pull.state === "open" && pull.head.sha === headSha)
+    ?? associated.data.find((pull) => pull.state === "open");
   if (open) return open;
 
   const pulls = await github.paginate(github.rest.pulls.list, {

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { STATE_LABELS, RUNNING, onStart } = require("./ci-state.js");
+
+test("STATE_LABELS names the seven labels this script manages", () => {
+  assert.deepEqual(STATE_LABELS, [
+    "needs-scan",
+    "needs-ci",
+    "needs-lint",
+    "needs-changes",
+    "needs-review",
+    "approved",
+    "ready-to-merge",
+  ]);
+});
+
+test("needs-rebase is not managed here", () => {
+  assert.equal(STATE_LABELS.includes("needs-rebase"), false);
+});
+
+test("RUNNING is ci-running", () => {
+  assert.equal(RUNNING, "ci-running");
+});
+
+test("onStart adds ci-running", () => {
+  assert.deepEqual(onStart([]), { add: ["ci-running"], remove: [] });
+});
+
+test("onStart removes the labels that describe the previous run", () => {
+  const result = onStart(["needs-ci", "cat-model"]);
+  assert.deepEqual(result.add, ["ci-running"]);
+  assert.deepEqual(result.remove, ["needs-ci"]);
+});
+
+test("onStart keeps approved, ready-to-merge and needs-scan", () => {
+  const result = onStart(["approved", "ready-to-merge", "needs-scan", "needs-review"]);
+  assert.deepEqual(result.remove, ["needs-review"]);
+});
+
+test("onStart never removes a label outside its list", () => {
+  const result = onStart(["unread", "cat-server", "changes requested"]);
+  assert.deepEqual(result.remove, []);
+});
+
+test("onStart does not re-add ci-running when it is already held", () => {
+  assert.deepEqual(onStart(["ci-running", "cat-model"]), { add: [], remove: [] });
+});

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -116,6 +116,26 @@ test("an infrastructure step failing alone asks for another run", () => {
   assert.deepEqual(result.add, ["needs-ci"]);
 });
 
+test("an unprefixed infrastructure step also asks for another run", () => {
+  const jobs = [
+    job("lint", "success"),
+    job("mac_build_and_test", "failure", [step("Verify MetalToolchain installed", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("an unprefixed infrastructure step alongside a real failure blames the author", () => {
+  const jobs = [
+    job("mac_build_and_test", "failure", [
+      step("Install MetalToolchain", "failure"),
+      step("Build (Xcode, macOS)", "failure"),
+    ]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-changes"]);
+});
+
 test("an infrastructure step alongside a real failure blames the author", () => {
   const jobs = [
     job("mac_build_and_test", "failure", [

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -217,18 +217,23 @@ const { jobSummaries, findPullRequest, applyLabels } = require("./ci-state.js");
 // given, which is how the real client distinguishes one endpoint from another.
 function makeGithub(options = {}) {
   const calls = [];
+  const requests = [];
   const jobsRoute = () => {};
   jobsRoute.__pages = options.jobs ?? [];
   const pullsRoute = () => {};
   pullsRoute.__pages = options.openPulls ?? [];
   return {
     calls,
-    paginate: async (route) => route.__pages ?? [],
+    requests,
+    paginate: async (route, params) => { requests.push(params); return route.__pages ?? []; },
     rest: {
       actions: { listJobsForWorkflowRun: jobsRoute },
       pulls: { list: pullsRoute },
       repos: {
-        listPullRequestsAssociatedWithCommit: async () => ({ data: options.associated ?? [] }),
+        listPullRequestsAssociatedWithCommit: async (params) => {
+          requests.push(params);
+          return { data: options.associated ?? [] };
+        },
       },
       issues: {
         addLabels: async (params) => {
@@ -259,6 +264,7 @@ test("jobSummaries keeps only the fields the rules read", async () => {
     conclusion: "failure",
     steps: [{ name: "Run style checks", conclusion: "failure" }],
   }]);
+  assert.deepEqual(github.requests, [{ owner: "o", repo: "r", run_id: 9, per_page: 100 }]);
 });
 
 test("jobSummaries copes with a job that reports no steps", async () => {
@@ -288,6 +294,21 @@ test("findPullRequest falls back to matching the head commit of an open pull req
   });
   const pull = await findPullRequest(github, { owner: "o", repo: "r", headSha: "aaa" });
   assert.equal(pull.number, 21);
+  assert.deepEqual(github.requests, [
+    { owner: "o", repo: "r", commit_sha: "aaa" },
+    { owner: "o", repo: "r", state: "open", per_page: 100 },
+  ]);
+});
+
+test("findPullRequest prefers the association whose head is the tested commit", async () => {
+  const github = makeGithub({
+    associated: [
+      { number: 30, state: "open", head: { sha: "ccc" }, labels: [] },
+      { number: 31, state: "open", head: { sha: "aaa" }, labels: [] },
+    ],
+  });
+  const pull = await findPullRequest(github, { owner: "o", repo: "r", headSha: "aaa" });
+  assert.equal(pull.number, 31);
 });
 
 test("findPullRequest returns null when no open pull request matches", async () => {

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -142,13 +142,17 @@ test("no failed job and a conclusion other than success asks for another run", (
 });
 
 test("a failed job with no failed step asks for another run", () => {
-  const jobs = [job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "success")])];
+  const jobs = [
+    contractJob(CONTRACT),
+    job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "success")]),
+  ];
   const result = onComplete({ conclusion: "failure", jobs, labels: [] });
   assert.deepEqual(result.add, ["needs-ci"]);
 });
 
 test("an infrastructure step failing alone asks for another run", () => {
   const jobs = [
+    contractJob(CONTRACT),
     job("lint", "success"),
     job("mac_build_and_test", "failure", [step("Infra: verify MetalToolchain installed", "failure")]),
   ];

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -172,3 +172,41 @@ test("onComplete leaves exactly one managed label and clears the rest", () => {
   assert.deepEqual(result.add, ["needs-lint"]);
   assert.deepEqual(result.remove, ["ci-running", "needs-ci", "needs-review", "approved"]);
 });
+
+const { onSynchronize } = require("./ci-state.js");
+
+test("a scanned pull request goes back in the CI queue", () => {
+  const result = onSynchronize(["needs-review", "cat-model"]);
+  assert.deepEqual(result.add, ["needs-ci"]);
+  assert.deepEqual(result.remove, ["needs-review"]);
+});
+
+test("a new commit clears an approval", () => {
+  const result = onSynchronize(["ready-to-merge", "approved", "cat-server"]);
+  assert.deepEqual(result.add, ["needs-ci"]);
+  assert.deepEqual(result.remove, ["approved", "ready-to-merge"]);
+});
+
+test("a new commit clears ci-running", () => {
+  const result = onSynchronize(["ci-running", "cat-misc"]);
+  assert.deepEqual(result.add, ["needs-ci"]);
+  assert.deepEqual(result.remove, ["ci-running"]);
+});
+
+test("a pull request already queued keeps its place and costs no write", () => {
+  const result = onSynchronize(["needs-ci", "cat-model"]);
+  assert.deepEqual(result.add, []);
+  assert.deepEqual(result.remove, []);
+});
+
+test("an unscanned pull request is cleared but not queued", () => {
+  const result = onSynchronize(["needs-review"]);
+  assert.deepEqual(result.add, []);
+  assert.deepEqual(result.remove, ["needs-review"]);
+});
+
+test("onSynchronize leaves labels outside its list alone", () => {
+  const result = onSynchronize(["cat-model", "unread", "changes requested"]);
+  assert.deepEqual(result.add, ["needs-ci"]);
+  assert.deepEqual(result.remove, []);
+});

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -210,3 +210,122 @@ test("onSynchronize leaves labels outside its list alone", () => {
   assert.deepEqual(result.add, ["needs-ci"]);
   assert.deepEqual(result.remove, []);
 });
+
+const { jobSummaries, findPullRequest, applyLabels } = require("./ci-state.js");
+
+// A fake Octokit. `paginate` reads the pages off the route function it is
+// given, which is how the real client distinguishes one endpoint from another.
+function makeGithub(options = {}) {
+  const calls = [];
+  const jobsRoute = () => {};
+  jobsRoute.__pages = options.jobs ?? [];
+  const pullsRoute = () => {};
+  pullsRoute.__pages = options.openPulls ?? [];
+  return {
+    calls,
+    paginate: async (route) => route.__pages ?? [],
+    rest: {
+      actions: { listJobsForWorkflowRun: jobsRoute },
+      pulls: { list: pullsRoute },
+      repos: {
+        listPullRequestsAssociatedWithCommit: async () => ({ data: options.associated ?? [] }),
+      },
+      issues: {
+        addLabels: async (params) => {
+          calls.push(`add:${params.labels.join("+")}`);
+        },
+        removeLabel: async (params) => {
+          if (options.removeError) throw options.removeError;
+          calls.push(`remove:${params.name}`);
+        },
+      },
+    },
+  };
+}
+
+test("jobSummaries keeps only the fields the rules read", async () => {
+  const github = makeGithub({
+    jobs: [{
+      id: 1,
+      name: "lint",
+      conclusion: "failure",
+      html_url: "https://example.invalid",
+      steps: [{ number: 1, name: "Run style checks", conclusion: "failure", status: "completed" }],
+    }],
+  });
+  const jobs = await jobSummaries(github, { owner: "o", repo: "r", runId: 9 });
+  assert.deepEqual(jobs, [{
+    name: "lint",
+    conclusion: "failure",
+    steps: [{ name: "Run style checks", conclusion: "failure" }],
+  }]);
+});
+
+test("jobSummaries copes with a job that reports no steps", async () => {
+  const github = makeGithub({ jobs: [{ name: "lint", conclusion: "success" }] });
+  const jobs = await jobSummaries(github, { owner: "o", repo: "r", runId: 9 });
+  assert.deepEqual(jobs, [{ name: "lint", conclusion: "success", steps: [] }]);
+});
+
+test("findPullRequest prefers the open pull request the commit belongs to", async () => {
+  const github = makeGithub({
+    associated: [
+      { number: 10, state: "closed", head: { sha: "aaa" }, labels: [] },
+      { number: 11, state: "open", head: { sha: "aaa" }, labels: [] },
+    ],
+  });
+  const pull = await findPullRequest(github, { owner: "o", repo: "r", headSha: "aaa" });
+  assert.equal(pull.number, 11);
+});
+
+test("findPullRequest falls back to matching the head commit of an open pull request", async () => {
+  const github = makeGithub({
+    associated: [],
+    openPulls: [
+      { number: 20, head: { sha: "bbb" }, labels: [] },
+      { number: 21, head: { sha: "aaa" }, labels: [] },
+    ],
+  });
+  const pull = await findPullRequest(github, { owner: "o", repo: "r", headSha: "aaa" });
+  assert.equal(pull.number, 21);
+});
+
+test("findPullRequest returns null when no open pull request matches", async () => {
+  const github = makeGithub({ associated: [], openPulls: [] });
+  const pull = await findPullRequest(github, { owner: "o", repo: "r", headSha: "aaa" });
+  assert.equal(pull, null);
+});
+
+test("applyLabels adds before it removes, so a state label is never absent", async () => {
+  const github = makeGithub();
+  await applyLabels(github, {
+    owner: "o", repo: "r", number: 5,
+    add: ["needs-review"], remove: ["ci-running", "needs-ci"],
+  });
+  assert.deepEqual(github.calls, ["add:needs-review", "remove:ci-running", "remove:needs-ci"]);
+});
+
+test("applyLabels writes nothing when there is nothing to add", async () => {
+  const github = makeGithub();
+  await applyLabels(github, { owner: "o", repo: "r", number: 5, add: [], remove: [] });
+  assert.deepEqual(github.calls, []);
+});
+
+test("applyLabels ignores a label that has already gone", async () => {
+  const error = new Error("Label does not exist");
+  error.status = 404;
+  const github = makeGithub({ removeError: error });
+  await applyLabels(github, {
+    owner: "o", repo: "r", number: 5, add: [], remove: ["needs-ci"],
+  });
+  assert.deepEqual(github.calls, []);
+});
+
+test("applyLabels reports any other failure", async () => {
+  const error = new Error("Forbidden");
+  error.status = 403;
+  const github = makeGithub({ removeError: error });
+  await assert.rejects(
+    applyLabels(github, { owner: "o", repo: "r", number: 5, add: [], remove: ["needs-ci"] }),
+    /Forbidden/);
+});

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -48,3 +48,127 @@ test("onStart never removes a label outside its list", () => {
 test("onStart does not re-add ci-running when it is already held", () => {
   assert.deepEqual(onStart(["ci-running", "cat-model"]), { add: [], remove: [] });
 });
+
+const { onComplete } = require("./ci-state.js");
+
+function step(name, conclusion) {
+  return { name, conclusion };
+}
+
+function job(name, conclusion, steps = []) {
+  return { name, conclusion, steps };
+}
+
+const GREEN = [
+  job("lint", "success", [step("Run style checks", "success")]),
+  job("mac_build_and_test", "success", [step("Build (Xcode, macOS)", "success")]),
+];
+
+test("everything green with no approval gives needs-review", () => {
+  const result = onComplete({ conclusion: "success", jobs: GREEN, labels: ["ci-running"] });
+  assert.deepEqual(result.add, ["needs-review"]);
+  assert.deepEqual(result.remove, ["ci-running"]);
+});
+
+test("green on an approved pull request gives ready-to-merge", () => {
+  const result = onComplete({
+    conclusion: "success",
+    jobs: GREEN,
+    labels: ["ci-running", "approved", "cat-model"],
+  });
+  assert.deepEqual(result.add, ["ready-to-merge"]);
+  assert.deepEqual(result.remove, ["ci-running", "approved"]);
+});
+
+test("green on a pull request already ready-to-merge writes nothing new", () => {
+  const result = onComplete({
+    conclusion: "success",
+    jobs: GREEN,
+    labels: ["ci-running", "ready-to-merge"],
+  });
+  assert.deepEqual(result.add, []);
+  assert.deepEqual(result.remove, ["ci-running"]);
+});
+
+test("a skipped job is not a failure", () => {
+  const jobs = [...GREEN, job("integration_build_xcode27", "skipped")];
+  const result = onComplete({ conclusion: "success", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-review"]);
+});
+
+test("no failed job and a conclusion other than success asks for another run", () => {
+  const result = onComplete({ conclusion: "cancelled", jobs: GREEN, labels: ["ci-running"] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("a failed job with no failed step asks for another run", () => {
+  const jobs = [job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "success")])];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("an infrastructure step failing alone asks for another run", () => {
+  const jobs = [
+    job("lint", "success"),
+    job("mac_build_and_test", "failure", [step("Infra: verify MetalToolchain installed", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("an infrastructure step alongside a real failure blames the author", () => {
+  const jobs = [
+    job("mac_build_and_test", "failure", [
+      step("Infra: verify MetalToolchain installed", "failure"),
+      step("Build (Xcode, macOS)", "failure"),
+    ]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-changes"]);
+});
+
+test("the lint job failing alone gives needs-lint", () => {
+  const jobs = [
+    job("lint", "failure", [step("Run style checks", "failure")]),
+    job("mac_build_and_test", "skipped"),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-lint"]);
+});
+
+test("lint and a substantive job failing together gives needs-changes", () => {
+  const jobs = [
+    job("lint", "failure", [step("Run style checks", "failure")]),
+    job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-changes"]);
+});
+
+test("the documentation check failing gives needs-changes", () => {
+  const jobs = [
+    job("lint", "success"),
+    job("mac_build_and_test", "failure", [step("Verify documentation", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-changes"]);
+});
+
+test("the classifier's own test job failing gives needs-changes", () => {
+  const jobs = [
+    job("lint", "success"),
+    job("ci_state_script", "failure", [step("Test the CI state classifier", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-changes"]);
+});
+
+test("onComplete leaves exactly one managed label and clears the rest", () => {
+  const result = onComplete({
+    conclusion: "failure",
+    jobs: [job("lint", "failure", [step("Run style checks", "failure")])],
+    labels: ["ci-running", "needs-ci", "needs-review", "approved", "cat-tools", "unread"],
+  });
+  assert.deepEqual(result.add, ["needs-lint"]);
+  assert.deepEqual(result.remove, ["ci-running", "needs-ci", "needs-review", "approved"]);
+});

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -156,7 +156,7 @@ test("an infrastructure step failing alone asks for another run", () => {
   assert.deepEqual(result.add, ["needs-ci"]);
 });
 
-test("an unprefixed infrastructure step also asks for another run", () => {
+test("a branch from before the rename has no contract, so it asks for another run", () => {
   const jobs = [
     job("lint", "success"),
     job("mac_build_and_test", "failure", [step("Verify MetalToolchain installed", "failure")]),
@@ -165,7 +165,7 @@ test("an unprefixed infrastructure step also asks for another run", () => {
   assert.deepEqual(result.add, ["needs-ci"]);
 });
 
-test("an unprefixed infrastructure step alongside a real failure blames the author", () => {
+test("an unknown step name alongside a real failure blames the author", () => {
   const jobs = [
     contractJob(CONTRACT),
     job("mac_build_and_test", "failure", [

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -5,6 +5,14 @@ const assert = require("node:assert/strict");
 
 const { STATE_LABELS, RUNNING, onStart } = require("./ci-state.js");
 
+function step(name, conclusion) {
+  return { name, conclusion };
+}
+
+function job(name, conclusion, steps = []) {
+  return { name, conclusion, steps };
+}
+
 test("STATE_LABELS names the seven labels this script manages", () => {
   assert.deepEqual(STATE_LABELS, [
     "needs-scan",
@@ -49,15 +57,41 @@ test("onStart does not re-add ci-running when it is already held", () => {
   assert.deepEqual(onStart(["ci-running", "cat-model"]), { add: [], remove: [] });
 });
 
+const { CONTRACT, CONTRACT_PREFIX, contractOf } = require("./ci-state.js");
+
+test("CONTRACT is a whole number above zero", () => {
+  assert.equal(Number.isInteger(CONTRACT), true);
+  assert.equal(CONTRACT > 0, true);
+});
+
+test("CONTRACT_PREFIX names the step prefix", () => {
+  assert.equal(CONTRACT_PREFIX, "Contract: ");
+});
+
+test("contractOf reads the number from a step that passed", () => {
+  const jobs = [job("ci_state_script", "success", [step("Contract: 4", "success")])];
+  assert.equal(contractOf(jobs), 4);
+});
+
+test("contractOf finds the marker in any job", () => {
+  const jobs = [
+    job("lint", "success", [step("Run style checks", "success")]),
+    job("ci_state_script", "success", [step("Contract: 7", "success")]),
+  ];
+  assert.equal(contractOf(jobs), 7);
+});
+
+test("contractOf returns null when no step names a number", () => {
+  const jobs = [job("lint", "success", [step("Run style checks", "success")]), job("x", "success")];
+  assert.equal(contractOf(jobs), null);
+});
+
+test("contractOf returns null for text that is not digits", () => {
+  assert.equal(contractOf([job("ci_state_script", "success", [step("Contract: two", "success")])]), null);
+  assert.equal(contractOf([job("ci_state_script", "success", [step("Contract: ", "success")])]), null);
+});
+
 const { onComplete } = require("./ci-state.js");
-
-function step(name, conclusion) {
-  return { name, conclusion };
-}
-
-function job(name, conclusion, steps = []) {
-  return { name, conclusion, steps };
-}
 
 const GREEN = [
   job("lint", "success", [step("Run style checks", "success")]),

--- a/.github/scripts/ci-state.test.js
+++ b/.github/scripts/ci-state.test.js
@@ -93,6 +93,12 @@ test("contractOf returns null for text that is not digits", () => {
 
 const { onComplete } = require("./ci-state.js");
 
+// Add this job to a fixture that expects needs-lint or needs-changes. Without
+// it, classify returns needs-ci for every failure in that fixture.
+function contractJob(number) {
+  return job("ci_state_script", "success", [step(`Contract: ${number}`, "success")]);
+}
+
 const GREEN = [
   job("lint", "success", [step("Run style checks", "success")]),
   job("mac_build_and_test", "success", [step("Build (Xcode, macOS)", "success")]),
@@ -161,6 +167,7 @@ test("an unprefixed infrastructure step also asks for another run", () => {
 
 test("an unprefixed infrastructure step alongside a real failure blames the author", () => {
   const jobs = [
+    contractJob(CONTRACT),
     job("mac_build_and_test", "failure", [
       step("Install MetalToolchain", "failure"),
       step("Build (Xcode, macOS)", "failure"),
@@ -172,6 +179,7 @@ test("an unprefixed infrastructure step alongside a real failure blames the auth
 
 test("an infrastructure step alongside a real failure blames the author", () => {
   const jobs = [
+    contractJob(CONTRACT),
     job("mac_build_and_test", "failure", [
       step("Infra: verify MetalToolchain installed", "failure"),
       step("Build (Xcode, macOS)", "failure"),
@@ -183,6 +191,7 @@ test("an infrastructure step alongside a real failure blames the author", () => 
 
 test("the lint job failing alone gives needs-lint", () => {
   const jobs = [
+    contractJob(CONTRACT),
     job("lint", "failure", [step("Run style checks", "failure")]),
     job("mac_build_and_test", "skipped"),
   ];
@@ -192,6 +201,7 @@ test("the lint job failing alone gives needs-lint", () => {
 
 test("lint and a substantive job failing together gives needs-changes", () => {
   const jobs = [
+    contractJob(CONTRACT),
     job("lint", "failure", [step("Run style checks", "failure")]),
     job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")]),
   ];
@@ -201,6 +211,7 @@ test("lint and a substantive job failing together gives needs-changes", () => {
 
 test("the documentation check failing gives needs-changes", () => {
   const jobs = [
+    contractJob(CONTRACT),
     job("lint", "success"),
     job("mac_build_and_test", "failure", [step("Verify documentation", "failure")]),
   ];
@@ -211,7 +222,10 @@ test("the documentation check failing gives needs-changes", () => {
 test("the classifier's own test job failing gives needs-changes", () => {
   const jobs = [
     job("lint", "success"),
-    job("ci_state_script", "failure", [step("Test the CI state classifier", "failure")]),
+    job("ci_state_script", "failure", [
+      step(`Contract: ${CONTRACT}`, "success"),
+      step("Test the CI state classifier", "failure"),
+    ]),
   ];
   const result = onComplete({ conclusion: "failure", jobs, labels: [] });
   assert.deepEqual(result.add, ["needs-changes"]);
@@ -220,11 +234,72 @@ test("the classifier's own test job failing gives needs-changes", () => {
 test("onComplete leaves exactly one managed label and clears the rest", () => {
   const result = onComplete({
     conclusion: "failure",
-    jobs: [job("lint", "failure", [step("Run style checks", "failure")])],
+    jobs: [contractJob(CONTRACT), job("lint", "failure", [step("Run style checks", "failure")])],
     labels: ["ci-running", "needs-ci", "needs-review", "approved", "cat-tools", "unread"],
   });
   assert.deepEqual(result.add, ["needs-lint"]);
   assert.deepEqual(result.remove, ["ci-running", "needs-ci", "needs-review", "approved"]);
+});
+
+test("a branch with no contract step asks for another run", () => {
+  const jobs = [job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")])];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("a branch behind the contract asks for another run", () => {
+  const jobs = [
+    contractJob(CONTRACT - 1),
+    job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("a branch ahead of the contract also asks for another run", () => {
+  const jobs = [
+    contractJob(CONTRACT + 1),
+    job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("a contract number that is not digits asks for another run", () => {
+  const jobs = [
+    job("ci_state_script", "success", [step("Contract: two", "success")]),
+    job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("a stale branch that passes still goes to review", () => {
+  const jobs = [contractJob(CONTRACT - 1), ...GREEN];
+  const result = onComplete({ conclusion: "success", jobs, labels: ["ci-running"] });
+  assert.deepEqual(result.add, ["needs-review"]);
+  assert.deepEqual(result.remove, ["ci-running"]);
+});
+
+test("a stale branch failing lint alone asks for another run", () => {
+  const jobs = [
+    contractJob(CONTRACT - 1),
+    job("lint", "failure", [step("Run style checks", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-ci"]);
+});
+
+test("the first contract step in a job wins", () => {
+  const jobs = [
+    job("ci_state_script", "success", [
+      step(`Contract: ${CONTRACT}`, "success"),
+      step(`Contract: ${CONTRACT + 1}`, "success"),
+    ]),
+    job("mac_build_and_test", "failure", [step("Build (Xcode, macOS)", "failure")]),
+  ];
+  const result = onComplete({ conclusion: "failure", jobs, labels: [] });
+  assert.deepEqual(result.add, ["needs-changes"]);
 });
 
 const { onSynchronize } = require("./ci-state.js");

--- a/.github/workflows/ci-state.yml
+++ b/.github/workflows/ci-state.yml
@@ -28,7 +28,9 @@ permissions:
 
 # The start and the finish of one commit's run must not interleave. Keyed on the
 # commit rather than the run, so a re-run of the same commit also serializes.
-# Never cancel: a discarded completed event leaves ci-running behind forever.
+# Never cancel, because a discarded completed event leaves ci-running set. This
+# narrows that window rather than closing it: GitHub holds one pending run per
+# group, so a third event for one commit can still displace a pending one.
 concurrency:
   group: ci-state-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false

--- a/.github/workflows/ci-state.yml
+++ b/.github/workflows/ci-state.yml
@@ -1,0 +1,140 @@
+name: CI state
+
+# Writes the CI state labels for one pull request.
+#
+# This cannot live in pull_request.yml. In a public repository GITHUB_TOKEN is
+# read-only for a workflow triggered by a fork's pull request, whatever the
+# permissions block says, so such a job cannot label a community contribution.
+# A workflow_run workflow always runs the default branch's copy of this file
+# and does hold a write token.
+#
+# in_progress, not requested: a run held for maintainer approval has been
+# requested and has not started, and stamping ci-running on it would lie.
+#
+# No job here checks out the pull request. The checkout is the default branch,
+# which is where the classifier lives.
+
+on:
+  workflow_run:
+    workflows: [Build and Test]
+    types:
+      - in_progress
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+# The start and the finish of one commit's run must not interleave. Keyed on the
+# commit rather than the run, so a re-run of the same commit also serializes.
+# Never cancel: a discarded completed event leaves ci-running behind forever.
+concurrency:
+  group: ci-state-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  mark_running:
+    name: Mark CI running
+    if: >-
+      github.event.action == 'in_progress'
+      && github.repository == 'ml-explore/mlx-swift-lm'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/github-script@v9
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            // A relative require inside github-script resolves against the
+            // action, not the workspace, so name the workspace explicitly.
+            const state = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-state.js`);
+            const { owner, repo } = context.repo;
+            const headSha = process.env.HEAD_SHA;
+
+            const pull = await state.findPullRequest(github, { owner, repo, headSha });
+            if (!pull) {
+              core.info(`No open pull request for ${headSha}. Nothing to label.`);
+              return;
+            }
+
+            // Diagnostic only, and the length alone. The payload carries
+            // contributor-controlled text, which does not belong in a log.
+            const carried = context.payload.workflow_run.pull_requests ?? [];
+            core.info(`workflow_run.pull_requests carried ${carried.length} entries.`);
+
+            // The same guard record_outcome uses. A delayed in_progress event
+            // must not claim a run for a commit the pull request has left:
+            // reset-ci-state.yml has already queued the newer commit, and
+            // removing needs-ci here would strand it.
+            if (pull.head.sha !== headSha) {
+              core.info(`#${pull.number} moved from ${headSha} to ${pull.head.sha}.`);
+              core.info("Not marking this run as running.");
+              return;
+            }
+
+            const change = state.onStart(pull.labels.map((label) => label.name));
+            core.info(`#${pull.number} add: ${change.add.join(", ") || "nothing"}`);
+            core.info(`#${pull.number} remove: ${change.remove.join(", ") || "nothing"}`);
+            await state.applyLabels(github, {
+              owner, repo, number: pull.number, ...change,
+            });
+
+  record_outcome:
+    name: Record the CI outcome
+    if: >-
+      github.event.action == 'completed'
+      && github.repository == 'ml-explore/mlx-swift-lm'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/github-script@v9
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        with:
+          script: |
+            const state = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-state.js`);
+            const { owner, repo } = context.repo;
+            const headSha = process.env.HEAD_SHA;
+
+            const pull = await state.findPullRequest(github, { owner, repo, headSha });
+            if (!pull) {
+              core.info(`No open pull request for ${headSha}. Nothing to label.`);
+              return;
+            }
+
+            // These results describe the commit the run tested. If the head has
+            // moved, they describe code that no longer exists, and
+            // reset-ci-state.yml has already queued the new commit.
+            if (pull.head.sha !== headSha) {
+              core.info(`#${pull.number} moved from ${headSha} to ${pull.head.sha}.`);
+              core.info("Discarding this run's result.");
+              return;
+            }
+
+            const jobs = await state.jobSummaries(github, {
+              owner, repo, runId: Number(process.env.RUN_ID),
+            });
+            const change = state.onComplete({
+              conclusion: process.env.CONCLUSION,
+              jobs,
+              labels: pull.labels.map((label) => label.name),
+            });
+            core.info(`#${pull.number} add: ${change.add.join(", ") || "nothing"}`);
+            core.info(`#${pull.number} remove: ${change.remove.join(", ") || "nothing"}`);
+            await state.applyLabels(github, {
+              owner, repo, number: pull.number, ...change,
+            });

--- a/.github/workflows/ci-state.yml
+++ b/.github/workflows/ci-state.yml
@@ -140,6 +140,13 @@ jobs:
             const jobs = await state.jobSummaries(github, {
               owner, repo, runId: Number(process.env.RUN_ID),
             });
+
+            // A step name is contributor-controlled text, and must not go into a log.
+            const branchContract = state.contractOf(jobs);
+            core.info(
+              `#${pull.number} contract ${branchContract ?? "absent"},`
+              + ` rules expect ${state.CONTRACT}.`);
+
             const change = state.onComplete({
               conclusion: process.env.CONCLUSION,
               jobs,

--- a/.github/workflows/ci-state.yml
+++ b/.github/workflows/ci-state.yml
@@ -1,18 +1,18 @@
 name: CI state
 
-# Writes the CI state labels for one pull request.
+# This workflow writes the CI state labels for one pull request.
 #
-# This cannot live in pull_request.yml. In a public repository GITHUB_TOKEN is
-# read-only for a workflow triggered by a fork's pull request, whatever the
-# permissions block says, so such a job cannot label a community contribution.
-# A workflow_run workflow always runs the default branch's copy of this file
-# and does hold a write token.
+# This cannot live in pull_request.yml. In a public repository, GITHUB_TOKEN is
+# read-only for a workflow that a fork's pull request triggers. The permissions
+# block does not change that, so such a job cannot label a community
+# contribution. A workflow_run workflow always runs the default branch copy of
+# this file, and it gets a write token.
 #
-# in_progress, not requested: a run held for maintainer approval has been
-# requested and has not started, and stamping ci-running on it would lie.
+# The trigger uses in_progress. A run held for maintainer approval is requested
+# but has not started, so the requested event would set ci-running too early.
 #
-# No job here checks out the pull request. The checkout is the default branch,
-# which is where the classifier lives.
+# No job here checks out the pull request. Each checkout takes the default
+# branch, which contains the classifier.
 
 on:
   workflow_run:
@@ -26,11 +26,11 @@ permissions:
   contents: read
   pull-requests: write
 
-# The start and the finish of one commit's run must not interleave. Keyed on the
-# commit rather than the run, so a re-run of the same commit also serializes.
-# Never cancel, because a discarded completed event leaves ci-running set. This
-# narrows that window rather than closing it: GitHub holds one pending run per
-# group, so a third event for one commit can still displace a pending one.
+# GitHub runs one workflow at a time for each concurrency group. The group name
+# below holds the commit SHA, so two events for one commit cannot run at the same
+# time. If a completed event is cancelled, ci-running stays set, so never cancel a
+# run here. GitHub also queues only one run per group, so a third event for one
+# commit can still drop a pending run.
 concurrency:
   group: ci-state-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
@@ -53,8 +53,8 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
           script: |
-            // A relative require inside github-script resolves against the
-            // action, not the workspace, so name the workspace explicitly.
+            // Inside github-script, a relative require resolves against the
+            // action directory. Name the workspace path explicitly.
             const state = require(
               `${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-state.js`);
             const { owner, repo } = context.repo;
@@ -66,15 +66,18 @@ jobs:
               return;
             }
 
-            // Diagnostic only, and the length alone. The payload carries
-            // contributor-controlled text, which does not belong in a log.
+            // This log line is a diagnostic, and it prints only the count. The
+            // payload holds contributor-controlled text, which must not go into
+            // a log.
             const carried = context.payload.workflow_run.pull_requests ?? [];
             core.info(`workflow_run.pull_requests carried ${carried.length} entries.`);
 
-            // The same guard record_outcome uses. A delayed in_progress event
-            // must not claim a run for a commit the pull request has left:
-            // reset-ci-state.yml has already queued the newer commit, and
-            // removing needs-ci here would strand it.
+            // The author can push another commit before this event arrives. The
+            // run then tests code the pull request no longer has. onStart would
+            // set ci-running and remove the needs-ci that reset-ci-state.yml
+            // added for the new commit. The labels would then say CI runs for
+            // the new commit, which is false. record_outcome makes the same
+            // check.
             if (pull.head.sha !== headSha) {
               core.info(`#${pull.number} moved from ${headSha} to ${pull.head.sha}.`);
               core.info("Not marking this run as running.");
@@ -90,10 +93,11 @@ jobs:
 
   record_outcome:
     name: Record the CI outcome
-    # A run held for maintainer approval, or one skipped outright, never
-    # executed. Its conclusion describes nothing, and letting it through
-    # would clear a maintainer's approval on a pull request whose CI has
-    # not run.
+    # GitHub sends a completed event even when the run never started. A fork pull
+    # request waits for a maintainer to approve the run, and reports the
+    # conclusion action_required. A skipped run reports skipped. Neither
+    # conclusion says anything about the code. onComplete would read both as a
+    # failure, and would remove an approved label that a maintainer set.
     if: >-
       github.event.action == 'completed'
       && github.repository == 'ml-explore/mlx-swift-lm'
@@ -125,8 +129,8 @@ jobs:
             }
 
             // These results describe the commit the run tested. If the head has
-            // moved, they describe code that no longer exists, and
-            // reset-ci-state.yml has already queued the new commit.
+            // moved, the results describe code the pull request no longer has.
+            // reset-ci-state.yml already queued the new commit.
             if (pull.head.sha !== headSha) {
               core.info(`#${pull.number} moved from ${headSha} to ${pull.head.sha}.`);
               core.info("Discarding this run's result.");

--- a/.github/workflows/ci-state.yml
+++ b/.github/workflows/ci-state.yml
@@ -88,9 +88,15 @@ jobs:
 
   record_outcome:
     name: Record the CI outcome
+    # A run held for maintainer approval, or one skipped outright, never
+    # executed. Its conclusion describes nothing, and letting it through
+    # would clear a maintainer's approval on a pull request whose CI has
+    # not run.
     if: >-
       github.event.action == 'completed'
       && github.repository == 'ml-explore/mlx-swift-lm'
+      && github.event.workflow_run.conclusion != 'action_required'
+      && github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,9 +74,9 @@ jobs:
   # built into Node, so this job needs no package.json and no install step.
   #
   # This runs the pull request's own copy of the tests, so a contributor could
-  # weaken them. That cannot change what gets written: ci-state.yml always
-  # loads the default branch's copy of both the script and the tests. This job
-  # exists so a reviewer sees a change to either one go red.
+  # weaken them. That cannot change what gets written: ci-state.yml loads the
+  # script from a repository-owned branch, never from the pull request. This
+  # job exists so a reviewer sees a change to either file go red.
   ci_state_script:
     if: github.repository == 'ml-explore/mlx-swift-lm'
     runs-on: ubuntu-22.04

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,14 +69,13 @@ jobs:
         run: |
           pre-commit run --all || (echo "Style checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
 
-  # Tests .github/scripts/ci-state.js, which decides the CI state labels for
-  # every pull request. Node is preinstalled on this image and `node --test` is
-  # built into Node, so this job needs no package.json and no install step.
+  # Runs the tests for .github/scripts/ci-state.js, which picks the CI state
+  # labels. Node has a built-in test runner, so this job needs no install step.
   #
-  # This runs the pull request's own copy of the tests, so a contributor could
-  # weaken them. That cannot change what gets written: ci-state.yml loads the
-  # script from a repository-owned branch, never from the pull request. This
-  # job exists so a reviewer sees a change to either file go red.
+  # A pull request runs its own copy of these tests and can weaken them. That
+  # cannot change the labels, because ci-state.yml runs the script from a
+  # repository branch, not from the pull request. This job makes a change to
+  # either file turn the check red.
   ci_state_script:
     if: github.repository == 'ml-explore/mlx-swift-lm'
     runs-on: ubuntu-22.04

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -81,6 +81,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
+      # This number must equal CONTRACT in .github/scripts/ci-state.js on the
+      # default branch, not in this branch's copy. If you rename a step, change
+      # both numbers in one commit. Keep this step first: a failure in any other
+      # step then cannot stop it running.
+      - name: "Contract: 1"
+        shell: bash
+        run: echo "CI state contract 1"
+
       - uses: actions/checkout@v6
 
       - name: Test the CI state classifier

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,6 +69,27 @@ jobs:
         run: |
           pre-commit run --all || (echo "Style checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
 
+  # Tests .github/scripts/ci-state.js, which decides the CI state labels for
+  # every pull request. Node is preinstalled on this image and `node --test` is
+  # built into Node, so this job needs no package.json and no install step.
+  #
+  # This runs the pull request's own copy of the tests, so a contributor could
+  # weaken them. That cannot change what gets written: ci-state.yml always
+  # loads the default branch's copy of both the script and the tests. This job
+  # exists so a reviewer sees a change to either one go red.
+  ci_state_script:
+    if: github.repository == 'ml-explore/mlx-swift-lm'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test the CI state classifier
+        shell: bash
+        run: |
+          node --version
+          node --test .github/scripts/ci-state.test.js
+
   mac_build_and_test:
     needs: lint
     if: github.repository == 'ml-explore/mlx-swift-lm'
@@ -78,7 +99,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Verify MetalToolchain installed
+      - name: "Infra: verify MetalToolchain installed"
         shell: bash
         run: xcodebuild -showComponent MetalToolchain
 
@@ -160,7 +181,7 @@ jobs:
             *)                echo "Host DeviceTier would be: absent (OS < 26)" ;;
           esac
 
-      - name: Assert Xcode 27 and the macOS 27 SDK
+      - name: "Infra: assert Xcode 27 and the macOS 27 SDK"
         shell: bash
         run: |
           # `xcode-27` is a preview label and its default toolchain has moved
@@ -181,7 +202,7 @@ jobs:
               ;;
           esac
 
-      - name: Install MetalToolchain
+      - name: "Infra: install MetalToolchain"
         shell: bash
         run: |
           # The self-hosted mac is provisioned with this already, so the jobs

--- a/.github/workflows/reset-ci-state.yml
+++ b/.github/workflows/reset-ci-state.yml
@@ -1,0 +1,54 @@
+name: Reset CI state
+
+# A new commit on an open pull request makes every CI result and every approval
+# stale, so this puts the pull request back in the queue.
+#
+# pull_request_target, not pull_request: in a public repository a pull_request
+# workflow holds a read-only token on a fork's pull request and could not write
+# a label. GitHub's warning about pull_request_target is about checking out and
+# running the pull request's code. The checkout below is pinned to the base
+# commit and never touches the contributor's branch.
+
+on:
+  pull_request_target:
+    types:
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Two pushes in quick succession must not interleave their label writes.
+concurrency:
+  group: reset-ci-state-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  requeue:
+    name: Requeue for CI
+    if: github.repository == 'ml-explore/mlx-swift-lm'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The base commit, never the pull request's head. This checkout exists
+          # only to load the classifier, and this job holds a write token, so it
+          # must not bring in contributor code.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const state = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-state.js`);
+            const { owner, repo } = context.repo;
+            const pull = context.payload.pull_request;
+
+            const change = state.onSynchronize(pull.labels.map((label) => label.name));
+            core.info(`#${pull.number} add: ${change.add.join(", ") || "nothing"}`);
+            core.info(`#${pull.number} remove: ${change.remove.join(", ") || "nothing"}`);
+            await state.applyLabels(github, {
+              owner, repo, number: pull.number, ...change,
+            });

--- a/.github/workflows/reset-ci-state.yml
+++ b/.github/workflows/reset-ci-state.yml
@@ -1,13 +1,13 @@
 name: Reset CI state
 
 # A new commit on an open pull request makes every CI result and every approval
-# stale, so this puts the pull request back in the queue.
+# stale. This workflow puts the pull request back in the queue.
 #
-# pull_request_target, not pull_request: in a public repository a pull_request
-# workflow holds a read-only token on a fork's pull request and could not write
-# a label. GitHub's warning about pull_request_target is about checking out and
-# running the pull request's code. The checkout below takes repository-owned
-# code and never touches the contributor's branch.
+# The trigger is pull_request_target. In a public repository, a pull_request
+# workflow gets a read-only token on a fork's pull request, so it cannot write a
+# label. GitHub warns that pull_request_target can check out and run the pull
+# request's code. The checkout below takes repository-owned code only. It never
+# checks out the contributor's branch.
 
 on:
   pull_request_target:
@@ -18,7 +18,7 @@ permissions:
   contents: read
   pull-requests: write
 
-# Two pushes in quick succession must not interleave their label writes.
+# Two fast pushes must not interleave their label writes.
 concurrency:
   group: reset-ci-state-${{ github.event.pull_request.number }}
   cancel-in-progress: false
@@ -32,12 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # No ref on purpose. A pull_request_target event runs in the context
-          # of a repository-owned branch, never the pull request's head, so this
-          # checkout always holds the classifier the script below loads. Pinning
-          # base.sha instead names the commit the pull request started from,
-          # which for any pull request opened before this merged holds no
-          # classifier at all, and the require would throw.
+          # The checkout takes no ref on purpose. A pull_request_target event
+          # runs on a repository-owned branch, never on the pull request head.
+          # This checkout therefore always contains the classifier that the
+          # script below loads. A ref of base.sha names the commit the pull
+          # request started from. That commit has no classifier for a pull
+          # request opened before this workflow merged, and the require throws.
           persist-credentials: false
 
       - uses: actions/github-script@v9

--- a/.github/workflows/reset-ci-state.yml
+++ b/.github/workflows/reset-ci-state.yml
@@ -32,10 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # The base commit, never the pull request's head. This checkout exists
-          # only to load the classifier, and this job holds a write token, so it
-          # must not bring in contributor code.
-          ref: ${{ github.event.pull_request.base.sha }}
+          # No ref on purpose. For a pull_request_target event GitHub sets
+          # GITHUB_REF to the default branch, so this takes our own code and
+          # never the pull request's head, and it always holds the classifier
+          # this job loads. Pinning the base commit instead would fail on every
+          # pull request opened before the classifier merged.
           persist-credentials: false
 
       - uses: actions/github-script@v9

--- a/.github/workflows/reset-ci-state.yml
+++ b/.github/workflows/reset-ci-state.yml
@@ -6,8 +6,8 @@ name: Reset CI state
 # pull_request_target, not pull_request: in a public repository a pull_request
 # workflow holds a read-only token on a fork's pull request and could not write
 # a label. GitHub's warning about pull_request_target is about checking out and
-# running the pull request's code. The checkout below takes the default branch
-# and never touches the contributor's branch.
+# running the pull request's code. The checkout below takes repository-owned
+# code and never touches the contributor's branch.
 
 on:
   pull_request_target:
@@ -32,11 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # No ref on purpose. For a pull_request_target event GitHub sets
-          # GITHUB_REF to the default branch, so this takes our own code and
-          # never the pull request's head, and it always holds the classifier
-          # this job loads. Pinning the base commit instead would fail on every
-          # pull request opened before the classifier merged.
+          # No ref on purpose. A pull_request_target event runs in the context
+          # of a repository-owned branch, never the pull request's head, so this
+          # checkout always holds the classifier the script below loads. Pinning
+          # base.sha instead names the commit the pull request started from,
+          # which for any pull request opened before this merged holds no
+          # classifier at all, and the require would throw.
           persist-credentials: false
 
       - uses: actions/github-script@v9

--- a/.github/workflows/reset-ci-state.yml
+++ b/.github/workflows/reset-ci-state.yml
@@ -6,8 +6,8 @@ name: Reset CI state
 # pull_request_target, not pull_request: in a public repository a pull_request
 # workflow holds a read-only token on a fork's pull request and could not write
 # a label. GitHub's warning about pull_request_target is about checking out and
-# running the pull request's code. The checkout below is pinned to the base
-# commit and never touches the contributor's branch.
+# running the pull request's code. The checkout below takes the default branch
+# and never touches the contributor's branch.
 
 on:
   pull_request_target:


### PR DESCRIPTION
## The problem

The triage labels on a pull request are set by hand. Someone opens the run, reads which job failed, and picks a label. That repeats on every push, and gets skipped often enough that the labels drift from the truth. A label can easily go stale: a pull request can sit on `needs-review` after the code a reviewer would open has been replaced.

## What this PR does

- Labels a pull request `ci-running` while its run is going, then replaces it when the run ends: `needs-review` when everything passed, `needs-lint` when only formatting failed, `needs-changes` when something the author owns failed, and `needs-ci` when the run needs repeating. If the label has already been labeled `approved` it becomes `ready-to-merge`.
- Asks for another run rather than a change from the author, when only the build machine failed. Three steps that check the machine now begin with `Infra: `. Without it, a runner missing its Metal toolchain would tell every open pull request author to fix code that is fine.
- When a contributor pushes a new commit, every label about the previous one goes, an approval included, and the pull request waits for CI again.
- Throws away a CI result if the contributor pushed while the run was going. It tested code that is gone.
- Puts all the label rules in one file, with tests that run on every pull request.
- The two workflows that write labels never check out the pull request. They run only code from this repo, so a contributor cannot reach the token that writes labels.

Nothing here changes when CI runs, or who can start it.

## Tests

- 39 unit tests on the rules that pick the label. None touch the network.
- One test per label, plus the awkward cases: formatting failing on its own, formatting failing next to a real build failure, a cancelled run, a failure with no failing step.
- Tried for real on a throwaway repo, with a pull request from a second account.
- No label while a run waits for approval. The label appears once approved.
- Pushing mid-run: old result thrown away, pull request queued again.
- Each kind of failure produced the label it should.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it accurately describes the code changes.
- [x] AI usage disclosure: I used AI for all of this, but can confirm I understand the code.