### PR TITLE
Add configuration-based LoRA metadata discovery

### DIFF
--- a/Libraries/MLXLLM/Documentation.docc/using-model.md
+++ b/Libraries/MLXLLM/Documentation.docc/using-model.md
@@ -56,6 +56,27 @@ public class LLMModelFactory: ModelFactory {
 Callers with specialized requirements can use these individual components to manually
 load models, if needed.
 
+### Inspecting LoRA Metadata
+
+Use ``LLMModelFactory/loraMetadata(configurationData:)`` to discover the model's LoRA
+layer count and default runtime module paths without loading checkpoint weights:
+
+```swift
+let configurationURL = modelDirectory.appending(component: "config.json")
+let configurationData = try Data(contentsOf: configurationURL)
+
+if let metadata = try await LLMModelFactory.shared.loraMetadata(
+    configurationData: configurationData
+) {
+    print(metadata.layerCount)
+    print(metadata.defaultKeys)
+}
+```
+
+The returned `LoRAModelMetadata.defaultKeys` come from the registered model architecture,
+not from safetensors names. This accounts for models that rename or reshape checkpoint weights
+while loading.
+
 ## Evaluation Flow
 
 - Load the Model

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -658,6 +658,18 @@ public final class LLMModelFactory: GenericModelFactory {
     /// by the model itself, e.g. DeepSeek-R1
     public let conventionsRegistry: ChatConventionsRegistry
 
+    /// Returns the model's LoRA metadata from its configuration without loading weights.
+    ///
+    /// The registered model architecture is instantiated so custom `LoRAModel.loraDefaultKeys`
+    /// implementations remain authoritative. No checkpoint files are read.
+    public func loraMetadata(configurationData: Data) async throws -> LoRAModelMetadata? {
+        let baseConfiguration = try JSONDecoder.json5().decode(
+            BaseConfiguration.self, from: configurationData)
+        let model = try await typeRegistry.createModel(
+            configuration: configurationData, modelType: baseConfiguration.modelType)
+        return (model as? LoRAModel)?.loraMetadata
+    }
+
     public func _load(
         configuration: ResolvedModelConfiguration,
         tokenizerLoader: any TokenizerLoader

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -663,11 +663,7 @@ public final class LLMModelFactory: GenericModelFactory {
     /// The registered model architecture is instantiated so custom `LoRAModel.loraDefaultKeys`
     /// implementations remain authoritative. No checkpoint files are read.
     public func loraMetadata(configurationData: Data) async throws -> LoRAModelMetadata? {
-        let baseConfiguration = try JSONDecoder.json5().decode(
-            BaseConfiguration.self, from: configurationData)
-        let model = try await typeRegistry.createModel(
-            configuration: configurationData, modelType: baseConfiguration.modelType)
-        return (model as? LoRAModel)?.loraMetadata
+        try await typeRegistry.loraMetadata(configurationData: configurationData)
     }
 
     public func _load(

--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAModel.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAModel.swift
@@ -9,6 +9,20 @@ import Foundation
 import MLX
 import MLXNN
 
+/// Metadata describing where a model applies LoRA adapters.
+public struct LoRAModelMetadata: Sendable, Equatable {
+    /// Number of model layers that support LoRA adapters.
+    public let layerCount: Int
+
+    /// Default module paths, relative to each LoRA layer, that receive adapters.
+    public let defaultKeys: [String]
+
+    public init(layerCount: Int, defaultKeys: [String]) {
+        self.layerCount = layerCount
+        self.defaultKeys = defaultKeys
+    }
+}
+
 public protocol LoRAModel {
 
     /// Return the layers to apply LoRA adapters to.
@@ -25,6 +39,14 @@ public protocol LoRAModel {
 }
 
 extension LoRAModel {
+
+    /// Metadata for configuring LoRA without inspecting checkpoint weight names.
+    public var loraMetadata: LoRAModelMetadata {
+        LoRAModelMetadata(
+            layerCount: loraLayers.count,
+            defaultKeys: loraDefaultKeys.sorted()
+        )
+    }
 
     /// By default we apply LoRA to all Linear layers.
     /// This is aligned with `mlx-lm` Python logic.

--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAModel.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAModel.swift
@@ -23,6 +23,22 @@ public struct LoRAModelMetadata: Sendable, Equatable {
     }
 }
 
+extension ModelTypeRegistry where T == any LanguageModel {
+    /// Inspects the registered model's LoRA layers without loading checkpoint weights.
+    ///
+    /// Model construction and metadata access use an independent random state.
+    /// Returns `nil` if the model does not conform to ``LoRAModel``.
+    public func loraMetadata(configurationData: Data) throws -> LoRAModelMetadata? {
+        try withRandomState(MLXRandom.RandomState(seed: 0)) {
+            let configuration = try JSONDecoder.json5().decode(
+                BaseConfiguration.self, from: configurationData)
+            let model = try createModel(
+                configuration: configurationData, modelType: configuration.modelType)
+            return (model as? LoRAModel)?.loraMetadata
+        }
+    }
+}
+
 public protocol LoRAModel {
 
     /// Return the layers to apply LoRA adapters to.

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -360,6 +360,13 @@ public final class VLMModelFactory: GenericModelFactory {
     /// resolvers for processor metadata that is absent or incorrect in a checkpoint
     public let processorLoadingRegistry: VLMProcessorLoadingRegistry
 
+    /// Returns the model's LoRA metadata without loading checkpoint weights or a processor.
+    ///
+    /// Uses the registered model's `LoRAModel` conformance to select adapter targets.
+    public func loraMetadata(configurationData: Data) async throws -> LoRAModelMetadata? {
+        try await typeRegistry.loraMetadata(configurationData: configurationData)
+    }
+
     public func _load(
         configuration: ResolvedModelConfiguration,
         tokenizerLoader: any TokenizerLoader

--- a/Tests/MLXLMTests/LoRAModelMetadataTests.swift
+++ b/Tests/MLXLMTests/LoRAModelMetadataTests.swift
@@ -1,0 +1,88 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+
+final class LoRAModelMetadataTests: XCTestCase {
+    func testFactoryUsesRegisteredModelLoRAMetadata() async throws {
+        let typeRegistry = ModelTypeRegistry<LanguageModel>()
+        await typeRegistry.registerModelType("metadata_test") { _ in
+            MetadataTestModel()
+        }
+        let factory = LLMModelFactory(
+            typeRegistry: typeRegistry,
+            modelRegistry: AbstractModelRegistry()
+        )
+
+        let result = try await factory.loraMetadata(
+            configurationData: Data(#"{"model_type":"metadata_test"}"#.utf8)
+        )
+        let metadata = try XCTUnwrap(result)
+
+        XCTAssertEqual(metadata.layerCount, 1)
+        XCTAssertEqual(metadata.defaultKeys, ["runtime.a_proj", "runtime.z_proj"])
+    }
+
+    func testBuiltInModelMetadataUsesRuntimeModulePaths() async throws {
+        let configuration = Data(
+            """
+            {
+              "model_type": "qwen3",
+              "hidden_size": 16,
+              "num_hidden_layers": 2,
+              "intermediate_size": 32,
+              "num_attention_heads": 2,
+              "num_key_value_heads": 1,
+              "head_dim": 8,
+              "rms_norm_eps": 1e-5,
+              "vocab_size": 64
+            }
+            """.utf8
+        )
+
+        let result = try await LLMModelFactory.shared.loraMetadata(
+            configurationData: configuration
+        )
+        let metadata = try XCTUnwrap(result)
+
+        XCTAssertEqual(metadata.layerCount, 2)
+        XCTAssertEqual(
+            metadata.defaultKeys,
+            [
+                "mlp.down_proj",
+                "mlp.gate_proj",
+                "mlp.up_proj",
+                "self_attn.k_proj",
+                "self_attn.o_proj",
+                "self_attn.q_proj",
+                "self_attn.v_proj",
+            ]
+        )
+    }
+}
+
+private final class MetadataTestModel: Module, LanguageModel, LoRAModel,
+    KVCacheDimensionProvider
+{
+    private let layer = Module()
+
+    let kvHeads: [Int] = []
+
+    var loraLayers: [Module] { [layer] }
+    var loraDefaultKeys: [String] { ["runtime.z_proj", "runtime.a_proj"] }
+
+    func prepare(
+        _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+    ) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        inputs
+    }
+}

--- a/Tests/MLXLMTests/LoRAModelMetadataTests.swift
+++ b/Tests/MLXLMTests/LoRAModelMetadataTests.swift
@@ -4,11 +4,107 @@ import Foundation
 import MLX
 import MLXLMCommon
 import MLXNN
+import MLXVLM
 import XCTest
 
 @testable import MLXLLM
 
 final class LoRAModelMetadataTests: XCTestCase {
+    func testVLMMetadataUsesLanguageLayers() async throws {
+        let configuration = Data(
+            """
+            {
+              "model_type": "gemma3",
+              "mm_tokens_per_image": 4,
+              "text_config": {
+                "model_type": "gemma3_text",
+                "hidden_size": 16,
+                "num_hidden_layers": 2,
+                "intermediate_size": 32,
+                "sliding_window": 16,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 8
+              },
+              "vision_config": {
+                "model_type": "siglip_vision_model",
+                "hidden_size": 16,
+                "num_hidden_layers": 1,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "patch_size": 2,
+                "image_size": 4
+              }
+            }
+            """.utf8
+        )
+        let result = try await VLMModelFactory.shared.loraMetadata(
+            configurationData: configuration)
+        let metadata = try XCTUnwrap(result)
+
+        XCTAssertEqual(metadata.layerCount, 2)
+        XCTAssertEqual(metadata.defaultKeys, Self.defaultKeys)
+    }
+
+    func testMetadataPreservesCallerRandomSequence() async throws {
+        let registry = ModelTypeRegistry<LanguageModel>()
+        await registry.registerModelType("metadata_test") { _ in MetadataTestModel() }
+        await registry.registerModelType("throwing_test") { _ in
+            _ = MLXRandom.uniform()
+            throw TestError.construction
+        }
+        let factory = LLMModelFactory(
+            typeRegistry: registry, modelRegistry: AbstractModelRegistry())
+        let expected = MLXRandom.RandomState(seed: 42)
+
+        try await withRandomState(MLXRandom.RandomState(seed: 42)) {
+            XCTAssertEqual(resolve().asArray(UInt32.self), expected.next().asArray(UInt32.self))
+            for _ in 0 ..< 2 {
+                _ = try await factory.loraMetadata(
+                    configurationData: Data(#"{"model_type":"metadata_test"}"#.utf8))
+                XCTAssertEqual(
+                    resolve().asArray(UInt32.self), expected.next().asArray(UInt32.self))
+            }
+
+            do {
+                _ = try await factory.loraMetadata(
+                    configurationData: Data(#"{"model_type":"throwing_test"}"#.utf8))
+                XCTFail("Expected the constructor error")
+            } catch TestError.construction {
+                XCTAssertEqual(
+                    resolve().asArray(UInt32.self), expected.next().asArray(UInt32.self))
+            }
+        }
+    }
+
+    func testModelWithoutLoRAConformanceReturnsNil() async throws {
+        let registry = ModelTypeRegistry<LanguageModel>()
+        await registry.registerModelType("plain_test") { _ in PlainTestModel() }
+        let result = try await registry.loraMetadata(
+            configurationData: Data(#"{"model_type":"plain_test"}"#.utf8))
+        XCTAssertNil(result)
+    }
+
+    func testUnknownModelTypeThrows() async throws {
+        let registry = ModelTypeRegistry<LanguageModel>()
+        do {
+            _ = try await registry.loraMetadata(
+                configurationData: Data(#"{"model_type":"unknown"}"#.utf8))
+            XCTFail("Expected an unsupported model type error")
+        } catch ModelFactoryError.unsupportedModelType(let type) {
+            XCTAssertEqual(type, "unknown")
+        }
+    }
+
+    func testInvalidConfigurationThrows() async throws {
+        do {
+            _ = try await LLMModelFactory.shared.loraMetadata(
+                configurationData: Data(#"{"model_type":"qwen3"}"#.utf8))
+            XCTFail("Expected a configuration decoding error")
+        } catch is DecodingError {
+        }
+    }
+
     func testFactoryUsesRegisteredModelLoRAMetadata() async throws {
         let typeRegistry = ModelTypeRegistry<LanguageModel>()
         await typeRegistry.registerModelType("metadata_test") { _ in
@@ -51,30 +147,26 @@ final class LoRAModelMetadataTests: XCTestCase {
         let metadata = try XCTUnwrap(result)
 
         XCTAssertEqual(metadata.layerCount, 2)
-        XCTAssertEqual(
-            metadata.defaultKeys,
-            [
-                "mlp.down_proj",
-                "mlp.gate_proj",
-                "mlp.up_proj",
-                "self_attn.k_proj",
-                "self_attn.o_proj",
-                "self_attn.q_proj",
-                "self_attn.v_proj",
-            ]
-        )
+        XCTAssertEqual(metadata.defaultKeys, Self.defaultKeys)
+    }
+
+    private static let defaultKeys = [
+        "mlp.down_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "self_attn.k_proj",
+        "self_attn.o_proj",
+        "self_attn.q_proj",
+        "self_attn.v_proj",
+    ]
+
+    private enum TestError: Error {
+        case construction
     }
 }
 
-private final class MetadataTestModel: Module, LanguageModel, LoRAModel,
-    KVCacheDimensionProvider
-{
-    private let layer = Module()
-
+private class PlainTestModel: Module, LanguageModel, KVCacheDimensionProvider {
     let kvHeads: [Int] = []
-
-    var loraLayers: [Module] { [layer] }
-    var loraDefaultKeys: [String] { ["runtime.z_proj", "runtime.a_proj"] }
 
     func prepare(
         _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
@@ -84,5 +176,16 @@ private final class MetadataTestModel: Module, LanguageModel, LoRAModel,
 
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         inputs
+    }
+}
+
+private final class MetadataTestModel: PlainTestModel, LoRAModel {
+    private let layer = Linear(4, 4)
+
+    var loraLayers: [Module] { [layer] }
+    var loraDefaultKeys: [String] {
+        // Exercise random-state isolation during metadata access as well as construction.
+        _ = MLXRandom.uniform()
+        return ["runtime.z_proj", "runtime.a_proj"]
     }
 }


### PR DESCRIPTION
## Proposed changes

Adds a public API for discovering a model’s LoRA layer count and default target module names from its configuration.

Reading these names from safetensors is unreliable because model loading may rename or reshape checkpoint weights. The new API instead uses the registered runtime model architecture, which is the source of truth for LoRA targets. It does not load checkpoint weights.

This is useful for applications that need to show valid LoRA options before loading a model, while remaining compatible with custom model registrations.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure:
