### PR TITLE
Await the async loadWeights overload in the IntegrationTesting tests

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/Gemma4AssistantDraftModelIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/Gemma4AssistantDraftModelIntegrationTests.swift
@@ -93,7 +93,7 @@ struct Gemma4AssistantIntegrationTests {
         // loadWeights enumerates *.safetensors in the directory, sanitizes via
         // the model's sanitize hook, and applies via update(parameters:verify:).
         // If any keys are missing or unexpected, update(verify: [.all]) throws.
-        try loadWeights(modelDirectory: drafterDir, model: model)
+        try await loadWeights(modelDirectory: drafterDir, model: model)
     }
 
     @Test
@@ -107,7 +107,7 @@ struct Gemma4AssistantIntegrationTests {
         let cfg = try JSONDecoder().decode(
             Gemma4AssistantConfiguration.self, from: Data(contentsOf: configURL))
         let model = Gemma4AssistantDraftModel(cfg)
-        try loadWeights(modelDirectory: drafterDir, model: model)
+        try await loadWeights(modelDirectory: drafterDir, model: model)
 
         let fixtureURL =
             fixturesDir

--- a/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
@@ -101,7 +101,7 @@ private func loadTargetAndDrafter(
         Gemma4AssistantConfiguration.self,
         from: Data(contentsOf: drafterDir.appendingPathComponent("config.json")))
     let drafter = Gemma4AssistantDraftModel(cfg)
-    try loadWeights(modelDirectory: drafterDir, model: drafter)
+    try await loadWeights(modelDirectory: drafterDir, model: drafter)
 
     return LoadedPair(context: context, drafter: drafter)
 }

--- a/IntegrationTesting/IntegrationTestingTests/MTPRung4TokenParityTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPRung4TokenParityTests.swift
@@ -98,7 +98,7 @@ private func loadRung4Drafter() async throws -> Rung4BoundDrafter {
         Gemma4AssistantConfiguration.self,
         from: Data(contentsOf: drafterDir.appendingPathComponent("config.json")))
     let drafter = Gemma4AssistantDraftModel(drafterCfg)
-    try loadWeights(modelDirectory: drafterDir, model: drafter)
+    try await loadWeights(modelDirectory: drafterDir, model: drafter)
 
     // Target — 8-bit quantized. `loadWeights` auto-applies group quantization
     // when weights carry `.scales` keys, per Libraries/MLXLMCommon/Load.swift:40-52.
@@ -109,7 +109,7 @@ private func loadRung4Drafter() async throws -> Rung4BoundDrafter {
     let targetCfg = try JSONDecoder().decode(
         Gemma4Configuration.self, from: targetConfigData)
     let target = Gemma4(targetCfg)
-    try loadWeights(
+    try await loadWeights(
         modelDirectory: targetDir,
         model: target,
         perLayerQuantization: targetBase.perLayerQuantization)


### PR DESCRIPTION
## The problem

The IntegrationTesting Xcode project does not compile on `main`. #579 added an async `loadWeights` overload beside the existing synchronous one. Swift prefers the async overload inside an async function, so five existing `try loadWeights(...)` calls in the integration tests now need `await` and fail to build without it. Nothing on the pull request path builds this project. `mac_build_and_test` only builds `-scheme mlx-swift-lm-Package`. The one job that does build it, `integration_build_xcode27`, is disabled at `.github/workflows/pull_request.yml:166`. #579 therefore merged green.

## What this PR does

- Adds `await` to the five `loadWeights` calls in the integration tests, so the project compiles again.
- Those five loads now suspend the caller instead of blocking a Swift concurrency cooperative thread, which is the behavior #579 added the overload for.

The synchronous call sites elsewhere in the repository are unchanged. Each one sits in a plain `throws` function, so each still resolves to the synchronous overload. This PR does not re-enable `integration_build_xcode27`. That is a separate decision.

## Tests

- Reproduced the failure at the base commit: `** TEST BUILD FAILED **`, "expression is 'async' but is not marked with 'await'".
- `xcodebuild build-for-testing -project IntegrationTesting/IntegrationTesting.xcodeproj -scheme IntegrationTesting`: `** TEST BUILD SUCCEEDED **`, zero errors.
- `xcodebuild build-for-testing -scheme mlx-swift-lm-Package`: `** TEST BUILD SUCCEEDED **`, which covers the synchronous call sites.
- `MLXLMTests.xctest`: 722 tests in 55 suites passed.
- `MLXFoundationModelsTests.xctest`: 139 tests in 21 suites passed.
- `pre-commit run --all`: swift-format passed and reformatted nothing.
- Established the full set of five call sites from the compiler, one file at a time. One `swift-frontend` process compiles the whole target and stops at the first failing batch. A single build therefore reports only the two errors in `MTPRung4TokenParityTests.swift`. Fixing one file and rebuilding surfaced the next, until the build was clean.
- Did not run the IntegrationTesting tests. They download models, and CI never runs them.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure: I used AI for all of these changes, but understand the changes and can speak to them.