### PR TITLE
Expose Falcon-H1 encoder surface at @_spi(FalconH1Encoder)

### DIFF
--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -20,11 +20,11 @@ public struct FalconH1Configuration: Codable, Sendable {
     var attentionInMultiplier: Float
     var attentionOutMultiplier: Float
     var bosTokenId: Int
-    var embeddingMultiplier: Float
+    @_spi(FalconH1Encoder) public var embeddingMultiplier: Float
     var eosTokenId: Int
     var headDim: Int
     var hiddenAct: String
-    var hiddenSize: Int
+    @_spi(FalconH1Encoder) public var hiddenSize: Int
     var initializerRange: Float
     var intermediateSize: Int?
     var keyMultiplier: Float
@@ -48,12 +48,12 @@ public struct FalconH1Configuration: Codable, Sendable {
     var mlpMultipliers: [Float]
     var modelType: String
     var numAttentionHeads: Int
-    var numHiddenLayers: Int
+    @_spi(FalconH1Encoder) public var numHiddenLayers: Int
     var numKeyValueHeads: Int
     var numLogitsToKeep: Int
     var padTokenId: Int
     var projectorsBias: Bool
-    var rmsNormEps: Float
+    @_spi(FalconH1Encoder) public var rmsNormEps: Float
     var ropeTraditional: Bool
     var ropeScaling: Float?
     var ropeTheta: Float
@@ -567,7 +567,12 @@ class FalconH1MLP: Module, UnaryLayer {
 
 // MARK: - DecoderLayer
 
-class FalconH1DecoderLayer: Module {
+/// One Falcon-H1 decoder layer (Mamba-2 mixer + attention + MLP, run in parallel).
+///
+/// Exposed at `@_spi(FalconH1Encoder)` scope so opted-in client code can drive the layer
+/// stack directly, keeping it off the advertised public API of MLXLLM. Mirrors the Gemma
+/// encoder exposures.
+@_spi(FalconH1Encoder) public class FalconH1DecoderLayer: Module {
     @ModuleInfo(key: "feed_forward") var feedForward: FalconH1MLP
     @ModuleInfo(key: "mamba") var mamba: FalconH1Mixer
     @ModuleInfo(key: "self_attn") var attention: FalconH1Attention
@@ -591,7 +596,7 @@ class FalconH1DecoderLayer: Module {
         )
     }
 
-    func callAsFunction(
+    @_spi(FalconH1Encoder) public func callAsFunction(
         _ h: MLXArray,
         cache: CacheList?,
         attnMask: MLXFast.ScaledDotProductAttentionMaskMode,
@@ -625,12 +630,17 @@ public class FalconH1ModelInner: Module {
     let hiddenSize: Int
 
     let _mupVector: MLXArray
-    let layers: [FalconH1DecoderLayer]
+    @_spi(FalconH1Encoder) public let layers: [FalconH1DecoderLayer]
 
-    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
-    @ModuleInfo(key: "final_layernorm") var finalLayerNorm: RMSNorm
+    @_spi(FalconH1Encoder) @ModuleInfo(key: "embed_tokens") public var embedTokens: Embedding
+    @_spi(FalconH1Encoder) @ModuleInfo(key: "final_layernorm") public var finalLayerNorm: RMSNorm
 
-    init(_ args: FalconH1Configuration) {
+    /// Exposed at `@_spi(FalconH1Encoder)` so a client can build the decoder stack on its
+    /// own, without `FalconH1Model`'s head. Constructing the wrapper instead is not
+    /// equivalent: it adds an `lm_head` whenever `tie_word_embeddings` is false (the
+    /// decoded default), which a client supplying its own head does not want and would
+    /// have to account for when matching module keys against a checkpoint.
+    @_spi(FalconH1Encoder) public init(_ args: FalconH1Configuration) {
         self.args = args
         self.vocabSize = args.vocabSize
         self.hiddenSize = args.hiddenSize
@@ -645,10 +655,39 @@ public class FalconH1ModelInner: Module {
         _finalLayerNorm.wrappedValue = RMSNorm(dimensions: hiddenSize, eps: args.rmsNormEps)
     }
 
-    func callAsFunction(_ inputs: MLXArray, mask: MLXArray? = nil, cache: [CacheList]? = nil)
-        -> MLXArray
-    {
-        var h = embedTokens(inputs)
+    /// Run the decoder stack over token ids, returning the final hidden state.
+    ///
+    /// Exposed at `@_spi(FalconH1Encoder)` alongside
+    /// ``callAsFunction(inputsEmbeds:cache:)`` so a client can reach hidden states rather
+    /// than logits, and can check its own composite-embedding path against the plain
+    /// token path.
+    @_spi(FalconH1Encoder) public func callAsFunction(
+        _ inputs: MLXArray, mask: MLXArray? = nil, cache: [CacheList]? = nil
+    ) -> MLXArray {
+        callAsFunction(inputsEmbeds: embedTokens(inputs), cache: cache)
+    }
+
+    /// Run the decoder stack over an already-computed input embedding.
+    ///
+    /// Exposed at `@_spi(FalconH1Encoder)` scope for models that build their own slow-stack
+    /// input rather than looking up a single token — for example a DualAR TTS model whose
+    /// input is a text embedding summed with several codebook embeddings. Such a client
+    /// cannot go through ``callAsFunction(_:mask:cache:)`` because it never has a single
+    /// token id to embed.
+    ///
+    /// - Important: ``FalconH1Model/sanitize(weights:)`` folds `embedding_multiplier` into
+    ///   `embed_tokens.weight`, which is correct when the token lookup is the only thing
+    ///   entering the stack. A client passing a COMPOSITE embedding must account for the
+    ///   multiplier over the whole composite. Either scale every non-`embedTokens`
+    ///   contribution by `embeddingMultiplier` before summing (so the folded lookup and the
+    ///   scaled remainder agree), or load an unfolded table and scale the sum. The two are
+    ///   algebraically identical — `(raw + other) * m == folded + other * m` — but mixing
+    ///   them silently leaves one half unscaled, which degrades output without any shape or
+    ///   load error to catch it.
+    @_spi(FalconH1Encoder) public func callAsFunction(
+        inputsEmbeds: MLXArray, cache: [CacheList]? = nil
+    ) -> MLXArray {
+        var h = inputsEmbeds
 
         let cache: [CacheList?] = cache ?? Array(repeating: nil, count: layers.count)
 

--- a/Tests/MLXLMTests/FalconH1EncoderAccessTests.swift
+++ b/Tests/MLXLMTests/FalconH1EncoderAccessTests.swift
@@ -1,0 +1,158 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+@_spi(FalconH1Encoder) import MLXLLM
+import MLXLMCommon
+import XCTest
+
+/// Proves the `@_spi(FalconH1Encoder)` surface is sufficient for a client that builds its
+/// own slow-stack input — the DualAR-TTS shape, where the embedding entering the stack is a
+/// text embedding summed with several codebook embeddings rather than one token lookup.
+///
+/// Deliberately imports MLXLLM WITHOUT `@testable`, so the suite fails to compile if any
+/// piece of the needed surface stops being exposed. Runs on a tiny randomly-initialized
+/// model; no weights are downloaded.
+final class FalconH1EncoderAccessTests: XCTestCase {
+
+    private func tinyConfiguration(embeddingMultiplier: Float = 0.125) throws
+        -> FalconH1Configuration
+    {
+        let json = """
+            {
+                "model_type": "falcon_h1",
+                "hidden_size": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "vocab_size": 100,
+                "mamba_d_ssm": 16,
+                "mamba_d_state": 8,
+                "mamba_d_head": 8,
+                "mamba_n_heads": 2,
+                "mamba_n_groups": 1,
+                "mamba_d_conv": 4,
+                "mamba_chunk_size": 64,
+                "embedding_multiplier": \(embeddingMultiplier)
+            }
+            """.data(using: .utf8)!
+        return try JSONDecoder.json5().decode(FalconH1Configuration.self, from: json)
+    }
+
+    // MARK: - The seam
+
+    /// A composite embedding runs through the stack and produces a well-formed hidden state.
+    func testInputsEmbedsEntryPointRunsTheStack() throws {
+        let config = try tinyConfiguration()
+        let model = FalconH1Model(config)
+        let inner = model.model
+
+        let (batch, length) = (1, 5)
+        let embeds = MLXRandom.normal([batch, length, config.hiddenSize])
+        let out = inner(inputsEmbeds: embeds)
+        eval(out)
+
+        XCTAssertEqual(out.shape, [batch, length, config.hiddenSize])
+        // The stack must actually transform the input — otherwise this test would pass on a
+        // seam that returned its argument (or ran zero layers).
+        XCTAssertGreaterThan(
+            (out - embeds).abs().max().item(Float.self), 1e-3,
+            "the layer stack did not transform the injected embedding")
+    }
+
+    /// Deterministic for identical input.
+    func testInputsEmbedsIsDeterministic() throws {
+        let config = try tinyConfiguration()
+        let inner = FalconH1Model(config).model
+
+        let embeds = MLXRandom.normal([1, 4, config.hiddenSize])
+        let a = inner(inputsEmbeds: embeds)
+        let b = inner(inputsEmbeds: embeds)
+        eval(a, b)
+        XCTAssertEqual((a - b).abs().max().item(Float.self), 0.0)
+    }
+
+    /// The token path and the seam agree when the seam is fed the same embedding the token
+    /// path would have built. This is what makes the seam a refactor rather than a fork.
+    func testInputsEmbedsMatchesTokenPath() throws {
+        let config = try tinyConfiguration()
+        let inner = FalconH1Model(config).model
+
+        let ids = MLXArray([3, 17, 42, 8]).reshaped([1, 4])
+        let viaTokens = inner(ids)
+        let viaEmbeds = inner(inputsEmbeds: inner.embedTokens(ids))
+        eval(viaTokens, viaEmbeds)
+
+        XCTAssertLessThan((viaTokens - viaEmbeds).abs().max().item(Float.self), 1e-5)
+    }
+
+    // MARK: - The multiplier trap
+
+    /// `(raw + other) * m == folded + other * m`.
+    ///
+    /// `sanitize()` folds `embedding_multiplier` into `embed_tokens.weight`, so a client
+    /// summing extra contributions onto the folded lookup must scale those contributions
+    /// too. This test pins that equivalence, and — by construction — fails if someone
+    /// "simplifies" a composite-embedding client to add unscaled contributions: that
+    /// variant is computed here and asserted to be DIFFERENT, so the trap cannot quietly
+    /// become the expected behaviour.
+    func testCompositeEmbeddingMultiplierEquivalence() throws {
+        let multiplier: Float = 0.125
+        let config = try tinyConfiguration(embeddingMultiplier: multiplier)
+        let inner = FalconH1Model(config).model
+
+        let ids = MLXArray([5, 11, 2]).reshaped([1, 3])
+        let raw = inner.embedTokens(ids)
+        let other = MLXRandom.normal([1, 3, config.hiddenSize])
+
+        let folded = raw * multiplier  // what sanitize() would bake into the table
+        let correctA = (raw + other) * multiplier  // unfolded table, scale the sum
+        let correctB = folded + other * multiplier  // folded table, scale the remainder
+        let wrong = folded + other  // folded table, remainder left unscaled
+        eval(correctA, correctB, wrong)
+
+        XCTAssertLessThan(
+            (correctA - correctB).abs().max().item(Float.self), 1e-6,
+            "the two correct orderings must agree")
+        XCTAssertGreaterThan(
+            (correctA - wrong).abs().max().item(Float.self), 1e-3,
+            "leaving the non-lookup contribution unscaled must be observably different")
+
+        // And the difference survives the stack, so it is a real output error rather than
+        // something the first layer norm washes out.
+        let outCorrect = inner(inputsEmbeds: correctA)
+        let outWrong = inner(inputsEmbeds: wrong)
+        eval(outCorrect, outWrong)
+        XCTAssertGreaterThan(
+            (outCorrect - outWrong).abs().max().item(Float.self), 1e-3,
+            "the unscaled-remainder error must be visible in the stack output")
+    }
+
+    // MARK: - Layer-level access
+
+    /// A client can also drive the layers itself, e.g. to tap every hidden state.
+    func testLayerStackIsDrivableDirectly() throws {
+        let config = try tinyConfiguration()
+        let inner = FalconH1Model(config).model
+
+        var h = MLXRandom.normal([1, 4, config.hiddenSize])
+        var states: [MLXArray] = [h]
+        let caches: [CacheList?] = Array(repeating: nil, count: inner.layers.count)
+        let mambaMask = createSSMMask(h: h, cache: nil)
+        let attnMask = createAttentionMask(h: h, cache: nil)
+        for (layer, cache) in zip(inner.layers, caches) {
+            h = layer(h, cache: cache, attnMask: attnMask, mambaMask: mambaMask)
+            states.append(h)
+        }
+        let out = inner.finalLayerNorm(h)
+        eval(out, states.last!)
+
+        XCTAssertEqual(states.count, config.numHiddenLayers + 1)
+        XCTAssertEqual(out.shape, [1, 4, config.hiddenSize])
+        // Same result as the seam, reached the long way round.
+        let viaSeam = inner(inputsEmbeds: states[0])
+        eval(viaSeam)
+        XCTAssertLessThan((out - viaSeam).abs().max().item(Float.self), 1e-5)
+    }
+}


### PR DESCRIPTION
Mirrors the Gemma 3/4 encoder exposures (#387 and the Gemma 4 follow-up) for Falcon-H1, so client code can run the decoder stack over an embedding it built itself rather than over a single token id.

### Motivation

The motivating case is a DualAR TTS model — [Audio8 TTS Preview 0.1b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b), `model_type: arktts`, `slow_backbone: falcon_h1` — whose slow-stack input is a text embedding summed with ten codec-codebook embeddings. Such a client never has a single token id to look up, so `FalconH1ModelInner.callAsFunction(_:mask:cache:)` is unreachable for it. Today the only options are to fork the file or re-implement the mask setup and layer loop against internal details.

### What is exposed

At `@_spi(FalconH1Encoder)` scope, keeping this off the advertised public API of MLXLLM:

- `FalconH1Configuration.hiddenSize` / `.numHiddenLayers` / `.rmsNormEps` / `.embeddingMultiplier`
- `FalconH1DecoderLayer` and its `callAsFunction`
- `FalconH1ModelInner.embedTokens` / `.layers` / `.finalLayerNorm`
- `FalconH1ModelInner.callAsFunction(inputsEmbeds:cache:)` — **new**
- `FalconH1ModelInner.callAsFunction(_:mask:cache:)` — was internal

`callAsFunction(inputsEmbeds:cache:)` is the seam, and the token-id overload now delegates to it so the two paths cannot drift. **No behaviour change for existing callers**: `FalconH1Model` still embeds, runs the stack, and applies the head exactly as before.

Unlike the Gemma 4 change, nothing else had to widen — `FalconH1Model.model` and the mask helpers were already public, and none of the decoder layer's stored property types are `private`.

### Tests

`FalconH1EncoderAccessTests` proves sufficiency the way the Gemma access tests do: it drives the stack using **only** the exposed surface, importing MLXLLM without `@testable` and opting in via `@_spi(FalconH1Encoder)`. It checks shape, determinism, seam-vs-token-path agreement, layer-at-a-time driving for an all-hidden-states tap, and that the stack actually transforms its input — the last so the suite cannot pass on a seam that returns its argument or runs zero layers.

One test earns its place beyond access checking. `sanitize()` folds `embedding_multiplier` into `embed_tokens.weight`, which is correct when the token lookup is the only thing entering the stack, but is a live trap for a composite-embedding client: fold it and then add unscaled contributions, and the lookup half is scaled while the rest is not. Measured against the PyTorch reference for the model above, that is **77% relative error on the embedding and 38% on the final hidden state** — while still producing plausible audio of the right length, so listening does not catch it. `testCompositeEmbeddingMultiplierEquivalence` pins `(raw + other) * m == folded + other * m` and asserts the unscaled-remainder variant is observably different, both at the embedding and after the stack, so the wrong form cannot quietly become the expected one. The doc comment on the new seam spells the same thing out.

Runs on a tiny randomly-initialized model; no weights are downloaded.

`swift test --filter FalconH1`: 14 tests, 0 failures (5 new, 8 existing, 1 registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)