### PR TITLE
Emit only the new scalars when a token extends the previous character

### DIFF
--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -113,8 +113,21 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
         // boundary, so that holds; a decode that rewrote an already-emitted
         // interior character would re-emit the tail (no worse than the old
         // behavior, and not observed in practice).
-        let common = newSegment.commonPrefix(with: segment)
-        let new = newSegment.dropFirst(common.count)
+        //
+        // The prefix is measured in Unicode scalars, not `Character`s. A
+        // `Character` is a grapheme cluster, and a token routinely appends a
+        // combining scalar to the cluster the previous token ended: a
+        // variation selector (`🏳` then U+FE0F), a zero-width joiner, a
+        // combining accent (`e` then U+0301). Compared as `Character`s the
+        // old text's last cluster no longer equals the merged cluster, so a
+        // `Character`-level prefix (`commonPrefix(with:)`) stops one cluster
+        // early and the whole merged cluster is emitted a second time — the
+        // consumer receives `🏳🏳️`, `''️`, `eé`. Scalars compare exactly (no
+        // canonical equivalence), and the emitted tail is precisely the
+        // scalars the new token added.
+        let common = zip(newSegment.unicodeScalars, segment.unicodeScalars)
+            .prefix { $0 == $1 }.count
+        let new = String(newSegment.unicodeScalars.dropFirst(common))
 
         // if the new segment ends with REPLACEMENT CHARACTER this means
         // that the token didn't produce a complete unicode character
@@ -128,6 +141,6 @@ public struct NaiveStreamingDetokenizer: StreamingDetokenizer {
             self.segment = newSegment
         }
 
-        return String(new)
+        return new
     }
 }

--- a/Tests/MLXLMTests/StreamingDetokenizerTests.swift
+++ b/Tests/MLXLMTests/StreamingDetokenizerTests.swift
@@ -78,6 +78,7 @@ private struct SplitMultibyteTokenizer: MLXLMCommon.Tokenizer {
                 out += "\u{fffd}"  // incomplete: only the first half so far
             case 51:
                 out += "\u{fffd}"  // second half without its first half
+            case 60: out += "\u{FE0F}"  // VARIATION SELECTOR-16, its own token
             case 65: out += "a"
             case 66: out += "b"
             default: break
@@ -165,5 +166,60 @@ final class StreamingDetokenizerTests: XCTestCase {
         XCTAssertTrue(
             streamed.contains(","),
             "comma dropped across a newline segment reset: \(streamed.debugDescription)")
+    }
+
+    // MARK: grapheme clusters that grow across a token boundary
+
+    /// Exact scalar sequences: `String ==` compares under canonical
+    /// equivalence, which would let `e` + U+0301 equal `é`.
+    private func scalars(_ text: String) -> [UInt32] {
+        text.unicodeScalars.map(\.value)
+    }
+
+    /// A token that appends a combining scalar to the previous token's
+    /// character must emit only that scalar. A `Character`-level common
+    /// prefix treats `🏳` and `🏳️` as different characters and re-emits the
+    /// base, so `🏳️‍🌈` streamed as `🏳🏳️🏳️‍🏳️‍🌈`.
+    func testCombiningScalarAppendedToPreviousCharacterIsEmittedOnce() {
+        let tokenizer = AppendOnlyTokenizer(pieces: [
+            1: "\u{1F3F3}",  // 🏳 WAVING WHITE FLAG
+            2: "\u{FE0F}",  // VARIATION SELECTOR-16
+            3: "\u{200D}",  // ZERO WIDTH JOINER
+            4: "\u{1F308}",  // 🌈 RAINBOW
+        ])
+        let tokens = [1, 2, 3, 4]
+        let streamed = stream(tokens, tokenizer)
+        XCTAssertEqual(
+            scalars(streamed), [0x1F3F3, 0xFE0F, 0x200D, 0x1F308],
+            "base character re-emitted: \(streamed.debugDescription)")
+        XCTAssertEqual(
+            streamed, tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false))
+    }
+
+    /// The same growth on an ASCII base: `'` then U+FE0F then `'` is three
+    /// scalars, not four.
+    func testVariationSelectorAfterASCIIDoesNotRepeatTheBase() {
+        let tokenizer = AppendOnlyTokenizer(pieces: [1: "'", 2: "\u{FE0F}", 3: "'"])
+        let streamed = stream([1, 2, 3], tokenizer)
+        XCTAssertEqual(scalars(streamed), [0x27, 0xFE0F, 0x27], streamed.debugDescription)
+    }
+
+    /// A combining accent arriving as its own token: `e` + U+0301 + `x`.
+    func testCombiningAccentDoesNotRepeatTheBase() {
+        let tokenizer = AppendOnlyTokenizer(pieces: [1: "e", 2: "\u{0301}", 3: "x"])
+        let streamed = stream([1, 2, 3], tokenizer)
+        XCTAssertEqual(scalars(streamed), [0x65, 0x0301, 0x78], streamed.debugDescription)
+    }
+
+    /// The REPLACEMENT CHARACTER hold-back and the cluster growth compose:
+    /// a multi-byte character completed across two tokens, then a variation
+    /// selector token joining it, emits each scalar exactly once.
+    func testVariationSelectorAfterSplitMultibyteCharacterIsEmittedOnce() {
+        let tokenizer = SplitMultibyteTokenizer()
+        let tokens = [65, 50, 51, 60, 66]  // "a", 中(first half), 中(second half), U+FE0F, "b"
+        let streamed = stream(tokens, tokenizer)
+        XCTAssertEqual(scalars(streamed), [0x61, 0x4E2D, 0xFE0F, 0x62], streamed.debugDescription)
+        XCTAssertEqual(
+            streamed, tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false))
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes #612.

`NaiveStreamingDetokenizer.next()` measured the common prefix between the previous decode and the new one in `Character`s, so a token that appended a combining scalar (U+FE0F, a zero-width joiner, an accent) to the previous character turned the whole merged grapheme cluster into "new" text and re-emitted its base. The prefix is now measured in Unicode scalars, which compares exactly and keeps the #465 behaviour for tokenizers whose decode is not append-only. Four tests in `StreamingDetokenizerTests` stream a ZWJ flag sequence, a variation selector after an ASCII quote, a combining accent, and a variation selector after a multi-byte character split across two tokens, and compare the scalar sequence with the full decode; they fail on `main` and pass with this change.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure: the diagnosis, the fix, the tests and this description were written with Claude Code (Anthropic) under the author's direction, and are posted from the author's account.
