### PR TITLE
Clear the compiler warnings from the library and both test targets

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/CoherenceIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/CoherenceIntegrationTests.swift
@@ -34,7 +34,7 @@ private func runCoherence(_ configuration: ModelConfiguration) async throws {
 private func releaseModel(_ configuration: ModelConfiguration) async {
     await models.evictLLM(configuration)
     Stream.gpu.synchronize()
-    GPU.clearCache()
+    Memory.clearCache()
 }
 
 /// Fast, reliable, architecturally-diverse subset that runs by default so the

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/HardReserveStressTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/HardReserveStressTests.swift
@@ -483,9 +483,9 @@ struct HardReserveStressTests {
     @Test("Cleanup: release GPU resources after stress tests")
     func releaseGPUResources() async {
         guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
-        let before = GPU.snapshot()
+        let before = Memory.snapshot()
         await releaseAllGPUMemory()
-        let after = GPU.snapshot()
+        let after = Memory.snapshot()
         let freed = before.activeMemory - after.activeMemory
         print(
             "[HardReserveCleanup] freed \(freed / (1024 * 1024))MB active, "

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/MultiModelGuidedGenerationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/MultiModelGuidedGenerationTests.swift
@@ -458,9 +458,9 @@ struct MultiModelGuidedGenerationTests {
     @Test("Cleanup: release multi-model GPU resources")
     func releaseGPUResources() async {
         guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
-        let before = GPU.snapshot()
+        let before = Memory.snapshot()
         await releaseAllGPUMemory()
-        let after = GPU.snapshot()
+        let after = Memory.snapshot()
         let freed = before.activeMemory - after.activeMemory
         print(
             "[MultiModelCleanup] freed \(freed / (1024 * 1024))MB active, "

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/Support/FMTestHelpers.swift
@@ -324,7 +324,7 @@ func releaseAllGPUMemory() async {
     Stream.gpu.synchronize()
     await MLXLanguageModel.evictAll()
     Stream.gpu.synchronize()
-    GPU.clearCache()
+    Memory.clearCache()
 }
 
 #endif  // FoundationModelsIntegration

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/FoundationModelsToolCallingTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/FoundationModelsToolCallingTests.swift
@@ -70,9 +70,9 @@ struct FoundationModelsToolCallingTests {
     @Test("Setup: release GPU state from prior suites")
     func clearGPUBeforeToolCalling() async {
         guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
-        let before = GPU.snapshot()
+        let before = Memory.snapshot()
         await releaseAllGPUMemory()
-        let after = GPU.snapshot()
+        let after = Memory.snapshot()
         let freed = (before.activeMemory - after.activeMemory) / (1024 * 1024)
         let cache = before.cacheMemory / (1024 * 1024)
         print("[ToolCallingSetup] freed \(freed)MB active, \(cache)MB cache")

--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallingReasoningTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/ToolCalling/ToolCallingReasoningTests.swift
@@ -30,9 +30,9 @@ struct ToolCallingReasoningTests {
     @Test("Setup: release GPU state from prior suites")
     func clearGPUBeforeToolCallingReasoning() async {
         guard #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) else { return }
-        let before = GPU.snapshot()
+        let before = Memory.snapshot()
         await releaseAllGPUMemory()
-        let after = GPU.snapshot()
+        let after = Memory.snapshot()
         let freed = (before.activeMemory - after.activeMemory) / (1024 * 1024)
         let cache = before.cacheMemory / (1024 * 1024)
         print("[ToolCallingReasoningSetup] freed \(freed)MB active, \(cache)MB cache")

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -293,7 +293,7 @@ public actor IntegrationTestModels {
     }
 
     /// Drop the cached container for `configuration` so ARC can free its
-    /// GPU-resident weights between tests. Pair with `GPU.clearCache()` at the
+    /// GPU-resident weights between tests. Pair with `Memory.clearCache()` at the
     /// call site to release the freed buffers back to the system — without this,
     /// loading many large models in one serialized run accumulates weights until
     /// the process is jetsammed (Metal compiler XPC failures / crashes).

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1224,7 +1224,6 @@ final class Gemma4TextBackbone: Module {
         }
         let finalPerLayerInputs = projectPerLayerInputs(h0, perLayerInputs: processedPerLayerInputs)
 
-        let hasExplicitCache = cache != nil
         let localCache =
             cache ?? Array(repeating: nil as KVCache?, count: max(firstKVSharedLayerIdx, 1))
         var fullMask: MLXFast.ScaledDotProductAttentionMaskMode

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -2754,14 +2754,15 @@ public struct Gemma4Processor: UserInputProcessor {
             ) { frame in
                 var userProcessing = processing ?? UserInput.Processing()
                 userProcessing.resize = targetSize
-                var image = MediaProcessing.apply(frame.frame, processing: userProcessing)
+                var image = MediaProcessing.apply(
+                    try frame.image.asCIImage(), processing: userProcessing)
                 image = MediaProcessing.inSRGBToneCurveSpace(image)
                 image = MediaProcessing.resampleBicubic(image, to: targetSize)
                 if config.doNormalize {
                     image = MediaProcessing.normalize(
                         image, mean: config.imageMeanTuple, std: config.imageStdTuple)
                 }
-                return VideoFrame(frame: image, timeStamp: frame.timeStamp)
+                return VideoFrame(image: .ciImage(image), timeStamp: frame.timeStamp)
             }
             allFrames.append(contentsOf: sequence.frames)
             frameCounts.append(sequence.frames.count)

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -112,7 +112,7 @@ private enum Language {
             var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
             freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]
 
-            var freqsT = freqs[0]
+            let freqsT = freqs[0]
             var offset = mropeSectionRaw[0]
             for dim in 1 ..< mropeSectionRaw.count {
                 let length = mropeSectionRaw[dim]

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -124,7 +124,7 @@ private enum Language {
             var freqs = matmul(invFreqExpanded, posExpanded)  // [3, batch, dim/2, seq]
             freqs = freqs.transposed(0, 1, 3, 2)  // [3, batch, seq, dim/2]
 
-            var freqsT = freqs[0]
+            let freqsT = freqs[0]
             var offset = mropeSectionRaw[0]
             for dim in 1 ..< mropeSectionRaw.count {
                 let length = mropeSectionRaw[dim]

--- a/Tests/MLXGuidedGenerationTests/CompositeLogitProcessorTests.swift
+++ b/Tests/MLXGuidedGenerationTests/CompositeLogitProcessorTests.swift
@@ -128,8 +128,8 @@ struct CompositeLogitProcessorTests {
 
     @Test
     func copyProducesIndependentProcessors() {
-        var first = AddConstantProcessor(constant: 1.0)
-        var composite = CompositeLogitProcessor([first])
+        let first = AddConstantProcessor(constant: 1.0)
+        let composite = CompositeLogitProcessor([first])
         var cloned = composite.copy()
 
         cloned.didSample(token: MLXArray(UInt32(10)))

--- a/Tests/MLXGuidedGenerationTests/GuidedGenerationDiagnosticSinkTests.swift
+++ b/Tests/MLXGuidedGenerationTests/GuidedGenerationDiagnosticSinkTests.swift
@@ -35,7 +35,7 @@ struct GuidedGenerationDiagnosticSinkTests {
     @Test
     func taskLocalBindingIsVisibleWithinScopeOnly() async {
         let sink = GuidedGenerationDiagnosticSink()
-        await GuidedGenerationDiagnosticSink.$current.withValue(sink) {
+        GuidedGenerationDiagnosticSink.$current.withValue(sink) {
             GuidedGenerationDiagnosticSink.current?.recordSampledToken(42)
         }
         #expect(sink.sampledTokenIDs == [42])

--- a/Tests/MLXGuidedGenerationTests/MaskSnapshotTests.swift
+++ b/Tests/MLXGuidedGenerationTests/MaskSnapshotTests.swift
@@ -33,8 +33,8 @@ struct MaskSnapshotTests {
     @Test
     func stableHashForIdenticalMasks() {
         // Same mask data should produce identical hashes
-        var mask1: [UInt32] = [0xDEAD_BEEF, 0xCAFE_BABE]
-        var mask2: [UInt32] = [0xDEAD_BEEF, 0xCAFE_BABE]
+        let mask1: [UInt32] = [0xDEAD_BEEF, 0xCAFE_BABE]
+        let mask2: [UInt32] = [0xDEAD_BEEF, 0xCAFE_BABE]
 
         let snapshot1 = mask1.withUnsafeBufferPointer { buf in
             MaskSnapshot.capture(sampleMask: buf.baseAddress!, vocabSize: 64, tokenIndex: 0)
@@ -48,8 +48,8 @@ struct MaskSnapshotTests {
 
     @Test
     func differentMasksProduceDifferentHashes() {
-        var mask1: [UInt32] = [0xDEAD_BEEF, 0xCAFE_BABE]
-        var mask2: [UInt32] = [0xDEAD_BEEF, 0x0000_0000]
+        let mask1: [UInt32] = [0xDEAD_BEEF, 0xCAFE_BABE]
+        let mask2: [UInt32] = [0xDEAD_BEEF, 0x0000_0000]
 
         let snapshot1 = mask1.withUnsafeBufferPointer { buf in
             MaskSnapshot.capture(sampleMask: buf.baseAddress!, vocabSize: 64, tokenIndex: 0)

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -222,7 +222,7 @@ public class ChatSessionTests: XCTestCase {
         }
 
         func prepare(input: UserInput) async throws -> LMInput {
-            let text = try await base.prepare(input: input).text
+            let text = try base.prepare(input: input).text
             guard consumeFirst() else { return LMInput(text: text) }
             return LMInput(
                 text: text,

--- a/Tests/MLXLMTests/GatedDeltaTests.swift
+++ b/Tests/MLXLMTests/GatedDeltaTests.swift
@@ -100,8 +100,8 @@ public class GatedDeltaTests: XCTestCase {
         )
 
         // Perturb only the trailing dims the truncating kernel would drop.
-        var qP = inputs.q
-        var kP = inputs.k
+        let qP = inputs.q
+        let kP = inputs.k
         qP[0..., 0..., 0..., 32...] = qP[0..., 0..., 0..., 32...] + MLXArray(1).asType(.bfloat16)
         kP[0..., 0..., 0..., 32...] = kP[0..., 0..., 0..., 32...] + MLXArray(1).asType(.bfloat16)
 

--- a/Tests/MLXLMTests/Gemma4VideoInputTests.swift
+++ b/Tests/MLXLMTests/Gemma4VideoInputTests.swift
@@ -115,8 +115,9 @@ struct Gemma4VideoInputTests {
         // Four synthetic 64x64 frames at 1s spacing.
         let frames = (0 ..< 4).map { i in
             UserInput.VideoFrame(
-                frame: CIImage(color: CIColor(red: 0.3, green: 0.5, blue: 0.7))
-                    .cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64)),
+                image: .ciImage(
+                    CIImage(color: CIColor(red: 0.3, green: 0.5, blue: 0.7))
+                        .cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64))),
                 timeStamp: CMTime(value: Int64(i), timescale: 1))
         }
         let (pixels, frameCounts) = try await processor.processVideos(

--- a/Tests/MLXLMTests/KVCacheConfigurationTests.swift
+++ b/Tests/MLXLMTests/KVCacheConfigurationTests.swift
@@ -371,7 +371,7 @@ struct KVCacheConfigurationTests {
 
     @Test func modelCacheOwnsHybridProgressAcrossPrefillAndDecode() throws {
         let model = HybridProgressModel()
-        let storage = KVCacheStorage(try model.newCache(parameters: nil), plan: .disabled)
+        let storage = KVCacheStorage(model.newCache(parameters: nil), plan: .disabled)
         var iterator = try TokenIterator(
             input: LMInput(tokens: MLXArray([1, 2, 3])),
             model: model,

--- a/Tests/MLXLMTests/MediaProcessingTests.swift
+++ b/Tests/MLXLMTests/MediaProcessingTests.swift
@@ -50,7 +50,7 @@ public class MediaProcesingTests: XCTestCase {
 
         let video = UserInput.Video.url(fileURL)
 
-        try await Device.withDefaultDevice(.cpu) {
+        await Device.withDefaultDevice(.cpu) {
             do {
                 let _ = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 1)
             } catch {

--- a/Tests/MLXLMTests/ParoQuantTests.swift
+++ b/Tests/MLXLMTests/ParoQuantTests.swift
@@ -183,14 +183,14 @@ public class ParoQuantTests: XCTestCase {
     /// isolation in between. Mixes batch=1 and batch=4 so both tile sizes
     /// race into the kernel cache on the first iteration.
     func testRotateQuantizedLinearConcurrentSafe() throws {
-        let layer = try makeTestLayer(hasBias: true)
+        let layer = SharedLayerRef(try makeTestLayer(hasBias: true))
         let numTasks = 8
         let buffer = SynchronizedShapeBuffer()
 
         DispatchQueue.concurrentPerform(iterations: numTasks) { i in
             let batch = i % 2 == 0 ? 1 : 4
             let x = MLXRandom.normal([batch, 128]).asType(.float16)
-            let y = layer(x)
+            let y = layer.layer(x)
             eval(y)
             buffer.append(y.shape)
         }
@@ -202,6 +202,18 @@ public class ParoQuantTests: XCTestCase {
                 shape == [1, 64] || shape == [4, 64],
                 "Unexpected output shape under concurrent load: \(shape)")
         }
+    }
+}
+
+/// Reference used to carry one layer into the `@Sendable` closure of
+/// `DispatchQueue.concurrentPerform`. `@unchecked Sendable` because the point of
+/// `testRotateQuantizedLinearConcurrentSafe` is deliberately unsynchronized
+/// concurrent access to the shared layer.
+private final class SharedLayerRef: @unchecked Sendable {
+    let layer: RotateQuantizedLinear
+
+    init(_ layer: RotateQuantizedLinear) {
+        self.layer = layer
     }
 }
 

--- a/Tests/MLXLMTests/Qwen35CompiledDecodeLifecycleTests.swift
+++ b/Tests/MLXLMTests/Qwen35CompiledDecodeLifecycleTests.swift
@@ -62,8 +62,8 @@ final class Qwen35CompiledDecodeLifecycleTests: XCTestCase {
             eval(logits)
         }
 
-        weak var gdn = model!.modules().compactMap { $0 as? Qwen35GatedDeltaNet }.first
-        weak var moe = model!.modules().compactMap { $0 as? Qwen35SparseMoeBlock }.first
+        weak let gdn = model!.modules().compactMap { $0 as? Qwen35GatedDeltaNet }.first
+        weak let moe = model!.modules().compactMap { $0 as? Qwen35SparseMoeBlock }.first
         XCTAssertNotNil(gdn, "expected a GDN layer in the config", file: file, line: line)
         XCTAssertNotNil(moe, "expected a MoE mlp in the config", file: file, line: line)
 

--- a/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
+++ b/Tests/MLXLMTests/Qwen35RouterTopKBitwiseTests.swift
@@ -88,7 +88,7 @@ final class Qwen35RouterTopKBitwiseTests: XCTestCase {
                         assertRouterMatchesChain(zeros, k: k, normalize: normalize, "±0 \(tag)")
 
                         // NaN above everything, all NaNs tie; indices only.
-                        var nans = MLX.where(
+                        let nans = MLX.where(
                             MLXRandom.uniform(low: Float(0), high: 1, [rows, e]) .< 0.05,
                             MLXArray(Float.nan), MLXRandom.normal([rows, e])
                         ).asType(dtype)

--- a/Tests/MLXLMTests/RerankerTests.swift
+++ b/Tests/MLXLMTests/RerankerTests.swift
@@ -555,7 +555,7 @@ struct RerankerTests {
         // neither `model*.safetensors` nor its own index selects, so the head is skipped unless
         // the model asks for the file by name (#560). Check the conformance, since that is what
         // `loadWeights` looks for.
-        let provider = try #require(model as? any AdditionalWeightFilesProviding)
+        let provider = model as any AdditionalWeightFilesProviding
         #expect(provider.additionalWeightFiles == ["projector.safetensors"])
     }
 


### PR DESCRIPTION
## The problem

The compiler printed many warnings. Most came from style diagnostics, and from calls to MLX functions that MLX has renamed. It printed them on every build and every test run, so a warning that mattered was hard to find.

Two warnings came from real defects. Gemma read each video frame through a deprecated property. That property traps when the frame's image is not a CoreImage image. The process then stops. A quantization test passes a model layer into a concurrent closure. Swift cannot prove that this is safe. The test does it on purpose, but the code never said so.

## What this PR does

- Gemma reads each video frame through the supported accessor. If a frame's image is not a CoreImage image, the caller now gets an error instead of a crash. Gemma was the last model still calling the deprecated frame API. Every other vision model already used the current one.
- The integration tests call MLX's Memory type for memory figures and for cache clearing, not the older GPU names. Behavior does not change, because the deprecated calls forward to the new ones.
- The quantization concurrency test now shares its layer through a small wrapper marked unchecked-Sendable, so the compiler no longer warns about the sharing. The test still uses that layer from several threads without synchronization, which is the behavior it checks.
- Removes the style diagnostics from the library and both test targets: an unused local, bindings that never change, and try and await markers on calls that neither throw nor suspend. One conditional cast tested a conformance that the compiler checks statically. If someone removes that conformance, the build still fails.

The compiler still warns about MLX's own Metal kernels. Those kernels come from a vendored dependency, so this repository cannot fix them.

## Tests

No file in this repository now produces a warning.

The unit suite passes: 549 XCTest cases, one skipped, and 938 swift-testing cases in four targets. The two integration suites whose files changed ran against real models. All 15 of their tests passed.
