### PR TITLE
Qwen3.5: don't shift norm weights just because a checkpoint has MTP tensors

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1153,11 +1153,14 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        let hasMTPWeights = weights.keys.contains { $0.contains("mtp.") }
         let hasUnsanitizedConv1d = weights.contains { key, value in
             key.contains("conv1d.weight") && value.dim(-1) != 1
         }
-        let shouldShiftNormWeights = hasMTPWeights || hasUnsanitizedConv1d
+        // MTP tensors are not proof of a raw checkpoint: a converted checkpoint can
+        // keep them (the framework uses them for speculative decoding), and shifting
+        // its already-shifted norms a second time produces garbage tokens. The conv1d
+        // layout is the reliable signal on its own.
+        let shouldShiftNormWeights = hasUnsanitizedConv1d
 
         var weights = weights.filter { !$0.key.contains("mtp.") }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1415,15 +1415,18 @@ public class Qwen35: Module, VLMModel {
         // Whether the checkpoint stores RMSNorm weights in the raw (un-shifted)
         // convention that needs the `+1` offset. Mirrors the MLXLLM Qwen35 gate
         // so the VLM and text paths agree: a pre-converted MLX checkpoint
-        // (conv1d already sanitized, no MTP tensors) has already been shifted at
+        // (conv1d already sanitized) has already been shifted at
         // conversion time and must NOT be shifted again — doing so double-shifts
         // every layernorm and produces garbage tokens. Computed on the incoming
         // weights, before the `mtp.` filter below.
-        let hasMTPWeights = weights.keys.contains { $0.contains("mtp.") }
         let hasUnsanitizedConv1d = weights.contains { key, value in
             key.contains("conv1d.weight") && value.dim(-1) != 1
         }
-        let shouldShiftNormWeights = hasMTPWeights || hasUnsanitizedConv1d
+        // MTP tensors are not proof of a raw checkpoint: a converted checkpoint can
+        // keep them (the framework uses them for speculative decoding), and shifting
+        // its already-shifted norms a second time produces garbage tokens. The conv1d
+        // layout is the reliable signal on its own.
+        let shouldShiftNormWeights = hasUnsanitizedConv1d
 
         var weights = weights.filter { !$0.key.contains("mtp.") }
 


### PR DESCRIPTION
MLX-converted Qwen3.5 checkpoints that retain their `mtp.*` tensors (e.g. for speculative decoding) generate garbage tokens.

`sanitize(weights:)` in both `MLXLLM/Models/Qwen35.swift` and `MLXVLM/Models/Qwen35.swift` applies the zero-centered RMSNorm `+1` shift when

```swift
let shouldShiftNormWeights = hasMTPWeights || hasUnsanitizedConv1d
```

The `hasMTPWeights` term assumes MTP tensors only occur in raw upstream checkpoints. That doesn't hold: a converted checkpoint (conv1d already `[.., .., 1]`, norms already shifted, metadata `format: "mlx"`) can keep its MTP weights, trips the term, and gets shifted twice — every layernorm lands near 2.0 instead of 1.0.

**Repro:** convert a Qwen3.5 checkpoint with mlx-lm keeping the `mtp.*` tensors, load through the text-model path, generate.

**Evidence:** in such a checkpoint the norm tensors are bit-identical to a working MTP-stripped conversion of the same base model (`input_layernorm` mean ≈ 0.97, i.e. already shifted) — the only difference is the presence of `mtp.*` keys.

**Change:** drop `hasMTPWeights` from the condition in both files. `hasUnsanitizedConv1d` alone identifies raw upstream checkpoints: transformers exports store conv1d as `[C, 1, K]`, and any converter that transposes conv1d shifts the norms in the same sanitize pass, so the two signals can't diverge in a valid checkpoint. MTP-only drafter checkpoints are unaffected — the `mtp.` filter removes all their tensors before the shift loop, so the flag never did anything there.

Side note: the VLM class already guards `sanitize(weights:metadata:)` with `format == "mlx"`, the LLM classes don't — this PR fixes the shared heuristic instead of duplicating that gate.