### PR TITLE
Declare module weights as compile state in compiled decode paths

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -550,24 +550,14 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         if x.dim(1) != 1 {
             return forward(x)
         }
-        compileLock.lock()
-        if compiledForward == nil {
-            // [unowned self]: stored only on self, so it cannot outlive self;
-            // a strong capture would cycle and leak the module, weights and
-            // compiled tape (pinned by Qwen35CompiledDecodeLifecycleTests).
-            // The trace bakes the weights it captured — recreate the module
-            // rather than swapping parameters on a live one.
-            compiledForward = compile { [unowned self] x in forward(x) }
-        }
-        let fn = compiledForward!
-        compileLock.unlock()
-        return fn(x)
+        return compiledForward(self, x)
     }
 
-    /// Compiled functions are created on first decode, not at init (the
-    /// weights aren't loaded yet), so the lazy assignment needs a lock.
-    private let compileLock = NSLock()
-    private var compiledForward: ((MLXArray) -> MLXArray)?
+    /// The body stays inside this block, so the trace's default state (the
+    /// block's own weights) is complete.
+    private let compiledForward = CompiledTrace<Qwen35SparseMoeBlock> { block, arguments in
+        [block.forward(arguments[0])]
+    }
 
     /// The uncompiled body; an enclosing layer trace inlines it rather than
     /// nesting this block's own compiled wrapper.
