### PR TITLE
Report prompt token counts to FoundationModels again

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/SessionUsageAccountingTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/TextGeneration/SessionUsageAccountingTests.swift
@@ -1,0 +1,120 @@
+// Copyright © 2026 Apple Inc.
+
+#if FoundationModelsIntegration && canImport(FoundationModels, _version: 2)
+
+import Testing
+import Foundation
+import FoundationModels
+@testable import MLXFoundationModels
+
+/// Assert on the public `LanguageModelSession.usage`. Check input tokens, not
+/// only a total. The executor notifies `generationObserver` before it sends to
+/// the channel, so an observer-based test passes when the consumer gets
+/// nothing. The framework counts output tokens from text fragments, so a
+/// total-only check passes when input tokens are zero.
+@Suite(.serialized, .timeLimit(.minutes(10)))
+struct SessionUsageAccountingTests {
+
+    @Test
+    func freshSessionReportsZeroUsage() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let model = makeTestModel(TestFixtures.defaultModelID)
+        let session = LanguageModelSession(model: model, tools: [], instructions: nil)
+
+        #expect(session.usage.input.totalTokenCount == 0)
+        #expect(session.usage.input.cachedTokenCount == 0)
+        #expect(session.usage.output.totalTokenCount == 0)
+        #expect(session.usage.output.reasoningTokenCount == 0)
+        #expect(session.usage.totalTokenCount == 0)
+    }
+
+    @Test
+    func singleResponseReportsInputAndOutputTokens() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let model = makeTestModel(TestFixtures.defaultModelID)
+        let session = LanguageModelSession(model: model, tools: [], instructions: nil)
+
+        let response = try await session.respond(to: "Say 'hi' briefly.")
+        let usage = response.usage
+
+        #expect(
+            usage.input.totalTokenCount > 0,
+            "Zero input tokens means the adapter did not send updateUsage")
+        #expect(usage.output.totalTokenCount > 0)
+        #expect(
+            usage.totalTokenCount == usage.input.totalTokenCount + usage.output.totalTokenCount)
+        #expect(usage.input.cachedTokenCount <= usage.input.totalTokenCount)
+        #expect(usage.output.reasoningTokenCount <= usage.output.totalTokenCount)
+
+        #expect(session.usage.input.totalTokenCount == usage.input.totalTokenCount)
+        #expect(session.usage.output.totalTokenCount == usage.output.totalTokenCount)
+    }
+
+    @Test
+    func sessionSumsUsageAcrossTurns() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let model = makeTestModel(TestFixtures.defaultModelID)
+        let session = LanguageModelSession(model: model, tools: [], instructions: nil)
+
+        var expectedInput = 0
+        var expectedOutput = 0
+        var previousTotal = 0
+
+        for prompt in ["Say 'hi' briefly.", "Name one color.", "Name one animal."] {
+            let response = try await session.respond(to: prompt)
+
+            #expect(response.usage.input.totalTokenCount > 0)
+            #expect(response.usage.output.totalTokenCount > 0)
+
+            expectedInput += response.usage.input.totalTokenCount
+            expectedOutput += response.usage.output.totalTokenCount
+
+            #expect(session.usage.input.totalTokenCount == expectedInput)
+            #expect(session.usage.output.totalTokenCount == expectedOutput)
+            #expect(
+                session.usage.totalTokenCount > previousTotal,
+                "Session usage must increase after every response")
+
+            previousTotal = session.usage.totalTokenCount
+        }
+    }
+
+    @Test
+    func separateSessionsDoNotShareUsage() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let model = makeTestModel(TestFixtures.defaultModelID)
+        let first = LanguageModelSession(model: model, tools: [], instructions: nil)
+        _ = try await first.respond(to: "Say 'hi' briefly.")
+        #expect(first.usage.totalTokenCount > 0)
+
+        let second = LanguageModelSession(model: model, tools: [], instructions: nil)
+        #expect(second.usage.totalTokenCount == 0)
+    }
+
+    /// The streaming path adds a usage delta for each snapshot. The `respond()`
+    /// path adds one total. The two paths can disagree, so test streaming too.
+    @Test
+    func streamingReportsUsageMatchingFinalSnapshot() async throws {
+        guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
+
+        let model = makeTestModel(TestFixtures.defaultModelID)
+        let session = LanguageModelSession(model: model, tools: [], instructions: nil)
+
+        var finalSnapshotUsage: LanguageModelSession.Usage?
+        for try await snapshot in session.streamResponse(to: "Say hello in three words.") {
+            finalSnapshotUsage = snapshot.usage
+        }
+
+        let usage = try #require(finalSnapshotUsage)
+        #expect(usage.input.totalTokenCount > 0)
+        #expect(usage.output.totalTokenCount > 0)
+        #expect(session.usage.input.totalTokenCount == usage.input.totalTokenCount)
+        #expect(session.usage.output.totalTokenCount == usage.output.totalTokenCount)
+    }
+}
+
+#endif  // FoundationModelsIntegration

