### PR TITLE
Add mid-turn steering to ChatSession

### DIFF
--- a/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationBenchmarkTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MLXFoundationModelsIntegration/GuidedGeneration/GuidedGenerationBenchmarkTests.swift
@@ -427,7 +427,7 @@ struct GuidedGenerationBenchmarkTests {
                 case .chunk(let text):
                     charCount += text.count
                     deltaCount += 1
-                case .info, .toolCall, .rejectedToolCall:
+                case .info, .toolCall, .rejectedToolCall, .steering:
                     break
                 }
             }

--- a/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/MTPIteratorEndToEndDiagnosticTests.swift
@@ -150,7 +150,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
             switch event {
             case .chunk(let chunk):
                 text += chunk
-            case .toolCall, .rejectedToolCall:
+            case .toolCall, .rejectedToolCall, .steering:
                 break
             case .info(let completionInfo):
                 info = completionInfo
@@ -370,7 +370,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in mtpStream {
             switch event {
             case .chunk(let chunk): mtpText += chunk
-            case .toolCall, .rejectedToolCall: break
+            case .toolCall, .rejectedToolCall, .steering: break
             case .info(let i): mtpInfo = i
             }
         }
@@ -494,7 +494,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in mtpStream {
             switch event {
             case .chunk(let chunk): mtpText += chunk
-            case .toolCall, .rejectedToolCall: break
+            case .toolCall, .rejectedToolCall, .steering: break
             case .info(let i): mtpInfo = i
             }
         }
@@ -510,7 +510,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in baselineStream {
             switch event {
             case .chunk(let chunk): baselineText += chunk
-            case .toolCall, .rejectedToolCall: break
+            case .toolCall, .rejectedToolCall, .steering: break
             case .info(let i): baselineInfo = i
             }
         }
@@ -691,7 +691,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in stream {
             switch event {
             case .chunk(let chunk): text += chunk
-            case .toolCall, .rejectedToolCall: break
+            case .toolCall, .rejectedToolCall, .steering: break
             case .info(let completionInfo): info = completionInfo
             }
         }
@@ -924,7 +924,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in mtpStream {
             switch event {
             case .chunk(let chunk): mtpText += chunk
-            case .toolCall, .rejectedToolCall: break
+            case .toolCall, .rejectedToolCall, .steering: break
             case .info(let i): mtpInfo = i
             }
         }
@@ -1002,7 +1002,7 @@ struct MTPIteratorEndToEndDiagnosticTests {
         for await event in stream {
             switch event {
             case .chunk(let chunk): text += chunk
-            case .toolCall, .rejectedToolCall: break
+            case .toolCall, .rejectedToolCall, .steering: break
             case .info(let completionInfo): info = completionInfo
             }
         }

--- a/IntegrationTesting/IntegrationTestingTests/SteeringIntegrationTests.swift
+++ b/IntegrationTesting/IntegrationTestingTests/SteeringIntegrationTests.swift
@@ -1,0 +1,67 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import HuggingFace
+import IntegrationTestHelpers
+import MLXHuggingFace
+import MLXLMCommon
+import Testing
+import Tokenizers
+
+private let models = IntegrationTestModels(
+    downloader: #hubDownloader(),
+    tokenizerLoader: #huggingFaceTokenizerLoader()
+)
+
+@Suite(.serialized)
+struct SteeringIntegrationTests {
+    @Test(
+        .timeLimit(.minutes(2)),
+        arguments: [
+            SteeringPolicy.nextSafeBoundary, .nextStepBoundary,
+        ])
+    func steersRunningResponse(policy: SteeringPolicy) async throws {
+        let container = try await models.vlmContainer(
+            for: .init(id: "mlx-community/Qwen3-VL-4B-Instruct-4bit"))
+        let configuration = await container.configuration
+        let session = ChatSession(
+            container, generateParameters: GenerateParameters(maxTokens: 128, temperature: 0))
+        let stream = session.streamDetails(
+            to: "List 50 facts about the ocean. Write one sentence per fact.")
+        var accepted: UUID?
+        var applied: [UUID] = []
+        var infos: [GenerateCompletionInfo] = []
+        var successorText = ""
+        for try await event in stream {
+            switch event {
+            case .chunk(let text):
+                if !applied.isEmpty { successorText += text }
+                if accepted == nil {
+                    accepted = try session.steer(
+                        "Stop the list. Reply only with STEERING_CONFIRMED.", policy: policy)
+                }
+            case .steering(.applied(let ids)):
+                applied += ids
+            case .steering(.failed(let failure)):
+                Issue.record("Steering failed: \(failure.reason)")
+            case .info(let info):
+                infos.append(info)
+            case .toolCall, .rejectedToolCall:
+                Issue.record("Unexpected tool output")
+            }
+        }
+        let id = try #require(accepted)
+        #expect(applied == [id])
+        #expect(infos.count == 2)
+        if case .nextSafeBoundary = policy, configuration.reasoningConfig == nil {
+            #expect(infos.first?.stopReason == .steered)
+        } else {
+            #expect(infos.first?.stopReason != .steered)
+        }
+        #expect(successorText.contains("STEERING_CONFIRMED"))
+        #expect(!session.canSteer())
+
+        let followup = try await session.respond(to: "What word did I ask you to reply with?")
+        #expect(followup.contains("STEERING_CONFIRMED"))
+    }
+}

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -436,6 +436,7 @@ public enum ChatSessionTests {
             to: "What is the weather in San Francisco?", images: [], videos: [])
         {
             switch generation {
+            case .steering: break
             case .chunk(let text):
                 print(text, terminator: "")
                 responseText += text
@@ -519,6 +520,7 @@ public enum ChatSessionTests {
                 id: call.id)
         ]) {
             switch generation {
+            case .steering: break
             case .chunk(let text):
                 followUpText += text
             case .toolCall(let call):
@@ -1243,6 +1245,7 @@ public enum ToolCallTests {
             var toolCalls: [ToolCall] = []
             for try await generation in stream {
                 switch generation {
+                case .steering: break
                 case .chunk(let chunk):
                     text += chunk
                 case .toolCall(let toolCall):

--- a/Libraries/MLXFoundationModels/MLXLanguageModel.swift
+++ b/Libraries/MLXFoundationModels/MLXLanguageModel.swift
@@ -1761,6 +1761,7 @@ public struct MLXLanguageModel: FoundationModels.LanguageModel, Sendable {
             ) {
                 try Task.checkCancellation()
                 switch generation {
+                case .steering: break
                 case .chunk(let text):
                     await Self.emit(
                         text: text, entryID: entryID, destination: .response, into: channel)

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -205,9 +205,9 @@ public final class ChatSession {
 
     private struct GenerationRun {
         let stream: AsyncStream<Generation>
-        let task: Task<[Int], Never>
+        let task: Task<RecordedGeneration, Never>
 
-        init(_ pair: (AsyncStream<Generation>, Task<[Int], Never>)) {
+        init(_ pair: (AsyncStream<Generation>, Task<RecordedGeneration, Never>)) {
             (stream, task) = pair
         }
     }
@@ -302,6 +302,7 @@ public final class ChatSession {
 
     private let model: ModelContainer
     public var instructions: String?
+    private let steeringRequests = SessionSteering()
     private let cache: SerialAccessContainer<Cache>
     private let loadedDraftModel: SerialAccessContainer<ModelContainer?>
     public var processing: UserInput.Processing
@@ -706,7 +707,7 @@ public final class ChatSession {
     ///   - videos: list of videos (for use with VLMs)
     ///   - audios: list of audios (for use with VLMs)
     /// - Returns: the model's response
-    public func respond(
+    nonisolated(nonsending) public func respond(
         to prompt: String,
         role: Chat.Message.Role = .user,
         images: consuming [UserInput.Image],
@@ -731,7 +732,7 @@ public final class ChatSession {
     ///   - video: optional video (for use with VLMs)
     ///   - audio: optional audio (for use with VLMs)
     /// - Returns: the model's response
-    public func respond(
+    nonisolated(nonsending) public func respond(
         to prompt: String,
         role: Chat.Message.Role = .user,
         image: consuming UserInput.Image? = nil,
@@ -759,7 +760,7 @@ public final class ChatSession {
     ///
     /// - Parameter messages: chat messages to append before generation
     /// - Returns: the model's response
-    public func respond(
+    nonisolated(nonsending) public func respond(
         to messages: consuming [Chat.Message]
     ) async throws -> String {
         var output = ""
@@ -852,6 +853,65 @@ public final class ChatSession {
         }
     }
 
+    /// Identifies one response created by this session.
+    ///
+    /// Read ``ChatSession/latestResponse`` immediately after creating a response
+    /// to capture its ID, then pass it to ``ChatSession/steer(_:policy:response:)``.
+    public struct ResponseID: Hashable, Sendable {
+        let rawValue: UUID
+    }
+
+    /// The response created most recently by this session, or `nil` when none
+    /// is outstanding.
+    ///
+    /// Stream creation registers the response synchronously, before inference
+    /// starts. `respond` registers its response when the async method begins.
+    public var latestResponse: ResponseID? {
+        steeringRequests.latestResponse
+    }
+
+    /// Whether the response is open to steering.
+    ///
+    /// Input validation and queue limits still apply. The answer can change
+    /// before the next call because a response can finish at any time.
+    ///
+    /// - Parameter response: a response to test, or `nil` for the response
+    ///   ``steer(_:policy:response:)`` would target by default.
+    public func canSteer(_ response: ResponseID? = nil) -> Bool {
+        steeringRequests.canSteer(response)
+    }
+
+    /// Add an instruction to a running response without waiting for inference.
+    ///
+    /// Use with `respond`, `streamResponse`, or `streamDetails`. Call from the
+    /// session's isolation domain, just like its other methods. Instructions are
+    /// accepted in order and joined with blank lines into one user message.
+    /// A ``SteeringPolicy/nextSafeBoundary`` request promotes the pending batch;
+    /// emitted output is retained.
+    ///
+    /// - Parameters:
+    ///   - text: the instruction. Whitespace-only text throws
+    ///     ``SteeringError/emptyInstruction``.
+    ///   - policy: when the instruction may enter the model's context.
+    ///   - response: the response to steer. The default targets the response
+    ///     that owns the cache, then the oldest response still accepting input.
+    ///     Pass a ``ResponseID`` from ``latestResponse`` when a session can have
+    ///     more than one response outstanding.
+    /// - Returns: an acceptance ID. `streamDetails` reports
+    ///   ``SteeringEvent/applied(_:)`` once the instruction reaches the
+    ///   model, or ``SteeringEvent/failed(_:)`` if it cannot.
+    /// - Throws: ``SteeringError`` when the instruction is not accepted.
+    ///   Acceptance failures never affect a running response.
+    ///
+    /// At most ``SteeringLimits/maxPendingInstructions`` instructions and
+    /// ``SteeringLimits/maxPendingBytes`` bytes may be pending.
+    @discardableResult
+    public func steer(
+        _ text: String, policy: SteeringPolicy = .nextSafeBoundary, response: ResponseID? = nil
+    ) throws -> UUID {
+        try steeringRequests.steer(text, policy: policy, response: response)
+    }
+
     /// Produces a streaming response to a prompt by transforming the
     /// raw `Generation` values.
     ///
@@ -885,6 +945,8 @@ public final class ChatSession {
         transform: @Sendable @escaping (Generation) -> R?
     ) -> AsyncThrowingStream<R, Error> {
         let (stream, continuation) = AsyncThrowingStream<R, Error>.makeStream()
+        let steering = SteeringControl()
+        steeringRequests.register(steering)
 
         // images and videos are not Sendable (MLXArray) but they are consumed
         // and are only being sent to the inner async
@@ -895,10 +957,15 @@ public final class ChatSession {
                 model,
                 instructions, processing, tools, toolDispatch,
                 additionalContext, cache, loadedDraftModel, generateParameters, components,
-                speculativeDecoding
+                speculativeDecoding, steeringRequests
             ] in
+            defer {
+                steering.finish()
+                steeringRequests.remove(steering)
+            }
             do {
                 try await cache.update { cache in
+                    steeringRequests.start(steering)
 
                     // these are all Sendable
                     let processor = await model.processor
@@ -932,7 +999,7 @@ public final class ChatSession {
                     var draftKVCache: KVCacheStorage?
                     // Per-call model state (e.g. M-RoPE rope deltas) carried
                     // across turns alongside the KV cache; updated after each
-                    // prefill and stored back at the end of the turn.
+                    // model step and stored back at the end of the turn.
                     var lmState: LMOutput.State?
                     var conversation: Conversation?
                     switch cache {
@@ -991,7 +1058,34 @@ public final class ChatSession {
                             .init(main: kvCache, conversation: conversation))
                     }
 
+                    let executionStream = StreamOrDevice.default.stream
+                    var needsExecutionFence = false
+                    defer {
+                        if needsExecutionFence { executionStream.synchronize() }
+                    }
                     var pendingMessages = inputMessages.consume()
+                    var applyingSteering: [SteeringControl.Request] = []
+
+                    // Reports instructions this response accepted but will not apply.
+                    // Steering is an input channel: a failure here reports the
+                    // instruction and leaves the response to finish normally.
+                    @Sendable func reportSteeringFailure(
+                        _ requests: [SteeringControl.Request], _ reason: SteeringError
+                    ) {
+                        guard !requests.isEmpty else { return }
+                        let failure = SteeringFailure(
+                            ids: requests.map(\.id), instructions: requests.map(\.text),
+                            reason: reason)
+                        if let value = transform(.steering(.failed(failure))) {
+                            _ = continuation.yield(value)
+                        }
+                    }
+
+                    // A raw restored cache has no transcript to continue from, so this
+                    // response cannot be steered. Answer future callers immediately and
+                    // report anything accepted before the cache was known.
+                    reportSteeringFailure(
+                        steering.setSteerable(conversation != nil), .notSteerable)
 
                     // How this model's generated token stream relates to a chat
                     // template re-render is a property of its response protocol,
@@ -1001,7 +1095,28 @@ public final class ChatSession {
                             .promptCacheReuseRules(tokenizer: tokenizer) ?? [])
 
                     // loop can restart on tool calls
-                    restart: while !pendingMessages.isEmpty {
+                    while !pendingMessages.isEmpty {
+                        let messageCheckpoint = conversation?.messages.count
+                        let committedToolResults =
+                            Array(pendingMessages.prefix { $0.role == .tool })
+                        var dispatchedResults: [Chat.Message] = []
+                        var recordedStep = false
+                        var finishedStep = false
+                        defer {
+                            if !recordedStep, let messageCheckpoint {
+                                conversation?.messages.removeSubrange(messageCheckpoint...)
+                                conversation?.messages.append(contentsOf: committedToolResults)
+                                conversation?.cachedTokens.removeAll()
+                                conversation?.uncommittedTokens.removeAll()
+                            }
+                            if recordedStep && !finishedStep {
+                                conversation?.messages.append(contentsOf: dispatchedResults)
+                            }
+                            cache = .kvcache(
+                                .init(
+                                    main: kvCache, draft: draftKVCache,
+                                    state: lmState, conversation: conversation))
+                        }
                         let isToolResultContinuation =
                             pendingMessages.contains { $0.role == .tool }
                             && conversation?.messages.last?.tool?.calls?.isEmpty == false
@@ -1020,6 +1135,7 @@ public final class ChatSession {
                             // continuation behavior for this explicitly low-level API.
                             templateMessages = leadingMessages + pendingMessages
                         }
+                        try Task.checkCancellation()
                         let containsNewMedia = pendingMessages.contains {
                             !$0.images.isEmpty || !$0.videos.isEmpty || !$0.audios.isEmpty
                         }
@@ -1030,6 +1146,7 @@ public final class ChatSession {
                             chat: templateMessages,
                             processing: processing,
                             tools: tools, additionalContext: additionalContext)
+                        needsExecutionFence = true
                         let preparedInput = try await processor.prepare(input: userInput)
                         var input = preparedInput
                         pendingMessages.removeAll()
@@ -1201,7 +1318,8 @@ public final class ChatSession {
                                     modelConfiguration: modelConfiguration,
                                     tokenizer: tokenizer,
                                     iterator: iterator,
-                                    tools: tools)
+                                    tools: tools,
+                                    steering: conversation == nil ? nil : steering)
                             )
                         }
 
@@ -1324,7 +1442,8 @@ public final class ChatSession {
                                             modelConfiguration: modelConfiguration,
                                             tokenizer: tokenizer,
                                             iterator: iterator,
-                                            tools: tools))
+                                            tools: tools,
+                                            steering: conversation == nil ? nil : steering))
                                 }
                             }
                         } else {
@@ -1332,6 +1451,15 @@ public final class ChatSession {
                             generation = try defaultGeneration()
                         }
 
+                        if !applyingSteering.isEmpty {
+                            if let value = transform(
+                                .steering(.applied(applyingSteering.map(\.id)))),
+                                case .terminated = continuation.yield(value)
+                            {
+                                generation.task.cancel()
+                            }
+                            applyingSteering.removeAll()
+                        }
                         var pendingToolCalls: [ToolCall] = []
                         var assistant = AssistantGeneration()
 
@@ -1344,7 +1472,10 @@ public final class ChatSession {
                             // the transform (streamDetails path)
                             if let toolCall = item.toolCall, toolDispatch != nil {
                                 pendingToolCalls.append(toolCall)
-                            } else if let value = transform(item) {
+                            }
+                            if item.toolCall == nil || toolDispatch == nil,
+                                let value = transform(item)
+                            {
                                 if case .terminated = continuation.yield(value) {
                                     assistant.wasTerminatedByConsumer = true
                                     generation.task.cancel()
@@ -1369,7 +1500,10 @@ public final class ChatSession {
                         // wait for the task to complete -- this is important in
                         // the case where we broke the loop early as the generation
                         // work may continue (briefly) and use the KVCache
-                        let generatedTokens = await generation.task.value
+                        let generated = await generation.task.value
+                        needsExecutionFence = false
+                        let generatedTokens = generated.tokens
+                        lmState = generated.state.consume()
 
                         if var currentConversation = conversation {
                             let recordedAssistant = currentConversation.record(
@@ -1385,9 +1519,13 @@ public final class ChatSession {
                                 // such as user/user on strict chat templates.
                                 currentConversation.messages.removeSubrange(
                                     conversationMessageCountBeforePending...)
+                                currentConversation.messages.append(
+                                    contentsOf: committedToolResults)
                             }
                             conversation = currentConversation
                         }
+
+                        recordedStep = true
 
                         if let rejection = assistant.rejectedToolCalls.first,
                             failOnRejectedToolCall || toolDispatch != nil
@@ -1413,15 +1551,46 @@ public final class ChatSession {
                                     .assistant("", toolCalls: pendingToolCalls))
                             }
                             for toolCall in pendingToolCalls {
+                                try Task.checkCancellation()
                                 let toolResult = try await toolDispatch(toolCall)
-                                pendingMessages.append(
-                                    .tool(
-                                        toolResult, id: toolCall.id,
-                                        name: toolCall.function.name))
+                                let result = Chat.Message.tool(
+                                    toolResult, id: toolCall.id, name: toolCall.function.name)
+                                pendingMessages.append(result)
+                                dispatchedResults.append(result)
                             }
-                            continue restart
                         }
+
+                        try Task.checkCancellation()
+                        applyingSteering = try steering.take(closeIfEmpty: pendingMessages.isEmpty)
+                        if !applyingSteering.isEmpty {
+                            // This step cannot carry the instructions into a new user
+                            // message. Report them and let the response finish; the
+                            // client still has its output and can resubmit.
+                            let blocked: SteeringError?
+                            if conversation == nil {
+                                blocked = .notSteerable
+                            } else if !assistant.toolCalls.isEmpty && toolDispatch == nil {
+                                blocked = .toolResultsRequired
+                            } else if !assistant.shouldRecord {
+                                blocked = .emptyResponse
+                            } else {
+                                blocked = nil
+                            }
+
+                            if let blocked {
+                                reportSteeringFailure(applyingSteering, blocked)
+                                applyingSteering.removeAll()
+                            } else {
+                                pendingMessages.append(
+                                    .user(applyingSteering.map(\.text).joined(separator: "\n\n")))
+                            }
+                        }
+                        finishedStep = true
                     }
+
+                    // Instructions accepted after the last step drained the mailbox,
+                    // including a batch this response reported as failed above.
+                    reportSteeringFailure(try steering.closeAndTake(), .responseEnded)
 
                     // Store the carried state back alongside the KV cache so
                     // the next turn resumes with correct position anchoring.
@@ -1435,12 +1604,19 @@ public final class ChatSession {
                     continuation.finish()
                 }
             } catch {
+                // Close the mailbox before the consumer observes the error, so a
+                // client that reacts by steering is told the response has ended.
+                steering.finish()
                 continuation.finish(throwing: error)
             }
         }
 
-        continuation.onTermination = { _ in
-            task.cancel()
+        steering.setTask(task)
+        continuation.onTermination = { termination in
+            if case .cancelled = termination {
+                steering.cancel()
+                task.cancel()
+            }
         }
 
         return stream
@@ -1475,11 +1651,11 @@ public final class ChatSession {
         }
     }
 
-    /// Wait for exclusive access to the KVCache.
+    /// Wait for registered response runners and exclusive access to the KVCache.
     ///
-    /// This is useful for cases where a program is terminating and wants to ensure that any
-    /// async operations are complete.
-    public func synchronize() async {
+    /// Use this after cancelling a stream consumer to await inference and GPU cleanup.
+    nonisolated(nonsending) public func synchronize() async {
+        await steeringRequests.synchronize()
         await cache.read { _ in }
     }
 

--- a/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/Documentation.md
@@ -8,6 +8,7 @@ Common language model code.
 - <doc:upgrade>
 - <doc:wired-memory>
 - <doc:kv-cache-quantization>
+- <doc:steering>
 
 ## Reranking
 

--- a/Libraries/MLXLMCommon/Documentation.docc/steering.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/steering.md
@@ -1,0 +1,133 @@
+# Steering an active response
+
+Add instructions while a response runs.
+
+Keep your normal streaming loop:
+
+```swift
+let response = session.streamResponse(to: "Explain this implementation")
+let consumer = Task {
+    for try await text in response {
+        print(text, terminator: "")
+    }
+}
+
+// From a later UI action, on the session's owning actor:
+try session.steer("Focus on memory usage")
+try session.steer("Include an example", policy: .nextStepBoundary)
+```
+
+``ChatSession/steer(_:policy:response:)`` also works with `respond` and
+`streamDetails`. `ChatSession` remains owned by the caller's isolation domain; it
+is not Sendable. The response stream can be passed to its consumer task.
+
+## Acceptance and application
+
+`steer` returns an acceptance UUID immediately, without waiting for inference.
+Acceptance means the instruction is queued, not that the model has acted on it.
+
+Acceptance fails, and throws, when the session has no response accepting input
+(``SteeringError/noActiveResponse``), when the named response has already ended
+(``SteeringError/responseEnded``), when the response cannot be steered
+(``SteeringError/notSteerable``), or when the queue is full
+(``SteeringError/queueFull``). A throw from `steer` never affects a running
+response. Use ``ChatSession/canSteer(_:)`` to enable UI without catching.
+
+By default `steer` targets the response that owns the session cache, then the
+oldest response still accepting input. A session that can have more than one
+response outstanding should name its target, which is never retargeted:
+
+```swift
+let stream = session.streamDetails(to: "Explain this implementation")
+let response = session.latestResponse
+// ...
+try session.steer("Focus on memory usage", response: response)
+```
+
+Use `streamDetails` when you need to know what happened to an instruction:
+
+```swift
+for try await event in session.streamDetails(to: "Explain this implementation") {
+    switch event {
+    case .steering(.applied(let ids)):
+        acknowledge(ids)
+    case .steering(.failed(let failure)):
+        report(failure.instructions, failure.reason)
+    case .chunk(let text):
+        display(text)
+    case .info(let info):
+        recordStatistics(info)
+    case .toolCall(let call):
+        handleTool(call)
+    case .rejectedToolCall(let rejection):
+        handleRejection(rejection)
+    }
+}
+```
+
+``SteeringEvent/applied(_:)`` identifies instructions included in a
+successful successor prefill. It confirms delivery to the model, not that the
+model followed the instruction. ``SteeringEvent/failed(_:)`` reports
+instructions the response accepted but could not apply, with the original text so
+you can resubmit them. **A steering failure never ends the response**: the output
+already generated is delivered and the stream finishes normally. Only a model,
+tool, or preparation error ends a response. If the stream throws or is cancelled,
+accepted instructions without an outcome must be treated as unresolved; they are
+not replayed automatically.
+
+Stream completion ends the whole response; `.info` is emitted separately for each
+model step.
+
+## Scheduling
+
+- ``SteeringPolicy/nextSafeBoundary`` is the default. Ordinary text stops at the
+  next supported complete text boundary. Partial Unicode, stop-string prefixes,
+  and incomplete tool payloads delay the handoff. The step reports
+  ``GenerateStopReason/steered``.
+- ``SteeringPolicy/nextStepBoundary`` lets the current model step finish
+  naturally. Use it for custom reasoning or output grammars without declared
+  protocol metadata.
+
+Prefill, dispatched tools, configured reasoning models, and framed Harmony/Onyx
+protocols finish their current step even with `.nextSafeBoundary`. Steering does
+not preempt GPU work or undo tool effects. Already emitted text is retained.
+
+Instructions are applied in acceptance order. A pending batch is joined with
+blank lines into one user message to support alternating-role templates. A
+`.nextSafeBoundary` request promotes the whole pending batch. The queue holds at
+most ``SteeringLimits/maxPendingInstructions`` instructions and
+``SteeringLimits/maxPendingBytes`` bytes.
+
+Generation limits apply per model step, as they do for the tool loop. A response
+steered twice can generate up to three times `maxTokens`.
+
+## Tools, cancellation, and cache reuse
+
+With `toolDispatch`, steering waits for all tools from the current step and
+places their results before the new instruction. Automatically dispatched calls
+remain hidden from the public stream, as in ordinary generation. Without a
+dispatcher, ordinary tool handling still works; a pending instruction that needs
+tool results is reported as ``SteeringError/toolResultsRequired`` and the
+response completes with its tool calls. Submit the results with the instruction
+through the normal session message API.
+
+Cancel the stream's consumer task to cancel generation and pending instructions.
+Await ``ChatSession/synchronize()`` to join registered runners and GPU cleanup.
+Tools must cooperate with Swift task cancellation.
+
+The model stays loaded. The session reuses a verified cache prefix and prefills
+the changed suffix when the template and cache permit it. Speculative lookahead
+is finalized before reconciliation. Rewritten templates, unrewindable caches, and
+models that carry per-call state (M-RoPE VLMs) require a rebuild instead.
+Inspect ``GenerateCompletionInfo/cachedPromptTokenCount`` for actual reuse.
+
+Steering accepts text and requires a structured conversation. Ordinary generation
+from a raw restored cache still works; that response reports
+``SteeringError/notSteerable`` and rejects later instructions up front. A model
+step that produced no recordable assistant output cannot establish a new message
+boundary and reports ``SteeringError/emptyResponse``. Local models follow
+instructions through their normal chat templates and weights.
+
+Existing string consumers need no changes. Exhaustive switches over `Generation`
+and `GenerateStopReason` need the new `.steering` and
+`.steered` cases respectively.

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -710,8 +710,8 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// Per-call model state (e.g. M-RoPE rope deltas), seeded from the
     /// initializer's `state`, replaced by prefill, then threaded through
     /// every decode step. A caller continuing this cache later (as
-    /// ``ChatSession`` does across turns) reads it back after
-    /// initialization and seeds the next iterator with it.
+    /// ``ChatSession`` does across turns) reads it back after generation
+    /// and seeds the next iterator with it.
     public internal(set) var state: LMOutput.State?
 
     var y: LMInput.Text
@@ -1738,6 +1738,7 @@ public func generate(
 /// // Process the stream asynchronously to handle text chunks and completion info.
 /// for await generation in stream {
 ///     switch generation {
+///     case .steering: break
 ///     case .chunk(let text):
 ///         print("Generated text: \(text)")
 ///     case .info(let info):
@@ -1793,6 +1794,7 @@ public func generate(
 ///
 /// for await generation in stream {
 ///     switch generation {
+///     case .steering: break
 ///     case .chunk(let text):
 ///         print("Generated text: \(text)")
 ///     case .info(let info):
@@ -1926,8 +1928,9 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
     tokenizer: Tokenizer,
     iterator: consuming TOKEN,
     wiredMemoryTicket: WiredMemoryTicket? = nil,
-    tools: [[String: any Sendable]]? = nil
-) -> (AsyncStream<Generation>, Task<[Int], Never>) {
+    tools: [[String: any Sendable]]? = nil,
+    steering: SteeringControl? = nil
+) -> (AsyncStream<Generation>, Task<RecordedGeneration, Never>) {
     generateLoopTask(
         promptTokenCount: promptTokenCount,
         modelConfiguration: modelConfiguration,
@@ -1935,6 +1938,7 @@ func generateTaskRecordingTokens<TOKEN: TokenIteratorProtocol>(
         iterator: iterator,
         wiredMemoryTicket: wiredMemoryTicket,
         tokenCollector: RecordingGeneratedTokens(),
+        steering: modelConfiguration.allowsEarlySteeringBoundary ? steering : nil,
         handler: TextToolTokenLoopHandler(
             tokenizer: tokenizer,
             stopStrings: modelConfiguration.effectiveStopStrings,
@@ -2266,12 +2270,17 @@ private protocol GeneratedTokenCollector: Sendable {
     associatedtype Result: Sendable
 
     mutating func record(_ token: Int)
-    consuming func result() -> Result
+    consuming func result(state: LMOutput.State?) -> Result
 }
 
 private struct IgnoringGeneratedTokens: GeneratedTokenCollector {
     mutating func record(_ token: Int) {}
-    consuming func result() {}
+    consuming func result(state: LMOutput.State?) {}
+}
+
+struct RecordedGeneration: Sendable {
+    let tokens: [Int]
+    let state: SendableBox<LMOutput.State?>
 }
 
 private struct RecordingGeneratedTokens: GeneratedTokenCollector {
@@ -2281,8 +2290,8 @@ private struct RecordingGeneratedTokens: GeneratedTokenCollector {
         tokens.append(token)
     }
 
-    consuming func result() -> [Int] {
-        tokens
+    consuming func result(state: LMOutput.State?) -> RecordedGeneration {
+        RecordedGeneration(tokens: tokens, state: SendableBox(state))
     }
 }
 
@@ -2316,10 +2325,12 @@ private func generateLoopTask<
     wiredMemoryTicket: WiredMemoryTicket? = nil,
     includeStopToken: Bool = false,
     tokenCollector: consuming Collector,
+    steering: SteeringControl? = nil,
     handler: consuming Handler
 ) -> (AsyncStream<Handler.Output>, Task<Collector.Result, Never>) {
     let (stream, continuation) = AsyncStream<Handler.Output>.makeStream()
 
+    let executionStream = StreamOrDevice.default.stream
     let iterator = SendableBox(iterator)
     let handler = SendableBox(handler)
     let tokenCollector = consume tokenCollector
@@ -2347,9 +2358,13 @@ private func generateLoopTask<
             // `while let token = iterator.next()` form) allowed one extra asyncEval to be
             // submitted post-cancellation, which faults if the app has backgrounded
             // (kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted). The
-            // post-loop block below assigns `.cancelled`; Stream().synchronize() still
+            // post-loop block below assigns `.cancelled`; the captured execution stream still
             // settles any in-flight evaluation at the end of the task body.
             tokenLoop: while !Task.isCancelled {
+                if let steering, handler.canEndForSteering, steering.requestsEarlyBoundary {
+                    stopReason = .steered
+                    break
+                }
                 guard let token = autoreleasepool(invoking: { iterator.next() }) else { break }
                 tokenCollector.record(token)
 
@@ -2442,12 +2457,12 @@ private func generateLoopTask<
             _ = continuation.yield(handler.infoEvent(info))
 
             // Synchronize with the stream to ensure tasks are completed
-            Stream().synchronize()
+            executionStream.synchronize()
 
             // Finalize the stream
             continuation.finish()
 
-            return tokenCollector.result()
+            return tokenCollector.result(state: iterator.state)
         }
 
         if let ticket = wiredMemoryTicket {
@@ -2485,6 +2500,10 @@ public enum GenerateStopReason: Sendable {
 
     /// Generation stopped because the configured max token limit was reached.
     case length
+
+    /// This model step ended at a supported boundary to apply pending steering.
+    /// The owning chat turn continues with the additional user input.
+    case steered
 
     /// Generation stopped due to explicit task cancellation or early stream termination.
     case cancelled
@@ -2627,6 +2646,7 @@ public struct GenerateCompletionInfo: Sendable {
 /// - `.toolCall`: A tool call parsed from the generated output.
 /// - `.rejectedToolCall`: Tool-call-shaped output that was not executable.
 /// - `.info`: Metadata and performance statistics about the generation process.
+/// - `.steering`: The outcome of accepted steering instructions.
 public enum Generation: Sendable {
     /// A generated text chunk as a String.
     case chunk(String)
@@ -2640,9 +2660,13 @@ public enum Generation: Sendable {
     /// A tool-call-shaped model output rejected by parsing or authorization.
     case rejectedToolCall(RejectedToolCall)
 
+    /// The outcome of steering instructions submitted to a chat session.
+    case steering(SteeringEvent)
+
     /// Generated text or nil
     public var chunk: String? {
         switch self {
+        case .steering: nil
         case .chunk(let string): string
         case .info: nil
         case .toolCall: nil
@@ -2653,6 +2677,7 @@ public enum Generation: Sendable {
     /// Completion info or nil
     public var info: GenerateCompletionInfo? {
         switch self {
+        case .steering: nil
         case .chunk: nil
         case .info(let info): info
         case .toolCall: nil
@@ -2663,6 +2688,7 @@ public enum Generation: Sendable {
     /// Tool call or nil
     public var toolCall: ToolCall? {
         switch self {
+        case .steering: nil
         case .chunk: nil
         case .info: nil
         case .toolCall(let toolCall): toolCall
@@ -2673,10 +2699,19 @@ public enum Generation: Sendable {
     /// Rejected tool call or nil.
     public var rejectedToolCall: RejectedToolCall? {
         switch self {
+        case .steering: nil
         case .chunk: nil
         case .info: nil
         case .toolCall: nil
         case .rejectedToolCall(let rejection): rejection
+        }
+    }
+
+    /// Steering event or nil.
+    public var steering: SteeringEvent? {
+        switch self {
+        case .steering(let event): event
+        default: nil
         }
     }
 
@@ -2756,6 +2791,7 @@ private protocol TokenLoopHandler {
     /// Whether semantic parsing needs to observe EOS tokens even though they
     /// are not included in the public output or generation token count.
     var receivesStopTokens: Bool { get }
+    var canEndForSteering: Bool { get }
 
     /// Return `.stop` for semantic generation stops, or `.cancelled` for consumer termination.
     mutating func onToken(
@@ -2779,6 +2815,7 @@ private protocol TokenLoopHandler {
 }
 
 extension TokenLoopHandler {
+    var canEndForSteering: Bool { false }
     var additionalStopTokenIDs: Set<Int> { [] }
     var receivesStopTokens: Bool { false }
 }
@@ -2789,6 +2826,12 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
     private static let logger = Logger(
         subsystem: "mlx-swift-lm", category: "TokenStreamProtocol")
     private var decoder: any TokenStreamDecoder
+    private var hasResponse = false
+    private var hasNonTextOutput = false
+
+    var canEndForSteering: Bool {
+        hasResponse && !hasNonTextOutput && decoder.canEndForSteering
+    }
 
     init(
         tokenizer: Tokenizer, stopStrings: Set<String> = [], format: ToolCallFormat,
@@ -2862,22 +2905,26 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler {
             return .more
 
         case .response(let response):
+            hasResponse = hasResponse || !response.isEmpty
             if case .terminated = emit(.chunk(response)) {
                 return .cancelled
             }
             return .more
 
         case .toolCall(let toolCall):
+            hasNonTextOutput = true
             if case .terminated = emit(.toolCall(toolCall)) {
                 return .cancelled
             }
             return .more
 
         case .protocolError(let message):
+            hasNonTextOutput = true
             Self.logger.error("\(message)")
             return .more
 
         case .rejectedToolCall(let rejection):
+            hasNonTextOutput = true
             if case .terminated = emit(.rejectedToolCall(rejection)) {
                 return .cancelled
             }

--- a/Libraries/MLXLMCommon/ModelConfiguration.swift
+++ b/Libraries/MLXLMCommon/ModelConfiguration.swift
@@ -121,6 +121,16 @@ public struct ModelConfiguration: Sendable {
     /// Reasoning (chain-of-thought) protocol for this model (nil = non-reasoning model)
     public var reasoningConfig: ReasoningConfig? = nil
 
+    /// Whether a complete text boundary in this model's stream is a safe place
+    /// to end a step for ``ChatSession/steer(_:policy:response:)``.
+    ///
+    /// A declared reasoning model streams its chain of thought as ordinary text,
+    /// so an early boundary could split a reasoning block. Those models take
+    /// their natural step boundary instead.
+    package var allowsEarlySteeringBoundary: Bool {
+        reasoningConfig == nil
+    }
+
     /// How to choose which safetensors files in the model directory hold the model's weights.
     ///
     /// The default, ``WeightFileSelection/automatic``, handles a well-packaged checkpoint and

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -179,6 +179,7 @@ public final class ModelContainer: Sendable {
     /// let stream = try modelContainer.generate(input: input, parameters: parameters)
     /// for await generation in stream {
     ///     switch generation {
+    ///     case .steering: break
     ///     case .chunk(let text): print(text)
     ///     case .info(let info): print(info.tokensPerSecond)
     ///     case .toolCall(let call): handleToolCall(call)

--- a/Libraries/MLXLMCommon/Steering.swift
+++ b/Libraries/MLXLMCommon/Steering.swift
@@ -1,0 +1,298 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// The outcome of steering instructions accepted by a chat session.
+public enum SteeringEvent: Sendable, Equatable {
+    /// Instructions included in the next model step's prefill, in acceptance order.
+    case applied([UUID])
+
+    /// Instructions that could not be applied. The response continues normally.
+    case failed(SteeringFailure)
+}
+
+/// When a steering instruction may enter the model's context.
+public enum SteeringPolicy: Sendable {
+    /// End decoding at the first supported text boundary. Prefill, tools,
+    /// reasoning models, and framed protocols finish their step.
+    case nextSafeBoundary
+    /// Allow the current model step and dispatched tools to finish.
+    case nextStepBoundary
+}
+
+/// Limits on steering input pending for one response.
+///
+/// Exceeding either limit throws ``SteeringError/queueFull``. The pending batch
+/// is cleared when a model step applies it, so a response can accept more
+/// instructions after each ``SteeringEvent/applied(_:)``.
+public enum SteeringLimits: Sendable {
+    /// Instructions that may be pending at once.
+    public static let maxPendingInstructions = 32
+    /// UTF-8 bytes that may be pending at once.
+    public static let maxPendingBytes = 64 * 1024
+}
+
+/// Why a steering instruction was not accepted or not applied.
+///
+/// ``ChatSession/steer(_:policy:response:)`` throws the acceptance failures. Application
+/// failures arrive as ``SteeringEvent/failed(_:)`` and never end the
+/// response that was running.
+public enum SteeringError: LocalizedError, Sendable, Equatable {
+    /// Instructions must contain non-whitespace text.
+    case emptyInstruction
+    /// The pending instruction count or UTF-8 byte limit would be exceeded.
+    case queueFull
+    /// The session has no response accepting instructions.
+    case noActiveResponse
+    /// The response ended before the instruction could be applied.
+    case responseEnded
+    /// This response cannot be steered. A session restored from a raw cache has
+    /// no transcript to continue from.
+    case notSteerable
+    /// The model step produced no assistant output to continue from: it was
+    /// empty, cancelled, or produced only a rejected tool call.
+    case emptyResponse
+    /// Supply `toolDispatch` to continue tool calls within a response.
+    case toolResultsRequired
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyInstruction: "A steering instruction must contain text."
+        case .queueFull: "The pending steering queue is full."
+        case .noActiveResponse: "This session has no response accepting steering."
+        case .responseEnded: "The response ended before this instruction was applied."
+        case .notSteerable: "Steering requires a structured conversation history."
+        case .emptyResponse: "The model produced no assistant output to continue from."
+        case .toolResultsRequired:
+            "Configure toolDispatch to continue tool calls within this response."
+        }
+    }
+}
+
+/// A steering instruction that was accepted but not applied.
+///
+/// Carries the original text so a client can resubmit it. Delivered through
+/// ``SteeringEvent/failed(_:)``; the response itself continues.
+public struct SteeringFailure: Sendable, Equatable {
+    /// Acceptance IDs returned by ``ChatSession/steer(_:policy:response:)``.
+    public let ids: [UUID]
+    /// The instruction text, in acceptance order.
+    public let instructions: [String]
+    /// Why the instructions were not applied.
+    public let reason: SteeringError
+
+    package init(ids: [UUID], instructions: [String], reason: SteeringError) {
+        self.ids = ids
+        self.instructions = instructions
+        self.reason = reason
+    }
+}
+
+/// All mutable state is protected by `lock`; no MLX arrays cross this mailbox.
+/// Only the session runner drains it. Task cancellation and joining happen outside the lock.
+final class SteeringControl: @unchecked Sendable {
+    struct Request: Sendable {
+        let id: UUID
+        let text: String
+    }
+
+    /// Stable identity for the response this mailbox belongs to.
+    let responseID = ChatSession.ResponseID(rawValue: UUID())
+
+    private let lock = NSLock()
+    private var pending: [Request] = []
+    private var pendingBytes = 0
+    private var early = false
+    private var closed = false
+    private var cancelled = false
+    private var finished = false
+    private var steerable = true
+    private var worker: Task<Void, Never>?
+
+    /// Accepts an instruction, or throws the reason it cannot be accepted.
+    ///
+    /// The caller has already rejected whitespace-only text so that an invalid
+    /// instruction fails the same way whatever the session is doing.
+    func enqueue(_ text: String, policy: SteeringPolicy) throws -> UUID {
+        let bytes = text.utf8.count
+        return try lock.withLock {
+            guard !closed else { throw SteeringError.responseEnded }
+            guard steerable else { throw SteeringError.notSteerable }
+            guard pending.count < SteeringLimits.maxPendingInstructions,
+                bytes <= SteeringLimits.maxPendingBytes - pendingBytes
+            else {
+                throw SteeringError.queueFull
+            }
+            let id = UUID()
+            pending.append(Request(id: id, text: text))
+            pendingBytes += bytes
+            if case .nextSafeBoundary = policy { early = true }
+            return id
+        }
+    }
+
+    var requestsEarlyBoundary: Bool {
+        lock.withLock { early && !closed }
+    }
+
+    /// Whether this response can still accept instructions.
+    var isOpen: Bool {
+        lock.withLock { !closed && steerable }
+    }
+
+    /// Whether this response has completed, failed, or been cancelled.
+    var isClosed: Bool {
+        lock.withLock { closed }
+    }
+
+    /// Records whether this response has the structured history steering needs.
+    /// Returns instructions accepted before the answer was known so the runner
+    /// can report them as failed.
+    func setSteerable(_ value: Bool) -> [Request] {
+        lock.withLock {
+            steerable = value
+            guard !value else { return [] }
+            let orphaned = pending
+            pending.removeAll(keepingCapacity: true)
+            pendingBytes = 0
+            early = false
+            return orphaned
+        }
+    }
+
+    /// Atomically resolve the last-input/completion race. A producer either
+    /// joins the next step or observes a closed response.
+    func take(closeIfEmpty: Bool) throws -> [Request] {
+        try lock.withLock {
+            if cancelled { throw CancellationError() }
+            let batch = pending
+            pending.removeAll(keepingCapacity: true)
+            pendingBytes = 0
+            early = false
+            if closeIfEmpty && batch.isEmpty { closed = true }
+            return batch
+        }
+    }
+
+    /// Close acceptance and return remaining instructions in one operation.
+    func closeAndTake() throws -> [Request] {
+        try lock.withLock {
+            if cancelled { throw CancellationError() }
+            closed = true
+            let batch = pending
+            pending.removeAll()
+            pendingBytes = 0
+            early = false
+            return batch
+        }
+    }
+
+    func setTask(_ task: Task<Void, Never>) {
+        let shouldCancel = lock.withLock {
+            if !finished { worker = task }
+            return cancelled
+        }
+        if shouldCancel { task.cancel() }
+    }
+
+    func cancel() {
+        let task = lock.withLock {
+            guard !closed else { return nil as Task<Void, Never>? }
+            cancelled = true
+            closed = true
+            pending.removeAll()
+            pendingBytes = 0
+            early = false
+            return worker
+        }
+        task?.cancel()
+    }
+
+    func synchronize() async {
+        let task = lock.withLock { worker }
+        await task?.value
+    }
+
+    func finish() {
+        lock.withLock {
+            closed = true
+            pending.removeAll()
+            pendingBytes = 0
+            early = false
+            finished = true
+            worker = nil
+        }
+    }
+}
+
+/// Tracks requests without acquiring the cache lock held during inference.
+/// All mutable state is protected by `lock`. Never calls into `SteeringControl`
+/// while holding `lock`, so the two locks cannot deadlock.
+final class SessionSteering: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [SteeringControl] = []
+    private var active: SteeringControl?
+
+    func register(_ control: SteeringControl) {
+        lock.withLock { requests.append(control) }
+    }
+
+    func start(_ control: SteeringControl) {
+        lock.withLock { active = control }
+    }
+
+    func remove(_ control: SteeringControl) {
+        lock.withLock {
+            requests.removeAll { $0 === control }
+            if active === control { active = nil }
+        }
+    }
+
+    /// The most recently created response, whatever its state.
+    var latestResponse: ChatSession.ResponseID? {
+        lock.withLock { requests.last?.responseID }
+    }
+
+    /// Answers the same question `steer` does: whether the response it would
+    /// select accepts instructions.
+    func canSteer(_ response: ChatSession.ResponseID?) -> Bool {
+        candidates(for: response).first { !$0.isClosed }?.isOpen ?? false
+    }
+
+    func steer(_ text: String, policy: SteeringPolicy, response: ChatSession.ResponseID?) throws
+        -> UUID
+    {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw SteeringError.emptyInstruction
+        }
+        var sawEndedResponse = false
+        for control in candidates(for: response) {
+            do {
+                return try control.enqueue(text, policy: policy)
+            } catch SteeringError.responseEnded {
+                // A cancelled or completed response is removed by its runner, which
+                // can lag the event that closed it. Skip it rather than reject input
+                // the session can still deliver.
+                sawEndedResponse = true
+            }
+        }
+        throw sawEndedResponse ? SteeringError.responseEnded : SteeringError.noActiveResponse
+    }
+
+    func synchronize() async {
+        let snapshot = lock.withLock { requests }
+        for control in snapshot { await control.synchronize() }
+    }
+
+    /// One named response, or the cache owner followed by registered responses
+    /// in call order.
+    private func candidates(for response: ChatSession.ResponseID?) -> [SteeringControl] {
+        lock.withLock {
+            if let response {
+                return requests.filter { $0.responseID == response }
+            }
+            guard let active else { return requests }
+            return [active] + requests.filter { $0 !== active }
+        }
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/TokenStreamDecoder.swift
+++ b/Libraries/MLXLMCommon/Tool/TokenStreamDecoder.swift
@@ -35,6 +35,9 @@ package protocol TokenStreamDecoder {
     /// Decoders whose response protocol never rejects tool calls report zero.
     var rejectedToolCallCount: Int { get }
 
+    /// Whether decoding can end here without flushing an incomplete payload.
+    var canEndForSteering: Bool { get }
+
     /// Consumes one generated token. Returns `false` when decoding should stop
     /// because of either a semantic boundary or consumer termination.
     mutating func push(_ token: Int, emit: (TokenStreamEvent) -> Bool) -> Bool
@@ -49,6 +52,7 @@ extension TokenStreamDecoder {
     package var receivesStopTokens: Bool { false }
     package var isInsideReasoning: Bool { false }
     package var rejectedToolCallCount: Int { 0 }
+    package var canEndForSteering: Bool { false }
 }
 
 /// Decoder for ordinary detokenized tool-call syntaxes.
@@ -56,6 +60,7 @@ struct StandardTokenStreamDecoder: TokenStreamDecoder {
     private var detokenizer: NaiveStreamingDetokenizer
     private let toolCallProcessor: ToolCallProcessor
     private var stopStringFilter: StopStringFilter
+    private var hasCompleteText = false
 
     init(
         tokenizer: any Tokenizer,
@@ -70,9 +75,16 @@ struct StandardTokenStreamDecoder: TokenStreamDecoder {
 
     var rejectedToolCallCount: Int { toolCallProcessor.rejectedToolCallCount }
 
+    var canEndForSteering: Bool {
+        hasCompleteText && stopStringFilter.buffer.isEmpty
+            && toolCallProcessor.canEndForSteering
+    }
+
     mutating func push(_ token: Int, emit: (TokenStreamEvent) -> Bool) -> Bool {
         detokenizer.append(token: token)
+        hasCompleteText = false
         guard let chunk = detokenizer.next() else { return true }
+        hasCompleteText = !chunk.isEmpty
 
         let result = stopStringFilter.process(chunk)
         if let text = result.text,

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -95,6 +95,11 @@ public class ToolCallProcessor {
 
     // MARK: - Computed Properties
 
+    var canEndForSteering: Bool {
+        state == .normal && toolCallBuffer.isEmpty && orderedOutputQueue.isEmpty
+            && toolCalls.isEmpty && rejectedToolCallCount == 0
+    }
+
     /// Whether this processor uses inline format (no start tag).
     private var isInlineFormat: Bool {
         parser.startTag == nil

--- a/Tests/MLXLMTests/ChatSessionTests.swift
+++ b/Tests/MLXLMTests/ChatSessionTests.swift
@@ -12,6 +12,505 @@ import XCTest
 /// See also ChatSessionIntegrationTests
 public class ChatSessionTests: XCTestCase {
 
+    private actor SteeringGate {
+        private var open = false
+        private var waiter: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            if !open { await withCheckedContinuation { waiter = $0 } }
+        }
+
+        func release() {
+            open = true
+            waiter?.resume()
+            waiter = nil
+        }
+    }
+
+    private struct GatedSteeringProcessor: UserInputProcessor {
+        let base: TestInputProcessor
+        let ready: AsyncStream<Void>.Continuation
+        let gate: SteeringGate
+        var rejectInstruction: String? = nil
+
+        func prepare(input: UserInput) async throws -> LMInput {
+            ready.yield(())
+            await gate.wait()
+            try Task.checkCancellation()
+            if let rejectInstruction, case .chat(let chat) = input.prompt,
+                chat.last?.content == rejectInstruction
+            {
+                throw SteeringTestError.preparationFailed
+            }
+            return try base.prepare(input: input)
+        }
+    }
+
+    private actor SteeringGateSequence {
+        let gates: [SteeringGate]
+        var step = 0
+
+        init(_ gates: [SteeringGate]) { self.gates = gates }
+
+        func next() -> SteeringGate {
+            defer { step += 1 }
+            return gates[step]
+        }
+    }
+
+    private struct SteppedSteeringProcessor: UserInputProcessor {
+        let base: TestInputProcessor
+        let ready: AsyncStream<Void>.Continuation
+        let gates: SteeringGateSequence
+
+        func prepare(input: UserInput) async throws -> LMInput {
+            let gate = await gates.next()
+            ready.yield(())
+            await gate.wait()
+            try Task.checkCancellation()
+            return try base.prepare(input: input)
+        }
+    }
+
+    func testSteeringReusesPrefixAndKeepsOneTurn() async throws {
+        try await checkSteering(policy: .nextSafeBoundary, speculative: false)
+    }
+
+    func testQueuedSteeringFinishesCurrentStep() async throws {
+        try await checkSteering(policy: .nextStepBoundary, speculative: false)
+    }
+
+    func testSteeringFinalizesSpeculativeLookahead() async throws {
+        try await checkSteering(policy: .nextSafeBoundary, speculative: true)
+    }
+
+    func testSteeringRebuildsWhenTemplateRewritesPrefix() async throws {
+        try await checkSteering(policy: .nextSafeBoundary, speculative: false, rewritePrefix: true)
+    }
+
+    private func checkSteering(
+        policy: SteeringPolicy, speculative: Bool, rewritePrefix: Bool = false
+    ) async throws {
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let (lengths, lengthContinuation) = AsyncStream<Int>.makeStream()
+        let (messages, messageContinuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let gate = SteeringGate()
+        let tokenizer = PrefixPreservingTokenizer(
+            renderedLengthContinuation: lengthContinuation,
+            rewritesPrefixOnContinuation: rewritePrefix)
+        let configuration = ModelConfiguration(id: "steering-test")
+        let base = TestInputProcessor(
+            tokenizer: tokenizer, configuration: configuration,
+            messageGenerator: RecordingMessageGenerator(continuation: messageContinuation))
+        let processor = GatedSteeringProcessor(base: base, ready: readyContinuation, gate: gate)
+        let context = Self.makeModel(
+            processor: processor, configuration: configuration, tokenizer: tokenizer)
+        let draft = speculative ? ModelContainer(context: model(processor: base)) : nil
+        let session = ChatSession(
+            context,
+            speculativeDecoding: draft.map { SpeculativeDecodingConfig(draftModel: $0) },
+            generateParameters: GenerateParameters(maxTokens: 8, temperature: 0),
+            components: GenerationComponents {
+                ForceTokenSequenceProcessor(state: TokenSequenceState(tokens: [7]))
+            })
+        let stream = session.streamDetails(to: "original task")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        let first = try session.steer("keep the original task", policy: policy)
+        let second = try session.steer("also include tests", policy: policy)
+        await gate.release()
+
+        var infos: [GenerateCompletionInfo] = []
+        var applied: [UUID] = []
+        for try await event in stream {
+            switch event {
+            case .info(let info): infos.append(info)
+            case .steering(.applied(let ids)):
+                XCTAssertEqual(infos.count, 1)
+                applied += ids
+            default: break
+            }
+        }
+        XCTAssertEqual(applied, [first, second])
+        XCTAssertEqual(infos.count, 2)
+        guard infos.count == 2 else { return }
+        if case .nextSafeBoundary = policy {
+            XCTAssertEqual(infos[0].stopReason, .steered)
+            XCTAssertEqual(infos[0].generationTokenCount, 1)
+        } else {
+            XCTAssertEqual(infos[0].stopReason, .length)
+            XCTAssertEqual(infos[0].generationTokenCount, 8)
+        }
+        XCTAssertEqual(infos[1].stopReason, .length)
+        XCTAssertEqual(
+            infos[1].cachedPromptTokenCount,
+            rewritePrefix ? 0 : infos[0].promptTokenCount + infos[0].generationTokenCount)
+        var lengthIterator = lengths.makeAsyncIterator()
+        _ = await lengthIterator.next()
+        let secondLength = await lengthIterator.next()
+        XCTAssertEqual(infos[1].totalPromptTokenCount, secondLength)
+        var messageIterator = messages.makeAsyncIterator()
+        _ = await messageIterator.next()
+        let rendered = await messageIterator.next()
+        XCTAssertEqual(rendered?.map(\.role), [.user, .assistant, .user])
+        XCTAssertEqual(rendered?.first?.content, "original task")
+        XCTAssertEqual(rendered?.last?.content, "keep the original task\n\nalso include tests")
+        XCTAssertFalse(session.canSteer())
+        XCTAssertThrowsError(try session.steer("too late")) {
+            XCTAssertEqual($0 as? SteeringError, .noActiveResponse)
+        }
+        // Subsequent calls reuse the same cache after all speculative cleanup.
+        let followup = try await collectGeneration(session.streamDetails(to: "next turn"))
+        XCTAssertEqual(followup.info.generationTokenCount, 8)
+        if !speculative { XCTAssertGreaterThan(followup.info.cachedPromptTokenCount, 0) }
+    }
+
+    func testSteeringDuringToolDispatchWaitsForResult() async throws {
+        let output = "{\"name\":\"weather\",\"arguments\":{}}"
+        let tokenizer = LiteralTokenizer(output: output + "done")
+        let configuration = ModelConfiguration(
+            id: "steering-tool-test", eosTokenIds: [99], toolCallFormat: .json)
+        let (messages, messageContinuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let base = TestInputProcessor(
+            tokenizer: tokenizer, configuration: configuration,
+            messageGenerator: RecordingMessageGenerator(continuation: messageContinuation))
+        let calls = TokenSequenceState(tokens: [0, 1])
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let gate = SteeringGate()
+        let session = ChatSession(
+            model(processor: base),
+            generateParameters: GenerateParameters(maxTokens: 100, temperature: 0),
+            components: GenerationComponents {
+                let text = calls.current == 0 ? output : "done"
+                calls.advance()
+                return ForceTokenSequenceProcessor(
+                    state: TokenSequenceState(tokens: tokenizer.tokens(for: text) + [99]))
+            },
+            toolDispatch: { _ in
+                readyContinuation.yield(())
+                await gate.wait()
+                try Task.checkCancellation()
+                return "sunny"
+            })
+        let stream = session.streamDetails(to: "weather please")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        let id = try session.steer("give temperatures in Celsius")
+        await gate.release()
+        var applied: [UUID] = []
+        var toolCount = 0
+        var infos: [GenerateCompletionInfo] = []
+        for try await event in stream {
+            switch event {
+            case .steering(.applied(let ids)): applied += ids
+            case .toolCall: toolCount += 1
+            case .info(let info): infos.append(info)
+            default: break
+            }
+        }
+        XCTAssertEqual(toolCount, 0)
+        XCTAssertEqual(applied, [id])
+        XCTAssertEqual(infos.count, 2)
+        XCTAssertTrue(infos.allSatisfy { $0.stopReason == .stop })
+        var messageIterator = messages.makeAsyncIterator()
+        _ = await messageIterator.next()
+        let rendered = await messageIterator.next()
+        XCTAssertEqual(rendered?.map(\.role), [.user, .assistant, .tool, .user])
+        XCTAssertEqual(rendered?[2].content, "sunny")
+        XCTAssertEqual(rendered?.last?.content, "give temperatures in Celsius")
+    }
+
+    func testFailedSteeringPreparationRetainsCompletedToolResult() async throws {
+        let output = "{\"name\":\"weather\",\"arguments\":{}}"
+        let tokenizer = LiteralTokenizer(output: output + "done")
+        let configuration = ModelConfiguration(
+            id: "steering-tool-failure-test", eosTokenIds: [99], toolCallFormat: .json)
+        let (messages, messageContinuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let base = TestInputProcessor(
+            tokenizer: tokenizer, configuration: configuration,
+            messageGenerator: RecordingMessageGenerator(continuation: messageContinuation))
+        let prepareGate = SteeringGate()
+        await prepareGate.release()
+        let processor = GatedSteeringProcessor(
+            base: base, ready: AsyncStream<Void>.makeStream().continuation,
+            gate: prepareGate, rejectInstruction: "fail preparation")
+        let context = Self.makeModel(
+            processor: processor, configuration: configuration, tokenizer: tokenizer)
+        let calls = TokenSequenceState(tokens: [0, 1])
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let toolGate = SteeringGate()
+        let session = ChatSession(
+            context, generateParameters: GenerateParameters(maxTokens: 100, temperature: 0),
+            components: GenerationComponents {
+                let text = calls.current == 0 ? output : "done"
+                calls.advance()
+                return ForceTokenSequenceProcessor(
+                    state: TokenSequenceState(tokens: tokenizer.tokens(for: text) + [99]))
+            },
+            toolDispatch: { _ in
+                readyContinuation.yield(())
+                await toolGate.wait()
+                return "sunny"
+            })
+        let stream = session.streamDetails(to: "weather please")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        try session.steer("fail preparation")
+        await toolGate.release()
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected preparation failure")
+        } catch SteeringTestError.preparationFailed {
+        }
+        _ = try await session.respond(to: "recover")
+        var messageIterator = messages.makeAsyncIterator()
+        _ = await messageIterator.next()
+        let recovered = await messageIterator.next()
+        XCTAssertEqual(recovered?.map(\.role), [.user, .assistant, .tool, .user])
+        XCTAssertEqual(recovered?[2].content, "sunny")
+        XCTAssertEqual(recovered?.last?.content, "recover")
+    }
+
+    /// Manual tool handling is a supported pattern. An instruction that needs
+    /// results the session cannot produce is reported, and the caller keeps the
+    /// tool call it asked for.
+    func testUnappliedSteeringReportsFailureAndKeepsTheResponse() async throws {
+        let session = rejectionSession(output: "{\"name\":\"weather\",\"arguments\":{}}")
+        let stream = session.streamDetails(to: "weather please")
+        let id = try session.steer("also explain the forecast")
+        var toolCount = 0
+        var failures: [SteeringFailure] = []
+        for try await event in stream {
+            if case .toolCall = event { toolCount += 1 }
+            if case .steering(.failed(let failure)) = event { failures.append(failure) }
+        }
+        XCTAssertEqual(toolCount, 1)
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(failures.first?.ids, [id])
+        XCTAssertEqual(failures.first?.instructions, ["also explain the forecast"])
+        XCTAssertEqual(failures.first?.reason, .toolResultsRequired)
+        XCTAssertThrowsError(try session.steer("late"))
+    }
+
+    func testSessionWithoutTranscriptRejectsSteeringUpFront() async throws {
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let gate = SteeringGate()
+        let base = TestInputProcessor()
+        let processor = GatedSteeringProcessor(base: base, ready: readyContinuation, gate: gate)
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(
+            context, cache: try context.model.newCache(parameters: nil),
+            generateParameters: GenerateParameters(maxTokens: 3))
+        let stream = session.streamDetails(to: "hello")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        XCTAssertFalse(session.canSteer())
+        XCTAssertThrowsError(try session.steer("more detail")) {
+            XCTAssertEqual($0 as? SteeringError, .notSteerable)
+        }
+        await gate.release()
+        var text = ""
+        for try await event in stream {
+            if let chunk = event.chunk { text += chunk }
+            if case .steering = event { XCTFail("No instruction was accepted") }
+        }
+        XCTAssertFalse(text.isEmpty)
+    }
+
+    func testChainedSteeringAddsOneStepPerInstruction() async throws {
+        let (messages, messageContinuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let gates = [SteeringGate(), SteeringGate(), SteeringGate()]
+        await gates[2].release()
+        let base = TestInputProcessor(
+            tokenizer: TestTokenizer(), configuration: ModelConfiguration(id: "chained"),
+            messageGenerator: RecordingMessageGenerator(continuation: messageContinuation))
+        let processor = SteppedSteeringProcessor(
+            base: base, ready: readyContinuation, gates: SteeringGateSequence(gates))
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(context, generateParameters: GenerateParameters(maxTokens: 4))
+        let stream = session.streamDetails(to: "start")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        let first = try session.steer("more 1", policy: .nextStepBoundary)
+        await gates[0].release()
+        _ = await readyIterator.next()
+        let second = try session.steer("more 2", policy: .nextStepBoundary)
+        await gates[1].release()
+
+        var infos: [GenerateCompletionInfo] = []
+        var applied: [UUID] = []
+        for try await event in stream {
+            if let info = event.info { infos.append(info) }
+            if case .steering(.applied(let ids)) = event { applied += ids }
+        }
+        XCTAssertEqual(applied, [first, second])
+        XCTAssertEqual(infos.count, 3)
+        XCTAssertEqual(infos.map(\.generationTokenCount), [4, 4, 4])
+        var messageIterator = messages.makeAsyncIterator()
+        _ = await messageIterator.next()
+        _ = await messageIterator.next()
+        let rendered = await messageIterator.next()
+        XCTAssertEqual(rendered?.map(\.role), [.user, .assistant, .user, .assistant, .user])
+        XCTAssertEqual(rendered?.last?.content, "more 2")
+    }
+
+    func testLatestResponseTargetsExactlyOneResponse() async throws {
+        let gate = SteeringGate()
+        let base = TestInputProcessor()
+        let processor = GatedSteeringProcessor(
+            base: base, ready: AsyncStream<Void>.makeStream().continuation, gate: gate)
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(context, generateParameters: GenerateParameters(maxTokens: 3))
+        XCTAssertNil(session.latestResponse)
+        let first = session.streamDetails(to: "first")
+        let firstID = session.latestResponse
+        let second = session.streamDetails(to: "second")
+        let secondID = session.latestResponse
+        XCTAssertNotNil(firstID)
+        XCTAssertNotEqual(firstID, secondID)
+
+        var appliedToSecond: [UUID] = []
+        let id = try session.steer("only the second", response: secondID)
+        await gate.release()
+        for try await _ in first {}
+        for try await event in second {
+            if case .steering(.applied(let ids)) = event { appliedToSecond += ids }
+        }
+        XCTAssertEqual(appliedToSecond, [id])
+    }
+
+    @MainActor
+    func testActorOwnedRespondAcceptsSteering() async throws {
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let gate = SteeringGate()
+        let base = TestInputProcessor()
+        let processor = GatedSteeringProcessor(base: base, ready: readyContinuation, gate: gate)
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(
+            context, generateParameters: GenerateParameters(maxTokens: 3),
+            components: GenerationComponents {
+                ForceTokenSequenceProcessor(state: TokenSequenceState(tokens: [7]))
+            })
+        let response = Task { @MainActor in try await session.respond(to: "original") }
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        try session.steer("continue", policy: .nextStepBoundary)
+        await gate.release()
+        let text = try await response.value
+        await session.synchronize()
+        XCTAssertEqual(
+            text, String(repeating: base.tokenizer.decode(tokenIds: [7, 7, 7]), count: 2))
+    }
+
+    func testSteeringKeepsStandardStringStream() async throws {
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let gate = SteeringGate()
+        let base = TestInputProcessor()
+        let processor = GatedSteeringProcessor(base: base, ready: readyContinuation, gate: gate)
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(
+            context, generateParameters: GenerateParameters(maxTokens: 3),
+            components: GenerationComponents {
+                ForceTokenSequenceProcessor(state: TokenSequenceState(tokens: [7]))
+            })
+        let stream = session.streamResponse(to: "original")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        try session.steer("continue", policy: .nextStepBoundary)
+        await gate.release()
+        var response = ""
+        for try await chunk in stream { response += chunk }
+        XCTAssertEqual(
+            response, String(repeating: base.tokenizer.decode(tokenIds: [7, 7, 7]), count: 2))
+        XCTAssertThrowsError(try session.steer("late"))
+    }
+
+    func testUnsteeredResponseStillSupportsManualTools() async throws {
+        let session = rejectionSession(output: "{\"name\":\"weather\",\"arguments\":{}}")
+        var calls = 0
+        for try await event in session.streamDetails(to: "weather please") {
+            if case .toolCall = event { calls += 1 }
+            if case .steering(.applied) = event { XCTFail("No instruction was submitted") }
+        }
+        XCTAssertEqual(calls, 1)
+    }
+
+    private enum SteeringTestError: Error { case preparationFailed }
+
+    func testFailedSteeringPreparationPreservesCommittedConversation() async throws {
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let (messages, messageContinuation) = AsyncStream<[RecordedMessage]>.makeStream()
+        let gate = SteeringGate()
+        let base = TestInputProcessor(
+            tokenizer: TestTokenizer(), configuration: ModelConfiguration(id: "test"),
+            messageGenerator: RecordingMessageGenerator(continuation: messageContinuation))
+        let processor = GatedSteeringProcessor(
+            base: base, ready: readyContinuation, gate: gate, rejectInstruction: "fail preparation")
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(context, generateParameters: GenerateParameters(maxTokens: 3))
+        let stream = session.streamDetails(to: "original")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        try session.steer("fail preparation")
+        await gate.release()
+        do {
+            for try await event in stream {
+                if case .steering(.applied) = event { XCTFail("Failed input cannot be applied") }
+            }
+            XCTFail("Expected preparation failure")
+        } catch SteeringTestError.preparationFailed {
+        }
+        _ = try await session.respond(to: "recover")
+        var messageIterator = messages.makeAsyncIterator()
+        _ = await messageIterator.next()
+        let recovered = await messageIterator.next()
+        XCTAssertEqual(recovered?.map(\.role), [.user, .assistant, .user])
+        XCTAssertEqual(recovered?.first?.content, "original")
+        XCTAssertEqual(recovered?.last?.content, "recover")
+        XCTAssertThrowsError(try session.steer("too late"))
+    }
+
+    func testCancelAndJoinTurnBeforeRunnerStarts() async throws {
+        let session = ChatSession(model(), generateParameters: GenerateParameters(maxTokens: 3))
+        let stream = session.streamDetails(to: "cancel immediately")
+        let consumer = Task { for try await _ in stream {} }
+        consumer.cancel()
+        _ = await consumer.result
+        await session.synchronize()
+        XCTAssertThrowsError(try session.steer("late"))
+        let result = try await session.respond(to: "new task")
+        XCTAssertFalse(result.isEmpty)
+    }
+
+    func testCancelSteerableTurnWhilePreparingThenReuseSession() async throws {
+        let (ready, readyContinuation) = AsyncStream<Void>.makeStream()
+        let gate = SteeringGate()
+        let base = TestInputProcessor()
+        let processor = GatedSteeringProcessor(base: base, ready: readyContinuation, gate: gate)
+        let context = Self.makeModel(
+            processor: processor, configuration: base.configuration, tokenizer: base.tokenizer)
+        let session = ChatSession(context, generateParameters: GenerateParameters(maxTokens: 3))
+        let stream = session.streamDetails(to: "cancel me")
+        var readyIterator = ready.makeAsyncIterator()
+        _ = await readyIterator.next()
+        try session.steer("pending instruction")
+        let consumer = Task { for try await _ in stream {} }
+        consumer.cancel()
+        _ = await consumer.result
+        await gate.release()
+        await session.synchronize()
+        XCTAssertThrowsError(try session.steer("late"))
+        let result = try await session.respond(to: "new task")
+        XCTAssertFalse(result.isEmpty)
+    }
+
     private struct RecordedMessage: Equatable, Sendable {
         var role: Chat.Message.Role
         var content: String
@@ -271,6 +770,59 @@ public class ChatSessionTests: XCTestCase {
         func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
             try inner.newCache(parameters: parameters)
         }
+    }
+
+    /// Advances its state on every decode step, not just on prefill. A session
+    /// must carry the state the model actually ended on.
+    private final class DecodeStateAdvancingModel: Module, LanguageModel, KVCacheDimensionProvider {
+        static let stepKey = LMOutput.Key<MLXArray>("test.decodeSteps")
+
+        @ModuleInfo var inner: Gemma3TextModel
+
+        var kvHeads: [Int] { (inner as? KVCacheDimensionProvider)?.kvHeads ?? [] }
+
+        init(_ inner: Gemma3TextModel) {
+            self.inner = inner
+        }
+
+        private func batched(_ tokens: MLXArray) -> MLXArray {
+            tokens.ndim == 1 ? tokens[.newAxis, 0...] : tokens
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], state: LMOutput.State?, prefill: PrefillParameters
+        ) throws -> PrepareResult {
+            let logits = inner(batched(input.text.tokens), cache: cache.isEmpty ? nil : cache)
+            var produced = LMOutput.State()
+            produced[Self.stepKey] = state?[Self.stepKey] ?? MLXArray([Int32(0)])
+            let total = input.text.tokens.dim(-1)
+            prefill.progress?(total, total)
+            return .logits(LMOutput(logits: logits, state: produced))
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            var advanced = LMOutput.State()
+            advanced[Self.stepKey] = (state?[Self.stepKey] ?? MLXArray([Int32(0)])) + 1
+            return LMOutput(logits: inner(batched(input.tokens), cache: cache), state: advanced)
+        }
+
+        func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+            try inner.newCache(parameters: parameters)
+        }
+    }
+
+    private static func makeDecodeStateAdvancingModel() -> ModelContext {
+        let base = makeModel()
+        guard let inner = base.model as? Gemma3TextModel else {
+            fatalError("expected the test model to be a Gemma3TextModel")
+        }
+        return .init(
+            configuration: base.configuration,
+            model: DecodeStateAdvancingModel(inner),
+            processor: base.processor,
+            tokenizer: base.tokenizer)
     }
 
     private static func makeStateProducingModel() -> ModelContext {
@@ -1778,9 +2330,31 @@ public class ChatSessionTests: XCTestCase {
             "the session dropped the model state produced by its turns")
     }
 
-    /// The end-to-end path the snapshot API exists for: a session that carries
-    /// model state saves it with its cache, and a new session restored from
-    /// that snapshot keeps generating.
+    /// Preserve the final decode state for the next model step.
+    func testSessionCarriesStateProducedWhileDecoding() async throws {
+        let session = ChatSession(
+            Self.makeDecodeStateAdvancingModel(),
+            generateParameters: GenerateParameters(maxTokens: 4))
+
+        func decodeSteps() async throws -> Int32? {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            try await session.saveCache(to: url)
+            return try loadPromptCacheSnapshot(url: url)
+                .state?[DecodeStateAdvancingModel.stepKey]?.item(Int32.self)
+        }
+
+        _ = try await session.respond(to: "first")
+        // Post-prefill state is 0; each of the four decode steps adds one. Storing
+        // the post-prefill value would leave this at 0 and re-anchor the next step
+        // to a position the model has already moved past.
+        let carried = try await decodeSteps()
+        XCTAssertEqual(carried, 4)
+    }
+
+    /// A session restored from a snapshot preserves the model state and cache.
     func testStateProducingSessionSurvivesSaveAndRestore() async throws {
         let context = Self.makeStateProducingModel()
         let session = ChatSession(context, generateParameters: generationParameters)

--- a/Tests/MLXLMTests/SteeringTests.swift
+++ b/Tests/MLXLMTests/SteeringTests.swift
@@ -1,0 +1,373 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLXLMCommon
+
+final class SteeringTests: XCTestCase {
+    private struct FinalizingIterator: GenerationFinalizingTokenIterator {
+        let tokens: [Int]
+        var onNext: @Sendable (Int) -> Void = { _ in }
+        var tokenCount = 0
+        var maxTokens: Int? { tokens.count }
+        var promptPrefillTime: TimeInterval { 0 }
+        var state: LMOutput.State? = LMOutput.State()
+
+        mutating func next() -> Int? {
+            guard tokenCount < tokens.count else { return nil }
+            onNext(tokenCount)
+            defer { tokenCount += 1 }
+            return tokens[tokenCount]
+        }
+
+        mutating func finalizeGeneration() {
+            state?[LMOutput.Key<Int>("finalizedAt")] = tokenCount
+        }
+    }
+
+    private struct BoundaryTokenizer: Tokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { "<eos>" }
+        var unknownToken: String? { nil }
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func convertTokenToId(_ token: String) -> Int? { token == "<eos>" ? 99 : nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]], tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            let pieces = [
+                1: "hello ", 2: "<en", 3: "ough", 4: " more",
+                5: "{\"name\":\"weather\",\"arguments\":", 6: "{}}",
+            ]
+            if tokenIds == [10] { return "\u{fffd}" }
+            if tokenIds == [10, 11] { return "é" }
+            return tokenIds.compactMap { pieces[$0] }.joined()
+        }
+    }
+
+    func testDecoderWaitsForCompleteUnicodeAndStopPrefix() {
+        var decoder = StandardTokenStreamDecoder(
+            tokenizer: BoundaryTokenizer(), format: .json, tools: nil, stopStrings: ["<end>"])
+        _ = decoder.push(10) { _ in true }
+        XCTAssertFalse(decoder.canEndForSteering)
+        _ = decoder.push(11) { _ in true }
+        XCTAssertTrue(decoder.canEndForSteering)
+
+        decoder = StandardTokenStreamDecoder(
+            tokenizer: BoundaryTokenizer(), format: .json, tools: nil, stopStrings: ["<end>"])
+        _ = decoder.push(1) { _ in true }
+        XCTAssertTrue(decoder.canEndForSteering)
+        _ = decoder.push(2) { _ in true }
+        XCTAssertFalse(decoder.canEndForSteering)
+        _ = decoder.push(3) { _ in true }
+        XCTAssertTrue(decoder.canEndForSteering)
+    }
+
+    func testSteeredStepReturnsFinalizedStateAndExactTokens() async throws {
+        let control = SteeringControl()
+        _ = try control.enqueue("now", policy: .nextSafeBoundary)
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 2, modelConfiguration: ModelConfiguration(id: "test"),
+            tokenizer: BoundaryTokenizer(), iterator: FinalizingIterator(tokens: [1, 4, 4]),
+            steering: control)
+        var info: GenerateCompletionInfo?
+        for await event in stream { info = event.info ?? info }
+        let result = await task.value
+        XCTAssertEqual(result.tokens, [1])
+        XCTAssertEqual(result.state.consume()?[LMOutput.Key<Int>("finalizedAt")], 1)
+        XCTAssertEqual(info?.stopReason, .steered)
+        // Ending a step does not consume or close its turn's mailbox.
+        XCTAssertTrue(control.requestsEarlyBoundary)
+    }
+
+    func testReasoningModelUsesNaturalStepBoundary() async throws {
+        let control = SteeringControl()
+        _ = try control.enqueue("now", policy: .nextSafeBoundary)
+        let configuration = ModelConfiguration(
+            id: "test", reasoningConfig: QwenReasoningProtocol.qwen3)
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 2, modelConfiguration: configuration,
+            tokenizer: BoundaryTokenizer(), iterator: FinalizingIterator(tokens: [1, 4, 4]),
+            steering: control)
+        var info: GenerateCompletionInfo?
+        for await event in stream { info = event.info ?? info }
+        let result = await task.value
+        XCTAssertEqual(result.tokens, [1, 4, 4])
+        XCTAssertEqual(info?.stopReason, .length)
+    }
+
+    func testInstructionDuringToolPayloadDoesNotTruncateCall() async throws {
+        let control = SteeringControl()
+        let iterator = FinalizingIterator(
+            tokens: [1, 5, 6, 99],
+            onNext: { index in
+                if index == 1 { _ = try? control.enqueue("now", policy: .nextSafeBoundary) }
+            })
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 2, modelConfiguration: ModelConfiguration(id: "test"),
+            tokenizer: BoundaryTokenizer(), iterator: iterator, steering: control)
+        var info: GenerateCompletionInfo?
+        var calls = 0
+        for await event in stream {
+            info = event.info ?? info
+            if event.toolCall != nil { calls += 1 }
+        }
+        let result = await task.value
+        XCTAssertEqual(result.tokens, [1, 5, 6, 99])
+        XCTAssertEqual(info?.stopReason, .stop)
+        XCTAssertEqual(calls, 1)
+        XCTAssertTrue(control.requestsEarlyBoundary)
+    }
+
+    func testInstructionArrivingDuringDecodingStopsAtNextBoundary() async throws {
+        let control = SteeringControl()
+        let iterator = FinalizingIterator(
+            tokens: [1, 4, 4, 4, 4],
+            onNext: { index in
+                if index == 2 { _ = try? control.enqueue("now", policy: .nextSafeBoundary) }
+            })
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 2, modelConfiguration: ModelConfiguration(id: "test"),
+            tokenizer: BoundaryTokenizer(), iterator: iterator, steering: control)
+        for await _ in stream {}
+        let result = await task.value
+        XCTAssertEqual(result.tokens, [1, 4, 4])
+    }
+
+    func testMailboxBoundsAndPromotion() throws {
+        let control = SteeringControl()
+        var ids: [UUID] = []
+        for _ in 0 ..< SteeringLimits.maxPendingInstructions - 1 {
+            ids.append(try control.enqueue("queued", policy: .nextStepBoundary))
+        }
+        XCTAssertFalse(control.requestsEarlyBoundary)
+        ids.append(try control.enqueue("now", policy: .nextSafeBoundary))
+        XCTAssertTrue(control.requestsEarlyBoundary)
+        XCTAssertThrowsError(try control.enqueue("full", policy: .nextStepBoundary))
+        XCTAssertEqual(try control.take(closeIfEmpty: true).map(\.id), ids)
+        XCTAssertFalse(control.requestsEarlyBoundary)
+        _ = try control.enqueue(
+            String(repeating: "a", count: SteeringLimits.maxPendingBytes),
+            policy: .nextStepBoundary)
+        XCTAssertThrowsError(try control.enqueue("é", policy: .nextStepBoundary))
+        XCTAssertEqual(try control.take(closeIfEmpty: false).count, 1)
+        XCTAssertTrue(try control.take(closeIfEmpty: true).isEmpty)
+        XCTAssertThrowsError(try control.enqueue("closed", policy: .nextSafeBoundary))
+    }
+
+    func testAcceptanceRacingCompletionIsNeverLost() async {
+        for _ in 0 ..< 100 {
+            let control = SteeringControl()
+            async let accepted: UUID? = try? control.enqueue("race", policy: .nextSafeBoundary)
+            async let taken = control.take(closeIfEmpty: true)
+            let id = await accepted
+            let batch = try? await taken
+            if let id {
+                XCTAssertEqual(batch?.map(\.id), [id])
+            } else {
+                XCTAssertEqual(batch?.count, 0)
+            }
+            control.finish()
+        }
+    }
+
+    func testFinalDrainClosesAcceptanceWithPendingInstructions() throws {
+        let control = SteeringControl()
+        let id = try control.enqueue("late", policy: .nextSafeBoundary)
+        XCTAssertEqual(try control.closeAndTake().map(\.id), [id])
+        XCTAssertFalse(control.isOpen)
+        XCTAssertFalse(control.requestsEarlyBoundary)
+        XCTAssertThrowsError(try control.enqueue("too late", policy: .nextStepBoundary)) {
+            XCTAssertEqual($0 as? SteeringError, .responseEnded)
+        }
+    }
+
+    func testAcceptanceRacingFinalDrainIsNeverLost() async throws {
+        for _ in 0 ..< 100 {
+            let control = SteeringControl()
+            let pending = try control.enqueue("pending", policy: .nextStepBoundary)
+            async let accepted: UUID? = try? control.enqueue("race", policy: .nextSafeBoundary)
+            async let drained = control.closeAndTake()
+            let id = await accepted
+            let batch = try await drained
+            XCTAssertEqual(batch.map(\.id), [pending] + (id.map { [$0] } ?? []))
+            XCTAssertFalse(control.isOpen)
+        }
+    }
+
+    func testCancelBeforeWorkerInstallation() async throws {
+        let control = SteeringControl()
+        _ = try control.enqueue("pending", policy: .nextSafeBoundary)
+        control.cancel()
+        let cancelled = expectation(description: "worker cancelled on attachment")
+        let task = Task {
+            do {
+                try await Task.sleep(for: .seconds(10))
+                XCTFail("Expected cancellation")
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+                cancelled.fulfill()
+            }
+        }
+        control.setTask(task)
+        await fulfillment(of: [cancelled], timeout: 1)
+        await control.synchronize()
+        XCTAssertFalse(control.requestsEarlyBoundary)
+        XCTAssertThrowsError(try control.take(closeIfEmpty: true)) {
+            XCTAssertTrue($0 is CancellationError)
+        }
+        XCTAssertThrowsError(try control.enqueue("late", policy: .nextStepBoundary))
+    }
+
+    func testSessionRoutesToActiveRequestBeforeQueuedRequests() throws {
+        let session = SessionSteering()
+        XCTAssertThrowsError(try session.steer("idle", policy: .nextSafeBoundary, response: nil)) {
+            XCTAssertEqual($0 as? SteeringError, .noActiveResponse)
+        }
+        let first = SteeringControl()
+        let second = SteeringControl()
+        session.register(first)
+        let beforeStart = try session.steer(
+            "before start", policy: .nextStepBoundary, response: nil)
+        session.start(first)
+        session.register(second)
+        let active = try session.steer("active", policy: .nextSafeBoundary, response: nil)
+        XCTAssertEqual(try first.take(closeIfEmpty: false).map(\.id), [beforeStart, active])
+        XCTAssertTrue(try second.take(closeIfEmpty: false).isEmpty)
+        XCTAssertTrue(try first.take(closeIfEmpty: true).isEmpty)
+        session.remove(first)
+        let queued = try session.steer("queued", policy: .nextStepBoundary, response: nil)
+        XCTAssertEqual(try second.take(closeIfEmpty: false).map(\.id), [queued])
+    }
+
+    func testRoutingSkipsAResponseThatHasNotBeenRemovedYet() throws {
+        // A cancelled runner closes its mailbox long before its `defer` removes it.
+        // Input must reach the response the session can still deliver to.
+        let session = SessionSteering()
+        let cancelled = SteeringControl()
+        let live = SteeringControl()
+        session.register(cancelled)
+        session.register(live)
+        session.start(cancelled)
+        cancelled.cancel()
+        XCTAssertFalse(session.canSteer(cancelled.responseID))
+        XCTAssertTrue(session.canSteer(nil))
+
+        let id = try session.steer("after cancel", policy: .nextSafeBoundary, response: nil)
+        XCTAssertEqual(try live.take(closeIfEmpty: false).map(\.id), [id])
+
+        // Naming the cancelled response reports it instead of retargeting.
+        XCTAssertThrowsError(
+            try session.steer("named", policy: .nextSafeBoundary, response: cancelled.responseID)
+        ) {
+            XCTAssertEqual($0 as? SteeringError, .responseEnded)
+        }
+        XCTAssertTrue(try live.take(closeIfEmpty: false).isEmpty)
+    }
+
+    func testNamedResponseIsNeverRetargeted() throws {
+        let session = SessionSteering()
+        let first = SteeringControl()
+        let second = SteeringControl()
+        session.register(first)
+        session.register(second)
+        session.start(first)
+        XCTAssertEqual(session.latestResponse, second.responseID)
+
+        let id = try session.steer(
+            "for second", policy: .nextStepBoundary, response: second.responseID)
+        XCTAssertEqual(try second.take(closeIfEmpty: false).map(\.id), [id])
+        XCTAssertTrue(try first.take(closeIfEmpty: false).isEmpty)
+
+        session.remove(second)
+        XCTAssertFalse(session.canSteer(second.responseID))
+        XCTAssertThrowsError(
+            try session.steer("gone", policy: .nextStepBoundary, response: second.responseID)
+        ) {
+            XCTAssertEqual($0 as? SteeringError, .noActiveResponse)
+        }
+    }
+
+    func testWhitespaceInstructionIsRejectedWhateverTheSessionIsDoing() throws {
+        let session = SessionSteering()
+        XCTAssertThrowsError(try session.steer(" \n", policy: .nextSafeBoundary, response: nil)) {
+            XCTAssertEqual($0 as? SteeringError, .emptyInstruction)
+        }
+        let control = SteeringControl()
+        session.register(control)
+        session.start(control)
+        XCTAssertThrowsError(try session.steer(" \n", policy: .nextSafeBoundary, response: nil)) {
+            XCTAssertEqual($0 as? SteeringError, .emptyInstruction)
+        }
+    }
+
+    /// `canSteer` and `steer` must select the same response, including when an
+    /// unsteerable response is followed by a steerable one.
+    func testCanSteerAgreesWithSteerSelection() throws {
+        let session = SessionSteering()
+        let unsteerable = SteeringControl()
+        let queued = SteeringControl()
+        session.register(unsteerable)
+        session.register(queued)
+        session.start(unsteerable)
+        _ = unsteerable.setSteerable(false)
+
+        XCTAssertFalse(session.canSteer(nil))
+        XCTAssertThrowsError(try session.steer("no", policy: .nextSafeBoundary, response: nil)) {
+            XCTAssertEqual($0 as? SteeringError, .notSteerable)
+        }
+        XCTAssertTrue(try queued.take(closeIfEmpty: false).isEmpty)
+
+        session.remove(unsteerable)
+        XCTAssertTrue(session.canSteer(nil))
+        let id = try session.steer("yes", policy: .nextSafeBoundary, response: nil)
+        XCTAssertEqual(try queued.take(closeIfEmpty: false).map(\.id), [id])
+    }
+
+    func testUnsteerableResponseRejectsInputAndReleasesWhatItAccepted() throws {
+        let session = SessionSteering()
+        let control = SteeringControl()
+        session.register(control)
+        session.start(control)
+        let early = try session.steer(
+            "before the cache was known", policy: .nextSafeBoundary, response: nil)
+
+        // The runner discovers it restored a raw cache with no transcript.
+        XCTAssertEqual(control.setSteerable(false).map(\.id), [early])
+        XCTAssertFalse(control.requestsEarlyBoundary)
+        XCTAssertFalse(session.canSteer(nil))
+        XCTAssertThrowsError(try session.steer("late", policy: .nextSafeBoundary, response: nil)) {
+            XCTAssertEqual($0 as? SteeringError, .notSteerable)
+        }
+    }
+
+    func testActualCacheOwnerWinsOverRegistrationOrder() throws {
+        let session = SessionSteering()
+        let first = SteeringControl()
+        let second = SteeringControl()
+        session.register(first)
+        session.register(second)
+        session.start(second)
+        let id = try session.steer("active", policy: .nextSafeBoundary, response: nil)
+        XCTAssertEqual(try second.take(closeIfEmpty: false).map(\.id), [id])
+        XCTAssertTrue(try first.take(closeIfEmpty: false).isEmpty)
+        session.start(first)
+        session.remove(second)
+        let next = try session.steer("next", policy: .nextStepBoundary, response: nil)
+        XCTAssertEqual(try first.take(closeIfEmpty: false).map(\.id), [next])
+    }
+
+    func testPartialToolPayloadCannotEndForSteering() {
+        let processor = ToolCallProcessor(format: .json)
+        _ = processor.processChunkOutputs("Some text ")
+        XCTAssertTrue(processor.canEndForSteering)
+        _ = processor.processChunkOutputs("{\"name\":\"weather\",\"arguments\":")
+        XCTAssertFalse(processor.canEndForSteering)
+        let output = processor.processChunkOutputs("{\"city\":\"Paris\"}}")
+        XCTAssertTrue(output.contains { if case .toolCall = $0 { true } else { false } })
+        XCTAssertTrue(processor.canEndForSteering)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adding this so that my app can add requirements or change direction while a response is running. The session queues the instruction, preserves output already emitted, and continues from its structured conversation using a verified cache prefix where possible.

The API supports:

- `session.steer(...)` with immediate acceptance IDs and bounded pending input.
- `.nextSafeBoundary` to end ordinary text decoding at a supported boundary, or `.nextStepBoundary` to let the current step finish.
- `Generation.steering(.applied(ids))` and `.steering(.failed(failure))` for tracking accepted instructions.
- Explicit response targeting through `latestResponse`, plus `canSteer` for UI state.
- Ordered tool-result handling, speculative-cache finalization, cancellation cleanup, and caller isolation for actor-owned sessions.

Steering does not undo emitted output or completed tool effects. Declared reasoning models and framed protocols finish their current step, including when `.nextSafeBoundary` is requested. Generation limits apply separately to each model step.

Existing string consumers keep the same API. Exhaustive switches over `Generation` and `GenerateStopReason` must handle the new `.steering` and `.steered` cases. Steering requires structured conversation history; sessions restored from a raw cache cannot accept it once that state is known.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it accurately describes the code changes.
- AI usage disclosure: GPT 6 assisted with API review, regression tests, validation, and drafting the documentation.