### PR TITLE
Harden the Foundation Models test fixtures

### DIFF
--- a/Tests/MLXFoundationModelsTests/AvailabilityTests.swift
+++ b/Tests/MLXFoundationModelsTests/AvailabilityTests.swift
@@ -87,12 +87,14 @@ extension FoundationModelsCacheTests {
                         configuration: configuration, progressHandler: progress)
                 })
 
-            let warmTask = Task { try? await model.warmUp() }
+            let warmTask = Task { try await model.warmUp() }
             await gate.waitUntilStarted()
 
             let availability = await model.availability
             await gate.release()
-            _ = await warmTask.value
+            await #expect(throws: BlockingDownloaderReleased.self) {
+                try await warmTask.value
+            }
 
             #expect(
                 availability == .available,
@@ -125,12 +127,14 @@ extension FoundationModelsCacheTests {
             // preload() is NOT a warmup, so its in-flight load is not suppressed —
             // proving the suppression is what differs (and that the real
             // `.downloading` signal is not regressed).
-            let loadTask = Task { try? await model.preload() }
+            let loadTask = Task { try await model.preload() }
             await gate.waitUntilStarted()
 
             let availability = await model.availability
             await gate.release()
-            _ = await loadTask.value
+            await #expect(throws: BlockingDownloaderReleased.self) {
+                try await loadTask.value
+            }
 
             #expect(
                 availability == .downloading,
@@ -160,12 +164,14 @@ extension FoundationModelsCacheTests {
                         configuration: configuration, progressHandler: progress)
                 })
 
-            let warmTask = Task { try? await model.warmUp() }
+            let warmTask = Task { try await model.warmUp() }
             await gate.waitUntilStarted()
 
             let availability = await model.availability
             await gate.release()
-            _ = await warmTask.value
+            await #expect(throws: BlockingDownloaderReleased.self) {
+                try await warmTask.value
+            }
 
             #expect(
                 availability == .downloading,