--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -726,39 +726,8 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             into channel: LanguageModelExecutorGenerationChannel
         ) async {
             generationObserver?(.updateUsage(input: input, output: output, entryID: entryID))
-
-            // TODO: papering over an FM-27 SDK symbol drift -- restore
-            // the channel usage send (the commented-out call at the end of this
-            // block) once the shipping dylib matches its own interface.
-            //
-            // Usage is intentionally NOT forwarded to the FoundationModels
-            // channel on this SDK. The FM-27 beta `.swiftinterface` declares
-            //   Response.Action.updateUsage(input:output:metadata: = [:])
-            // (three parameters), but the shipping FoundationModels dylib only
-            // exports the older two-parameter
-            //   Response.Action.updateUsage(input:output:)
-            // Because our call relies on the `metadata:` default, the compiler
-            // resolves it to the three-parameter symbol, which does not exist
-            // at runtime. dyld cannot bind it: under chained-fixups linking
-            // (the arm64 default) the reference aborts the process the moment
-            // the image loads, and under lazy binding it faults through null
-            // (SIGSEGV at 0x0) the instant this send executes -- crashing every
-            // `respond()` path right after generation completes.
-            //
-            // A runtime `dlsym` guard cannot save this: the compiled reference
-            // to the missing symbol is enough to abort at launch regardless of
-            // any surrounding check. The only safe option is to not reference
-            // the symbol at all, so no `channel.send(.updateUsage(...))` here.
-            //
-            // Effect: the framework does not receive our per-response usage
-            // event, so consumer-visible usage for these responses may be
-            // absent or zero. Tests still observe usage through
-            // `generationObserver` above. When a later SDK ships a dylib that
-            // matches its interface, restore the send:
-            //   await channel.send(
-            //       .response(
-            //           entryID: entryID,
-            //           action: .updateUsage(input: input, output: output)))
+            await channel.send(
+                .response(entryID: entryID, action: .updateUsage(input: input, output: output)))
         }
 
         static func emitToolCall(


### PR DESCRIPTION
## The problem

An app that runs a model through this adapter reads its token usage from the session. Prompt tokens always came back zero. A fix in July removed the usage update the adapter sends after each response, because the beta SDK declared a call the shipping system library did not contain, and every request crashed the moment generation finished. Completion tokens kept working, because the framework counts those from the streamed text on its own. A total still looked plausible, so the missing half was easy to miss.

## What this PR does

- Sends the usage update again. A caller reads prompt tokens as well as completion tokens, per response and added up across a session.
- Confirms the mismatch that caused the crash is gone on the current toolchain, on macOS and on iOS.

It adds no continuous integration coverage. The nightly job runs an older toolchain, where this code compiles to nothing, and the newer job only compiles.

## Tests

- A new session reports zero.
- One response reports both prompt and completion tokens.
- A session adds usage across three turns.
- Two sessions stay independent.
- The streaming path agrees with its own final snapshot.

Three of the five fail without the change and pass with it, against a real model on macOS 27 with Xcode 27 beta 6. The other two check the zero state, which the bug did not affect.