@@ -669,11 +659,25 @@ final class Qwen35DecoderLayer: Module {
 
     // MARK: - Compiled decode blocks
 
-    // Lock rationale: see Qwen35SparseMoeBlock.compileLock.
-    private let compileLock = NSLock()
-    private var compiledLinearLayer: (([MLXArray]) -> [MLXArray])?
-    private var compiledAttentionPre: (([MLXArray]) -> [MLXArray])?
-    private var compiledAttentionPost: (([MLXArray]) -> [MLXArray])?
+    // Every body stays inside this layer, so each trace's default state (the
+    // layer's own weights) is complete.
+    private let compiledLinearLayer = CompiledTrace<Qwen35DecoderLayer> { layer, arguments in
+        let (out, newConvState, newRecState) = layer.linearLayerBody(
+            x: arguments[0], convState: arguments[1], recState: arguments[2])
+        return [out, newConvState, newRecState]
+    }
+
+    private let compiledAttentionPre = CompiledTrace<Qwen35DecoderLayer> { layer, arguments in
+        let (queries, gate, keys, values) = layer.attentionPreBody(x: arguments[0])
+        return [queries, gate, keys, values]
+    }
+
+    private let compiledAttentionPost = CompiledTrace<Qwen35DecoderLayer> { layer, arguments in
+        [
+            layer.attentionPostBody(
+                x: arguments[0], attention: arguments[1], gate: arguments[2])
+        ]
+    }
 
     /// GDN decode layer as one traced function. A compiled function must be
     /// pure, so conv/recurrent state crosses the boundary explicitly.
@@ -682,19 +686,7 @@ final class Qwen35DecoderLayer: Module {
         let convState = cache[0] ?? zero.conv
         let recState = cache[1] ?? zero.rec
 
-        compileLock.lock()
-        if compiledLinearLayer == nil {
-            // [unowned self]: see Qwen35SparseMoeBlock.callAsFunction.
-            compiledLinearLayer = compile { [unowned self] args in
-                let (out, newConvState, newRecState) = linearLayerBody(
-                    x: args[0], convState: args[1], recState: args[2])
-                return [out, newConvState, newRecState]
-            }
-        }
-        let fn = compiledLinearLayer!
-        compileLock.unlock()
-
-        let out = fn([x, convState, recState])
+        let out = compiledLinearLayer(self, [x, convState, recState])
         cache[0] = out[1]
         cache[1] = out[2]
         cache.advance(1)
@@ -706,27 +698,11 @@ final class Qwen35DecoderLayer: Module {
     private func decodeAttentionLayer(
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache
     ) -> MLXArray {
-        compileLock.lock()
-        if compiledAttentionPre == nil {
-            compiledAttentionPre = compile { [unowned self] args in
-                let (queries, gate, keys, values) = attentionPreBody(x: args[0])
-                return [queries, gate, keys, values]
-            }
-        }
-        if compiledAttentionPost == nil {
-            compiledAttentionPost = compile { [unowned self] args in
-                [attentionPostBody(x: args[0], attention: args[1], gate: args[2])]
-            }
-        }
-        let pre = compiledAttentionPre!
-        let post = compiledAttentionPost!
-        compileLock.unlock()
-
-        let projected = pre([x])
+        let projected = compiledAttentionPre(self, [x])
         let attention = attentionCacheStep(
             queries: projected[0], keys: projected[2], values: projected[3],
             cache: cache, mask: mask)
-        return post([x, attention, projected[1]])[0]
+        return compiledAttentionPost(self, [x, attention, projected[1]])[0]
     }
 
     /// The part of a full-attention decode step that cannot be traced: rope
@@ -810,7 +786,23 @@ public class Qwen35TextModelInner: Module {
         let segments = CompiledDecodeSegment.schedule(
             linearLayers: layers.map(\.isLinear))
         self.decodeSegments = segments
-        self.compiledSegments = CompiledDecodeSegmentCache(count: segments.count)
+        self.compiledSegments = CompiledDecodeSegmentCache(
+            count: segments.count,
+            state: { model, index in
+                // Everything `segmentBody` reads: the layers it runs, the
+                // embedding it starts from, the final norm it ends with.
+                var modules: [Module] = segments[index].layerIndices.map { model.layers[$0] }
+                if index == 0 {
+                    modules.append(model.embedTokens)
+                }
+                if index == segments.count - 1 {
+                    modules.append(model.norm)
+                }
+                return modules
+            },
+            body: { model, index, arguments in
+                model.segmentBody(at: index, arguments)
+            })
 
         super.init()
     }
@@ -865,7 +857,9 @@ public class Qwen35TextModelInner: Module {
     /// full-attention layer, a run of GDN layers, then the head of the next
     /// one (whose SDPA runs between this segment and the next).
     private let decodeSegments: [CompiledDecodeSegment]
-    private let compiledSegments: CompiledDecodeSegmentCache
+    private let compiledSegments: CompiledDecodeSegmentCache<Qwen35TextModelInner>
+
+    var compiledDecodeSegmentCount: Int { compiledSegments.compiledCount }
 
     /// Flat argument/result lists because `compile` takes `[MLXArray]`.
     /// In: `[x]` (token ids for segment 0), then `[attention, gate]` when
@@ -945,11 +939,7 @@ public class Qwen35TextModelInner: Module {
                 args.append(mambaCache[1]!)
             }
 
-            let outputs = compiledSegments.call(
-                at: segmentIndex, arguments: args
-            ) { [unowned self] segmentArgs in
-                segmentBody(at: segmentIndex, segmentArgs)
-            }
+            let outputs = compiledSegments(self, at: segmentIndex, args)
 
             carry = outputs[0]
             for (i, layerIndex) in segment.linearLayers.enumerated() {

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -524,7 +524,7 @@ public class Qwen3NextModelInner: Module {
     let faIdx: Int
 
     private let decodeSegments: [CompiledDecodeSegment]
-    private let compiledSegments: CompiledDecodeSegmentCache
+    private let compiledSegments: CompiledDecodeSegmentCache<Qwen3NextModelInner>
 
     var compiledDecodeSegmentCount: Int { compiledSegments.compiledCount }
 
@@ -549,7 +549,21 @@ public class Qwen3NextModelInner: Module {
         let segments = CompiledDecodeSegment.schedule(
             linearLayers: layers.map(\.isLinear))
         self.decodeSegments = segments
-        self.compiledSegments = CompiledDecodeSegmentCache(count: segments.count)
+        self.compiledSegments = CompiledDecodeSegmentCache(
+            count: segments.count,
+            state: { model, index in
+                // Everything `segmentBody` reads: the layers it runs, plus the
+                // final norm the last segment ends with. The embedding runs
+                // outside the trace.
+                var modules: [Module] = segments[index].layerIndices.map { model.layers[$0] }
+                if index == segments.count - 1 {
+                    modules.append(model.norm)
+                }
+                return modules
+            },
+            body: { model, index, arguments in
+                model.segmentBody(at: index, arguments)
+            })
 
         super.init()
     }
@@ -668,11 +682,7 @@ public class Qwen3NextModelInner: Module {
                 arguments.append(mambaCache[1]!)
             }
 
-            let outputs = compiledSegments.call(
-                at: segmentIndex, arguments: arguments
-            ) { [unowned self] arguments in
-                segmentBody(at: segmentIndex, arguments)
-            }
+            let outputs = compiledSegments(self, at: segmentIndex, arguments)
 
             carry = outputs[0]
             for (stateIndex, layerIndex) in segment.linearLayers.enumerated() {

--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
@@ -141,7 +141,7 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
         model.freeze()
         let layers = lora.loraLayers.suffix(configuration.numLayers)
         let keys = configuration.loraParameters.keys ?? lora.loraDefaultKeys
-        replaceLayers(layers: layers, keys: keys) { (layer: Module) in
+        replaceLayers(in: model, layers: layers, keys: keys) { (layer: Module) in
             createReplacementLayer(target: layer, configuration: configuration)
         }
 
@@ -182,7 +182,7 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
 
         let layers = lora.loraLayers.suffix(configuration.numLayers)
         let keys = configuration.loraParameters.keys ?? lora.loraDefaultKeys
-        replaceLayers(layers: layers, keys: keys) { (layer: Module) in
+        replaceLayers(in: model, layers: layers, keys: keys) { (layer: Module) in
             createReplacementLayer(target: layer, configuration: configuration)
         }
 
@@ -204,7 +204,7 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
         try load(into: model)
         let layers = lora.loraLayers.suffix(configuration.numLayers)
         let keys = configuration.loraParameters.keys ?? lora.loraDefaultKeys
-        replaceLayers(layers: layers, keys: keys) { (lora: LoRALayer) in
+        replaceLayers(in: model, layers: layers, keys: keys) { (lora: LoRALayer) in
             lora.fused()
         }
     }
@@ -219,7 +219,7 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
 
         let layers = lora.loraLayers.suffix(configuration.numLayers)
         let keys = configuration.loraParameters.keys ?? lora.loraDefaultKeys
-        replaceLayers(layers: layers, keys: keys) { (lora: LoRALayer) in
+        replaceLayers(in: model, layers: layers, keys: keys) { (lora: LoRALayer) in
             lora.reverted()
         }
     }
@@ -251,11 +251,17 @@ private func createReplacementLayer(
 }
 
 /// Traverses the model and replaces its layers using a transformation closure.
+///
+/// Invalidates the model's compiled traces on any replacement: a trace holds the
+/// module tree it was built from, so an adapter added, fused, or reverted here
+/// would otherwise be invisible to it.
 private func replaceLayers<T>(
+    in model: Module,
     layers: ArraySlice<Module>,
     keys: [String],
     transforming transform: (T) -> Module?
 ) {
+    var replaced = false
     for layer in layers {
         var update: [(String, Module)] = []
         for (key, child) in layer.namedModules() where keys.contains(key) {
@@ -266,6 +272,11 @@ private func replaceLayers<T>(
 
         if !update.isEmpty {
             layer.update(modules: .unflattened(update))
+            replaced = true
         }
+    }
+
+    if replaced {
+        model.invalidateCompiledTraces()
     }
 }

--- a/Libraries/MLXLMCommon/CompileOverloads.swift
+++ b/Libraries/MLXLMCommon/CompileOverloads.swift
@@ -1,0 +1,332 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+// The rest of the stateless `compile` surface, mirroring MLX's own overload
+// matrix (1 to 8 inputs, 1 to 4 results). See CompiledTrace.swift for what
+// these are for: a `@Sendable` body cannot capture a Module or an MLXArray, so
+// weights cannot be frozen into a trace by accident. A shape missing here would
+// fall through to MLX's unchecked overload, which is why the matrix is complete
+// rather than only the shapes models happen to use today.
+//
+// Hidden from DocC, as upstream hides the equivalent list.
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray) -> (MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray, MLXArray
+    )
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray
+    )
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray, MLXArray
+    )
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray
+    )
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (MLXArray, MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray
+    )
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (MLXArray, MLXArray, MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray, MLXArray
+    )
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        ) -> MLXArray
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    MLXArray
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        ) -> (MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    (MLXArray, MLXArray)
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        ) -> (MLXArray, MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    (MLXArray, MLXArray, MLXArray)
+{
+    MLX.compile(shapeless: shapeless, body)
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ body:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        ) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    (MLXArray, MLXArray, MLXArray, MLXArray)
+{
+    MLX.compile(shapeless: shapeless, body)
+}

--- a/Libraries/MLXLMCommon/CompiledDecodeSegments.swift
+++ b/Libraries/MLXLMCommon/CompiledDecodeSegments.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MLX
+import MLXNN
 
 /// One static-shaped piece of a hybrid model's single-token decode graph.
 ///
@@ -29,6 +30,13 @@ package struct CompiledDecodeSegment: Sendable, Equatable {
     /// two updated state tensors per linear layer.
     package var attentionOutputOffset: Int { 1 + 2 * linearLayers.count }
 
+    /// Every decoder layer this segment runs, in order. The weights of these
+    /// layers are the compile state of the segment's trace.
+    package var layerIndices: [Int] {
+        (attentionPostLayer.map { [$0] } ?? []) + linearLayers
+            + (attentionPreLayer.map { [$0] } ?? [])
+    }
+
     /// Build the maximal segments separated by full-attention cache writes.
     package static func schedule(linearLayers: [Bool]) -> [Self] {
         var segments: [Self] = []
@@ -47,37 +55,45 @@ package struct CompiledDecodeSegment: Sendable, Equatable {
     }
 }
 
-/// Lazily compiles and retains one MLX function for every decode segment.
+/// Lazily compiles and retains one `CompiledTrace` per decode segment.
 ///
-/// Models create this after their schedule is known. Compilation remains lazy
-/// because model weights are loaded after initialization. The lock ensures two
-/// concurrent first decode calls cannot install different traces.
-package final class CompiledDecodeSegmentCache {
-    private let lock = NSLock()
-    private var functions: [(([MLXArray]) -> [MLXArray])?]
+/// Models create this with their schedule; compilation stays lazy because
+/// weights load after initialization. Each segment declares the modules its
+/// body reads, so the trace sees current weights rather than the ones it was
+/// first traced with.
+package final class CompiledDecodeSegmentCache<Owner: Module>: CompiledTraceInvalidating {
 
-    package init(count: Int) {
+    /// Runs segment `index` over the flat argument list.
+    package typealias Body = @Sendable (Owner, Int, [MLXArray]) -> [MLXArray]
+
+    /// Returns the modules whose weights segment `index` reads: the layers in
+    /// `layerIndices`, plus anything else the body touches such as the
+    /// embedding or the final norm.
+    package typealias StateProvider = @Sendable (Owner, Int) -> [Module]
+
+    private let traces: [CompiledTrace<Owner>]
+
+    package init(count: Int, state: @escaping StateProvider, body: @escaping Body) {
         precondition(count > 0, "compiled decode requires at least one segment")
-        self.functions = Array(repeating: nil, count: count)
+        self.traces = (0 ..< count).map { index in
+            CompiledTrace<Owner>(
+                state: { state($0, index) },
+                body: { owner, arguments in body(owner, index, arguments) })
+        }
     }
 
     package var compiledCount: Int {
-        lock.withLock { functions.compactMap { $0 }.count }
+        traces.filter(\.isCompiled).count
     }
 
-    package func call(
-        at index: Int,
-        arguments: [MLXArray],
-        body: @escaping ([MLXArray]) -> [MLXArray]
+    package func callAsFunction(
+        _ owner: Owner, at index: Int, _ arguments: [MLXArray]
     ) -> [MLXArray] {
-        let function = lock.withLock {
-            if let function = functions[index] {
-                return function
-            }
-            let function = compile(body)
-            functions[index] = function
-            return function
-        }
-        return function(arguments)
+        traces[index](owner, arguments)
+    }
+
+    /// Drops every segment trace. See `CompiledTrace.invalidate()`.
+    package func invalidate() {
+        traces.forEach { $0.invalidate() }
     }
 }

--- a/Libraries/MLXLMCommon/CompiledTrace.swift
+++ b/Libraries/MLXLMCommon/CompiledTrace.swift
@@ -1,0 +1,193 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+
+// MLX traces a compiled function once. Any MLXArray the body reads but does not
+// take as an argument becomes a constant of that trace, so weights read through
+// a captured module freeze at the values of the first call. Plain inference
+// never notices. An adapter load, fuse, or unload, or a training step, keeps
+// producing the old weights.
+//
+// The `compile` overloads below shadow MLX's stateless ones with a `@Sendable`
+// body. `MLXArray` and `Module` are not `Sendable`, so that capture no longer
+// builds. Bodies that read weights use `CompiledTrace`, which declares them as
+// compile state.
+//
+// `MLX.compile(inputs:outputs:)` is untouched: declaring captured state there
+// is correct, and it remains the way to compile a training step.
+
+/// Compiles a function that reads nothing but its arguments.
+///
+/// Shadows MLX's `compile` with a `@Sendable` body, which cannot capture an
+/// `MLXArray` or a `Module`. Use ``CompiledTrace`` for a body that has to read
+/// module weights.
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable ([MLXArray]) -> [MLXArray]
+) -> @Sendable ([MLXArray]) -> [MLXArray] {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+/// Overload of ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])`` for one input and one
+/// output.
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray) -> MLXArray
+) -> @Sendable (MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+/// Overload of ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])`` for two inputs and one
+/// output.
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+/// Overload of ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])`` for three inputs and one
+/// output.
+public func compile(
+    shapeless: Bool = false,
+    _ body: @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray {
+    MLX.compile(shapeless: shapeless, body)
+}
+
+/// A compiled trace of a body that reads module weights.
+///
+/// The declared modules' weights become compile `inputs:`, so every call reads
+/// their current values instead of the ones the first call happened to see.
+/// Without that, a compiled forward silently ignores a loaded adapter or a
+/// training step.
+///
+/// The body takes its owner as a parameter and is `@Sendable`, so it cannot
+/// reach the weights any other way: capturing `self` does not compile.
+///
+/// ```swift
+/// final class MoEBlock: Module, UnaryLayer {
+///     // The body stays inside this module, so the default state covers it.
+///     private let compiledForward = CompiledTrace<MoEBlock> { block, arguments in
+///         [block.forward(arguments[0])]
+///     }
+///
+///     func callAsFunction(_ x: MLXArray) -> MLXArray {
+///         compiledForward(self, x)
+///     }
+/// }
+/// ```
+///
+/// Compilation is lazy, so a module can create its traces in `init` and they
+/// still read weights loaded later. Traces never retain their owner.
+///
+/// A trace is built from the modules present when it first ran, so replacing
+/// modules invalidates it: see `Module.invalidateCompiledTraces()`.
+public final class CompiledTrace<Owner: Module>: CompiledTraceInvalidating {
+
+    /// The traced body. Receives the owner whose weights it may read.
+    public typealias Body = @Sendable (Owner, [MLXArray]) -> [MLXArray]
+
+    /// Returns the modules whose weights the body reads.
+    public typealias StateProvider = @Sendable (Owner) -> [Module]
+
+    private let state: StateProvider
+    private let body: Body
+
+    // Compiled on first call rather than at init, because weights load later.
+    // The lock keeps two concurrent first calls from installing rival traces.
+    private let lock = NSLock()
+    private var function: (@Sendable ([MLXArray]) -> [MLXArray])?
+    private var tracedOwner: ObjectIdentifier?
+
+    /// - Parameters:
+    ///   - state: the modules whose weights the body reads; the owner by
+    ///     default, which covers a body that stays inside its own subtree
+    ///   - body: the function to trace
+    public init(state: @escaping StateProvider = { [$0] }, body: @escaping Body) {
+        self.state = state
+        self.body = body
+    }
+
+    /// Whether the trace has been compiled.
+    public var isCompiled: Bool {
+        lock.withLock { function != nil }
+    }
+
+    /// Drops the compiled trace; the next call re-reads the module tree.
+    public func invalidate() {
+        lock.withLock {
+            function = nil
+            tracedOwner = nil
+        }
+    }
+
+    /// Runs the trace, compiling it on first use.
+    public func callAsFunction(_ owner: Owner, _ arguments: [MLXArray]) -> [MLXArray] {
+        let traced = lock.withLock {
+            if let function {
+                precondition(
+                    tracedOwner == ObjectIdentifier(owner),
+                    "a CompiledTrace belongs to the module it first ran on")
+                return function
+            }
+            let function = compiled(owner)
+            self.function = function
+            self.tracedOwner = ObjectIdentifier(owner)
+            return function
+        }
+        return traced(arguments)
+    }
+
+    /// Convenience for a single argument and a single result.
+    public func callAsFunction(_ owner: Owner, _ argument: MLXArray) -> MLXArray {
+        self(owner, [argument])[0]
+    }
+
+    private func compiled(_ owner: Owner) -> @Sendable ([MLXArray]) -> [MLXArray] {
+        let body = self.body
+
+        // A snapshot is enough: `update(parameters:)`, the path optimizers and
+        // adapter weights take, writes through these same MLXArray objects.
+        // Replacing modules makes new ones, which is what
+        // `invalidateCompiledTraces()` is for. Re-reading the tree every call
+        // would cost more than the trace saves (~35µs per decoder layer).
+        let weights = state(owner).flatMap { $0.innerState() }
+
+        // The one place in this package that captures a module in a compiled
+        // body: `unowned` because the module stores the trace, and a strong
+        // capture would cycle and leak the weights with it.
+        return MLX.compile(inputs: [weights]) { [unowned owner] arguments in
+            body(owner, arguments)
+        }
+    }
+}
+
+/// Something `Module.invalidateCompiledTraces()` can reset: a ``CompiledTrace``
+/// or a container of them.
+public protocol CompiledTraceInvalidating: AnyObject {
+    func invalidate()
+}
+
+extension Module {
+
+    /// Drops every compiled trace stored in this module tree.
+    ///
+    /// A ``CompiledTrace`` is built from the modules present when it first ran,
+    /// so anything that replaces modules leaves it stale: loading, fusing, or
+    /// unloading an adapter, quantizing a loaded model. Weight updates that
+    /// keep the tree intact, such as training steps, do not need this.
+    /// Traces are found by reflection, so storing one is all a module has to
+    /// do: there is no conformance to remember.
+    public func invalidateCompiledTraces() {
+        visit { _, module in
+            for value in module.items().flattenedValues() {
+                if case .other(let value) = value, let trace = value as? CompiledTraceInvalidating {
+                    trace.invalidate()
+                }
+            }
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/ModelConversion.swift
+++ b/Libraries/MLXLMCommon/ModelConversion.swift
@@ -652,6 +652,9 @@ private func quantizeForModelConversion(
         }
 
     model.update(modules: ModuleChildren.unflattened(updates))
+    // Quantized layers replace their float counterparts; drop traces of the
+    // old tree.
+    model.invalidateCompiledTraces()
 
     return .init(
         defaultQuantization: effectiveDefaultQuantization.asModelConversionQuantization,

--- a/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
+++ b/Libraries/MLXLMCommon/ParoQuant/ParoQuantLoader.swift
@@ -279,6 +279,7 @@ private func patchRotationLayers(
 
     if !updates.isEmpty {
         try model.update(modules: ModuleChildren.unflattened(updates), verify: [.noUnusedKeys])
+        model.invalidateCompiledTraces()
 
         let patchedLeaves = rotationLeafModules(model: model)
         for (path, _) in updates {

--- a/Tests/MLXLMTests/CompiledDecodeWeightUpdateTests.swift
+++ b/Tests/MLXLMTests/CompiledDecodeWeightUpdateTests.swift
@@ -1,0 +1,217 @@
+// Copyright © 2026 Apple Inc.
+//
+// A compiled decode path must read the weights a model has now, not the ones
+// its traces were built with. Each test warms a model until its traces are
+// compiled, changes every weight, and compares it against an identical model
+// whose traces are built after the change. Any weight left out of a trace's
+// declared compile state shows up as a mismatch.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+
+final class CompiledDecodeWeightUpdateTests: XCTestCase {
+
+    private func logits(
+        _ model: some LLMModel, tokens: [Int32], cache: [KVCache]
+    ) -> [Float] {
+        var result: [Float] = []
+        for token in tokens {
+            let output = model(MLXArray([token]).reshaped(1, 1), cache: cache)
+            eval(output)
+            result += output.asArray(Float.self)
+        }
+        return result
+    }
+
+    /// Scales every parameter of both models to the same new values.
+    private func perturb(_ warm: some Module, _ reference: some Module) {
+        let updated = warm.parameters().mapValues { $0 * 1.5 }
+        warm.update(parameters: updated)
+        reference.update(parameters: updated)
+    }
+
+    // MARK: - Qwen 3.5
+
+    private func qwen35Configuration(
+        numExperts: Int, headDim: Int = 16
+    ) throws -> Qwen35TextConfiguration {
+        let json = """
+            {
+                "model_type": "qwen3_5",
+                "hidden_size": 32, "num_hidden_layers": 4, "intermediate_size": 64,
+                "num_attention_heads": 2, "num_key_value_heads": 1, "head_dim": \(headDim),
+                "linear_num_value_heads": 2, "linear_num_key_heads": 1,
+                "linear_key_head_dim": 16, "linear_value_head_dim": 16,
+                "linear_conv_kernel_dim": 4, "vocab_size": 32,
+                "full_attention_interval": 2,
+                "num_experts": \(numExperts), "num_experts_per_tok": \(min(2, numExperts)),
+                "moe_intermediate_size": 16, "shared_expert_intermediate_size": 16
+            }
+            """
+        return try JSONDecoder().decode(Qwen35TextConfiguration.self, from: Data(json.utf8))
+    }
+
+    private func assertQwen35TracksWeights(
+        numExperts: Int,
+        headDim: Int = 16,
+        usesSegments: Bool = true,
+        cache makeCache: (Qwen35TextModel) throws -> [KVCache] = {
+            try $0.newCache(parameters: nil)
+        }
+    ) throws {
+        let configuration = try qwen35Configuration(numExperts: numExperts, headDim: headDim)
+        let (warm, reference) = withRandomState(MLXRandom.RandomState(seed: 17)) {
+            let warm = Qwen35TextModel(configuration)
+            let reference = Qwen35TextModel(configuration)
+            reference.update(parameters: warm.parameters())
+            return (warm, reference)
+        }
+
+        // Compile the traces against the original weights.
+        _ = logits(warm, tokens: [1, 2, 3], cache: try makeCache(warm))
+        if usesSegments {
+            XCTAssertGreaterThan(warm.model.compiledDecodeSegmentCount, 0)
+        } else {
+            XCTAssertEqual(warm.model.compiledDecodeSegmentCount, 0)
+        }
+
+        perturb(warm, reference)
+
+        let updated = logits(warm, tokens: [4, 5, 6], cache: try makeCache(warm))
+        let expected = logits(reference, tokens: [4, 5, 6], cache: try makeCache(reference))
+        XCTAssertEqual(updated, expected, "compiled decode used stale weights")
+    }
+
+    func testQwen35CompiledDecodeTracksWeightUpdates() throws {
+        try assertQwen35TracksWeights(numExperts: 0)
+    }
+
+    func testQwen35MoECompiledDecodeTracksWeightUpdates() throws {
+        try assertQwen35TracksWeights(numExperts: 4)
+    }
+
+    /// A quantized KV cache falls back to the per-layer traces, which are the
+    /// other place Qwen 3.5 compiles module weights.
+    func testQwen35PerLayerTracesTrackWeightUpdates() throws {
+        try assertQwen35TracksWeights(numExperts: 4, headDim: 32, usesSegments: false) { model in
+            try model.newCache(parameters: nil).map { cache in
+                cache is MambaCache ? cache : QuantizedKVCache(groupSize: 32, bits: 8)
+            }
+        }
+    }
+
+    // MARK: - Qwen 3 Next
+
+    func testQwen3NextCompiledDecodeTracksWeightUpdates() throws {
+        let json = """
+            {
+                "hidden_size": 16, "num_hidden_layers": 4, "intermediate_size": 32,
+                "num_attention_heads": 2, "num_key_value_heads": 1, "head_dim": 8,
+                "linear_num_value_heads": 2, "linear_num_key_heads": 2,
+                "linear_key_head_dim": 8, "linear_value_head_dim": 8,
+                "linear_conv_kernel_dim": 4,
+                "num_experts": 4, "num_experts_per_tok": 2, "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": 16, "mlp_only_layers": [],
+                "moe_intermediate_size": 16, "rms_norm_eps": 1e-6, "vocab_size": 32,
+                "rope_theta": 10000.0, "partial_rotary_factor": 0.25,
+                "max_position_embeddings": 128, "norm_topk_prob": true,
+                "tie_word_embeddings": true, "attention_bias": false,
+                "full_attention_interval": 2
+            }
+            """
+        let configuration = try JSONDecoder().decode(
+            Qwen3NextConfiguration.self, from: Data(json.utf8))
+
+        // The compiled decode path is fp16 only.
+        let (warm, reference) = withRandomState(MLXRandom.RandomState(seed: 19)) {
+            let warm = Qwen3NextModel(configuration)
+            warm.update(parameters: warm.parameters().mapValues { $0.asType(.float16) })
+            let reference = Qwen3NextModel(configuration)
+            reference.update(parameters: warm.parameters())
+            return (warm, reference)
+        }
+
+        _ = logits(warm, tokens: [1, 2, 3], cache: try warm.newCache(parameters: nil))
+        XCTAssertGreaterThan(warm.model.compiledDecodeSegmentCount, 0)
+
+        perturb(warm, reference)
+
+        let updated = logits(warm, tokens: [4, 5, 6], cache: try warm.newCache(parameters: nil))
+        let expected = logits(
+            reference, tokens: [4, 5, 6], cache: try reference.newCache(parameters: nil))
+        XCTAssertEqual(updated, expected, "compiled decode used stale weights")
+    }
+
+    // MARK: - Adapters
+
+    /// Loading an adapter into a model that has already run replaces modules
+    /// under the traces. `LoRAContainer.load` invalidates them.
+    func testLoRALoadAfterCompiledDecodeChangesOutput() throws {
+        let configuration = try qwen35Configuration(numExperts: 0)
+        let model = withRandomState(MLXRandom.RandomState(seed: 23)) {
+            Qwen35TextModel(configuration)
+        }
+        let cache = try model.newCache(parameters: nil)
+        _ = logits(model, tokens: [1, 2, 3], cache: cache)
+        XCTAssertGreaterThan(model.model.compiledDecodeSegmentCount, 0)
+
+        let baseline = logits(model, tokens: [4], cache: try model.newCache(parameters: nil))
+
+        let rank = 4
+        let adapter = LoRAContainer(
+            configuration: .init(
+                numLayers: 4,
+                loraParameters: .init(rank: rank, scale: 1.0, keys: ["self_attn.q_proj"])),
+            parameters: ModuleParameters.unflattened([
+                "model.layers.1.self_attn.q_proj.lora_a": MLXArray.full(
+                    [32, rank], values: MLXArray(Float(0.05))),
+                "model.layers.1.self_attn.q_proj.lora_b": MLXArray.full(
+                    [rank, 64], values: MLXArray(Float(0.05))),
+                "model.layers.3.self_attn.q_proj.lora_a": MLXArray.full(
+                    [32, rank], values: MLXArray(Float(0.05))),
+                "model.layers.3.self_attn.q_proj.lora_b": MLXArray.full(
+                    [rank, 64], values: MLXArray(Float(0.05))),
+            ]))
+        try adapter.load(into: model)
+
+        let adapted = logits(model, tokens: [4], cache: try model.newCache(parameters: nil))
+        XCTAssertNotEqual(adapted, baseline, "compiled decode ignored the loaded adapter")
+
+        adapter.unload(from: model)
+        let restored = logits(model, tokens: [4], cache: try model.newCache(parameters: nil))
+        XCTAssertEqual(restored, baseline, "compiled decode kept the unloaded adapter")
+    }
+
+    /// The training entry point replaces the same layers as `load(into:)`.
+    /// Fresh adapters are zero-initialized, so the trace has to survive until
+    /// the first optimizer step to be caught here.
+    func testLoRAConversionAfterCompiledDecodeSeesTrainedAdapter() throws {
+        let configuration = try qwen35Configuration(numExperts: 0)
+        let model = withRandomState(MLXRandom.RandomState(seed: 29)) {
+            Qwen35TextModel(configuration)
+        }
+        _ = logits(model, tokens: [1, 2, 3], cache: try model.newCache(parameters: nil))
+        XCTAssertGreaterThan(model.model.compiledDecodeSegmentCount, 0)
+
+        let baseline = logits(model, tokens: [4], cache: try model.newCache(parameters: nil))
+
+        _ = try LoRAContainer.from(
+            model: model,
+            configuration: .init(
+                numLayers: 4,
+                loraParameters: .init(rank: 4, scale: 1.0, keys: ["self_attn.q_proj"])))
+
+        let trainable = model.trainableParameters()
+        XCTAssertFalse(trainable.isEmpty, "conversion produced no trainable adapter parameters")
+        model.update(parameters: trainable.mapValues { $0 + 0.05 })
+
+        let trained = logits(model, tokens: [4], cache: try model.newCache(parameters: nil))
+        XCTAssertNotEqual(
+            trained, baseline, "compiled decode ignored the adapter it was trained on")
+    }
+}

--- a/Tests/MLXLMTests/CompiledTraceTests.swift
+++ b/Tests/MLXLMTests/CompiledTraceTests.swift
@@ -1,0 +1,189 @@
+// Copyright © 2026 Apple Inc.
+//
+// MLX traces a compiled function once: every array the body reads without
+// receiving it as an argument or declaring it as `inputs:` state becomes a
+// constant of the trace. These tests pin that behaviour for plain `compile`
+// (the hazard) and pin that `CompiledTrace` does not have it (the fix).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+private final class ScaleLayer: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+
+    init(_ value: Float) {
+        self._weight.wrappedValue = MLXArray([value])
+        super.init()
+    }
+
+    func forward(_ x: MLXArray) -> MLXArray {
+        x * weight
+    }
+
+    let compiledForward = CompiledTrace<ScaleLayer> { layer, arguments in
+        [layer.forward(arguments[0])]
+    }
+}
+
+private final class ScaleContainer: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    override init() {
+        _linear.wrappedValue = Linear(1, 1, bias: false)
+        super.init()
+    }
+
+    func forward(_ x: MLXArray) -> MLXArray {
+        linear(x)
+    }
+
+    let compiledForward = CompiledTrace<ScaleContainer> { container, arguments in
+        [container.forward(arguments[0])]
+    }
+}
+
+/// Traces held in a collection, like the per-segment traces a model keeps.
+private final class ScaleBank: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    let traces: [CompiledTrace<ScaleBank>]
+
+    init(_ value: Float) {
+        self._weight.wrappedValue = MLXArray([value])
+        self.traces = (0 ..< 2).map { _ in
+            CompiledTrace<ScaleBank> { bank, arguments in [arguments[0] * bank.weight] }
+        }
+        super.init()
+    }
+}
+
+private final class ScaleParent: Module {
+    @ModuleInfo(key: "child") var child: ScaleLayer
+
+    init(_ child: ScaleLayer) {
+        _child.wrappedValue = child
+        super.init()
+    }
+}
+
+final class CompiledTraceTests: XCTestCase {
+
+    private func setWeight(_ layer: ScaleLayer, _ value: Float) {
+        layer.update(parameters: ModuleParameters.unflattened(["weight": MLXArray([value])]))
+    }
+
+    private func value(_ array: MLXArray) -> Float {
+        eval(array)
+        return array.item(Float.self)
+    }
+
+    /// The hazard, straight from MLX: a body that reads weights through a
+    /// capture keeps the values of its first call. Reproducing it takes
+    /// `MLX.compile` by name, since the `compile` this package exposes rejects
+    /// the capture at build time. A failure here means MLX changed its capture
+    /// rules and `CompiledTrace` can be revisited.
+    func testPlainCompileFreezesCapturedWeights() {
+        let layer = ScaleLayer(2)
+        let captured = MLX.compile { [unowned layer] (x: MLXArray) in layer.forward(x) }
+
+        XCTAssertEqual(value(captured(MLXArray([Float(1)]))), 2)
+
+        setWeight(layer, 5)
+        XCTAssertEqual(value(layer.forward(MLXArray([Float(1)]))), 5)
+        XCTAssertEqual(
+            value(captured(MLXArray([Float(1)]))), 2,
+            "plain compile baked the captured weight into the trace")
+    }
+
+    /// The same body through ``CompiledTrace``: weights are compile `inputs:`,
+    /// so every call reads their current values.
+    func testCompiledTraceSeesWeightUpdates() {
+        let layer = ScaleLayer(2)
+
+        XCTAssertEqual(value(layer.compiledForward(layer, MLXArray([Float(1)]))), 2)
+
+        setWeight(layer, 5)
+        XCTAssertEqual(value(layer.compiledForward(layer, MLXArray([Float(1)]))), 5)
+
+        setWeight(layer, -3)
+        XCTAssertEqual(value(layer.compiledForward(layer, MLXArray([Float(1)]))), -3)
+    }
+
+    /// Gradients flow to the declared state, which is what training a LoRA
+    /// adapter through a compiled forward needs.
+    func testCompiledTraceIsDifferentiableThroughWeights() throws {
+        let layer = ScaleLayer(2)
+        let x = MLXArray([Float(3)])
+
+        let gradients = valueAndGrad(model: layer) { (layer: ScaleLayer, x: MLXArray) in
+            [layer.compiledForward(layer, x).sum()]
+        }(layer, x).1
+        let flattened = Dictionary(uniqueKeysWithValues: gradients.flattened())
+
+        XCTAssertEqual(value(try XCTUnwrap(flattened["weight"])), 3)
+    }
+
+    /// A trace is stored on the module it traces, so it must not retain it.
+    func testCompiledTraceDoesNotRetainItsOwner() {
+        var layer: ScaleLayer? = ScaleLayer(2)
+        _ = value(layer!.compiledForward(layer!, MLXArray([Float(1)])))
+
+        weak var released = layer
+        layer = nil
+
+        XCTAssertNil(released, "the compiled trace retained its owner")
+    }
+
+    /// Loading, fusing, or unloading an adapter replaces modules, which leaves
+    /// the trace holding the old tree. Invalidating rebuilds it.
+    func testInvalidateCompiledTracesPicksUpReplacedModules() throws {
+        func weight(_ value: Float) -> MLXArray {
+            MLXArray([value]).reshaped(1, 1)
+        }
+        let one = MLXArray([Float(1)]).reshaped(1, 1)
+
+        let container = ScaleContainer()
+        container.update(parameters: ModuleParameters.unflattened(["linear.weight": weight(2)]))
+        XCTAssertEqual(value(container.compiledForward(container, one)), 2)
+
+        let replacement = Linear(1, 1, bias: false)
+        replacement.update(parameters: ModuleParameters.unflattened(["weight": weight(7)]))
+        container.update(modules: ModuleChildren.unflattened([("linear", replacement)]))
+
+        container.invalidateCompiledTraces()
+        XCTAssertEqual(value(container.compiledForward(container, one)), 7)
+    }
+
+    /// `invalidateCompiledTraces()` reaches owners nested in the tree.
+    func testInvalidateCompiledTracesWalksTheModuleTree() {
+        let layer = ScaleLayer(2)
+        let parent = ScaleParent(layer)
+
+        XCTAssertFalse(layer.compiledForward.isCompiled)
+        _ = value(layer.compiledForward(layer, MLXArray([Float(1)])))
+        XCTAssertTrue(layer.compiledForward.isCompiled)
+
+        parent.invalidateCompiledTraces()
+        XCTAssertFalse(layer.compiledForward.isCompiled)
+    }
+
+    /// Traces reach invalidation whether a module stores one directly or keeps
+    /// several in a collection.
+    func testInvalidateCompiledTracesFindsTracesInCollections() {
+        let bank = ScaleBank(2)
+        for trace in bank.traces {
+            _ = value(trace(bank, MLXArray([Float(1)]))[0])
+        }
+        XCTAssertTrue(bank.traces.allSatisfy(\.isCompiled))
+
+        bank.invalidateCompiledTraces()
+        XCTAssertTrue(bank.traces.allSatisfy { !$0.isCompiled })
+    }
+
+    func testCompileRunsBodyWithoutState() {
+        let f = compile(shapeless: true) { (a: MLXArray, b: MLXArray) in a * b + 1 }
+        XCTAssertEqual(value(f(MLXArray([Float(2)]), MLXArray([Float(3)]))), 7)
+    }
+}

--- a/skills/mlx-swift-lm/references/model-porting.md
+++ b/skills/mlx-swift-lm/references/model-porting.md
@@ -332,6 +332,45 @@ extension YourModel: LoRAModel {
 
 If you need custom keys, override `loraDefaultKeys`.
 
+## Compiled decode paths
+
+`compile` traces a function once and turns every `MLXArray` the body reads, but
+does not take as an argument, into a constant of that trace. A body that reads
+weights through a captured module therefore keeps the values of its first call
+and ignores a loaded adapter or a training step.
+
+`compile` in this package resolves to the `MLXLMCommon` overload, whose
+`@Sendable` body cannot capture a `Module` or an `MLXArray`, so that mistake
+does not build. Use it for bodies that read only their arguments:
+
+```swift
+private let siluProduct: @Sendable (MLXArray, MLXArray) -> MLXArray = compile(shapeless: true) {
+    gate, up in silu(gate) * up
+}
+```
+
+For a body that reads weights, use `CompiledTrace`. It takes the owner as a
+parameter and declares the modules whose weights the body reads, which become
+compile `inputs:`:
+
+```swift
+final class YourMoEBlock: Module, UnaryLayer {
+    // Default state is the owner, which covers a body that stays inside it.
+    private let compiledForward = CompiledTrace<YourMoEBlock> { block, arguments in
+        [block.forward(arguments[0])]
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        compiledForward(self, x)
+    }
+}
+```
+
+Traces are lazy, so a trace created in `init` still reads weights loaded later,
+and it never retains its owner. Anything that replaces modules invalidates a
+trace: `Module.invalidateCompiledTraces()` resets every trace in a model tree
+and already runs on the adapter and quantization paths.
+
 ## Registration
 
 1. Add model type mapping in `Libraries/MLXLLM/LLMModelFactory.swift`:
@@ -349,6 +388,8 @@ If you need custom keys, override `loraDefaultKeys`.
 - Bias flags are model-specific (check config and Python implementation).
 - GQA models require `kvHeads` distinct from `attentionHeads`.
 - Sliding-window or special caches may require overriding `newCache` or `prepare`.
+- A compiled body must read weights through `CompiledTrace`, not through a
+  captured `self`, or the trace bakes them in.
 
 ## Minimal checklist
 


### PR DESCRIPTION
## Proposed changes

Fixes #586, rightfully raised by @davidkoski on #569. Pairs with ml-explore/mlx-swift#465, which confirms the same behaviour upstream.

### Design

**1. Attempt to make the mistake unbuildable.** `MLXLMCommon` shadows MLX's stateless `compile` overloads with versions that take a `@Sendable` body. Neither `MLXArray` nor `Module` is `Sendable`, so the capture that causes the bug is a
compile error:

```
error: capture of 'self' with non-Sendable type 'Qwen35SparseMoeBlock'
       in a '@Sendable' closure
```

This is the part that prevents the next occurrence. A future model port cannot reintroduce the bug by writing the natural-looking thing; the compiler stops it at the keystroke, not in review.

`MLX.compile(inputs:outputs:)` is deliberately not shadowed. Capturing a module *and declaring it* is correct, and it stays the way to compile a training step, exactly as mlx-swift#465 documents.

**2. `CompiledTrace<Owner>` when a body must read weights.** The body takes its owner as a parameter instead of capturing it, and declares which modules it reads. Those become the compile `inputs:`.

```swift
private let compiledForward = CompiledTrace<Qwen35SparseMoeBlock> { block, arguments in
    [block.forward(arguments[0])]
}

func callAsFunction(_ x: MLXArray) -> MLXArray {
    x.dim(1) != 1 ? forward(x) : compiledForward(self, x)
}
```

Compilation stays lazy, so a trace built in `init` still reads weights loaded later. Traces never retain their owner, so the existing deallocation tests hold.
Default state is the owner itself, which is complete for a body that stays in its own subtree, which is every per-layer trace here.

**3. Invalidate when the module tree changes.** Declared state fixes changing *values*. It does not fix a changing *tree*: after a LoRA load the trace still describes a `Linear` where a `LoRALinear` now sits.
`Module.invalidateCompiledTraces()` resets every trace in a tree, and lives in `replaceLayers`, the one helper all four adapter paths (`from`, `load`, `fuse`, `unload`) already share, plus the two quantization paths. Traces are found by reflection, so a model owns one just by storing it. Nothing to conform to, nothing to remember, no per-model boilerplate to forget in the next port.

### Why snapshot weights instead of re-reading them

`compile(inputs:)` re-flattens its inputs on every call, so passing the `Module` would walk the module tree once per segment per token. Measured on an MacBook M2 machine: flattening one decoder layer takes ~35us, a 48 layer model ~1.6ms.
Passing already-flattened arrays costs ~60ns each per call.

So the snapshot is taken once, when the trace compiles. It stays correct because `Module.update(parameters:)`, the path both optimizers and adapter weight loading take, writes *through* the same `MLXArray` objects rather than replacing them.
Replacing modules does create new objects, which is exactly what invalidation covers.


## Questions

- **Deliberately not included:** a lint hook banning explicit `MLX.compile`
  outside `CompiledTrace.swift`. The type system covers the accidental case and
  the bypass is visible in review. Easy to add later if it ever appears in a diff.
- **Open question.** `ModelConversion` and `ParoQuant` invalidate after replacing
  modules, but both run at load time before any trace exists. I kept the calls as
  cheap insurance against future reordering. Happy to drop them if you would
  rather not pay for the noise.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure: