### PR TITLE
Gemma 4 VLM: fuse float32 logit softcapping

### DIFF
--- a/Libraries/MLXLMCommon/Gemma4Fusions.swift
+++ b/Libraries/MLXLMCommon/Gemma4Fusions.swift
@@ -1,0 +1,14 @@
+import MLX
+
+private let compiledGemma4Softcap = compile(shapeless: true) {
+    (logits: MLXArray, cap: MLXArray) in tanh(logits / cap) * cap
+}
+
+package func gemma4LogitSoftcap(_ logits: MLXArray, _ cap: MLXArray) -> MLXArray {
+    guard cap.dtype == .float32 else { return tanh(logits / cap) * cap }
+    // Promote before tracing: mixed float16/float32 division can round differently inside compile.
+    if logits.dtype == .float16 || logits.dtype == .bfloat16 {
+        return compiledGemma4Softcap(logits.asType(.float32), cap)
+    }
+    return compiledGemma4Softcap(logits, cap)
+}

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1425,7 +1425,7 @@ final class Gemma4TextLanguageModel: Module, KVCacheDimensionProvider {
         let softcappedLogits: MLXArray
         if let finalLogitSoftcapping, finalLogitSoftcapping > 0 {
             let scale = MLXArray(finalLogitSoftcapping)
-            softcappedLogits = tanh(logits / scale) * scale
+            softcappedLogits = gemma4LogitSoftcap(logits, scale)
         } else {
             softcappedLogits = logits
         }

--- a/Tests/MLXLMTests/Gemma4FusionTests.swift
+++ b/Tests/MLXLMTests/Gemma4FusionTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import XCTest
+
+final class Gemma4FusionTests: XCTestCase {
+    private func assertIdentical(
+        _ actual: MLXArray, _ expected: MLXArray,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.shape, expected.shape, file: file, line: line)
+        XCTAssertEqual(actual.dtype, expected.dtype, file: file, line: line)
+        XCTAssertEqual(
+            actual.asType(.float32).asArray(Float.self).map(\.bitPattern),
+            expected.asType(.float32).asArray(Float.self).map(\.bitPattern),
+            file: file, line: line)
+    }
+
+    func testSoftcapPreservesScalarPromotionAndRuntimeCaps() {
+        for dtype in [DType.float16, .bfloat16, .float32] {
+            let x = MLX.linspace(Float(-100), Float(100), count: 4096).reshaped(1, 4096)
+                .asType(dtype)
+            for value: Float in [30, 7.25, 1] {
+                for cap in [MLXArray(value), value.asMLXArray(dtype: dtype)] {
+                    assertIdentical(gemma4LogitSoftcap(x, cap), tanh(x / cap) * cap)
+                    let strided = x[.ellipsis, .stride(by: 2)]
+                    assertIdentical(
+                        gemma4LogitSoftcap(strided, cap), tanh(strided / cap) * cap)
+                }
+            }
+        }
+    }
+
+    func testGradientsMatchOriginal() {
+        let cap = MLXArray(Float(30))
+        for dtype in [DType.float16, .bfloat16, .float32] {
+            let logits = MLX.linspace(Float(-3), Float(3), count: 64)
+                .reshaped(1, 1, 64).asType(dtype)
+            assertIdentical(
+                grad({ sum(gemma4LogitSoftcap($0, cap)) })(logits),
+                grad({ sum(tanh($0 / cap) * cap) })(logits))
+        }
+    }
+
+    func testFusionLatency() throws {
+        guard ProcessInfo.processInfo.environment["MLX_BENCHMARK_GEMMA4_FUSIONS"] == "1" else {
+            throw XCTSkip("Set MLX_BENCHMARK_GEMMA4_FUSIONS=1 to benchmark")
+        }
+        let logits = MLXRandom.normal([1, 1, 262144]).asType(.bfloat16)
+        let cap = MLXArray(Float(30))
+        eval(logits, cap)
+        let cases: [(String, () -> MLXArray, () -> MLXArray)] = [
+            ("VLM softcap", { tanh(logits / cap) * cap }, { gemma4LogitSoftcap(logits, cap) })
+        ]
+        for (name, original, fused) in cases {
+            assertIdentical(fused(), original())
+            for _ in 0 ..< 10 { eval(original(), fused()) }
+            var samples = [[Double]](repeating: [], count: 2)
+            for round in 0 ..< 10 {
+                for arm in (round.isMultiple(of: 2) ? [0, 1] : [1, 0]) {
+                    let body = arm == 0 ? original : fused
+                    let start = ProcessInfo.processInfo.systemUptime
+                    for _ in 0 ..< 100 { eval(body()) }
+                    samples[arm].append((ProcessInfo.processInfo.systemUptime - start) * 10000)
+                }
+            }
+            let medians = samples.map { values in
+                let sorted = values.sorted()
+                return (sorted[4] + sorted[5]) / 2
+            }
+            print("[Gemma4 fusion] \(name): original \(medians[0]) µs, fused \(medians[1]) µs")
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fuse `tanh(logits / cap) * cap` in the Gemma 4 VLM text decoder using a stateless compiled function. Pass the cap as a runtime input and explicitly promote float16/bfloat16 logits to float32 before compilation to preserve the original rounding.

This changes one production call site. Public APIs, checkpoint loading, cache handling, and the text-only LLM implementation remain unchanged.

## Performance

Apple M2, Release build, bfloat16 logits with a float32 cap. Each run alternated the original and fused expressions within the same process, measuring warmed, synchronized operation latency.

| Run | Original | Fused | Latency reduction |
|---|---:|---:|---:|
| 1 | 309.8 µs | 298.3 µs | 3.7% |
| 2 | 316.8 µs | 311.2 µs | 1.8% |
| 3 | 318.1 µs | 281.0 µs | 11.7% |

**Median latency reduction: 3.7% for softcapping.** No reliable whole-model tokens/sec improvement was established.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift-lm/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

## AI usage

- [ ] I have read this PR description in full and approve it as my own, and it
      accurately describes the code changes.
- AI usage disclosure:
