### PR TITLE
Rename async version of loadWeights to loadWeightsAsync

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/Gemma4AssistantDraftModelIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/Gemma4AssistantDraftModelIntegrationTests.swift
@@ -93,7 +93,7 @@ struct Gemma4AssistantIntegrationTests {
         // loadWeights enumerates *.safetensors in the directory, sanitizes via
         // the model's sanitize hook, and applies via update(parameters:verify:).
         // If any keys are missing or unexpected, update(verify: [.all]) throws.
-        try loadWeights(modelDirectory: drafterDir, model: model)
+        try await loadWeightsAsync(modelDirectory: drafterDir, model: model)
     }
 
     @Test
@@ -107,7 +107,7 @@ struct Gemma4AssistantIntegrationTests {
         let cfg = try JSONDecoder().decode(
             Gemma4AssistantConfiguration.self, from: Data(contentsOf: configURL))
         let model = Gemma4AssistantDraftModel(cfg)
-        try loadWeights(modelDirectory: drafterDir, model: model)
+        try await loadWeightsAsync(modelDirectory: drafterDir, model: model)
 
         let fixtureURL =
             fixturesDir

--- a/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
@@ -101,7 +101,7 @@ private func loadTargetAndDrafter(
         Gemma4AssistantConfiguration.self,
         from: Data(contentsOf: drafterDir.appendingPathComponent("config.json")))
     let drafter = Gemma4AssistantDraftModel(cfg)
-    try loadWeights(modelDirectory: drafterDir, model: drafter)
+    try await loadWeightsAsync(modelDirectory: drafterDir, model: drafter)
 
     return LoadedPair(context: context, drafter: drafter)
 }

--- a/IntegrationTesting/IntegrationTestingTests/MTPRung4TokenParityTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPRung4TokenParityTests.swift
@@ -98,7 +98,7 @@ private func loadRung4Drafter() async throws -> Rung4BoundDrafter {
         Gemma4AssistantConfiguration.self,
         from: Data(contentsOf: drafterDir.appendingPathComponent("config.json")))
     let drafter = Gemma4AssistantDraftModel(drafterCfg)
-    try loadWeights(modelDirectory: drafterDir, model: drafter)
+    try await loadWeightsAsync(modelDirectory: drafterDir, model: drafter)
 
     // Target — 8-bit quantized. `loadWeights` auto-applies group quantization
     // when weights carry `.scales` keys, per Libraries/MLXLMCommon/Load.swift:40-52.
@@ -109,7 +109,7 @@ private func loadRung4Drafter() async throws -> Rung4BoundDrafter {
     let targetCfg = try JSONDecoder().decode(
         Gemma4Configuration.self, from: targetConfigData)
     let target = Gemma4(targetCfg)
-    try loadWeights(
+    try await loadWeightsAsync(
         modelDirectory: targetDir,
         model: target,
         perLayerQuantization: targetBase.perLayerQuantization)

--- a/Libraries/MLXEmbedders/ModelFactory.swift
+++ b/Libraries/MLXEmbedders/ModelFactory.swift
@@ -231,7 +231,7 @@ public final class EmbedderModelFactory: GenericModelFactory {
         async let tokenizerTask = tokenizerLoader.load(
             from: configuration.tokenizerDirectory)
 
-        try await loadWeights(
+        try await loadWeightsAsync(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection)

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -730,7 +730,7 @@ public final class LLMModelFactory: GenericModelFactory {
         async let tokenizerTask = tokenizerLoader.load(
             from: configuration.tokenizerDirectory)
 
-        try await loadWeights(
+        try await loadWeightsAsync(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection)

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -415,7 +415,7 @@ public func loadWeights(
 /// Swift concurrency's cooperative threads must never block, so this overload runs the load
 /// on a global queue and suspends the caller instead. Async callers resolve to this overload;
 /// the synchronous one remains for synchronous code such as model conversion.
-public func loadWeights(
+public func loadWeightsAsync(
     modelDirectory: URL, model: BaseLanguageModel,
     quantization: BaseConfiguration.Quantization? = nil,
     perLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil,

--- a/Libraries/MLXLMCommon/MTPDrafterModelFactory.swift
+++ b/Libraries/MLXLMCommon/MTPDrafterModelFactory.swift
@@ -92,7 +92,7 @@ public final class MTPDrafterModelFactory: GenericModelFactory {
                 configurationURL.lastPathComponent, configuration.name, error)
         }
 
-        try await loadWeights(
+        try await loadWeightsAsync(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -444,7 +444,7 @@ public final class VLMModelFactory: GenericModelFactory {
             context: processorLoadingContext,
             registry: processorLoadingRegistry)
 
-        try await loadWeights(
+        try await loadWeightsAsync(
             modelDirectory: modelDirectory, model: model,
             perLayerQuantization: baseConfig.perLayerQuantization,
             weightFileSelection: configuration.weightFileSelection)


### PR DESCRIPTION
## Proposed changes

- swift's selection rules with default parameters are inscrutable
- even with @_disfavoredOverload it still tries to call the async variant sometimes (with no await)
- distinguish by name to get reliable resolution
- fixes #601

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure: none
