### PR TITLE
Fix DeepSeek MTP layer filtering

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -426,6 +426,16 @@ public class DeepseekV3Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
         return lmHead(out)
     }
 
+    private func isMultiTokenPredictionLayer(_ key: String) -> Bool {
+        let components = key.split(separator: ".", maxSplits: 3)
+        guard components.count >= 3,
+            components[0] == "model", components[1] == "layers",
+            let layerIndex = Int(components[2])
+        else { return false }
+
+        return layerIndex >= args.numHiddenLayers
+    }
+
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         var newWeights = weights
 
@@ -469,7 +479,7 @@ public class DeepseekV3Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
         }
 
         return newWeights.filter { key, _ in
-            !key.starts(with: "model.layers.61") && !key.contains("rotary_emb.inv_freq")
+            !isMultiTokenPredictionLayer(key) && !key.contains("rotary_emb.inv_freq")
         }
     }
 

--- a/Tests/MLXLMTests/DeepseekV3Tests.swift
+++ b/Tests/MLXLMTests/DeepseekV3Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class DeepseekV3Tests: XCTestCase {
 
     // Tiny MoE config: 4 routed experts in 2 groups, top-1 group, top-2 experts.
-    private func makeConfig() throws -> DeepseekV3Configuration {
+    private func makeConfig(numHiddenLayers: Int = 2) throws -> DeepseekV3Configuration {
         let json = """
             {
                 "model_type": "deepseek_v3",
@@ -17,7 +17,7 @@ final class DeepseekV3Tests: XCTestCase {
                 "hidden_size": 8,
                 "intermediate_size": 16,
                 "moe_intermediate_size": 8,
-                "num_hidden_layers": 2,
+                "num_hidden_layers": \(numHiddenLayers),
                 "num_attention_heads": 2,
                 "num_key_value_heads": 2,
                 "n_routed_experts": 4,
@@ -74,5 +74,29 @@ final class DeepseekV3Tests: XCTestCase {
         eval(logits)
 
         XCTAssertEqual(logits.shape, [1, 3, 32])
+    }
+
+    func testSanitizeDropsPredictionLayerAfterDeepseekV3Stack() throws {
+        let model = DeepseekV3Model(try makeConfig(numHiddenLayers: 61))
+        let sanitized = model.sanitize(weights: [
+            "model.layers.60.self_attn.q_proj.weight": MLXArray.zeros([1]),
+            "model.layers.61.self_attn.q_proj.weight": MLXArray.zeros([1]),
+        ])
+
+        XCTAssertNotNil(sanitized["model.layers.60.self_attn.q_proj.weight"])
+        XCTAssertNil(sanitized["model.layers.61.self_attn.q_proj.weight"])
+    }
+
+    func testSanitizeUsesConfiguredLayerCount() throws {
+        let model = DeepseekV3Model(try makeConfig(numHiddenLayers: 78))
+        let sanitized = model.sanitize(weights: [
+            "model.layers.61.self_attn.q_proj.weight": MLXArray.zeros([1]),
+            "model.layers.77.self_attn.q_proj.weight": MLXArray.zeros([1]),
+            "model.layers.78.self_attn.q_proj.weight": MLXArray.zeros([1]),
+        ])
+
+        XCTAssertNotNil(sanitized["model.layers.61.self_attn.q_proj.weight"])
+        XCTAssertNotNil(sanitized["model.layers.77.self_attn.q_proj.weight"])
+        XCTAssertNil(sanitized["model.layers.78.self_attn.q_proj.weight"])
     }
 }


### PR DESCRIPTION
## Proposed changes

DeepSeek V3 checkpoint filtering assumed that multi-token prediction (MTP) weights always started at layer 61. That is correct for the standard model, but not for variants with a different number of hidden layers. For example, GLM-5.2 has 78 hidden layers and one appended MTP layer: layer 61 is a valid model layer, while layer 78 is the MTP layer. Deriving the boundary from `num_hidden_layers` prevents valid weights from being discarded and keeps checkpoint filtering consistent with the model configuration.

### Note

This PR does not add GLM-5.2 support itself; it removes the hardcoded assumption from the shared DeepSeek V3 stack and prepares it for architectures with different configured depths.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (not needed for this internal fix)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
  accurately describes the code changes.
- AI usage disclosure: none