### PR TITLE
Reduce unused vocabulary projections during Qwen prefill (~8% speedup)

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen3.swift
+++ b/Libraries/MLXLLM/Models/Qwen3.swift
@@ -184,13 +184,24 @@ public class Qwen3Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
-        var out = model(inputs, cache: cache)
-        if let lmHead {
-            out = lmHead(out)
-        } else {
-            out = model.embedTokens.asLinear(out)
+        project(model(inputs, cache: cache))
+    }
+
+    public func nextTokenLogits(
+        _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        var hidden = model(input.tokens, cache: cache)
+        if lmHead == nil {
+            hidden = quantizedVocabularyProjectionInput(hidden, projection: model.embedTokens)
         }
-        return out
+        return .init(logits: project(hidden))
+    }
+
+    private func project(_ hidden: MLXArray) -> MLXArray {
+        if let lmHead {
+            return lmHead(hidden)
+        }
+        return model.embedTokens.asLinear(hidden)
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1091,6 +1091,18 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
     public func callAsFunction(
         _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
     ) -> LMOutput {
+        forward(input, cache: cache, state: state, lastTokenOnly: false)
+    }
+
+    public func nextTokenLogits(
+        _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        forward(input, cache: cache, state: state, lastTokenOnly: true)
+    }
+
+    private func forward(
+        _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?, lastTokenOnly: Bool
+    ) -> LMOutput {
         let emitDrafterState = state?[mtpEmitFlagKey] ?? false
         let hiddenStates: MLXArray
         if emitDrafterState {
@@ -1102,11 +1114,16 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider {
             hiddenStates = model(input.tokens, cache: cache)
         }
 
+        let projection: Module = lmHead ?? model.embedTokens
+        let projectionInput =
+            lastTokenOnly && !emitDrafterState
+            ? quantizedVocabularyProjectionInput(hiddenStates, projection: projection)
+            : hiddenStates
         let logits: MLXArray
         if let lmHead {
-            logits = lmHead(hiddenStates)
+            logits = lmHead(projectionInput)
         } else {
-            logits = model.embedTokens.asLinear(hiddenStates)
+            logits = model.embedTokens.asLinear(projectionInput)
         }
 
         guard emitDrafterState else {
@@ -1240,6 +1257,12 @@ public class Qwen35Model: Module, LLMModel, KVCacheDimensionProvider {
         _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
     ) -> LMOutput {
         languageModel(input, cache: cache, state: state)
+    }
+
+    public func nextTokenLogits(
+        _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        languageModel.nextTokenLogits(input, cache: cache, state: state)
     }
 
     public func newCache(parameters: GenerateParameters?) throws -> [KVCache] {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -910,7 +910,8 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// Evaluate the next token and return the new token (y), updating cache state
     mutating func step(previous: LMInput.Text) -> MLXArray {
         let result = withPreparedCache(cache, lengths: previous.sequenceLengths) {
-            model(previous[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: state)
+            model.nextTokenLogits(
+                previous[text: .newAxis], cache: cache.isEmpty ? nil : cache, state: state)
         }
         cacheStorage.commitProcessedTokens(previous.cacheSequenceLength)
         self.state = result.state

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -346,6 +346,14 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
     func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
         -> LMOutput
 
+    /// Evaluate all input positions when only the final position's logits are needed.
+    ///
+    /// Implementations may omit earlier logit rows, but must preserve cache updates and
+    /// output state. The default uses the regular forward. Scoring and speculative
+    /// verification must use the regular forward when they need multiple positions.
+    func nextTokenLogits(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+
     /// Models may implement this simplified interface if they do not produce any ``LMOutput/State``
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray
 
@@ -375,6 +383,12 @@ public protocol LanguageModel: BaseLanguageModel, ChatConventionsProviding {
 }
 
 extension LanguageModel {
+    public func nextTokenLogits(
+        _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+    ) -> LMOutput {
+        callAsFunction(input, cache: cache, state: state)
+    }
+
     /// Most language models have no derived inference state to prepare.
     public func prepare() throws {}
 

--- a/Libraries/MLXLMCommon/QuantizedVocabularyProjection.swift
+++ b/Libraries/MLXLMCommon/QuantizedVocabularyProjection.swift
@@ -1,0 +1,22 @@
+// Copyright © 2026 Apple Inc.
+
+import MLX
+import MLXNN
+
+/// Retain the final quantized matrix tiles when only the last logit row is needed.
+package func quantizedVocabularyProjectionInput(_ hidden: MLXArray, projection: Module) -> MLXArray
+{
+    guard hidden.dim(0) == 1,
+        type(of: projection) == QuantizedEmbedding.self
+            || type(of: projection) == QuantizedLinear.self,
+        let quantized = projection as? any Quantized,
+        quantized.mode == .affine, quantized.bits == 4 || quantized.bits == 8
+    else {
+        return hidden
+    }
+
+    // Preserve the quantized matrix kernel and its 32/64-row tile alignment.
+    // A single-row projection changes the reduction order.
+    let start = max(0, ((hidden.dim(1) - 32) / 64) * 64)
+    return start > 0 ? hidden[0..., start..., 0...] : hidden
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -920,7 +920,8 @@ public enum Qwen35Language {
             positionIds providedPositionIds: MLXArray? = nil,
             pixelValues: MLXArray? = nil,
             imageGridTHW: [THW]? = nil,
-            videoGridTHW: [THW]? = nil
+            videoGridTHW: [THW]? = nil,
+            lastTokenOnly: Bool = false
         ) -> LMOutput {
             var state = state ?? .init()
 
@@ -1007,7 +1008,11 @@ public enum Qwen35Language {
             )
             let hiddenStates = emitDrafterState ? model.norm(preNormHidden) : preNormHidden
 
-            var out = hiddenStates
+            let projection: Module = lmHead ?? model.embedTokens
+            var out =
+                lastTokenOnly && !emitDrafterState
+                ? quantizedVocabularyProjectionInput(hiddenStates, projection: projection)
+                : hiddenStates
             if let lmHead {
                 out = lmHead(out)
             } else {
@@ -1264,7 +1269,8 @@ public class Qwen35: Module, VLMModel {
                 positionIds: nil,
                 pixelValues: pixelValues,
                 imageGridTHW: imageFrames,
-                videoGridTHW: videoFrames
+                videoGridTHW: videoFrames,
+                lastTokenOnly: true
             )
         }
 

--- a/Tests/MLXLMTests/Qwen35PrefillLogitsTests.swift
+++ b/Tests/MLXLMTests/Qwen35PrefillLogitsTests.swift
@@ -1,0 +1,255 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+final class Qwen35PrefillLogitsTests: XCTestCase {
+    private func configuration(tied: Bool = false, moe: Bool = false) -> Data {
+        Data(
+            """
+            {
+                "model_type": "qwen3_5", "vocab_size": 512,
+                "image_token_id": 500, "video_token_id": 501,
+                "vision_start_token_id": 502, "vision_end_token_id": 503,
+                "text_config": {
+                    "model_type": "qwen3_5_text", "hidden_size": 64,
+                    "num_hidden_layers": 2, "intermediate_size": 128,
+                    "num_attention_heads": 2, "num_key_value_heads": 1, "head_dim": 32,
+                    "vocab_size": 512, "full_attention_interval": 2,
+                    "tie_word_embeddings": \(tied), "linear_num_value_heads": 2,
+                    "linear_num_key_heads": 1, "linear_key_head_dim": 32,
+                    "linear_value_head_dim": 32, "linear_conv_kernel_dim": 4,
+                    "num_experts": \(moe ? 4 : 0), "num_experts_per_tok": 2,
+                    "moe_intermediate_size": 64, "shared_expert_intermediate_size": 64,
+                    "max_position_embeddings": 4096,
+                    "rope_parameters": {"mrope_section": [8,4,4], "rope_theta": 100000,
+                        "partial_rotary_factor": 1.0, "type": "default"}
+                },
+                "vision_config": {"model_type": "qwen3_vl", "depth": 1,
+                    "hidden_size": 32, "intermediate_size": 64, "out_hidden_size": 64,
+                    "num_heads": 2, "patch_size": 16, "spatial_merge_size": 2,
+                    "temporal_patch_size": 2, "num_position_embeddings": 64}
+            }
+            """.utf8)
+    }
+
+    private func prepareWeights(_ model: Module, bits: Int? = 4, dtype: DType = .bfloat16) {
+        if let bits { quantize(model: model, groupSize: 32, bits: bits) }
+        model.apply { $0.dtype == .float32 ? $0.asType(dtype) : $0 }
+        eval(model)
+    }
+
+    private func text(_ count: Int, batch: Int = 1) -> LMInput.Text {
+        .init(
+            tokens: MLXArray((0 ..< count * batch).map { ($0 * 13 + 7) % 480 }).reshaped(
+                batch, count))
+    }
+
+    private func equal(
+        _ a: MLXArray, _ b: MLXArray, file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(a.shape, b.shape, file: file, line: line)
+        XCTAssertEqual(a.dtype, b.dtype, file: file, line: line)
+        XCTAssertTrue(allClose(a, b, rtol: 0, atol: 0).item(Bool.self), file: file, line: line)
+    }
+
+    private func equalCache(
+        _ a: [KVCache], _ b: [KVCache], file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(a.count, b.count, file: file, line: line)
+        for (x, y) in zip(a, b) {
+            XCTAssertEqual(x.offset, y.offset, file: file, line: line)
+            XCTAssertEqual(x.state.count, y.state.count, file: file, line: line)
+            for (u, v) in zip(x.state, y.state) { equal(u, v, file: file, line: line) }
+        }
+    }
+
+    func testTextDenseAndMoEPreserveLogitsAndRecurrentCache() throws {
+        for tied in [false, true] {
+            for moe in [false, true] {
+                for dtype: DType in [.float32, .float16, .bfloat16] {
+                    let config = try JSONDecoder().decode(
+                        MLXLLM.Qwen35Configuration.self, from: configuration(tied: tied, moe: moe))
+                    let model = withRandomState(MLXRandom.RandomState(seed: 17)) {
+                        Qwen35Model(config)
+                    }
+                    prepareWeights(model, dtype: dtype)
+                    for count in [
+                        1, 31, 32, 63, 64, 65, 95, 96, 97, 127, 128, 129, 255, 256, 257, 511, 512,
+                        513,
+                    ] {
+                        try autoreleasepool {
+                            let a = try model.newCache(parameters: nil)
+                            let b = try model.newCache(parameters: nil)
+                            let expected = model(text(count), cache: a, state: nil).logits
+                            let actual = model.nextTokenLogits(text(count), cache: b, state: nil)
+                                .logits
+                            XCTAssertEqual(expected.dim(1), count)
+                            if count >= 96 { XCTAssertLessThanOrEqual(actual.dim(1), 95) }
+                            equal(actual[0..., -1, 0...], expected[0..., -1, 0...])
+                            equalCache(a, b)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func testTextWarmContinuationAndMTPState() throws {
+        let model = Qwen35Model(
+            try JSONDecoder().decode(MLXLLM.Qwen35Configuration.self, from: configuration()))
+        prepareWeights(model, bits: 8)
+        for parameters in [
+            GenerateParameters(), GenerateParameters(maxKVSize: 128),
+            GenerateParameters(kvBits: 4, kvGroupSize: 32, quantizedKVStart: 0),
+        ] {
+            let prefix = try model.newCache(parameters: parameters)
+            eval(model(text(97), cache: prefix, state: nil).logits, prefix)
+            let a = prefix.map { $0.copy() }
+            let b = prefix.map { $0.copy() }
+            for count in [129, 1, 1, 96, 1] {
+                let expected = model(text(count), cache: a, state: nil).logits
+                let actual = model.nextTokenLogits(text(count), cache: b, state: nil).logits
+                equal(actual[0..., -1, 0...], expected[0..., -1, 0...])
+                equalCache(a, b)
+            }
+        }
+        var state = LMOutput.State()
+        state[mtpEmitFlagKey] = true
+        let a = try model.newCache(parameters: nil)
+        let b = try model.newCache(parameters: nil)
+        let expected = model(text(128), cache: a, state: state)
+        let actual = model.nextTokenLogits(text(128), cache: b, state: state)
+        equal(actual.logits, expected.logits)
+        equal(
+            try XCTUnwrap(actual.state?[mtpLastHiddenStatesKey]),
+            try XCTUnwrap(expected.state?[mtpLastHiddenStatesKey]))
+        XCTAssertEqual(actual.state?[mtpSharedKVOffsetsKey], expected.state?[mtpSharedKVOffsetsKey])
+        equalCache(a, b)
+    }
+
+    func testTextFallbacksKeepFullLogits() throws {
+        for (bits, batch) in [(nil, 1), (Optional(2), 1), (Optional(4), 2)] {
+            let model = Qwen35Model(
+                try JSONDecoder().decode(MLXLLM.Qwen35Configuration.self, from: configuration()))
+            prepareWeights(model, bits: bits)
+            equal(
+                model.nextTokenLogits(text(128, batch: batch), cache: nil, state: nil).logits,
+                model(text(128, batch: batch), cache: nil, state: nil).logits)
+        }
+    }
+
+    func testLocalCheckpointTextAndVisionParity() throws {
+        guard let path = ProcessInfo.processInfo.environment["MLX_QWEN35_PREFILL_MODEL"],
+            !path.isEmpty
+        else {
+            throw XCTSkip("set MLX_QWEN35_PREFILL_MODEL to validate a local Qwen3.5 checkpoint")
+        }
+        let directory = URL(fileURLWithPath: path)
+        let data = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        let base = try JSONDecoder().decode(BaseConfiguration.self, from: data)
+        for vision in [false, true] {
+            try autoreleasepool {
+                let model: any LanguageModel
+                if vision {
+                    model = Qwen35(
+                        try JSONDecoder().decode(MLXVLM.Qwen35Configuration.self, from: data))
+                } else {
+                    model = Qwen35Model(
+                        try JSONDecoder().decode(MLXLLM.Qwen35Configuration.self, from: data))
+                }
+                try loadWeights(
+                    modelDirectory: directory, model: model,
+                    perLayerQuantization: base.perLayerQuantization)
+                for count in [128, 512] {
+                    let a = try model.newCache(parameters: nil)
+                    let b = try model.newCache(parameters: nil)
+                    var fullState = LMOutput.State()
+                    fullState[mtpEmitFlagKey] = true
+                    let expected = withPreparedCache(a, lengths: text(count).sequenceLengths) {
+                        model(text(count), cache: a, state: fullState)
+                    }
+                    let actual: LMOutput
+                    if vision {
+                        guard
+                            case .logits(let output) = try model.prepare(
+                                LMInput(text: text(count)), cache: b, state: nil, prefill: .init())
+                        else { return XCTFail("Expected prefill logits") }
+                        actual = output
+                    } else {
+                        actual = withPreparedCache(b, lengths: text(count).sequenceLengths) {
+                            model.nextTokenLogits(text(count), cache: b, state: nil)
+                        }
+                    }
+                    equal(actual.logits[0..., -1, 0...], expected.logits[0..., -1, 0...])
+                    equalCache(a, b)
+                    var stateA = expected.state
+                    stateA?[mtpEmitFlagKey] = false
+                    var stateB = actual.state
+                    var token = argMax(expected.logits[0..., -1, 0...], axis: -1).item(Int.self)
+                    for _ in 0 ..< 16 {
+                        let input = LMInput.Text(tokens: MLXArray([token])[.newAxis])
+                        let expected = model(input, cache: a, state: stateA)
+                        let actual = model.nextTokenLogits(input, cache: b, state: stateB)
+                        equal(actual.logits, expected.logits)
+                        token = argMax(expected.logits[0..., -1, 0...], axis: -1).item(Int.self)
+                        stateA = expected.state
+                        stateB = actual.state
+                    }
+                    equalCache(a, b)
+                }
+            }
+            Memory.clearCache()
+        }
+    }
+
+    func testVisionPreparationPreservesImageStateAndContinuation() throws {
+        let model = Qwen35(
+            try JSONDecoder().decode(MLXVLM.Qwen35Configuration.self, from: configuration()))
+        prepareWeights(model)
+        let fixtures = ContinuationAssertions(imageTokenId: 500, visionStartTokenId: 502)
+        for withImage in [false, true] {
+            let tokens =
+                withImage
+                ? concatenated([fixtures.imageRun(), fixtures.textTokens(123)], axis: 1)
+                : fixtures.textTokens(128)
+            let input = LMInput(
+                text: .init(tokens: tokens), image: withImage ? fixtures.image() : nil)
+            let a = try model.newCache(parameters: nil)
+            let b = try model.newCache(parameters: nil)
+            var fullState = LMOutput.State()
+            fullState[mtpEmitFlagKey] = true
+            guard
+                case .logits(let expected) = try model.prepare(
+                    input, cache: a, state: fullState, prefill: .init()),
+                case .logits(let actual) = try model.prepare(
+                    input, cache: b, state: nil, prefill: .init())
+            else {
+                return XCTFail("Expected prefill logits")
+            }
+            XCTAssertEqual(expected.logits.dim(1), 128)
+            XCTAssertEqual(actual.logits.dim(1), 64)
+            equal(actual.logits[0..., -1, 0...], expected.logits[0..., -1, 0...])
+            equalCache(a, b)
+            let ropeKey = LMOutput.Key<MLXArray>("qwen35.ropeDeltas")
+            equal(try XCTUnwrap(actual.state?[ropeKey]), try XCTUnwrap(expected.state?[ropeKey]))
+            var stateA = expected.state
+            stateA?[mtpEmitFlagKey] = false
+            var stateB = actual.state
+            for _ in 0 ..< 4 {
+                let expected = model(text(1), cache: a, state: stateA)
+                let actual = model(text(1), cache: b, state: stateB)
+                equal(actual.logits, expected.logits)
+                equalCache(a, b)
+                stateA = expected.state
+                stateB = actual.state
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen3PrefillLogitsTests.swift
+++ b/Tests/MLXLMTests/Qwen3PrefillLogitsTests.swift
@@ -1,0 +1,240 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+final class Qwen3PrefillLogitsTests: XCTestCase {
+    private func makeModel(tied: Bool = true, bits: Int? = 4, dtype: DType = .bfloat16)
+        throws -> Qwen3Model
+    {
+        let configuration = """
+            {
+                "hidden_size": 64, "num_hidden_layers": 2,
+                "intermediate_size": 128, "num_attention_heads": 2,
+                "num_key_value_heads": 1, "head_dim": 32,
+                "rms_norm_eps": 0.000001, "vocab_size": 256,
+                "tie_word_embeddings": \(tied)
+            }
+            """
+        MLXRandom.seed(17)
+        let model = Qwen3Model(
+            try JSONDecoder().decode(Qwen3Configuration.self, from: Data(configuration.utf8)))
+        if let bits {
+            quantize(model: model, groupSize: 32, bits: bits)
+        }
+        model.apply { $0.dtype == .float32 ? $0.asType(dtype) : $0 }
+        eval(model)
+        return model
+    }
+
+    private func input(_ count: Int, batch: Int = 1) -> LMInput.Text {
+        .init(
+            tokens: MLXArray((0 ..< count * batch).map { ($0 * 37 + 11) % 256 })
+                .reshaped(batch, count))
+    }
+
+    private func assertEqual(
+        _ actual: MLXArray, _ expected: MLXArray,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.shape, expected.shape, file: file, line: line)
+        XCTAssertEqual(actual.dtype, expected.dtype, file: file, line: line)
+        XCTAssertTrue(
+            allClose(actual, expected, rtol: 0, atol: 0).item(Bool.self),
+            "Expected exact equality", file: file, line: line)
+    }
+
+    private func assertCacheEqual(
+        _ actual: [KVCache], _ expected: [KVCache],
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.count, expected.count, file: file, line: line)
+        for (a, b) in zip(actual, expected) {
+            XCTAssertEqual(a.offset, b.offset, file: file, line: line)
+            XCTAssertEqual(a.state.count, b.state.count, file: file, line: line)
+            for (x, y) in zip(a.state, b.state) {
+                assertEqual(x, y, file: file, line: line)
+            }
+        }
+    }
+
+    func testQuantizedProjectionPreservesExactLogitsAndCacheAtBoundaries() throws {
+        let lengths = [
+            1, 8, 9, 31, 32, 33, 63, 64, 65, 95, 96, 97,
+            127, 128, 129, 255, 256, 257, 511, 512, 513,
+        ]
+        for dtype: DType in [.float32, .float16, .bfloat16] {
+            for bits in [4, 8] {
+                let model = try makeModel(bits: bits, dtype: dtype)
+                let languageModel: any LanguageModel = model
+                for length in lengths {
+                    try autoreleasepool {
+                        let expectedCache = try model.newCache(parameters: nil)
+                        let actualCache = try model.newCache(parameters: nil)
+                        let text = input(length)
+                        let expected = languageModel(text, cache: expectedCache, state: nil)
+                        let actual = languageModel.nextTokenLogits(
+                            text, cache: actualCache, state: nil)
+                        XCTAssertEqual(expected.logits.shape, [1, length, 256])
+                        if length >= 96 {
+                            XCTAssertLessThanOrEqual(actual.logits.dim(1), 95)
+                        }
+                        assertEqual(actual.logits[0..., -1, 0...], expected.logits[0..., -1, 0...])
+                        assertCacheEqual(actualCache, expectedCache)
+                    }
+                }
+            }
+        }
+    }
+
+    func testUnquantizedUntiedAndBatchedForwardsKeepAllRows() throws {
+        for (tied, bits, batch) in [
+            (true, nil, 1), (false, nil, 1),
+            (false, Optional(4), 1), (true, Optional(2), 1), (true, Optional(4), 2),
+        ] {
+            let model = try makeModel(tied: tied, bits: bits)
+            let text = input(128, batch: batch)
+            let expected = model(text, cache: nil, state: nil)
+            let actual = model.nextTokenLogits(text, cache: nil, state: nil)
+            assertEqual(actual.logits, expected.logits)
+            XCTAssertEqual(model(text.tokens, cache: nil).shape, [batch, 128, 256])
+        }
+    }
+
+    func testWarmSuffixAndContinuationPreserveEntireCache() throws {
+        let model = try makeModel()
+        for parameters in [
+            GenerateParameters(), GenerateParameters(maxKVSize: 128),
+            GenerateParameters(kvBits: 4, kvGroupSize: 32, quantizedKVStart: 0),
+        ] {
+            let prefix = try model.newCache(parameters: parameters)
+            eval(model(input(97), cache: prefix, state: nil).logits, prefix)
+            let expectedCache = prefix.map { $0.copy() }
+            let actualCache = prefix.map { $0.copy() }
+            for length in [129, 1, 1, 96, 1] {
+                let text = input(length)
+                let expected = model(text, cache: expectedCache, state: nil)
+                let actual = model.nextTokenLogits(text, cache: actualCache, state: nil)
+                assertEqual(actual.logits[0..., -1, 0...], expected.logits[0..., -1, 0...])
+                assertCacheEqual(actualCache, expectedCache)
+            }
+        }
+    }
+
+    func testOrdinaryIteratorUsesOptimizedEntryPointAndSpeculationKeepsFullForward() throws {
+        let model = try makeModel()
+        let recording = RecordingQwen(model)
+        let parameters = GenerateParameters(maxTokens: 6, temperature: 0)
+        var iterator = try TokenIterator(
+            input: LMInput(tokens: input(128).tokens.squeezed(axis: 0)),
+            model: recording, parameters: parameters)
+        while iterator.next() != nil {}
+        XCTAssertGreaterThan(recording.nextTokenCalls, 0)
+        XCTAssertEqual(recording.fullForwardCalls, 0)
+
+        recording.nextTokenCalls = 0
+        var speculative = try SpeculativeTokenIterator(
+            input: LMInput(tokens: input(128).tokens.squeezed(axis: 0)),
+            mainModel: recording, draftModel: model, parameters: parameters, numDraftTokens: 2)
+        while speculative.next() != nil {}
+        XCTAssertEqual(recording.nextTokenCalls, 0)
+        XCTAssertGreaterThan(recording.fullForwardCalls, 0)
+    }
+
+    func testLocalCheckpointPreservesLogitsCacheAndContinuation() throws {
+        guard let path = ProcessInfo.processInfo.environment["MLX_QWEN3_PREFILL_MODEL"],
+            !path.isEmpty
+        else {
+            throw XCTSkip("set MLX_QWEN3_PREFILL_MODEL to validate a local Qwen3 checkpoint")
+        }
+        let directory = URL(fileURLWithPath: path)
+        let data = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        let model = Qwen3Model(try JSONDecoder().decode(Qwen3Configuration.self, from: data))
+        let base = try JSONDecoder().decode(BaseConfiguration.self, from: data)
+        try loadWeights(
+            modelDirectory: directory, model: model,
+            perLayerQuantization: base.perLayerQuantization)
+
+        for length in [96, 128, 512, 513] {
+            try autoreleasepool {
+                let prefix = try model.newCache(parameters: nil)
+                eval(model(input(97), cache: prefix, state: nil).logits, prefix)
+                let expectedCache = prefix.map { $0.copy() }
+                let actualCache = prefix.map { $0.copy() }
+                var text = input(length)
+                for step in 0 ... 16 {
+                    let expected = model(text, cache: expectedCache, state: nil).logits[
+                        0..., -1, 0...]
+                    let actual = model.nextTokenLogits(text, cache: actualCache, state: nil).logits[
+                        0..., -1, 0...]
+                    assertEqual(actual, expected)
+                    if step == 0 || step == 16 {
+                        assertCacheEqual(actualCache, expectedCache)
+                    }
+                    let expectedToken = argMax(expected, axis: -1).item(Int.self)
+                    XCTAssertEqual(argMax(actual, axis: -1).item(Int.self), expectedToken)
+                    text = .init(tokens: MLXArray([expectedToken])[.newAxis])
+                }
+            }
+        }
+    }
+
+    func testDefaultEntryPointPreservesFullLogitsAndState() throws {
+        let model: any LanguageModel = StatefulFullLogitModel()
+        var state = LMOutput.State()
+        state[StatefulFullLogitModel.key] = 7
+        let text = input(128)
+        let output = model.nextTokenLogits(text, cache: nil, state: state)
+        XCTAssertEqual(output.logits.shape, [1, 128, 1])
+        XCTAssertEqual(output.state?[StatefulFullLogitModel.key], 8)
+        assertEqual(output.logits, text.tokens.asType(.float32)[.ellipsis, .newAxis])
+    }
+}
+
+private final class RecordingQwen: Module, LLMModel {
+    var loraLayers: [Module] { wrapped.loraLayers }
+    let wrapped: Qwen3Model
+    var nextTokenCalls = 0
+    var fullForwardCalls = 0
+    var vocabularySize: Int { wrapped.vocabularySize }
+
+    init(_ wrapped: Qwen3Model) { self.wrapped = wrapped }
+
+    func newCache(parameters: GenerateParameters?) throws -> [KVCache] {
+        try wrapped.newCache(parameters: parameters)
+    }
+
+    func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+    {
+        fullForwardCalls += 1
+        return wrapped(input, cache: cache, state: state)
+    }
+
+    func nextTokenLogits(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+    {
+        nextTokenCalls += 1
+        return wrapped.nextTokenLogits(input, cache: cache, state: state)
+    }
+}
+
+private final class StatefulFullLogitModel: Module, LLMModel {
+    var loraLayers: [Module] { [] }
+    static let key = LMOutput.Key<Int>("step")
+    let vocabularySize = 1
+
+    func newCache(parameters: GenerateParameters?) throws -> [KVCache] { [] }
+
+    func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+    {
+        var next = state ?? .init()
+        next[Self.key] = (state?[Self.key] ?? 0) + 1
+        return .init(logits: input.tokens.asType(.float32)[.ellipsis, .newAxis], state: next)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Qwen currently computes output scores for prompt positions that normal generation discards. This change reduces that work, making prompt processing faster and reducing peak memory usage.

Applies to supported quantized Qwen3 and Qwen3.5 models, including Qwen3.5’s vision-language path. It keeps the same calculation order for the final scores and preserves full outputs where needed, including speculative decoding.

On my Apple M2 with 16GB RAM, using 512-token text prompts and alternating baseline/optimized runs:

| Model | Before → after | Lower prefill latency |
|---|---|---|
| Qwen3-4B-4bit | 3.45 → 3.17 s | 8.1% |
| Qwen3.5-9B-4bit, text model | 5.42 → 4.84 s | 10.7% |
| Qwen3.5-9B-4bit, vision-language model with text input | 5.40 → 4.82 s | 10.7% |

Peak memory decreased by approximately 130, 185, and 212 MiB respectively. Gains depend on prompt length and prefill chunking.

Exact comparisons passed for final scores, cache contents, and generated tokens on both cached checkpoints. 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)

## AI usage

- [x] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure:
