### PR TITLE
Fix generation loop blocking Swift cooperative workers

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2324,9 +2324,11 @@ private func generateLoopTask<
     let handler = SendableBox(handler)
     let tokenCollector = consume tokenCollector
 
-    // Launch a Task to perform iteration asynchronously.
+    // Keep task cancellation and task-local values while moving blocking MLX work
+    // onto a separate queue for each generation.
     let task = Task {
-        let performIteration = {
+        let worker = GenerationWorker()
+        let performIteration = { @Sendable in
             var iterator = iterator.consume()
             var handler = handler.consume()
             var tokenCollector = tokenCollector
@@ -2452,10 +2454,10 @@ private func generateLoopTask<
 
         if let ticket = wiredMemoryTicket {
             return await WiredMemoryTicket.withWiredLimit(ticket) {
-                performIteration()
+                await worker.run(performIteration)
             }
         } else {
-            return performIteration()
+            return await worker.run(performIteration)
         }
     }
 
@@ -2746,7 +2748,7 @@ private enum TokenLoopDisposition {
     }
 }
 
-private protocol TokenLoopHandler {
+private protocol TokenLoopHandler: SendableMetatype {
     associatedtype Output
 
     /// Semantic boundaries contributed by the response protocol handled by

--- a/Libraries/MLXLMCommon/Utilities/GenerationWorker.swift
+++ b/Libraries/MLXLMCommon/Utilities/GenerationWorker.swift
@@ -1,0 +1,18 @@
+// Copyright © 2026 Apple Inc.
+
+import Dispatch
+
+/// Runs one generation's blocking work outside Swift's cooperative pool.
+actor GenerationWorker {
+    private nonisolated let queue = DispatchSerialQueue(
+        label: "ml-explore.mlx-swift-lm.generation")
+
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        queue.asUnownedSerialExecutor()
+    }
+
+    // Keep the body synchronous so all evaluation and cleanup stay on this executor.
+    func run<R: Sendable>(_ body: @Sendable () -> R) -> R {
+        body()
+    }
+}

--- a/Tests/MLXLMTests/GenerationExecutionTests.swift
+++ b/Tests/MLXLMTests/GenerationExecutionTests.swift
@@ -1,0 +1,303 @@
+// Copyright © 2026 Apple Inc.
+
+import Dispatch
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+
+final class GenerationExecutionTests: XCTestCase {
+    private enum Context {
+        @TaskLocal static var value = 0
+    }
+
+    private struct CancellingPolicy: WiredMemoryPolicy {
+        let identifier = UUID()
+        var id: AnyHashable { identifier }
+
+        func limit(baseline: Int, activeSizes: [Int]) -> Int { baseline }
+
+        func canAdmit(baseline: Int, activeSizes: [Int], newSize: Int) -> Bool {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return true
+        }
+    }
+
+    private struct Iterator: GenerationFinalizingTokenIterator {
+        var maxTokens: Int? = 1
+        var tokenCount = 0
+        var promptPrefillTime: TimeInterval { 0 }
+        var onNext: @Sendable () -> Void = {}
+        var onFinalize: @Sendable () -> Void = {}
+
+        mutating func next() -> Int? {
+            guard tokenCount < (maxTokens ?? Int.max) else { return nil }
+            onNext()
+            tokenCount += 1
+            return 42
+        }
+
+        mutating func finalizeGeneration() {
+            onFinalize()
+        }
+    }
+
+    // Run with LIBDISPATCH_COOPERATIVE_POOL_STRICT=1 to expose pool starvation
+    // deterministically. The timeout also lets a regressed implementation finish.
+    func testBlockingIteratorLeavesCooperativeWorkerAvailable() async {
+        for useTicket in [false, true] {
+            let iterator = Iterator(
+                onNext: Self.assertCooperativeProgress,
+                onFinalize: Self.assertCooperativeProgress)
+            let ticket = useTicket ? MLX.WiredSumPolicy().ticket(size: 0) : nil
+            let (stream, task) = generateTask(
+                promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+                tokenizer: TestTokenizer(), iterator: iterator, wiredMemoryTicket: ticket)
+            for await _ in stream {}
+            await task.value
+        }
+    }
+
+    private static func assertCooperativeProgress() {
+        let resumed = DispatchSemaphore(value: 0)
+        Task { resumed.signal() }
+        XCTAssertEqual(resumed.wait(timeout: .now() + 5), .success)
+    }
+
+    func testGenerationPreservesDeviceOverrideAndCooperativeProgress() async {
+        await Device.withDefaultDevice(.cpu) {
+            let (stream, task) = generateTaskRecordingTokens(
+                promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+                tokenizer: TestTokenizer(),
+                iterator: Iterator(
+                    maxTokens: 3,
+                    onNext: {
+                        XCTAssertEqual(Device.defaultDevice().deviceType, .cpu)
+                        Self.assertCooperativeProgress()
+                    },
+                    onFinalize: {
+                        XCTAssertEqual(Device.defaultDevice().deviceType, .cpu)
+                        Self.assertCooperativeProgress()
+                    }))
+            var completion: GenerateCompletionInfo?
+            for await event in stream {
+                if case .info(let info) = event { completion = info }
+            }
+            let tokens = await task.value
+            XCTAssertEqual(tokens, [42, 42, 42])
+            XCTAssertEqual(completion?.generationTokenCount, 3)
+            XCTAssertEqual(completion?.stopReason, .length)
+        }
+    }
+
+    func testCancellingOneGenerationDoesNotCancelAnother() async {
+        let firstEntered = expectation(description: "first generation entered next")
+        let secondEntered = expectation(description: "second generation entered next")
+        let resumeFirst = DispatchSemaphore(value: 0)
+        let resumeSecond = DispatchSemaphore(value: 0)
+        let (firstStream, first) = generateTaskRecordingTokens(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(
+                maxTokens: 10,
+                onNext: {
+                    firstEntered.fulfill()
+                    XCTAssertEqual(resumeFirst.wait(timeout: .now() + 5), .success)
+                    XCTAssertTrue(Task.isCancelled)
+                },
+                onFinalize: { XCTAssertTrue(Task.isCancelled) }))
+        let (secondStream, second) = generateTaskRecordingTokens(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(
+                onNext: {
+                    secondEntered.fulfill()
+                    XCTAssertEqual(resumeSecond.wait(timeout: .now() + 5), .success)
+                    XCTAssertFalse(Task.isCancelled)
+                },
+                onFinalize: { XCTAssertFalse(Task.isCancelled) }))
+
+        await fulfillment(of: [firstEntered, secondEntered], timeout: 5)
+        first.cancel()
+        resumeFirst.signal()
+        let firstTokens = await first.value
+        XCTAssertEqual(firstTokens, [42])
+        XCTAssertFalse(second.isCancelled)
+        resumeSecond.signal()
+        let secondTokens = await second.value
+        XCTAssertEqual(secondTokens, [42])
+
+        var firstCompletion: GenerateCompletionInfo?
+        for await event in firstStream {
+            if case .info(let info) = event { firstCompletion = info }
+        }
+        var secondCompletion: GenerateCompletionInfo?
+        for await event in secondStream {
+            if case .info(let info) = event { secondCompletion = info }
+        }
+        XCTAssertEqual(firstCompletion?.stopReason, .cancelled)
+        XCTAssertEqual(secondCompletion?.stopReason, .length)
+    }
+
+    func testIndependentGenerationsCanMakeProgressConcurrently() async {
+        let firstStarted = DispatchSemaphore(value: 0)
+        let secondStarted = DispatchSemaphore(value: 0)
+        let (firstStream, first) = generateTask(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(onNext: {
+                firstStarted.signal()
+                XCTAssertEqual(secondStarted.wait(timeout: .now() + 5), .success)
+            }))
+        let (secondStream, second) = generateTask(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(onNext: {
+                XCTAssertEqual(firstStarted.wait(timeout: .now() + 5), .success)
+                secondStarted.signal()
+            }))
+        await first.value
+        await second.value
+        withExtendedLifetime((firstStream, secondStream)) {}
+    }
+
+    func testCancellationDuringNextStillFinalizesBeforeTaskCompletes() async {
+        let entered = expectation(description: "entered next")
+        let resume = DispatchSemaphore(value: 0)
+        let finalized = expectation(description: "finalized after cancellation")
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(
+                maxTokens: 10,
+                onNext: {
+                    entered.fulfill()
+                    XCTAssertEqual(resume.wait(timeout: .now() + 5), .success)
+                    XCTAssertTrue(Task.isCancelled)
+                },
+                onFinalize: {
+                    XCTAssertTrue(Task.isCancelled)
+                    finalized.fulfill()
+                }))
+        await fulfillment(of: [entered], timeout: 5)
+        task.cancel()
+        resume.signal()
+        var completion: GenerateCompletionInfo?
+        for await event in stream {
+            if case .info(let info) = event { completion = info }
+        }
+        let tokens = await task.value
+        XCTAssertEqual(tokens, [42])
+        XCTAssertEqual(completion?.stopReason, .cancelled)
+        XCTAssertEqual(completion?.generationTokenCount, 1)
+        await fulfillment(of: [finalized], timeout: 0)
+    }
+
+    func testCancellationDuringTicketAdmissionSkipsNextAndFinalizes() async throws {
+        try XCTSkipIf(Device.defaultDevice().deviceType != .gpu, "Admission requires a GPU backend")
+        let finalized = expectation(description: "cancelled iterator finalized")
+        let ticket = CancellingPolicy().ticket(size: 0)
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(
+                onNext: { XCTFail("Cancelled generation must not call next") },
+                onFinalize: {
+                    XCTAssertTrue(Task.isCancelled)
+                    finalized.fulfill()
+                }),
+            wiredMemoryTicket: ticket)
+        var completion: GenerateCompletionInfo?
+        for await event in stream {
+            if case .info(let info) = event { completion = info }
+        }
+        let tokens = await task.value
+        XCTAssertEqual(tokens, [])
+        XCTAssertEqual(completion?.stopReason, .cancelled)
+        await fulfillment(of: [finalized], timeout: 0)
+    }
+
+    func testConsumerCancellationReachesBlockedGeneration() async {
+        let entered = expectation(description: "entered next")
+        let resume = DispatchSemaphore(value: 0)
+        let finalized = expectation(description: "consumer cancellation finalized")
+        let (stream, task) = generateTask(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(
+                onNext: {
+                    entered.fulfill()
+                    XCTAssertEqual(resume.wait(timeout: .now() + 5), .success)
+                    XCTAssertTrue(Task.isCancelled)
+                },
+                onFinalize: { finalized.fulfill() }))
+        let consumer = Task {
+            for await _ in stream {}
+        }
+        await fulfillment(of: [entered], timeout: 5)
+        consumer.cancel()
+        await consumer.value
+        resume.signal()
+        await task.value
+        XCTAssertTrue(task.isCancelled)
+        await fulfillment(of: [finalized], timeout: 0)
+    }
+
+    @MainActor
+    func testMainActorCallerDoesNotRunIteratorOnMainThread() async {
+        let (stream, task) = generateTask(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(onNext: {
+                XCTAssertFalse(Thread.isMainThread)
+                Self.assertCooperativeProgress()
+            }))
+        for await _ in stream {}
+        await task.value
+    }
+
+    func testEmptyGenerationStillFinalizes() async {
+        let finalized = expectation(description: "empty iterator finalized")
+        let (stream, task) = generateTaskRecordingTokens(
+            promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+            tokenizer: TestTokenizer(),
+            iterator: Iterator(
+                maxTokens: 0, onNext: { XCTFail("Empty iterator must not produce a token") },
+                onFinalize: { finalized.fulfill() }))
+        var completion: GenerateCompletionInfo?
+        for await event in stream {
+            if case .info(let info) = event { completion = info }
+        }
+        let tokens = await task.value
+        XCTAssertEqual(tokens, [])
+        XCTAssertEqual(completion?.stopReason, .length)
+        XCTAssertEqual(completion?.generationTokenCount, 0)
+        await fulfillment(of: [finalized], timeout: 0)
+    }
+
+    func testTaskContextAndRecordedTokensSurviveExecutionHop() async {
+        let finalized = expectation(description: "iterator finalized")
+        let (stream, task) = Context.$value.withValue(123) {
+            generateTaskRecordingTokens(
+                promptTokenCount: 1, modelConfiguration: .init(id: "test"),
+                tokenizer: TestTokenizer(),
+                iterator: Iterator(
+                    onNext: {
+                        XCTAssertEqual(Context.value, 123)
+                        XCTAssertTrue(withUnsafeCurrentTask { $0 != nil })
+                    },
+                    onFinalize: {
+                        XCTAssertEqual(Context.value, 123)
+                        finalized.fulfill()
+                    }))
+        }
+        var completion: GenerateCompletionInfo?
+        for await event in stream {
+            if case .info(let info) = event { completion = info }
+        }
+        let tokens = await task.value
+        XCTAssertEqual(tokens, [42])
+        XCTAssertEqual(completion?.stopReason, .length)
+        await fulfillment(of: [finalized], timeout: 5)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fixes #600.

`generateLoopTask` runs its token loop in an unstructured `Task`. Although `asyncEval` schedules GPU evaluation asynchronously, it can block the calling thread when MLX applies backpressure to bound outstanding work. That wait occupies a Swift cooperative worker and prevents it from running unrelated async work.

### The fix

Run the synchronous generation loop on a private actor backed by `DispatchSerialQueue`, using its built-in `SerialExecutor` conformance. Each generation has its own queue. The same Swift task hops onto that executor, preserving cancellation and task-local values. Iteration, speculative iterator finalization, and the final `Stream().synchronize()` all stay on that executor until cleanup finishes. One blocked generation does not serialize other generations.

MLX's backpressure remains necessary. This change gives the blocking work an appropriate execution context. Synchronous iterator construction and prefill before `generateLoopTask` remain in the caller's context.

### Dependency

The investigation also exposed wired-memory ticket lifecycle defects in mlx-swift, addressed separately in [ml-explore/mlx-swift#471](https://github.com/ml-explore/mlx-swift/pull/471). Cancellation could release a ticket before generation cleanup finished, and cancellation while waiting for admission could trigger a debug assertion.

**Complete wired-memory cancellation correctness depends on #471.** The scheduling fix works with the currently resolved mlx-swift 0.31.6, but that release still contains those lifecycle defects.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it accurately describes the code changes.
- AI usage disclosure: 