@@ -189,7 +195,7 @@ extension FoundationModelsCacheTests {
 
 // MARK: - Test Stubs
 
-private final class StubAvailabilityDownloader: Downloader, @unchecked Sendable {
+private struct StubAvailabilityDownloader: Downloader {
     func download(
         id: String,
         revision: String?,
@@ -201,7 +207,7 @@ private final class StubAvailabilityDownloader: Downloader, @unchecked Sendable 
     }
 }
 
-private final class StubAvailabilityTokenizerLoader: TokenizerLoader, @unchecked Sendable {
+private struct StubAvailabilityTokenizerLoader: TokenizerLoader {
     func load(from directory: URL) async throws -> any Tokenizer {
         StubAvailabilityTokenizer()
     }
@@ -267,9 +273,8 @@ private struct BlockingDownloaderReleased: Error {}
 
 /// A `Downloader` that parks inside `download` until the gate is released, so a
 /// load stays deterministically in flight while the test reads `availability`.
-private final class BlockingDownloader: Downloader, @unchecked Sendable {
-    private let gate: LoadGate
-    init(gate: LoadGate) { self.gate = gate }
+private struct BlockingDownloader: Downloader {
+    let gate: LoadGate
 
     func download(
         id: String,

--- a/Tests/MLXFoundationModelsTests/GenerationEventObserverTests.swift
+++ b/Tests/MLXFoundationModelsTests/GenerationEventObserverTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import FoundationModels
+import Synchronization
 import Testing
 
 @testable import MLXFoundationModels
@@ -14,6 +15,28 @@ import Testing
 @Suite("GenerationEvent observer")
 struct GenerationEventObserverTests {
 
+    /// Drains `channel` until it closes or the caller cancels this task.
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    private func drain(
+        _ channel: LanguageModelExecutorGenerationChannel
+    ) -> Task<Void, any Error> {
+        Task {
+            for try await _ in channel {}
+        }
+    }
+
+    /// Awaits a cancelled drain task, recording any error other than the
+    /// expected `CancellationError`.
+    private func assertDrainCancelled(_ task: Task<Void, any Error>) async {
+        do {
+            try await task.value
+        } catch is CancellationError {
+            // expected: the drain loop was still running when we cancelled it.
+        } catch {
+            Issue.record("drain task failed with unexpected error: \(error)")
+        }
+    }
+
     /// Runs `body` with an attached observer and a drained channel, returning
     /// every mirrored event the observer received.
     @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
@@ -21,30 +44,27 @@ struct GenerationEventObserverTests {
         _ body: (LanguageModelExecutorGenerationChannel) async -> Void
     ) async -> [MLXLanguageModel.Executor.GenerationEvent] {
         let channel = LanguageModelExecutorGenerationChannel()
-        let drain = Task<Void, Never> {
-            do { for try await _ in channel {} } catch {}
-        }
+        let drainTask = drain(channel)
         let box = EventBox()
-        await MLXLanguageModel.Executor.$generationObserver.withValue({ box.append($0) }) {
-            await body(channel)
-        }
-        drain.cancel()
+        await MLXLanguageModel.Executor.$generationObserver.withValue(
+            { box.append($0) },
+            operation: { await body(channel) }
+        )
+        drainTask.cancel()
+        await assertDrainCancelled(drainTask)
         return box.events
     }
 
     @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
-    private final class EventBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var storage: [MLXLanguageModel.Executor.GenerationEvent] = []
-        func append(_ e: MLXLanguageModel.Executor.GenerationEvent) {
-            lock.lock()
-            storage.append(e)
-            lock.unlock()
+    private final class EventBox: Sendable {
+        private let storage = Mutex<[MLXLanguageModel.Executor.GenerationEvent]>([])
+
+        func append(_ event: MLXLanguageModel.Executor.GenerationEvent) {
+            storage.withLock { $0.append(event) }
         }
+
         var events: [MLXLanguageModel.Executor.GenerationEvent] {
-            lock.lock()
-            defer { lock.unlock() }
-            return storage
+            storage.withLock { $0 }
         }
     }
 
@@ -87,11 +107,12 @@ struct GenerationEventObserverTests {
 
         // Not inside withValue: generationObserver is nil (shipping behavior).
         let channel = LanguageModelExecutorGenerationChannel()
-        let drain = Task<Void, Never> { do { for try await _ in channel {} } catch {} }
+        let drainTask = drain(channel)
         await MLXLanguageModel.Executor.emit(
             text: "x", entryID: nil, destination: .reasoning, into: channel)
-        drain.cancel()
+        drainTask.cancel()
         // Reaching here without trapping is the assertion.
+        await assertDrainCancelled(drainTask)
     }
 }
 

--- a/Tests/MLXFoundationModelsTests/GenerationOptionsForwardingTests.swift
+++ b/Tests/MLXFoundationModelsTests/GenerationOptionsForwardingTests.swift
@@ -4,12 +4,12 @@
 
 import Foundation
 import FoundationModels
+import Synchronization
 import Testing
 
 @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
-private final class SeedRecorder: @unchecked Sendable, Hashable {
-    private let lock = NSLock()
-    private var storage: UInt64?
+private final class SeedRecorder: Sendable, Hashable {
+    private let storage = Mutex<UInt64?>(nil)
 
     static func == (lhs: SeedRecorder, rhs: SeedRecorder) -> Bool {
         lhs === rhs
@@ -20,15 +20,11 @@ private final class SeedRecorder: @unchecked Sendable, Hashable {
     }
 
     func record(_ seed: UInt64?) {
-        lock.lock()
-        storage = seed
-        lock.unlock()
+        storage.withLock { $0 = seed }
     }
 
     var seed: UInt64? {
-        lock.lock()
-        defer { lock.unlock() }
-        return storage
+        storage.withLock { $0 }
     }
 }
 

--- a/Tests/MLXFoundationModelsTests/MLXLanguageModelCapabilitiesTests.swift
+++ b/Tests/MLXFoundationModelsTests/MLXLanguageModelCapabilitiesTests.swift
@@ -99,7 +99,7 @@ struct MLXLanguageModelCapabilitiesTests {
 
 // MARK: - Stubs (no download/load occurs in these tests; we only check stored state)
 
-private final class CapabilitiesStubDownloader: Downloader, @unchecked Sendable {
+private struct CapabilitiesStubDownloader: Downloader {
     func download(
         id: String,
         revision: String?,
@@ -111,7 +111,7 @@ private final class CapabilitiesStubDownloader: Downloader, @unchecked Sendable 
     }
 }
 
-private final class CapabilitiesStubTokenizerLoader: TokenizerLoader, @unchecked Sendable {
+private struct CapabilitiesStubTokenizerLoader: TokenizerLoader {
     func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
         struct EmptyTokenizer: MLXLMCommon.Tokenizer {
             func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }

--- a/Tests/MLXFoundationModelsTests/MLXLanguageModelTests.swift
+++ b/Tests/MLXFoundationModelsTests/MLXLanguageModelTests.swift
@@ -38,7 +38,7 @@ struct MLXLanguageModelInitTests {
 
 /// Minimal `Downloader` conformance. The tests in this suite only verify
 /// MLXLanguageModel's construction surface; no download is actually invoked.
-private final class StubDownloader: Downloader, @unchecked Sendable {
+private struct StubDownloader: Downloader {
     func download(
         id: String,
         revision: String?,
@@ -51,7 +51,7 @@ private final class StubDownloader: Downloader, @unchecked Sendable {
 }
 
 /// Minimal `TokenizerLoader` conformance. As above, never invoked here.
-private final class StubTokenizerLoader: TokenizerLoader, @unchecked Sendable {
+private struct StubTokenizerLoader: TokenizerLoader {
     func load(from directory: URL) async throws -> any Tokenizer {
         StubTokenizer()
     }

--- a/Tests/MLXFoundationModelsTests/ModelCacheEvictionTests.swift
+++ b/Tests/MLXFoundationModelsTests/ModelCacheEvictionTests.swift
@@ -60,10 +60,12 @@ extension FoundationModelsCacheTests {
                 })
 
             // Drive a load that parks, then fails — populating lastErrors[id].
-            let loadTask = Task { try? await model.preload() }
+            let loadTask = Task { try await model.preload() }
             await gate.waitUntilStarted()
             await gate.release()
-            _ = await loadTask.value
+            await #expect(throws: BlockingDownloaderReleased.self) {
+                try await loadTask.value
+            }
 
             let before = await MLXLanguageModel.lastLoadErrorInCache(modelID: id)
             #expect(before != nil, "a failed load should record a cached lastError")
@@ -92,10 +94,12 @@ extension FoundationModelsCacheTests {
                             using: EvictStubTokenizerLoader(),
                             configuration: configuration, progressHandler: progress)
                     })
-                let task = Task { try? await model.preload() }
+                let task = Task { try await model.preload() }
                 await gate.waitUntilStarted()
                 await gate.release()
-                _ = await task.value
+                await #expect(throws: BlockingDownloaderReleased.self) {
+                    try await task.value
+                }
                 return model
             }
 
@@ -137,7 +141,7 @@ extension FoundationModelsCacheTests {
                 })
 
             // Park a genuine (non-warmup) load in flight.
-            let loadTask = Task { try? await model.preload() }
+            let loadTask = Task { try await model.preload() }
             await gate.waitUntilStarted()
 
             // In-flight load is registered and reported.
@@ -154,7 +158,9 @@ extension FoundationModelsCacheTests {
             // Let the parked load fail. The catch-path guard must NOT re-add lastError
             // for the now-superseded task.
             await gate.release()
-            _ = await loadTask.value
+            await #expect(throws: BlockingDownloaderReleased.self) {
+                try await loadTask.value
+            }
 
             let lastError = await MLXLanguageModel.lastLoadErrorInCache(modelID: id)
             #expect(lastError == nil, "a superseded load must not re-populate cache state")
@@ -199,9 +205,8 @@ private struct BlockingDownloaderReleased: Error {}
 
 /// A `Downloader` that parks inside `download` until the gate is released, so a load
 /// stays deterministically in flight, then fails the load on release.
-private final class BlockingDownloader: Downloader, @unchecked Sendable {
-    private let gate: LoadGate
-    init(gate: LoadGate) { self.gate = gate }
+private struct BlockingDownloader: Downloader {
+    let gate: LoadGate
     func download(
         id: String,
         revision: String?,
@@ -215,7 +220,7 @@ private final class BlockingDownloader: Downloader, @unchecked Sendable {
     }
 }
 
-private final class EvictStubTokenizerLoader: TokenizerLoader, @unchecked Sendable {
+private struct EvictStubTokenizerLoader: TokenizerLoader {
     func load(from directory: URL) async throws -> any Tokenizer { EvictStubTokenizer() }
 }
 

--- a/Tests/MLXFoundationModelsTests/TestHelpers.swift
+++ b/Tests/MLXFoundationModelsTests/TestHelpers.swift
@@ -29,7 +29,7 @@ import UniformTypeIdentifiers
 // For tests that construct an `MLXLanguageModel` but never actually load one:
 // capability assertions and construction paths. No network, no weights.
 
-private struct StubDownloader: MLXLMCommon.Downloader, @unchecked Sendable {
+private struct StubDownloader: MLXLMCommon.Downloader {
     func download(
         id: String,
         revision: String?,
@@ -41,7 +41,7 @@ private struct StubDownloader: MLXLMCommon.Downloader, @unchecked Sendable {
     }
 }
 
-private struct StubTokenizerLoader: MLXLMCommon.TokenizerLoader, @unchecked Sendable {
+private struct StubTokenizerLoader: MLXLMCommon.TokenizerLoader {
     func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer { StubTokenizer() }
 }
 

--- a/Tests/MLXFoundationModelsTests/TokenizerBiasCacheTests.swift
+++ b/Tests/MLXFoundationModelsTests/TokenizerBiasCacheTests.swift
@@ -3,6 +3,7 @@
 import Foundation
 import FoundationModels
 import MLXLMCommon
+import Synchronization
 import Testing
 
 @testable import MLXFoundationModels
@@ -152,7 +153,7 @@ extension FoundationModelsCacheTests {
 
 /// Minimal no-op transport stubs so an `MLXLanguageModel` can be constructed purely to
 /// exercise the instance `evict()` path. They are never driven to a real load here.
-private final class EvictBiasStubDownloader: Downloader, @unchecked Sendable {
+private struct EvictBiasStubDownloader: Downloader {
     func download(
         id: String,
         revision: String?,
@@ -162,7 +163,8 @@ private final class EvictBiasStubDownloader: Downloader, @unchecked Sendable {
     ) async throws -> URL { URL(fileURLWithPath: "/no/such/path") }
 }
 
-private final class EvictBiasStubTokenizerLoader: TokenizerLoader, @unchecked Sendable {
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+private struct EvictBiasStubTokenizerLoader: TokenizerLoader {
     func load(from directory: URL) async throws -> any Tokenizer {
         CountingTokenizer(tokens: [])
     }
@@ -170,18 +172,22 @@ private final class EvictBiasStubTokenizerLoader: TokenizerLoader, @unchecked Se
 
 /// Tokenizer with a fixed vocab that counts `convertIdToToken` calls, so a test can
 /// assert whether a bias computation re-scanned the vocab (cache miss) or not (hit).
-/// `@unchecked Sendable`: the counter is mutated only from serialized test calls.
-private final class CountingTokenizer: Tokenizer, @unchecked Sendable {
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+private final class CountingTokenizer: Tokenizer, Sendable {
     let tokens: [String]
-    private(set) var idLookupCount = 0
+    private let lookupCount = Mutex(0)
 
-    init(tokens: [String]) { self.tokens = tokens }
+    init(tokens: [String]) {
+        self.tokens = tokens
+    }
+
+    var idLookupCount: Int { lookupCount.withLock { $0 } }
 
     func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
     func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
     func convertTokenToId(_ token: String) -> Int? { tokens.firstIndex(of: token) }
     func convertIdToToken(_ id: Int) -> String? {
-        idLookupCount += 1
+        lookupCount.withLock { $0 += 1 }
         guard id >= 0, id < tokens.count else { return nil }
         return tokens[id]
     }


### PR DESCRIPTION
## The problem

An audit of `MLXFoundationModels` against Swift's published style guidance surfaced eight test fixture files that broke concrete rules, not just style preferences. Two channel drains swallowed every error in an empty `catch` block. Six load and warmup tasks discarded their result with `try?`. Five stub types asserted thread safety with `@unchecked Sendable` instead of the compiler proving it. One stub enforced an OS availability requirement with a runtime guard the compiler could enforce instead. Each of these could hide a real failure or a real race and let a broken fixture report a passing test.

## What this PR does

- Extracts one channel-drain helper in `GenerationEventObserverTests` and asserts its result. A drain that fails with anything but cancellation now fails the test, instead of vanishing into an empty `catch {}`.
- Asserts the specific error every load and warmup task throws in `AvailabilityTests` and `ModelCacheEvictionTests`, instead of discarding it with `try?`.
- Converts five stateless downloader and tokenizer-loader stubs from classes marked `@unchecked Sendable` to structs, so the compiler proves `Sendable` instead of the annotation asserting it.
- Replaces `NSLock` and `@unchecked Sendable` on `EventBox` and `SeedRecorder`, the two fixtures that hold mutable state across a task boundary, with the standard library's `Mutex`.
- Spells out a two-closure call in `GenerationEventObserverTests` that swift-format's `OnlyOneTrailingClosureArgument` rule flagged, so it is unambiguous which parameter each closure binds to.
- Marks `EvictBiasStubTokenizerLoader` with the OS 27 availability its returned tokenizer already requires, replacing a runtime `guard` and a `preconditionFailure` that could never fire.

## Tests

- `pre-commit run --all` (swift-format): passes with zero files changed.
- `xcodebuild build-for-testing` for `mlx-swift-lm-Package`: builds clean.
- `xcrun xctest MLXFoundationModelsTests.xctest`: 139 tests in 21 suites pass, run 20 times in a row with no flakes.
- `xcrun xctest MLXLMTests.xctest`: 722 tests in 55 suites pass. This is CI's only required suite, but it covers none of this PR's diff; `MLXFoundationModelsTests.xctest` is the suite that exercises it.
- Mutation check: inverted one `#expect` in each of the six affected test files, confirmed all six produce the expected failure, then reverted and confirmed the suite returns to 139 tests in 21 suites passing.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure: I used AI for all of this, but understand the code that I'm contributing.
