### PR TITLE
Keep the text before a `<` that turns out not to be a tool-call tag

### DIFF
--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -595,7 +595,9 @@ public class ToolCallProcessor {
                 } else {
                     recordResponse(leadingToken ?? "")
                     leadingTokenWasRecorded = true
-                    return nil
+                    // Keep buffering the possible tag, but hand back the text
+                    // that preceded it: this call is the only one that knows it.
+                    return leadingToken?.isEmpty ?? true ? nil : leadingToken
                 }
             } else {
                 // Otherwise, return the collected text and reset the state.
@@ -619,7 +621,7 @@ public class ToolCallProcessor {
 
         case .collectingToolCall:
             guard let endTag = parser.endTag else {
-                return nil
+                return leadingToken?.isEmpty ?? true ? nil : leadingToken
             }
 
             if toolCallBuffer.contains(endTag) {
@@ -672,7 +674,9 @@ public class ToolCallProcessor {
                 return combine(leadingToken, trailingToken)
             }
 
-            return nil
+            // The call stays buffered until its end tag; the text that
+            // preceded the start tag in this chunk does not.
+            return leadingToken?.isEmpty ?? true ? nil : leadingToken
 
         case .collectingJSONToolCall:
             return processCollectingJSONToolCall(

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -450,6 +450,96 @@ struct ToolTests {
         #expect(toolCall.function.arguments["location"] == .string("Osaka"))
     }
 
+    /// Drives the legacy `processChunk` API and returns everything it hands
+    /// back as visible text, end-of-sequence residue included.
+    private func legacyText(_ processor: ToolCallProcessor, chunks: [String]) -> String {
+        var emitted = ""
+        for chunk in chunks {
+            if let text = processor.processChunk(chunk) {
+                emitted += text
+            }
+        }
+        if let text = processor.processEOS(returnBufferedText: true) {
+            emitted += text
+        }
+        return emitted
+    }
+
+    /// Drives the ordered-output API and returns its visible text.
+    private func orderedText(_ processor: ToolCallProcessor, chunks: [String]) -> String {
+        var outputs: [ToolCallProcessor.Output] = []
+        for chunk in chunks {
+            outputs += processor.processChunkOutputs(chunk)
+        }
+        outputs += processor.processEOSOutputs()
+        return outputs.reduce(into: "") { text, output in
+            if case .response(let piece) = output { text += piece }
+        }
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Text Before A Non-Tag Angle Bracket Survives")
+    func testJSONFormatProcessorTextBeforeNonTagAngleBracketSurvives() {
+        // Detokenized chunks arrive one token at a time; a token like " `<" ends
+        // in a possible start tag, and the next token proves it was prose.
+        let chunks = [" injected as a", " `<", "memory", ">`", " block"]
+
+        let legacy = ToolCallProcessor(format: .json)
+        #expect(legacyText(legacy, chunks: chunks) == " injected as a `<memory>` block")
+        #expect(legacy.toolCalls.isEmpty)
+
+        let ordered = ToolCallProcessor(format: .json)
+        #expect(orderedText(ordered, chunks: chunks) == " injected as a `<memory>` block")
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Space Before A Comparison Operator Survives")
+    func testJSONFormatProcessorSpaceBeforeComparisonOperatorSurvives() {
+        let chunks = ["if a", " <", " b", " {"]
+
+        let legacy = ToolCallProcessor(format: .json)
+        #expect(legacyText(legacy, chunks: chunks) == "if a < b {")
+
+        let ordered = ToolCallProcessor(format: .json)
+        #expect(orderedText(ordered, chunks: chunks) == "if a < b {")
+    }
+
+    @Test("Test JSON Format via ToolCallProcessor - Text Before A Split Start Tag Is Emitted Once")
+    func testJSONFormatProcessorTextBeforeSplitStartTagEmittedOnce() throws {
+        let chunks = [
+            "Let me check.\n<tool",
+            "_call>{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Osaka\"}}",
+            "</tool_call>",
+        ]
+
+        let legacy = ToolCallProcessor(format: .json)
+        #expect(legacyText(legacy, chunks: chunks) == "Let me check.\n")
+        #expect(legacy.toolCalls.count == 1)
+        let toolCall = try #require(legacy.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Osaka"))
+
+        let ordered = ToolCallProcessor(format: .json)
+        #expect(orderedText(ordered, chunks: chunks) == "Let me check.\n")
+    }
+
+    @Test(
+        "Test JSON Format via ToolCallProcessor - Text Before A Multi-Chunk Tool Call Is Emitted Once"
+    )
+    func testJSONFormatProcessorTextBeforeMultiChunkToolCallEmittedOnce() throws {
+        let chunks = [
+            "Note: <tool_call>{\"name\":\"get_weather\",",
+            "\"arguments\":{\"location\":\"Osaka\"}}</tool_call>",
+        ]
+
+        let legacy = ToolCallProcessor(format: .json)
+        #expect(legacyText(legacy, chunks: chunks) == "Note: ")
+        #expect(legacy.toolCalls.count == 1)
+        let toolCall = try #require(legacy.toolCalls.first)
+        #expect(toolCall.function.name == "get_weather")
+
+        let ordered = ToolCallProcessor(format: .json)
+        #expect(orderedText(ordered, chunks: chunks) == "Note: ")
+    }
+
     @Test("Test JSON Format via ToolCallProcessor - Incomplete Bare Tool Rejects At EOS")
     func testJSONFormatProcessorIncompleteBareToolRejectsAtEOS() throws {
         let processor = ToolCallProcessor(format: .json)


### PR DESCRIPTION
## Proposed changes

Fixes #609.

`processChunk` held back the text in front of a `<` while it waited to see whether a `<tool_call>` tag was starting, and never returned it once the next chunk settled the question. Now each call returns that text itself, the way it already did when the tag resolved inside the same chunk. Four tests in `ToolTests` feed the chunks from the issue through both `processChunk` and `processChunkOutputs` and check that they return the same text.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure: the diagnosis, the fix, the tests and this description were produced with Claude Code under my direction; I reviewed the diff and this text before opening the PR.
